### PR TITLE
Remove capability stuff for CAP_IPC_LOCK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Example usage:
-#   docker build -t splinterdb . && docker --rm run --cap-add=IPC_LOCK splinterdb
+#   docker build -t splinterdb . && docker --rm run splinterdb
 
 # see Dockerfile.build-env
 ARG build_env_image=projects.registry.vmware.com/splinterdb/build-env:latest

--- a/Dockerfile.build-env
+++ b/Dockerfile.build-env
@@ -15,7 +15,7 @@ RUN /bin/bash -c ' \
 set -euo pipefail; \
 export DEBIAN_FRONTEND=noninteractive; \
 apt-get update -y; \
-apt-get install -y make libaio-dev libconfig-dev libxxhash-dev libcap2-bin;'
+apt-get install -y make libaio-dev libconfig-dev libxxhash-dev;'
 
 ARG compiler=clang-12
 RUN /bin/bash -c "DEBIAN_FRONTEND=noninteractive; apt-get install -y $compiler"

--- a/Makefile
+++ b/Makefile
@@ -133,11 +133,7 @@ tags:
 #*************************************************************#
 # Testing
 #
-.PHONY: setcap test
-
-# Run this once with sudo, and then you don't need sudo for executing tests
-setcap: $(BINDIR)/driver_test
-	setcap CAP_IPC_LOCK+ep $(BINDIR)/driver_test
+.PHONY: test
 
 test: $(BINDIR)/driver_test
 	./test.sh

--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ See
 ### Pre-built binary with Docker
 The most recent build from `main` can be tested from a local Docker container:
 ```shell
-docker run --rm --cap-add=IPC_LOCK projects.registry.vmware.com/splinterdb/splinterdb
+docker run --rm projects.registry.vmware.com/splinterdb/splinterdb
 ```
 Or add `/bin/bash` to get a shell in the container:
 ```shell
-docker run -it --rm --cap-add=IPC_LOCK projects.registry.vmware.com/splinterdb/splinterdb /bin/bash
+docker run -it --rm projects.registry.vmware.com/splinterdb/splinterdb /bin/bash
 ```
 
 ### Build from source with Docker
@@ -24,7 +24,7 @@ docker build -t splinterdb .
 ```
 and then get a shell in that image:
 ```shell
-docker run -it --rm --cap-add=IPC_LOCK splinterdb /bin/bash
+docker run -it --rm splinterdb /bin/bash
 ```
 
 ### Build from source on Linux
@@ -39,18 +39,8 @@ sudo apt install -y libaio-dev libconfig-dev libxxhash-dev $COMPILER
 export CC=$COMPILER
 export LD=$COMPILER
 make
-```
-
-The test binary needs [CAP_IPC_LOCK](https://man7.org/linux/man-pages/man7/capabilities.7.html), but you can set it once
-```shell
-sudo make setcap
-```
-
-so that you can run the tests without `sudo`
-```shell
 make test
 ```
-
 
 ## Test configuration
 By default the configuration file `default.cfg` is used. This creates a `db` file in the working directory to use as back end. To modify this configuration, copy to `splinter_test.cfg` and make changes.


### PR DESCRIPTION
Unnecessary since #27 made `mlock()` usage opt-in