### PR TITLE
Separate Disk Allocation from Cache Allocation

### DIFF
--- a/src/clockcache.h
+++ b/src/clockcache.h
@@ -15,11 +15,13 @@
 #include "io.h"
 #include "task.h"
 
-#define CC_ENTRIES_PER_BATCH 64
-#define CC_CLEANER_GAP_FRAC 8
 //#define ADDR_TRACING
-#define TRACE_ADDR 7213056
+#define TRACE_ADDR  (UINT64_MAX - 1)
 #define TRACE_ENTRY (UINT32_MAX-1)
+
+/* how distributed the rw locks are */
+#define CC_RC_WIDTH 4
+
 
 typedef struct clockcache_config {
    uint64 page_size;
@@ -124,8 +126,9 @@ struct clockcache {
    platform_heap_id      heap_id;
 
    // Distributed locks (the write bit is in the status uint32 of the entry)
-   volatile uint16      *refcount;
-   volatile uint8        *pincount;
+   buffer_handle  *rc_bh;
+   volatile uint8 *refcount;
+   volatile uint8 *pincount;
 
    // Clock hands and related metadata
    volatile uint32       evict_hand;

--- a/src/mini_allocator.c
+++ b/src/mini_allocator.c
@@ -42,43 +42,45 @@ mini_allocator_init(mini_allocator *mini,
                     uint64          num_batches,
                     page_type       type)
 {
-   page_handle *meta_page;
-   const uint64 pages_per_extent = cache_extent_size(cc) / cache_page_size(cc);
-   page_handle *new_pages[MAX_PAGES_PER_EXTENT];
-   uint64 i;
-   uint64 batch;
-   uint64 wait = 1;
-
-   memset(mini, 0, sizeof(mini_allocator));
-   mini->cc           = cc;
-   mini->data_cfg     = data_cfg;
-   mini->meta_head    = meta_head;
-   if (meta_tail == 0) {
-      mini->meta_tail = meta_head;
-   } else {
-      mini->meta_tail = meta_tail;
-   }
-   mini->type         = type;
-   mini->num_batches  = num_batches;
    platform_assert(num_batches <= MINI_MAX_BATCHES);
 
-   meta_page = cache_get(cc, mini->meta_tail, TRUE, type);
-   while (!cache_claim(cc, meta_page)) {
-      // should never happen
-      platform_sleep(wait);
-      wait = wait > 1024 ? wait : 2 * wait;
+   memset(mini, 0, sizeof(mini_allocator));
+
+   mini->cc          = cc;
+   mini->al          = cache_allocator(cc);
+   mini->data_cfg    = data_cfg;
+   mini->meta_head   = meta_head;
+   mini->type        = type;
+   mini->num_batches = num_batches;
+   platform_assert(num_batches <= MINI_MAX_BATCHES);
+
+   page_handle *meta_page;
+   if (meta_tail == 0) {
+      // new mini allocator
+      mini->meta_tail = meta_head;
+      meta_page       = cache_alloc(cc, mini->meta_head, type);
+   } else {
+      // load mini allocator
+      mini->meta_tail = meta_tail;
+      meta_page       = cache_get(cc, mini->meta_tail, TRUE, type);
+      uint64 wait     = 1;
+      while (!cache_claim(cc, meta_page)) {
+         // should never happen
+         platform_sleep(wait);
+         wait = wait > 1024 ? wait : 2 * wait;
+      }
+      cache_lock(cc, meta_page);
    }
-   wait = 1;
-   cache_lock(cc, meta_page);
    mini_allocator_meta_hdr *hdr = (mini_allocator_meta_hdr *)meta_page->data;
    if (meta_tail == 0) {
       hdr->next_meta_addr = 0;
       hdr->pos = 0;
    }
 
-   for (batch = 0; batch < num_batches; batch++) {
-      cache_extent_alloc(cc, new_pages, type);
-      mini->next_extent[batch] = new_pages[0]->disk_addr;
+   for (uint64 batch = 0; batch < num_batches; batch++) {
+      platform_status rc =
+         allocator_alloc_extent(mini->al, &mini->next_extent[batch]);
+      platform_assert_status_ok(rc);
       //platform_log("mini_allocator_alloc %lu-%lu.%lu : %lu\n",
       //      mini->meta_head, mini->meta_tail, hdr->pos, mini->next_extent[batch]);
       if (hdr->pos == (cache_page_size(mini->cc)
@@ -87,36 +89,18 @@ mini_allocator_init(mini_allocator *mini,
          mini->meta_tail += cache_page_size(mini->cc);
          if (mini->meta_tail % cache_extent_size(mini->cc) == 0) {
             // need to allocate the next meta extent
-            page_handle *new_pages[MAX_PAGES_PER_EXTENT];
-            cache_extent_alloc(mini->cc, new_pages, type);
-            mini->meta_tail = new_pages[0]->disk_addr;
-            for (i = 0; i < pages_per_extent; i++) {
-               cache_unlock(mini->cc, new_pages[i]);
-               cache_unclaim(mini->cc, new_pages[i]);
-               cache_unget(mini->cc, new_pages[i]);
-            }
+            rc = allocator_alloc_extent(mini->al, (uint64 *)&mini->meta_tail);
+            platform_assert_status_ok(rc);
          }
          hdr->next_meta_addr = mini->meta_tail;
          page_handle *last_meta_page = meta_page;
-         meta_page = cache_get(mini->cc, mini->meta_tail, TRUE, type);
-         while (!cache_claim(mini->cc, meta_page)) {
-            platform_sleep(wait);
-            wait = wait > 1024 ? wait : 2 * wait;
-         }
-         wait = 1;
-         cache_lock(mini->cc, meta_page);
-         cache_mark_dirty(mini->cc, last_meta_page);
+         meta_page = cache_alloc(mini->cc, mini->meta_tail, type);
          cache_unlock(mini->cc, last_meta_page);
          cache_unclaim(mini->cc, last_meta_page);
          cache_unget(mini->cc, last_meta_page);
          hdr = (mini_allocator_meta_hdr *)meta_page->data;
          hdr->pos = 0;
          hdr->next_meta_addr = 0;
-      }
-      for (i = 0; i < pages_per_extent; i++) {
-         cache_unlock(cc, new_pages[i]);
-         cache_unclaim(cc, new_pages[i]);
-         cache_unget(cc, new_pages[i]);
       }
    }
 
@@ -134,18 +118,13 @@ mini_allocator_alloc(mini_allocator *mini,
                      char           *key,
                      uint64         *next_extent)
 {
-   uint64                   next_addr = mini->next_addr[batch];
-   uint64                   next_extent_addr;
-   page_handle             *meta_page;
-   uint64                   i;
-   mini_allocator_meta_hdr *hdr;
-   uint64                   new_meta_tail;
-   uint64                   wait = 1;
-   platform_status          rc = STATUS_OK;
-
    platform_assert(batch < mini->num_batches);
 
+   platform_status rc        = STATUS_OK;
+   uint64          next_addr = mini->next_addr[batch];
+
    // wait until we hold the lock for our batch
+   uint64 wait = 1;
    while (0 || next_addr == MINI_WAIT
             || !__sync_bool_compare_and_swap(&mini->next_addr[batch],
                                              next_addr, MINI_WAIT))
@@ -158,34 +137,24 @@ mini_allocator_alloc(mini_allocator *mini,
 
    if (next_addr % cache_extent_size(mini->cc) == 0) {
       // need to allocate the next extent
-      uint64 pages_per_extent =
-         cache_extent_size(mini->cc) / cache_page_size(mini->cc);
-      page_handle *new_pages[MAX_PAGES_PER_EXTENT];
-      rc = cache_extent_alloc(mini->cc, new_pages, mini->type);
+
+      uint64 next_extent_addr = mini->next_extent[batch];
+      rc = allocator_alloc_extent(mini->al, &mini->next_extent[batch]);
       platform_assert_status_ok(rc);
-      //platform_log("meta_head %lu next_extent %lu new_extent %lu\n",
-      //      mini->meta_head, mini->next_extent[batch], new_pages[0]->disk_addr);
-      debug_assert(mini->next_extent[batch] != new_pages[0]->disk_addr);
-      next_extent_addr = mini->next_extent[batch];
-      mini->next_extent[batch] = new_pages[0]->disk_addr;
       next_addr = next_extent_addr;
       if (next_extent) {
          *next_extent = mini->next_extent[batch];
       }
+      // platform_log("meta_head %lu next_extent %lu new_extent %lu\n",
+      //       mini->meta_head, mini->next_extent[batch],
+      //       new_pages[0]->disk_addr);
       mini->next_addr[batch] = next_extent_addr + cache_page_size(mini->cc);
-      for (i = 0; i < pages_per_extent; i++) {
-         cache_unlock(mini->cc, new_pages[i]);
-         cache_unclaim(mini->cc, new_pages[i]);
-         cache_unget(mini->cc, new_pages[i]);
-      }
 
+      page_handle *meta_page;
       while (1) {
          meta_page = cache_get(mini->cc, mini->meta_tail, TRUE, mini->type);
          if (cache_claim(mini->cc, meta_page)) {
-            if (meta_page->disk_addr == mini->meta_tail)
-               break;
-            else
-               cache_unclaim(mini->cc, meta_page);
+            break;
          }
          cache_unget(mini->cc, meta_page);
          platform_sleep(wait);
@@ -193,37 +162,23 @@ mini_allocator_alloc(mini_allocator *mini,
       }
       wait = 1;
       cache_lock(mini->cc, meta_page);
+      // FIXME: [aconway 2021-05-10] This is residual, delete eventually:
       debug_assert(meta_page->disk_addr == mini->meta_tail);
 
-      hdr = (mini_allocator_meta_hdr *)meta_page->data;
+      mini_allocator_meta_hdr *hdr = (mini_allocator_meta_hdr *)meta_page->data;
       if (hdr->pos == (cache_page_size(mini->cc)
             - sizeof(mini_allocator_meta_hdr))
             / sizeof(mini_allocator_meta_entry)) {
          // need a new meta page
-         new_meta_tail = mini->meta_tail + cache_page_size(mini->cc);
+         uint64 new_meta_tail = mini->meta_tail + cache_page_size(mini->cc);
          if (new_meta_tail % cache_extent_size(mini->cc) == 0) {
             // need to allocate the next meta extent
-            uint64 pages_per_extent =
-               cache_extent_size(mini->cc) / cache_page_size(mini->cc);
-            page_handle *new_pages[MAX_PAGES_PER_EXTENT];
-            cache_extent_alloc(mini->cc, new_pages, mini->type);
-            new_meta_tail = new_pages[0]->disk_addr;
-            for (i = 0; i < pages_per_extent; i++) {
-               cache_unlock(mini->cc, new_pages[i]);
-               cache_unclaim(mini->cc, new_pages[i]);
-               cache_unget(mini->cc, new_pages[i]);
-            }
+            rc = allocator_alloc_extent(mini->al, &new_meta_tail);
+            platform_assert_status_ok(rc);
          }
          hdr->next_meta_addr = new_meta_tail;
          page_handle *last_meta_page = meta_page;
-         meta_page = cache_get(mini->cc, new_meta_tail, TRUE, mini->type);
-         while (!cache_claim(mini->cc, meta_page)) {
-            // should never happen
-            platform_sleep(wait);
-            wait = wait > 1024 ? wait : 2 * wait;
-         }
-         wait = 1;
-         cache_lock(mini->cc, meta_page);
+         meta_page       = cache_alloc(mini->cc, new_meta_tail, mini->type);
          mini->meta_tail = new_meta_tail;
          cache_mark_dirty(mini->cc, last_meta_page);
          cache_unlock(mini->cc, last_meta_page);

--- a/src/mini_allocator.h
+++ b/src/mini_allocator.h
@@ -19,16 +19,17 @@
 #define MINI_MAX_BATCHES 8
 
 typedef struct mini_allocator {
-   cache           *cc;
-   data_config     *data_cfg;
-   uint64           meta_head;
-   volatile uint64  meta_tail;
-   uint64           num_batches;
-   volatile uint64  next_addr[MINI_MAX_BATCHES];
-   uint64           next_extent[MINI_MAX_BATCHES];
-   uint64           last_meta_addr[MINI_MAX_BATCHES];
-   uint64           last_meta_pos[MINI_MAX_BATCHES];
-   page_type        type;
+   allocator      *al;
+   cache          *cc;
+   data_config    *data_cfg;
+   uint64          meta_head;
+   volatile uint64 meta_tail;
+   uint64          num_batches;
+   volatile uint64 next_addr[MINI_MAX_BATCHES];
+   uint64          next_extent[MINI_MAX_BATCHES];
+   uint64          last_meta_addr[MINI_MAX_BATCHES];
+   uint64          last_meta_pos[MINI_MAX_BATCHES];
+   page_type       type;
 } mini_allocator;
 
 typedef struct mini_allocator_sync_arg {

--- a/src/routing_filter.c
+++ b/src/routing_filter.c
@@ -200,23 +200,6 @@ routing_header_length(routing_config *cfg,
    return metamessage_size + sizeof(routing_hdr);
 }
 
-static inline page_handle *
-routing_get_and_lock_page(cache  *cc,
-                          uint64  addr)
-{
-   page_handle *page = cache_get(cc, addr, TRUE, PAGE_TYPE_FILTER);
-   uint64 wait = 100;
-   while (!cache_claim(cc, page)) {
-      cache_unget(cc, page);
-      platform_sleep(wait);
-      wait *= 2;
-      page = cache_get(cc, addr, TRUE, PAGE_TYPE_FILTER);
-   }
-   cache_lock(cc, page);
-   cache_mark_dirty(cc, page);
-   return page;
-}
-
 static inline void
 routing_unlock_and_unget_page(cache       *cc,
                               page_handle *page)
@@ -441,35 +424,31 @@ routing_filter_add(cache            *cc,
    memset(encoding_buffer, 0xff, ROUTING_FPS_PER_PAGE / 32 * sizeof(uint32));
 
    // we use a mini_allocator to obtain pages
+   allocator      *al = cache_allocator(cc);
+   uint64          meta_head;
+   platform_status rc = allocator_alloc_extent(al, &meta_head);
+   platform_assert_status_ok(rc);
+   filter->meta_head = meta_head;
    mini_allocator mini;
-   page_handle *meta_page[MAX_PAGES_PER_EXTENT];
-   cache_extent_alloc(cc, meta_page, PAGE_TYPE_FILTER);
-   for (uint64 i = 0; i < pages_per_extent; i++) {
-      routing_unlock_and_unget_page(cc, meta_page[i]);
-   }
-   filter->meta_head = meta_page[0]->disk_addr;
-   mini_allocator_init(&mini, cc, NULL, filter->meta_head, 0, 1,
-         PAGE_TYPE_FILTER);
+   mini_allocator_init(
+      &mini, cc, NULL, filter->meta_head, 0, 1, PAGE_TYPE_FILTER);
 
-   /* set up the index pages
-    * we use the mini allocator to alloc the extent so that it can be zapped
-    * that way
-    */
+   // set up the index pages
    uint64 addrs_per_page = page_size / sizeof(uint64);
    page_handle *index_page[MAX_PAGES_PER_EXTENT];
    uint64 index_addr = mini_allocator_alloc(&mini, 0, NULL, NULL);
-   assert(index_addr % extent_size == 0);
-   index_page[0] = routing_get_and_lock_page(cc, index_addr);
+   platform_assert(index_addr % extent_size == 0);
+   index_page[0] = cache_alloc(cc, index_addr, PAGE_TYPE_FILTER);
    for (uint64 i = 1; i < pages_per_extent; i++) {
       uint64 next_index_addr = mini_allocator_alloc(&mini, 0, NULL, NULL);
-      assert(next_index_addr == index_addr + i * page_size);
-      index_page[i] = routing_get_and_lock_page(cc, next_index_addr);
+      platform_assert(next_index_addr == index_addr + i * page_size);
+      index_page[i] = cache_alloc(cc, next_index_addr, PAGE_TYPE_FILTER);
    }
    filter->addr = index_addr;
 
    // we write to the filter with the filter cursor
    uint64 addr = mini_allocator_alloc(&mini, 0, NULL, NULL);
-   page_handle *filter_page = routing_get_and_lock_page(cc, addr);
+   page_handle *filter_page   = cache_alloc(cc, addr, PAGE_TYPE_FILTER);
    char *filter_cursor = filter_page->data;
    uint64 bytes_remaining_on_page = page_size;
 
@@ -600,7 +579,7 @@ routing_filter_add(cache            *cc,
          if (header_size + remainder_block_size > bytes_remaining_on_page) {
             routing_unlock_and_unget_page(cc, filter_page);
             addr = mini_allocator_alloc(&mini, 0, NULL, NULL);
-            filter_page = routing_get_and_lock_page(cc, addr);
+            filter_page = cache_alloc(cc, addr, PAGE_TYPE_FILTER);
 
             bytes_remaining_on_page = page_size;
             filter_cursor = filter_page->data;

--- a/src/splinter.c
+++ b/src/splinter.c
@@ -569,6 +569,7 @@ typedef struct splinter_system_state {
  *-----------------------------------------------------------------------------
  */
 
+// clang-format off
 static inline bool                 splinter_is_leaf                   (splinter_handle *spl, page_handle *node);
 static inline uint64               splinter_next_addr                 (splinter_handle *spl, page_handle *node);
 static inline int                  splinter_key_compare               (splinter_handle *spl, const char *key1, const char *key2);
@@ -578,7 +579,7 @@ static inline void                 splinter_node_claim                (splinter_
 static inline void                 splinter_node_unclaim              (splinter_handle *spl, page_handle *node);
 static inline void                 splinter_node_lock                 (splinter_handle *spl, page_handle *node);
 static inline void                 splinter_node_unlock               (splinter_handle *spl, page_handle *node);
-uint64                             splinter_alloc                     (splinter_handle *spl, uint64 height);
+page_handle *                      splinter_alloc                     (splinter_handle *spl, uint64 height);
 static inline char *               splinter_get_pivot                 (splinter_handle *spl, page_handle *node, uint16 pivot_no);
 static inline splinter_pivot_data *splinter_get_pivot_data            (splinter_handle *spl, page_handle *node, uint16 pivot_no);
 static inline uint16               splinter_find_pivot                (splinter_handle *spl, page_handle *node, char *key, lookup_type comp);
@@ -653,6 +654,8 @@ const static iterator_ops splinter_btree_skiperator_ops = {
    .advance  = splinter_btree_skiperator_advance,
    .print    = splinter_btree_skiperator_print,
 };
+
+// clang-format on
 
 /*
  *-----------------------------------------------------------------------------
@@ -947,10 +950,11 @@ splinter_node_unlock(splinter_handle *spl,
    cache_unlock(spl->cc, node);
 }
 
-uint64 splinter_alloc(splinter_handle *spl,
-                      uint64           height)
+page_handle *
+splinter_alloc(splinter_handle *spl, uint64 height)
 {
-   return mini_allocator_alloc(&spl->mini, height, NULL, NULL);
+   uint64 addr = mini_allocator_alloc(&spl->mini, height, NULL, NULL);
+   return cache_alloc(spl->cc, addr, PAGE_TYPE_TRUNK);
 }
 
 void splinter_dealloc(splinter_handle *spl,
@@ -5005,10 +5009,8 @@ splinter_split_index(splinter_handle *spl,
       spl->stats[platform_get_tid()].index_splits++;
 
    // allocate right node and write lock it
-   uint64 right_addr = splinter_alloc(spl, height);
-   page_handle *right_node = splinter_node_get(spl, right_addr);
-   splinter_node_claim(spl, &right_node);
-   splinter_node_lock(spl, right_node);
+   page_handle *right_node = splinter_alloc(spl, height);
+   uint64       right_addr = right_node->disk_addr;
 
    // ALEX: Maybe worth figuring out the real page size
    memmove(right_node->data, left_node->data, spl->cfg.page_size);
@@ -5353,10 +5355,7 @@ splinter_split_leaf(splinter_handle *spl,
       page_handle *new_leaf;
       if (leaf_no != 0) {
          // allocate a new leaf
-         uint64 addr = splinter_alloc(spl, 0);
-         new_leaf = splinter_node_get(spl, addr);
-         splinter_node_claim(spl, &new_leaf);
-         splinter_node_lock(spl, new_leaf);
+         new_leaf = splinter_alloc(spl, 0);
 
          // copy leaf to new leaf
          memmove(new_leaf->data, leaf->data, spl->cfg.page_size);
@@ -5498,17 +5497,11 @@ int
 splinter_split_root(splinter_handle *spl,
                     page_handle     *root)
 {
-   uint64 child_addr;
    splinter_trunk_hdr *root_hdr = (splinter_trunk_hdr *)root->data;
-   page_handle *child;
-   splinter_trunk_hdr *child_hdr;
 
    // allocate a new child node
-   child_addr = splinter_alloc(spl, root_hdr->height);
-   child = splinter_node_get(spl, child_addr);
-   splinter_node_claim(spl, &child);
-   splinter_node_lock(spl, child);
-   child_hdr = (splinter_trunk_hdr *)child->data;
+   page_handle        *child     = splinter_alloc(spl, root_hdr->height);
+   splinter_trunk_hdr *child_hdr = (splinter_trunk_hdr *)child->data;
 
    // copy root to child, fix up root, then split
    memmove(child_hdr, root_hdr, spl->cfg.page_size);
@@ -6912,39 +6905,31 @@ splinter_create(splinter_config  *cfg,
    srq_init(&spl->srq, platform_get_module_id(), hid);
 
    // get a free node for the root
-   // we don't use the mini allocator for this, since the root doesn't
-   // maintain constant height
-   // FIXME: [yfogel 2020-03-30] add a constant for max pages_per_extent
-   //        and enforce it in config?  there are a lot of VLAs
-   //        that could become fixed at size MAX_PAGES_PER_EXTENT and that
-   //        would be convenient.  Probably not big enough to be a problem
-   //        and skip a lot of mallocs and cleanup
-   uint64 pages_per_extent = cfg->extent_size / cfg->page_size;
-   page_handle *new_pages[MAX_PAGES_PER_EXTENT];
-   cache_extent_alloc(spl->cc, new_pages, PAGE_TYPE_TRUNK);
-
-   page_handle *root = new_pages[0];
-   spl->root_addr = root->disk_addr;
+   //    we don't use the mini allocator for this, since the root doesn't
+   //    maintain constant height
+   platform_status rc = allocator_alloc_extent(spl->al, &spl->root_addr);
+   platform_assert_status_ok(rc);
+   page_handle *root = cache_alloc(spl->cc, spl->root_addr, PAGE_TYPE_TRUNK);
    splinter_trunk_hdr *root_hdr = (splinter_trunk_hdr *)root->data;
-   memset(root_hdr, 0, sizeof(*root_hdr));
+   ZERO_CONTENTS(root_hdr);
 
+   // set up the mini allocator
+   //    we use the root extent as the initial mini_allocator head
+   uint64 meta_addr = spl->root_addr + cfg->page_size;
+   mini_allocator_init(&spl->mini,
+                       cc,
+                       spl->cfg.data_cfg,
+                       meta_addr,
+                       0,
+                       SPLINTER_MAX_HEIGHT,
+                       PAGE_TYPE_TRUNK);
+
+   // set up the memtable context
    memtable_config *mt_cfg = &spl->cfg.mt_cfg;
    spl->mt_ctxt = memtable_context_create(spl->heap_id, cc, mt_cfg,
          splinter_memtable_flush_virtual, spl);
 
-   uint64 meta_addr = new_pages[1]->disk_addr;
-
-   // release all the blocks except the root
-   for (uint64 i = 1; i < pages_per_extent; i++) {
-      cache_unlock(cc, new_pages[i]);
-      cache_unclaim(cc, new_pages[i]);
-      cache_unget(cc, new_pages[i]);
-   }
-
-   // set up the mini allocator
-   mini_allocator_init(&spl->mini, cc, spl->cfg.data_cfg, meta_addr, 0,
-         SPLINTER_MAX_HEIGHT, PAGE_TYPE_TRUNK);
-
+   // set up the log
    if (spl->cfg.use_log) {
       spl->log = log_create(cc, spl->cfg.log_cfg, spl->heap_id);
    }
@@ -6953,10 +6938,7 @@ splinter_create(splinter_config  *cfg,
    splinter_set_super_block(spl, FALSE, FALSE, TRUE);
 
    // set up the initial leaf
-   uint64 leaf_addr = splinter_alloc(spl, 0);
-   page_handle *leaf = splinter_node_get(spl, leaf_addr);
-   splinter_node_claim(spl, &leaf);
-   splinter_node_lock(spl, leaf);
+   page_handle        *leaf     = splinter_alloc(spl, 0);
    splinter_trunk_hdr *leaf_hdr = (splinter_trunk_hdr *)leaf->data;
    memset(leaf_hdr, 0, spl->cfg.page_size);
    const char *min_key = spl->cfg.data_cfg->min_key;


### PR DESCRIPTION
Breaks out the disk allocation from cache_alloc.

The new API for cache_alloc takes a disk_addr and returns a new
write-locked page.

Allocation now happens in two steps:
1. Allocate a new disk_addr using allocator_alloc_extent or
   mini_allocator_alloc.
2. Allocate a new page for disk_addr using cache_alloc

This commit also includes some minor cleanup and reformatting of changed
functions and definitions.