### PR TITLE
Fixes for compiling with gcc

### DIFF
--- a/src/clockcache.c
+++ b/src/clockcache.c
@@ -920,7 +920,11 @@ clockcache_try_set_writeback(clockcache *cc,
  *----------------------------------------------------------------------
  */
 
-__attribute__((no_sanitize("memory")))
+#if defined(__has_feature)
+#  if __has_feature(memory_sanitizer)
+  __attribute__((no_sanitize("memory")))
+#  endif
+#endif
 void
 clockcache_write_callback(void            *metadata,
                           struct iovec    *iovec,
@@ -2456,7 +2460,11 @@ typedef struct clockcache_sync_callback_req {
    uint64     *pages_outstanding;
 } clockcache_sync_callback_req;
 
-__attribute__((no_sanitize("memory")))
+#if defined(__has_feature)
+#  if __has_feature(memory_sanitizer)
+  __attribute__((no_sanitize("memory")))
+#  endif
+#endif
 void
 clockcache_sync_callback(void            *arg,
                          struct iovec    *iovec,
@@ -2548,7 +2556,11 @@ clockcache_extent_sync(clockcache *cc,
  *----------------------------------------------------------------------
  */
 
-__attribute__((no_sanitize("memory")))
+#if defined(__has_feature)
+#  if __has_feature(memory_sanitizer)
+  __attribute__((no_sanitize("memory")))
+#  endif
+#endif
 void
 clockcache_read_callback(void            *metadata,
                          struct iovec    *iovec,

--- a/tests/splinter_test.c
+++ b/tests/splinter_test.c
@@ -853,7 +853,7 @@ test_splinter_perf(splinter_config  *cfg,
    FILE *fp = popen("/home/aconway/bytes_read.sh", "r");// | awk '{print $7}'",  "r");
    platform_assert(fp != NULL);
    char buffer[128];
-   fgets(buffer, 128, fp);
+   platform_assert(fgets(buffer, 128, fp) == buffer);
    uint64 kb_written_start = atoll(buffer);
    uint64 start_time = platform_get_timestamp();
 
@@ -879,7 +879,7 @@ test_splinter_perf(splinter_config  *cfg,
    timestamp insert_latency_max = 0;
    fp = popen("/home/aconway/bytes_read.sh", "r");// | awk '{print $7}'",  "r");
    platform_assert(fp != NULL);
-   fgets(buffer, 128, fp);
+   platform_assert(fgets(buffer, 128, fp) == buffer);
    uint64 kb_written_end = atoll(buffer);
    uint64 io_mib = (kb_written_end - kb_written_start) / 1024;
    uint64 bandwidth = io_mib / NSEC_TO_SEC(total_time);
@@ -1227,7 +1227,7 @@ test_splinter_periodic(splinter_config  *cfg,
    FILE *fp = popen("/home/aconway/bytes_read.sh", "r");// | awk '{print $7}'",  "r");
    platform_assert(fp != NULL);
    char buffer[128];
-   fgets(buffer, 128, fp);
+   platform_assert(fgets(buffer, 128, fp) == buffer);
    uint64 kb_written_start = atoll(buffer);
    uint64 start_time = platform_get_timestamp();
 
@@ -1253,7 +1253,7 @@ test_splinter_periodic(splinter_config  *cfg,
    timestamp insert_latency_max = 0;
    fp = popen("/home/aconway/bytes_read.sh", "r");// | awk '{print $7}'",  "r");
    platform_assert(fp != NULL);
-   fgets(buffer, 128, fp);
+   platform_assert(fgets(buffer, 128, fp) == buffer);
    uint64 kb_written_end = atoll(buffer);
    uint64 io_mib = (kb_written_end - kb_written_start) / 1024;
    uint64 bandwidth = io_mib / NSEC_TO_SEC(total_time);
@@ -1320,7 +1320,7 @@ test_splinter_periodic(splinter_config  *cfg,
       insert_latency_max = 0;
       fp = popen("/home/aconway/bytes_read.sh", "r");// | awk '{print $7}'",  "r");
       platform_assert(fp != NULL);
-      fgets(buffer, 128, fp);
+      platform_assert(fgets(buffer, 128, fp) == buffer);
       kb_written_end = atoll(buffer);
       io_mib = (kb_written_end - kb_written_start) / 1024;
       bandwidth = io_mib / NSEC_TO_SEC(total_time);


### PR DESCRIPTION
This fixes all the errors without needing to set `-Wno-error=attributes.`

To test using docker:
```
docker build -t build-env:gcc --build-arg compiler=gcc - < Dockerfile.build-env
docker build -t splinterdb:gcc --build-arg "build_env_image=build-env:gcc" .
docker run -it --rm --cap-add=IPC_LOCK splinterdb:gcc
```