### PR TITLE
Simple testing

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+.gitignore

--- a/Makefile
+++ b/Makefile
@@ -128,3 +128,16 @@ clean :
 
 tags:
 	ctags -R src
+
+
+#*************************************************************#
+# Testing
+#
+.PHONY: setcap test
+
+# Run this once with sudo, and then you don't need sudo for executing tests
+setcap: $(BINDIR)/driver_test
+	setcap CAP_IPC_LOCK+ep $(BINDIR)/driver_test
+
+test: $(BINDIR)/driver_test
+	./test.sh

--- a/README.md
+++ b/README.md
@@ -1,22 +1,45 @@
-SplinterDB
-==========
-
+# SplinterDB
 SplinterDB is a key-value store designed for high performance on fast storage devices.
 
-Installation
-============
-To compile this repository, you need `gawk`, `libaio`, and 'libconfig' dev headers installed.
-You can do this with
+## Build and test
+
+### Option 1: On Linux
+Install dependencies
 ```
-  sudo apt update
-  sudo apt install -y gawk libaio-dev libconfig-dev libxxhash-dev
+sudo apt update
+sudo apt install -y libaio-dev libconfig-dev libxxhash-dev
 ```
 
-Then, to compile:
+Build
 ```
-  make
+make
 ```
 
-Configuration
-=============
-By default the configuration file default.cfg is used. This creates a db file in the working directory to use as back end. To modify this configuration, copy to "splinter_test.cfg" and make changes.
+The test binary needs [CAP_IPC_LOCK](https://man7.org/linux/man-pages/man7/capabilities.7.html), but you can set it once
+```
+sudo make setcap
+```
+
+so that you can run the tests without `sudo`
+```
+make test
+```
+
+### Option 2: With Docker
+Build
+```
+docker build -t splinterdb .
+```
+
+Run tests
+```
+docker run --rm --cap-add=IPC_LOCK splinterdb
+```
+
+Or to get a shell in the container where you can interactively run tests
+```
+docker run --rm -it --cap-add=IPC_LOCK splinterdb /bin/bash
+```
+
+## Test configuration
+By default the configuration file `default.cfg` is used. This creates a `db` file in the working directory to use as back end. To modify this configuration, copy to `splinter_test.cfg` and make changes.

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+SEED="${SEED:-135}"
+DRIVER="${DRIVER:-"${BINDIR:-bin}/driver_test"}"
+
+"$DRIVER" splinter_test --functionality 1000000 100 --seed "$SEED"
+
+"$DRIVER" cache_test --seed "$SEED"
+
+"$DRIVER" btree_test --seed "$SEED"


### PR DESCRIPTION
Two easy ways to run the tests:
- `make test`
- `docker build` + `docker run`

Note that CI is still executing tests the old way.  Once this merges to `main`, I'll update our Concourse config to just run `./test.sh`.  That will then make it possible for a PR to change / add-to the set of tests which are run by CI.