### PR TITLE
fix debug build error

### DIFF
--- a/src/clockcache.c
+++ b/src/clockcache.c
@@ -2578,7 +2578,7 @@ clockcache_prefetch_callback(void *          metadata,
       debug_assert(addr != CC_UNMAPPED_ADDR);
       debug_assert(addr == last_addr + cc->cfg->page_size ||
                    last_addr == CC_UNMAPPED_ADDR);
-      debug_assert(addr == iovec[page_off].iov_base);
+      debug_assert(addr == (int64)(iovec[page_off].iov_base));
       debug_code(last_addr = addr);
       debug_assert(entry_no == clockcache_lookup(cc, addr));
    }


### PR DESCRIPTION
without this, `make debug` fails with
```
fatal error: comparison between pointer and integer ('int64' (aka 'long') and 'void *')
```

With it, it builds, but then
```
bin/driver_test splinter_test --seed 1
Dispatch test splinter_test
fingerprint_size: 27
Running splinter_test with 1 caches
splinter_test: splinter basic test started
inserting  48% completedriver_test: src/clockcache.c:2581: void clockcache_prefetch_callback(void *, struct iovec *, uint64, platform_status): Assertion `addr == (int64)(iovec[page_off].iov_base)' failed.
[1]    3592906 abort (core dumped)  bin/driver_test splinter_test --seed 1
```

came from 5e1b09be566f584e6471205818afcc4f270ff287 but this is all very much over my head