### PR TITLE
Aconway cache alloc

### DIFF
--- a/src/btree.c
+++ b/src/btree.c
@@ -75,12 +75,19 @@ struct PACKED btree_hdr {
  *-----------------------------------------------------------------------------
  */
 
-uint64 btree_alloc(mini_allocator *mini,
-                   uint64          height,
-                   char           *key,
-                   uint64         *next_extent)
+void
+btree_alloc(cache *         cc,
+            mini_allocator *mini,
+            uint64          height,
+            char *          key,
+            uint64 *        next_extent,
+            page_type       type,
+            btree_node *    node)
 {
-   return mini_allocator_alloc(mini, height, key, next_extent);
+   node->addr = mini_allocator_alloc(mini, height, key, next_extent);
+   debug_assert(node->addr != 0);
+   node->page = cache_alloc(cc, node->addr, type);
+   node->hdr  = (btree_hdr *)(node->page->data);
 }
 
 
@@ -905,14 +912,8 @@ btree_add_shared_pivot(cache          *cc,
    debug_assert(!btree_is_packed(cfg, child));
    debug_assert(btree_height(cfg, parent) != 0);
 
-   uint64 wait = 1;
-   new_child->addr = btree_alloc(mini, btree_height(cfg, child), NULL, NULL);
-   btree_node_get(cc, cfg, new_child, PAGE_TYPE_MEMTABLE);
-   while (!btree_node_claim(cc, cfg, new_child)) {
-      platform_sleep(wait);
-      wait = wait > 2048 ? wait : 2 * wait;
-   }
-   btree_node_lock(cc, cfg, new_child);
+   uint16 height = btree_height(cfg, child);
+   btree_alloc(cc, mini, height, NULL, NULL, PAGE_TYPE_MEMTABLE, new_child);
    cache_share(cc, child->page, new_child->page);
    uint16 child_num_entries = btree_num_entries(cfg, child);
    uint16 new_entry_num = child_num_entries - child_num_entries / 2;
@@ -954,15 +955,8 @@ int btree_split_root(btree_config   *cfg,       // IN
 {
    // allocate a new left node
    btree_node left_node;
-   left_node.addr = btree_alloc(mini, btree_height(cfg, root_node), NULL, NULL);
-   btree_node_get(cc, cfg, &left_node, PAGE_TYPE_MEMTABLE);
-   uint64 wait = 1;
-   while(!btree_node_claim(cc, cfg, &left_node)) {
-      platform_sleep(wait);
-      wait = wait > 1024 ? wait : 2 * wait;
-   }
-   wait = 1;
-   btree_node_lock(cc, cfg, &left_node);
+   uint16     height = btree_height(cfg, root_node);
+   btree_alloc(cc, mini, height, NULL, NULL, PAGE_TYPE_MEMTABLE, &left_node);
 
    // copy root to left, then split
    memmove(left_node.hdr, root_node->hdr, btree_page_size(cfg));
@@ -1004,22 +998,27 @@ btree_init(cache          *cc,
    // get a free node for the root
    // we don't use the next_addr arr for this, since the root doesn't
    // maintain constant height
-   page_handle *new_pages[MAX_PAGES_PER_EXTENT];
    page_type type = is_packed ? PAGE_TYPE_BRANCH : PAGE_TYPE_MEMTABLE;
-   cache_extent_alloc(cc, new_pages, type);
+   allocator *     al   = cache_allocator(cc);
+   uint64          base_addr;
+   platform_status rc = allocator_alloc_extent(al, &base_addr);
+   platform_assert_status_ok(rc);
+   page_handle *root_page = cache_alloc(cc, base_addr, type);
 
    // FIXME: [yfogel 2020-07-01] maybe here (or refactor?)
    //    we need to be able to have range tree initialized
    // set up the root
    btree_node root;
-   root.page = new_pages[0];
-   root.addr = new_pages[0]->disk_addr;
-   root.hdr  = (btree_hdr *)new_pages[0]->data;
-   root.hdr->next_addr = 0;
-   root.hdr->generation = 0;
+   root.page = root_page;
+   root.addr = base_addr;
+   root.hdr  = (btree_hdr *)root_page->data;
+
+   root.hdr->next_addr   = 0;
+   root.hdr->generation  = 0;
    root.hdr->num_entries = 0;
-   root.hdr->height = 0;
-   root.hdr->is_packed = is_packed;
+   root.hdr->height      = 0;
+   root.hdr->is_packed   = is_packed;
+
    if (!is_packed) {
       uint8 *table = btree_get_table(cfg, &root);
       for (uint64 i = 0; i < cfg->tuples_per_leaf; i++) {
@@ -1027,12 +1026,10 @@ btree_init(cache          *cc,
       }
    }
    cache_mark_dirty(cc, root.page);
-   // release all the blocks
-   for (uint64 i = 0; i < 32; i++) {
-      cache_unlock(cc, new_pages[i]);
-      cache_unclaim(cc, new_pages[i]);
-      cache_unget(cc, new_pages[i]);
-   }
+   // release root
+   cache_unlock(cc, root_page);
+   cache_unclaim(cc, root_page);
+   cache_unget(cc, root_page);
 
    // set up the mini allocator
    mini_allocator_init(mini, cc, cfg->data_cfg, root.addr + cfg->page_size, 0,
@@ -2351,13 +2348,13 @@ btree_pack_setup(btree_pack_req *req, btree_pack_internal *tree)
 
    // set up the first leaf
    char first_key[MAX_KEY_SIZE] = { 0 };
-   tree->edge[0].addr =
-      btree_alloc(&tree->mini, 0, first_key, &tree->next_extent);
-   btree_node_get(cc, cfg, &tree->edge[0], PAGE_TYPE_BRANCH);
-   // FIXME: [aconway 2020-08-07] Why are we sure this claim will be successful?
-   bool success = btree_node_claim(cc, cfg, &tree->edge[0]);
-   platform_assert(success);
-   btree_node_lock(cc, cfg, &tree->edge[0]);
+   btree_alloc(cc,
+               &tree->mini,
+               0,
+               first_key,
+               &tree->next_extent,
+               PAGE_TYPE_BRANCH,
+               &tree->edge[0]);
    debug_assert(cache_page_valid(cc, tree->next_extent));
    btree_pack_node_init_hdr(&tree->edge[0], tree->next_extent, 0, TRUE);
 }
@@ -2371,17 +2368,15 @@ btree_pack_loop(btree_pack_internal *tree,   // IN/OUT
    if (tree->idx[0] == tree->cfg->tuples_per_packed_leaf) {
       // the current leaf is full, allocate a new one and add to index
       tree->old_edge = tree->edge[0];
-      // FIXME: [yfogel 2020-07-02] we can use 2 dynamic handle or ... (Ask Alex)
-      tree->new_edge.addr =
-         btree_alloc(&tree->mini, 0, key, &tree->next_extent);
+      btree_alloc(tree->cc,
+                  &tree->mini,
+                  0,
+                  key,
+                  &tree->next_extent,
+                  PAGE_TYPE_BRANCH,
+                  &tree->new_edge);
       tree->edge[0].hdr->next_addr = tree->new_edge.addr;
       btree_node_full_unlock(tree->cc, tree->cfg, &tree->edge[0]);
-      btree_node_get(tree->cc, tree->cfg, &tree->new_edge, PAGE_TYPE_BRANCH);
-
-      __attribute__((unused))
-         bool success = btree_node_claim(tree->cc, tree->cfg, &tree->new_edge);
-      debug_assert(success);
-      btree_node_lock(tree->cc, tree->cfg, &tree->new_edge);
 
       // initialize the new leaf edge
       tree->edge[0] = tree->new_edge;
@@ -2410,14 +2405,15 @@ btree_pack_loop(btree_pack_internal *tree,   // IN/OUT
       // along the way it allocates new index nodes as necessary
       for (i = 1; tree->idx[i] == tree->cfg->pivots_per_packed_index; i++) {
          tree->old_edge = tree->edge[i];
-         tree->new_edge.addr =
-            btree_alloc(&tree->mini, i, key, &tree->next_extent);
+         btree_alloc(tree->cc,
+                     &tree->mini,
+                     i,
+                     key,
+                     &tree->next_extent,
+                     PAGE_TYPE_BRANCH,
+                     &tree->new_edge);
          tree->edge[i].hdr->next_addr = tree->new_edge.addr;
          btree_node_full_unlock(tree->cc, tree->cfg, &tree->edge[i]);
-         btree_node_get(tree->cc, tree->cfg, &tree->new_edge, PAGE_TYPE_BRANCH);
-         success = btree_node_claim(tree->cc, tree->cfg, &tree->new_edge);
-         debug_assert(success);
-         btree_node_lock(tree->cc, tree->cfg, &tree->new_edge);
 
          // initialize the new index edge
          tree->edge[i] = tree->new_edge;
@@ -2432,12 +2428,13 @@ btree_pack_loop(btree_pack_internal *tree,   // IN/OUT
       if (i > tree->height) {
          // need to add a new root
          char first_key[MAX_KEY_SIZE] = { 0 };
-         tree->edge[i].addr =
-            btree_alloc(&tree->mini, i, first_key, &tree->next_extent);
-         btree_node_get(tree->cc, tree->cfg, &tree->edge[i], PAGE_TYPE_BRANCH);
-         success = btree_node_claim(tree->cc, tree->cfg, &tree->edge[i]);
-         debug_assert(success);
-         btree_node_lock(tree->cc, tree->cfg, &tree->edge[i]);
+         btree_alloc(tree->cc,
+                     &tree->mini,
+                     i,
+                     first_key,
+                     &tree->next_extent,
+                     PAGE_TYPE_BRANCH,
+                     &tree->edge[i]);
          btree_pack_node_init_hdr(&tree->edge[i], tree->next_extent, i, TRUE);
          tree->height++;
 

--- a/src/cache.h
+++ b/src/cache.h
@@ -67,11 +67,6 @@ typedef struct cache_stats {
 _Static_assert(IS_POWER_OF_2(MAX_PAGES_PER_EXTENT),
                "MAX_PAGES_PER_EXTENT not a power of 2");
 
-typedef platform_status (*extent_alloc_fn)(
-   cache *cc,
-   page_handle *page_arr[static MAX_PAGES_PER_EXTENT],
-   page_type type);
-
 typedef enum {
    // Success without needing async IO because of cache hit.
    async_success = 0xc0ffee,
@@ -103,95 +98,99 @@ typedef struct cache_async_ctxt {
    } stats;
 } cache_async_ctxt;
 
-typedef bool          (*page_dealloc_fn)       (cache *cc, uint64 addr, page_type type);
-typedef uint8         (*page_get_ref_fn)       (cache *cc, uint64 addr);
-typedef page_handle * (*page_get_fn)           (cache *cc, uint64 addr, bool blocking, page_type type);
-typedef cache_async_result (*page_get_async_fn)(cache *cc, uint64 addr, page_type type, cache_async_ctxt *ctxt);
-typedef void          (*page_async_done_fn)    (cache *cc, page_type type, cache_async_ctxt *ctxt);
-typedef void          (*page_unget_fn)         (cache *cc, page_handle *page);
-typedef bool          (*page_claim_fn)         (cache *cc, page_handle *page);
-typedef void          (*page_unclaim_fn)       (cache *cc, page_handle *page);
-typedef void          (*page_lock_fn)          (cache *cc, page_handle *page);
-typedef void          (*page_unlock_fn)        (cache *cc, page_handle *page);
+typedef page_handle *(*page_alloc_fn)(cache *cc, uint64 addr, page_type type);
+typedef bool (*page_dealloc_fn)(cache *cc, uint64 addr, page_type type);
+typedef uint8 (*page_get_ref_fn)(cache *cc, uint64 addr);
+typedef page_handle *(*page_get_fn)(cache *   cc,
+                                    uint64    addr,
+                                    bool      blocking,
+                                    page_type type);
+typedef cache_async_result (*page_get_async_fn)(cache *           cc,
+                                                uint64            addr,
+                                                page_type         type,
+                                                cache_async_ctxt *ctxt);
+typedef void (*page_async_done_fn)(cache *           cc,
+                                   page_type         type,
+                                   cache_async_ctxt *ctxt);
+typedef void (*page_unget_fn)(cache *cc, page_handle *page);
+typedef bool (*page_claim_fn)(cache *cc, page_handle *page);
+typedef void (*page_unclaim_fn)(cache *cc, page_handle *page);
+typedef void (*page_lock_fn)(cache *cc, page_handle *page);
+typedef void (*page_unlock_fn)(cache *cc, page_handle *page);
+typedef void (*page_pin_fn)(cache *cc, page_handle *page);
+typedef void (*page_unpin_fn)(cache *cc, page_handle *page);
+typedef void (*page_sync_fn)(cache *      cc,
+                             page_handle *page,
+                             bool         is_blocking,
+                             page_type    type);
+typedef uint64 (*extent_sync_fn)(cache * cc,
+                                 uint64  addr,
+                                 uint64 *pages_outstanding);
 
-typedef void          (*page_pin_fn)           (cache *cc, page_handle *page);
-typedef void          (*page_unpin_fn)         (cache *cc, page_handle *page);
-typedef void          (*page_sync_fn)          (cache *cc, page_handle *page, bool is_blocking, page_type type);
-typedef uint64        (*extent_sync_fn)        (cache *cc, uint64 addr, uint64 *pages_outstanding);
-
-typedef void          (*share_fn)              (cache *cc, page_handle *page_to_share, page_handle *anon_page);
-typedef void          (*unshare_fn)            (cache *cc, page_handle *anon_page);
-
+typedef void (*share_fn)(cache *      cc,
+                         page_handle *page_to_share,
+                         page_handle *anon_page);
+typedef void (*unshare_fn)(cache *cc, page_handle *anon_page);
 typedef void (*page_prefetch_fn)(cache *cc, uint64 addr, page_type type);
+typedef void (*page_mark_dirty_fn)(cache *cc, page_handle *page);
+typedef void (*flush_fn)(cache *cc);
+typedef int (*evict_fn)(cache *cc, bool ignore_pinned);
+typedef void (*cleanup_fn)(cache *cc);
+typedef uint64 (*get_cache_size_fn)(cache *cc);
+typedef void (*assert_ungot_fn)(cache *cc, uint64 addr);
+typedef void (*assert_free_fn)(cache *cc);
+typedef void (*assert_noleaks)(cache *cc);
+typedef bool (*page_valid_fn)(cache *cc, uint64 addr);
+typedef void (*validate_page_fn)(cache *cc, page_handle *page, uint64 addr);
+typedef void (*print_fn)(cache *cc);
+typedef void (*reset_stats_fn)(cache *cc);
+typedef void (*io_stats_fn)(cache *cc, uint64 *read_bytes, uint64 *write_bytes);
+typedef uint32 (*count_dirty_fn)(cache *cc);
+typedef uint32 (*page_get_read_ref_fn)(cache *cc, page_handle *page);
+typedef bool (*cache_present_fn)(cache *cc, page_handle *page);
+typedef void (*enable_sync_get_fn)(cache *cc, bool enabled);
 
-typedef void          (*page_mark_dirty_fn)    (cache *cc, page_handle *page);
-
-typedef void          (*flush_fn)              (cache *cc);
-typedef int           (*evict_fn)              (cache *cc, bool ignore_pinned);
-typedef void          (*cleanup_fn)            (cache *cc);
-
-typedef uint64        (*get_cache_size_fn)     (cache *cc);
-
-typedef void          (*assert_ungot_fn)       (cache *cc, uint64 addr);
-
-typedef void          (*assert_free_fn)        (cache *cc);
-typedef void          (*assert_noleaks)        (cache *cc);
-typedef bool          (*page_valid_fn)         (cache *cc, uint64 addr);
-typedef void          (*validate_page_fn)      (cache *cc, page_handle *page, uint64 addr);
-
-typedef void          (*print_fn)              (cache *cc);
-typedef void          (*reset_stats_fn)        (cache *cc);
-typedef void          (*io_stats_fn)           (cache *cc, uint64 *read_bytes, uint64 *write_bytes);
-
-typedef uint32        (*count_dirty_fn)        (cache *cc);
-typedef uint32        (*page_get_read_ref_fn)  (cache *cc, page_handle *page);
-
-typedef bool          (*cache_present_fn)      (cache *cc, page_handle *page);
-typedef void          (*enable_sync_get_fn)    (cache *cc, bool enabled);
-
-typedef allocator *   (*cache_allocator_fn)    (cache *cc);
+typedef allocator *(*cache_allocator_fn)(cache *cc);
 
 typedef struct cache_ops {
-   extent_alloc_fn       extent_alloc;
-   page_dealloc_fn       page_dealloc;
-   page_get_ref_fn       page_get_ref;
-   page_get_fn           page_get;
-   page_get_async_fn     page_get_async;
-   page_async_done_fn    page_async_done;
-   page_unget_fn         page_unget;
-   page_claim_fn         page_claim;
-   page_unclaim_fn       page_unclaim;
-   page_lock_fn          page_lock;
-   page_unlock_fn        page_unlock;
-   share_fn              share;
-   unshare_fn            unshare;
-   page_prefetch_fn      page_prefetch;
-   page_mark_dirty_fn    page_mark_dirty;
-   page_pin_fn           page_pin;
-   page_unpin_fn         page_unpin;
-   page_sync_fn          page_sync;
-   extent_sync_fn        extent_sync;
-   flush_fn              flush;
-   evict_fn              evict;
-   cleanup_fn            cleanup;
-   get_cache_size_fn     get_page_size;
-   get_cache_size_fn     get_extent_size;
-   assert_ungot_fn       assert_ungot;
-   assert_free_fn        assert_free;
-   assert_noleaks        assert_noleaks;
-   print_fn              print;
-   print_fn              print_stats;
-   io_stats_fn           io_stats;
-   reset_stats_fn        reset_stats;
-   page_valid_fn         page_valid;
-   validate_page_fn      validate_page;
-
-   count_dirty_fn        count_dirty;
-   page_get_read_ref_fn  page_get_read_ref;
-
-   cache_present_fn      cache_present;
-   enable_sync_get_fn    enable_sync_get;
-   cache_allocator_fn    cache_allocator;
+   page_alloc_fn        page_alloc;
+   page_dealloc_fn      page_dealloc;
+   page_get_ref_fn      page_get_ref;
+   page_get_fn          page_get;
+   page_get_async_fn    page_get_async;
+   page_async_done_fn   page_async_done;
+   page_unget_fn        page_unget;
+   page_claim_fn        page_claim;
+   page_unclaim_fn      page_unclaim;
+   page_lock_fn         page_lock;
+   page_unlock_fn       page_unlock;
+   share_fn             share;
+   unshare_fn           unshare;
+   page_prefetch_fn     page_prefetch;
+   page_mark_dirty_fn   page_mark_dirty;
+   page_pin_fn          page_pin;
+   page_unpin_fn        page_unpin;
+   page_sync_fn         page_sync;
+   extent_sync_fn       extent_sync;
+   flush_fn             flush;
+   evict_fn             evict;
+   cleanup_fn           cleanup;
+   get_cache_size_fn    get_page_size;
+   get_cache_size_fn    get_extent_size;
+   assert_ungot_fn      assert_ungot;
+   assert_free_fn       assert_free;
+   assert_noleaks       assert_noleaks;
+   print_fn             print;
+   print_fn             print_stats;
+   io_stats_fn          io_stats;
+   reset_stats_fn       reset_stats;
+   page_valid_fn        page_valid;
+   validate_page_fn     validate_page;
+   count_dirty_fn       count_dirty;
+   page_get_read_ref_fn page_get_read_ref;
+   cache_present_fn     cache_present;
+   enable_sync_get_fn   enable_sync_get;
+   cache_allocator_fn   cache_allocator;
 } cache_ops;
 
 // To sub-class cache, make a cache your first field;
@@ -199,12 +198,10 @@ struct cache {
    const cache_ops *ops;
 };
 
-static inline platform_status
-cache_extent_alloc(cache *cc,
-                   page_handle *page_arr[static MAX_PAGES_PER_EXTENT],
-                   page_type type)
+static inline page_handle *
+cache_alloc(cache *cc, uint64 addr, page_type type)
 {
-   return cc->ops->extent_alloc(cc, page_arr, type);
+   return cc->ops->page_alloc(cc, addr, type);
 }
 
 static inline bool

--- a/src/clockcache.c
+++ b/src/clockcache.c
@@ -23,15 +23,12 @@
  * unmapped */
 #define CC_UNMAPPED_ENTRY UINT32_MAX
 #define CC_UNMAPPED_ADDR  UINT64_MAX
-#define CC_PIN_TID        (MAX_THREADS - 1)
 
-/* how distributed the rw locks are */
-#define CC_RC_WIDTH 4
+// Number of entries to clean/evict/get_free in a per-thread batch
+#define CC_ENTRIES_PER_BATCH 64
 
 /* number of events to poll for during clockcache_wait */
 #define CC_DEFAULT_MAX_IO_EVENTS 32
-
-#define CC_DEFAULT_CLEANUP 32
 
 /*
  * clockcache_log, etc. are used to write an output of cache operations to a
@@ -101,7 +98,8 @@
 #endif
 
 
-platform_status clockcache_alloc_extent      (clockcache *cc, page_handle **page_arr, page_type type);
+// clang-format off
+page_handle *clockcache_alloc                (clockcache *cc, uint64 addr, page_type type);
 bool         clockcache_dealloc              (clockcache *cc, uint64 addr, page_type type);
 uint8        clockcache_get_allocator_ref    (clockcache *cc, uint64 addr);
 page_handle *clockcache_get                  (clockcache *cc, uint64 addr, bool blocking, page_type type);
@@ -148,7 +146,7 @@ static void  clockcache_enable_sync_get      (clockcache *cc, bool enabled);
 allocator *  clockcache_allocator            (clockcache *cc);
 
 static cache_ops clockcache_ops = {
-   .extent_alloc      = (extent_alloc_fn)      clockcache_alloc_extent,
+   .page_alloc        = (page_alloc_fn)        clockcache_alloc,
    .page_dealloc      = (page_dealloc_fn)      clockcache_dealloc,
    .page_get_ref      = (page_get_ref_fn)      clockcache_get_allocator_ref,
    .page_get          = (page_get_fn)          clockcache_get,
@@ -189,6 +187,7 @@ static cache_ops clockcache_ops = {
    .enable_sync_get   = (enable_sync_get_fn)   clockcache_enable_sync_get,
    .cache_allocator   = (cache_allocator_fn)   clockcache_allocator,
 };
+// clang-format on
 
 /*
  *----------------------------------------------------------------------
@@ -922,6 +921,8 @@ clockcache_write_callback(void            *metadata,
    __attribute__ ((unused)) uint32 debug_status;
 
    platform_assert_status_ok(status);
+   platform_assert(count > 0);
+   platform_assert(count <= cc->cfg->pages_per_extent);
 
    for (i = 0; i < count; i++) {
       entry_number
@@ -1502,11 +1503,12 @@ clockcache_init(clockcache           *cc,     // OUT
    }
 
    /* Entry per-thread ref counts */
-   cc->refcount = TYPED_ARRAY_ZALLOC(cc->heap_id, cc->refcount,
-                                     CC_RC_WIDTH * cc->cfg->page_capacity);
-   if (!cc->refcount) {
+   size_t refcount_size = cc->cfg->page_capacity * CC_RC_WIDTH * sizeof(uint8);
+   cc->rc_bh = platform_buffer_create(refcount_size, cc->heap_handle, mid);
+   if (!cc->rc_bh) {
       goto alloc_error;
    }
+   cc->refcount = platform_buffer_getaddr(cc->rc_bh);
    /* Separate ref counts for pins */
    cc->pincount = TYPED_ARRAY_ZALLOC(cc->heap_id, cc->pincount,
                                      cc->cfg->page_capacity);
@@ -1552,8 +1554,9 @@ clockcache_deinit(clockcache *cc) // IN/OUT
 #endif
    }
 
-   platform_free_volatile(cc->heap_id, cc->refcount);
-   platform_free_volatile(cc->heap_id, cc->pincount);
+   if (cc->rc_bh) {
+      platform_buffer_destroy(cc->rc_bh);
+   }
 
    platform_free(cc->heap_id, cc->entry);
    platform_free(cc->heap_id, cc->lookup);
@@ -1568,52 +1571,37 @@ clockcache_deinit(clockcache *cc) // IN/OUT
 /*
  *----------------------------------------------------------------------
  *
- * clockcache_alloc_extent --
+ * clockcache_alloc --
  *
- *      Allocates an extent of pages in memory and on disk. The extent is
- *      guaranteed to be contiguous on disk, but not in memory.
+ *      Given a disk_addr, allocate entry in the cache and return its page with
+ *      a write lock.
  *
  *----------------------------------------------------------------------
  */
 
-platform_status
-clockcache_alloc_extent(clockcache   *cc,
-                        page_handle  *page_arr[static MAX_PAGES_PER_EXTENT],
-                        page_type     type)
+page_handle *
+clockcache_alloc(clockcache *cc, uint64 addr, page_type type)
 {
-   int i;
-   uint32 entry_no;
-   clockcache_entry *entry;
-   uint64 base_addr;
-   const threadid tid = platform_get_tid();
-   uint64 lookup_no;
-   platform_status rc = allocator_alloc_extent(cc->al, &base_addr);
-   if (!SUCCESS(rc)) {
-      platform_log("extent allocation failed\n");
-      return rc;
+   uint32            entry_no = clockcache_get_free_page(cc,
+                                              CC_ALLOC_STATUS,
+                                              TRUE,  // refcount
+                                              TRUE); // blocking
+   clockcache_entry *entry    = &cc->entry[entry_no];
+   entry->page.disk_addr      = addr;
+   entry->type                = type;
+   if (cc->cfg->use_stats) {
+      const threadid tid = platform_get_tid();
+      cc->stats[tid].page_allocs[type]++;
    }
+   uint64 lookup_no = clockcache_divide_by_page_size(cc, entry->page.disk_addr);
+   cc->lookup[lookup_no] = entry_no;
 
-   for (i = 0; i < cc->cfg->pages_per_extent; i++) {
-      entry_no = clockcache_get_free_page(cc, CC_ALLOC_STATUS,
-                                          TRUE,  // refcount
-                                          TRUE); // blocking
-      entry = &cc->entry[entry_no];
-      entry->page.disk_addr
-         = base_addr + clockcache_multiply_by_page_size(cc, i);
-      entry->type = type;
-      if (cc->cfg->use_stats) {
-         cc->stats[tid].page_allocs[type]++;
-      }
-      lookup_no = clockcache_divide_by_page_size(cc, entry->page.disk_addr);
-      cc->lookup[lookup_no] = entry_no;
-      page_arr[i] = &entry->page;
-
-      clockcache_log(entry->page.disk_addr, entry_no,
-            "alloc_extent: entry %u addr %lu\n",
-            entry_no, entry->page.disk_addr);
-   }
-
-   return STATUS_OK;
+   clockcache_log(entry->page.disk_addr,
+                  entry_no,
+                  "alloc: entry %u addr %lu\n",
+                  entry_no,
+                  entry->page.disk_addr);
+   return &entry->page;
 }
 
 /*
@@ -2560,6 +2548,8 @@ clockcache_prefetch_callback(void *          metadata,
    debug_only uint64 last_addr = CC_UNMAPPED_ADDR;
 
    platform_assert_status_ok(status);
+   platform_assert(count > 0);
+   platform_assert(count <= cc->cfg->pages_per_extent);
 
    for (uint64 page_off = 0; page_off < count; page_off++) {
       uint32 entry_no =

--- a/src/clockcache.h
+++ b/src/clockcache.h
@@ -15,11 +15,13 @@
 #include "io.h"
 #include "task.h"
 
-#define CC_ENTRIES_PER_BATCH 64
-#define CC_CLEANER_GAP_FRAC 8
 //#define ADDR_TRACING
-#define TRACE_ADDR 7213056
+#define TRACE_ADDR  (UINT64_MAX - 1)
 #define TRACE_ENTRY (UINT32_MAX-1)
+
+/* how distributed the rw locks are */
+#define CC_RC_WIDTH 4
+
 
 typedef struct clockcache_config {
    uint64 page_size;
@@ -124,8 +126,9 @@ struct clockcache {
    platform_heap_id      heap_id;
 
    // Distributed locks (the write bit is in the status uint32 of the entry)
-   volatile uint16      *refcount;
-   volatile uint8        *pincount;
+   buffer_handle * rc_bh;
+   volatile uint8 *refcount;
+   volatile uint8 *pincount;
 
    // Clock hands and related metadata
    volatile uint32       evict_hand;

--- a/src/memtable.c
+++ b/src/memtable.c
@@ -293,19 +293,24 @@ memtable_context_create(platform_heap_id  hid,
    ctxt->cc = cc;
    memmove(&ctxt->cfg, cfg, sizeof(ctxt->cfg));
 
-   uint64 pages_per_extent =
-      cfg->btree_cfg->extent_size / cfg->btree_cfg->page_size;
-   page_handle *lock_pages[MAX_PAGES_PER_EXTENT];
-   cache_extent_alloc(cc, lock_pages, PAGE_TYPE_LOCK_NO_DATA);
+   uint64          base_addr;
+   allocator *     al = cache_allocator(cc);
+   platform_status rc = allocator_alloc_extent(al, &base_addr);
+   platform_assert_status_ok(rc);
 
-   ctxt->insert_lock_addr = lock_pages[0]->disk_addr;
-   ctxt->lookup_lock_addr = lock_pages[1]->disk_addr;
+   ctxt->insert_lock_addr = base_addr;
+   ctxt->lookup_lock_addr = base_addr + cache_page_size(cc);
 
-   for (uint64 page_no = 0; page_no < pages_per_extent; page_no++) {
-      cache_unlock(cc, lock_pages[page_no]);
-      cache_unclaim(cc, lock_pages[page_no]);
-      cache_unget(cc, lock_pages[page_no]);
-   }
+   page_handle *lock_page =
+      cache_alloc(cc, ctxt->insert_lock_addr, PAGE_TYPE_LOCK_NO_DATA);
+   cache_unlock(cc, lock_page);
+   cache_unclaim(cc, lock_page);
+   cache_unget(cc, lock_page);
+
+   lock_page = cache_alloc(cc, ctxt->lookup_lock_addr, PAGE_TYPE_LOCK_NO_DATA);
+   cache_unlock(cc, lock_page);
+   cache_unclaim(cc, lock_page);
+   cache_unget(cc, lock_page);
 
    platform_mutex_init(&ctxt->incorporation_mutex, platform_get_module_id(),
          hid);

--- a/src/mini_allocator.c
+++ b/src/mini_allocator.c
@@ -42,43 +42,45 @@ mini_allocator_init(mini_allocator *mini,
                     uint64          num_batches,
                     page_type       type)
 {
-   page_handle *meta_page;
-   const uint64 pages_per_extent = cache_extent_size(cc) / cache_page_size(cc);
-   page_handle *new_pages[MAX_PAGES_PER_EXTENT];
-   uint64 i;
-   uint64 batch;
-   uint64 wait = 1;
-
-   memset(mini, 0, sizeof(mini_allocator));
-   mini->cc           = cc;
-   mini->data_cfg     = data_cfg;
-   mini->meta_head    = meta_head;
-   if (meta_tail == 0) {
-      mini->meta_tail = meta_head;
-   } else {
-      mini->meta_tail = meta_tail;
-   }
-   mini->type         = type;
-   mini->num_batches  = num_batches;
    platform_assert(num_batches <= MINI_MAX_BATCHES);
 
-   meta_page = cache_get(cc, mini->meta_tail, TRUE, type);
-   while (!cache_claim(cc, meta_page)) {
-      // should never happen
-      platform_sleep(wait);
-      wait = wait > 1024 ? wait : 2 * wait;
+   memset(mini, 0, sizeof(mini_allocator));
+
+   mini->cc          = cc;
+   mini->al          = cache_allocator(cc);
+   mini->data_cfg    = data_cfg;
+   mini->meta_head   = meta_head;
+   mini->type        = type;
+   mini->num_batches = num_batches;
+   platform_assert(num_batches <= MINI_MAX_BATCHES);
+
+   page_handle *meta_page;
+   if (meta_tail == 0) {
+      // new mini allocator
+      mini->meta_tail = meta_head;
+      meta_page       = cache_alloc(cc, mini->meta_head, type);
+   } else {
+      // load mini allocator
+      mini->meta_tail = meta_tail;
+      meta_page       = cache_get(cc, mini->meta_tail, TRUE, type);
+      uint64 wait     = 1;
+      while (!cache_claim(cc, meta_page)) {
+         // should never happen
+         platform_sleep(wait);
+         wait = wait > 1024 ? wait : 2 * wait;
+      }
+      cache_lock(cc, meta_page);
    }
-   wait = 1;
-   cache_lock(cc, meta_page);
    mini_allocator_meta_hdr *hdr = (mini_allocator_meta_hdr *)meta_page->data;
    if (meta_tail == 0) {
       hdr->next_meta_addr = 0;
       hdr->pos = 0;
    }
 
-   for (batch = 0; batch < num_batches; batch++) {
-      cache_extent_alloc(cc, new_pages, type);
-      mini->next_extent[batch] = new_pages[0]->disk_addr;
+   for (uint64 batch = 0; batch < num_batches; batch++) {
+      platform_status rc =
+         allocator_alloc_extent(mini->al, &mini->next_extent[batch]);
+      platform_assert_status_ok(rc);
       //platform_log("mini_allocator_alloc %lu-%lu.%lu : %lu\n",
       //      mini->meta_head, mini->meta_tail, hdr->pos, mini->next_extent[batch]);
       if (hdr->pos == (cache_page_size(mini->cc)
@@ -87,36 +89,18 @@ mini_allocator_init(mini_allocator *mini,
          mini->meta_tail += cache_page_size(mini->cc);
          if (mini->meta_tail % cache_extent_size(mini->cc) == 0) {
             // need to allocate the next meta extent
-            page_handle *new_pages[MAX_PAGES_PER_EXTENT];
-            cache_extent_alloc(mini->cc, new_pages, type);
-            mini->meta_tail = new_pages[0]->disk_addr;
-            for (i = 0; i < pages_per_extent; i++) {
-               cache_unlock(mini->cc, new_pages[i]);
-               cache_unclaim(mini->cc, new_pages[i]);
-               cache_unget(mini->cc, new_pages[i]);
-            }
+            rc = allocator_alloc_extent(mini->al, (uint64 *)&mini->meta_tail);
+            platform_assert_status_ok(rc);
          }
          hdr->next_meta_addr = mini->meta_tail;
          page_handle *last_meta_page = meta_page;
-         meta_page = cache_get(mini->cc, mini->meta_tail, TRUE, type);
-         while (!cache_claim(mini->cc, meta_page)) {
-            platform_sleep(wait);
-            wait = wait > 1024 ? wait : 2 * wait;
-         }
-         wait = 1;
-         cache_lock(mini->cc, meta_page);
-         cache_mark_dirty(mini->cc, last_meta_page);
+         meta_page = cache_alloc(mini->cc, mini->meta_tail, type);
          cache_unlock(mini->cc, last_meta_page);
          cache_unclaim(mini->cc, last_meta_page);
          cache_unget(mini->cc, last_meta_page);
          hdr = (mini_allocator_meta_hdr *)meta_page->data;
          hdr->pos = 0;
          hdr->next_meta_addr = 0;
-      }
-      for (i = 0; i < pages_per_extent; i++) {
-         cache_unlock(cc, new_pages[i]);
-         cache_unclaim(cc, new_pages[i]);
-         cache_unget(cc, new_pages[i]);
       }
    }
 
@@ -134,18 +118,13 @@ mini_allocator_alloc(mini_allocator *mini,
                      char           *key,
                      uint64         *next_extent)
 {
-   uint64                   next_addr = mini->next_addr[batch];
-   uint64                   next_extent_addr;
-   page_handle             *meta_page;
-   uint64                   i;
-   mini_allocator_meta_hdr *hdr;
-   uint64                   new_meta_tail;
-   uint64                   wait = 1;
-   platform_status          rc = STATUS_OK;
-
    platform_assert(batch < mini->num_batches);
 
+   platform_status rc        = STATUS_OK;
+   uint64          next_addr = mini->next_addr[batch];
+
    // wait until we hold the lock for our batch
+   uint64 wait = 1;
    while (0 || next_addr == MINI_WAIT
             || !__sync_bool_compare_and_swap(&mini->next_addr[batch],
                                              next_addr, MINI_WAIT))
@@ -158,34 +137,24 @@ mini_allocator_alloc(mini_allocator *mini,
 
    if (next_addr % cache_extent_size(mini->cc) == 0) {
       // need to allocate the next extent
-      uint64 pages_per_extent =
-         cache_extent_size(mini->cc) / cache_page_size(mini->cc);
-      page_handle *new_pages[MAX_PAGES_PER_EXTENT];
-      rc = cache_extent_alloc(mini->cc, new_pages, mini->type);
+
+      uint64 next_extent_addr = mini->next_extent[batch];
+      rc = allocator_alloc_extent(mini->al, &mini->next_extent[batch]);
       platform_assert_status_ok(rc);
-      //platform_log("meta_head %lu next_extent %lu new_extent %lu\n",
-      //      mini->meta_head, mini->next_extent[batch], new_pages[0]->disk_addr);
-      debug_assert(mini->next_extent[batch] != new_pages[0]->disk_addr);
-      next_extent_addr = mini->next_extent[batch];
-      mini->next_extent[batch] = new_pages[0]->disk_addr;
       next_addr = next_extent_addr;
       if (next_extent) {
          *next_extent = mini->next_extent[batch];
       }
+      // platform_log("meta_head %lu next_extent %lu new_extent %lu\n",
+      //       mini->meta_head, mini->next_extent[batch],
+      //       new_pages[0]->disk_addr);
       mini->next_addr[batch] = next_extent_addr + cache_page_size(mini->cc);
-      for (i = 0; i < pages_per_extent; i++) {
-         cache_unlock(mini->cc, new_pages[i]);
-         cache_unclaim(mini->cc, new_pages[i]);
-         cache_unget(mini->cc, new_pages[i]);
-      }
 
+      page_handle *meta_page;
       while (1) {
          meta_page = cache_get(mini->cc, mini->meta_tail, TRUE, mini->type);
          if (cache_claim(mini->cc, meta_page)) {
-            if (meta_page->disk_addr == mini->meta_tail)
-               break;
-            else
-               cache_unclaim(mini->cc, meta_page);
+            break;
          }
          cache_unget(mini->cc, meta_page);
          platform_sleep(wait);
@@ -193,37 +162,23 @@ mini_allocator_alloc(mini_allocator *mini,
       }
       wait = 1;
       cache_lock(mini->cc, meta_page);
+      // FIXME: [aconway 2021-05-10] This is residual, delete eventually:
       debug_assert(meta_page->disk_addr == mini->meta_tail);
 
-      hdr = (mini_allocator_meta_hdr *)meta_page->data;
+      mini_allocator_meta_hdr *hdr = (mini_allocator_meta_hdr *)meta_page->data;
       if (hdr->pos == (cache_page_size(mini->cc)
             - sizeof(mini_allocator_meta_hdr))
             / sizeof(mini_allocator_meta_entry)) {
          // need a new meta page
-         new_meta_tail = mini->meta_tail + cache_page_size(mini->cc);
+         uint64 new_meta_tail = mini->meta_tail + cache_page_size(mini->cc);
          if (new_meta_tail % cache_extent_size(mini->cc) == 0) {
             // need to allocate the next meta extent
-            uint64 pages_per_extent =
-               cache_extent_size(mini->cc) / cache_page_size(mini->cc);
-            page_handle *new_pages[MAX_PAGES_PER_EXTENT];
-            cache_extent_alloc(mini->cc, new_pages, mini->type);
-            new_meta_tail = new_pages[0]->disk_addr;
-            for (i = 0; i < pages_per_extent; i++) {
-               cache_unlock(mini->cc, new_pages[i]);
-               cache_unclaim(mini->cc, new_pages[i]);
-               cache_unget(mini->cc, new_pages[i]);
-            }
+            rc = allocator_alloc_extent(mini->al, &new_meta_tail);
+            platform_assert_status_ok(rc);
          }
          hdr->next_meta_addr = new_meta_tail;
          page_handle *last_meta_page = meta_page;
-         meta_page = cache_get(mini->cc, new_meta_tail, TRUE, mini->type);
-         while (!cache_claim(mini->cc, meta_page)) {
-            // should never happen
-            platform_sleep(wait);
-            wait = wait > 1024 ? wait : 2 * wait;
-         }
-         wait = 1;
-         cache_lock(mini->cc, meta_page);
+         meta_page       = cache_alloc(mini->cc, new_meta_tail, mini->type);
          mini->meta_tail = new_meta_tail;
          cache_mark_dirty(mini->cc, last_meta_page);
          cache_unlock(mini->cc, last_meta_page);

--- a/src/mini_allocator.h
+++ b/src/mini_allocator.h
@@ -19,16 +19,17 @@
 #define MINI_MAX_BATCHES 8
 
 typedef struct mini_allocator {
-   cache           *cc;
-   data_config     *data_cfg;
-   uint64           meta_head;
-   volatile uint64  meta_tail;
-   uint64           num_batches;
-   volatile uint64  next_addr[MINI_MAX_BATCHES];
-   uint64           next_extent[MINI_MAX_BATCHES];
-   uint64           last_meta_addr[MINI_MAX_BATCHES];
-   uint64           last_meta_pos[MINI_MAX_BATCHES];
-   page_type        type;
+   allocator *     al;
+   cache *         cc;
+   data_config *   data_cfg;
+   uint64          meta_head;
+   volatile uint64 meta_tail;
+   uint64          num_batches;
+   volatile uint64 next_addr[MINI_MAX_BATCHES];
+   uint64          next_extent[MINI_MAX_BATCHES];
+   uint64          last_meta_addr[MINI_MAX_BATCHES];
+   uint64          last_meta_pos[MINI_MAX_BATCHES];
+   page_type       type;
 } mini_allocator;
 
 typedef struct mini_allocator_sync_arg {

--- a/src/platform_linux/laio.c
+++ b/src/platform_linux/laio.c
@@ -212,9 +212,6 @@ laio_callback(io_context_t  ctx,
 
    platform_assert(res2 == 0);
    req = (io_async_req *)((char *)iocb - offsetof(io_async_req, iocb));
-   if (UNLIKELY(res != req->bytes)) {
-      status = STATUS_IO_ERROR;
-   }
    req->callback(req->metadata, req->iovec, req->count, status);
    req->busy = FALSE;
 }

--- a/src/shard_log.c
+++ b/src/shard_log.c
@@ -56,11 +56,11 @@ shard_log_get_thread_data(shard_log *log,
    return &log->thread_data[thr_id];
 }
 
-uint64
-shard_log_alloc(shard_log *log,
-                uint64    *next_extent)
+page_handle *
+shard_log_alloc(shard_log *log, uint64 *next_extent)
 {
-   return mini_allocator_alloc(&log->mini, 0, NULL, next_extent);
+   uint64 addr = mini_allocator_alloc(&log->mini, 0, NULL, next_extent);
+   return cache_alloc(log->cc, addr, PAGE_TYPE_LOG);
 }
 
 platform_status
@@ -76,16 +76,9 @@ shard_log_init(shard_log        *log,
    uint64 magic_idx = __sync_fetch_and_add(&shard_log_magic_idx, 1);
    log->magic = platform_checksum64(&magic_idx, sizeof(uint64), cfg->seed);
 
-   page_handle *meta_pages[MAX_PAGES_PER_EXTENT];
-   cache_extent_alloc(cc, meta_pages, PAGE_TYPE_LOG);
-   log->meta_head = meta_pages[0]->disk_addr;
-
-   uint64 pages_per_extent = cfg->extent_size / cfg->page_size;
-   for (uint64 i = 0; i < pages_per_extent; i++) {
-      cache_unlock(cc, meta_pages[i]);
-      cache_unclaim(cc, meta_pages[i]);
-      cache_unget(cc, meta_pages[i]);
-   }
+   allocator *     al = cache_allocator(cc);
+   platform_status rc = allocator_alloc_extent(al, &log->meta_head);
+   platform_assert_status_ok(rc);
 
    for (threadid thr_i = 0; thr_i < MAX_THREADS; thr_i++) {
       shard_log_thread_data *thread_data
@@ -124,51 +117,40 @@ shard_log_write(log_handle *logh,
                 uint64      generation)
 {
    shard_log *log = (shard_log *)logh;
-   cache                 *cc = log->cc;
-   char                  *key_cursor;
-   char                  *data_cursor;
-   uint64                 next_extent;
-   shard_log_hdr         *hdr;
+   cache *    cc  = log->cc;
+
+   page_handle *          page;
    shard_log_thread_data *thread_data =
       shard_log_get_thread_data(log, platform_get_tid());
-   uint64                 wait = 1;
-
-   page_handle *page;
-   char *cursor;
    if (thread_data->addr == SHARD_UNMAPPED) {
-      thread_data->addr = shard_log_alloc(log, &next_extent);
-      page = cache_get(cc, thread_data->addr, TRUE, PAGE_TYPE_LOG);
-      while (!cache_claim(cc, page)) {
-         platform_sleep(wait);
-         wait = wait > 1024 ? wait : 2 * wait;
-      }
-      wait = 1;
-      cache_lock(cc, page);
-      shard_log_hdr *hdr = (shard_log_hdr *)page->data;
-      hdr->magic = log->magic;
+      uint64 next_extent;
+      page                  = shard_log_alloc(log, &next_extent);
+      thread_data->addr     = page->disk_addr;
+      shard_log_hdr *hdr    = (shard_log_hdr *)page->data;
+      hdr->magic            = log->magic;
       hdr->next_extent_addr = next_extent;
-      thread_data->offset = sizeof(shard_log_hdr);
-      thread_data->pos = 0;
+      thread_data->offset   = sizeof(shard_log_hdr);
+      thread_data->pos      = 0;
    } else {
-      page = cache_get(cc, thread_data->addr, TRUE, PAGE_TYPE_LOG);
+      page        = cache_get(cc, thread_data->addr, TRUE, PAGE_TYPE_LOG);
+      uint64 wait = 1;
       while (!cache_claim(cc, page)) {
          platform_sleep(wait);
          wait = wait > 1024 ? wait : 2 * wait;
       }
-      wait = 1;
       cache_lock(cc, page);
    }
-   cursor = page->data + thread_data->offset;
+   char *cursor = page->data + thread_data->offset;
 
    uint64 *generation_cursor = (uint64 *)cursor;
    cursor += sizeof(uint64);
    thread_data->offset += sizeof(uint64);
 
-   key_cursor = cursor;
+   char *key_cursor = cursor;
    cursor += log->cfg->data_cfg->key_size;
    thread_data->offset += log->cfg->data_cfg->key_size;
 
-   data_cursor = cursor;
+   char *data_cursor = cursor;
    cursor += log->cfg->data_cfg->message_size;
    thread_data->offset += log->cfg->data_cfg->message_size;
    debug_assert(cursor - page->data < log->cfg->page_size);
@@ -179,7 +161,7 @@ shard_log_write(log_handle *logh,
 
    thread_data->pos++;
    if (thread_data->pos == log->cfg->entries_per_page) {
-      hdr = (shard_log_hdr *)page->data;
+      shard_log_hdr *hdr = (shard_log_hdr *)page->data;
       hdr->checksum = shard_log_checksum(log->cfg, page);
 
       cache_unlock(cc, page);

--- a/tests/cache_test.c
+++ b/tests/cache_test.c
@@ -65,29 +65,26 @@ cache_test_alloc_extents(cache *cc,
                          uint64 addr_arr[],
                          uint32 extents_to_allocate)
 {
-   uint32 ea;
-   platform_status rc = STATUS_OK;
-
-   for (ea = 0; ea < extents_to_allocate; ea++) {
-      page_handle *extent_page_arr[MAX_PAGES_PER_EXTENT];
-
-      rc = cache_extent_alloc(cc, extent_page_arr, PAGE_TYPE_MISC);
+   allocator *     al = cache_allocator(cc);
+   platform_status rc;
+   for (uint32 j = 0; j < extents_to_allocate; j++) {
+      uint64 base_addr;
+      rc = allocator_alloc_extent(al, &base_addr);
       if (!SUCCESS(rc)) {
          platform_error_log("Expected to be able to allocate %u entries,"
-                            "but only allocated: %u", extents_to_allocate, ea);
-         for (uint32 i = 0; i < ea; i++) {
-            cache_dealloc(cc, addr_arr[i * cfg->pages_per_extent],
-                          PAGE_TYPE_MISC);
-         }
+                            "but only allocated: %u",
+                            extents_to_allocate,
+                            j);
          break;
       }
 
       for (uint32 i = 0; i < cfg->pages_per_extent; i++) {
-         addr_arr[ea * cfg->pages_per_extent + i]
-            = extent_page_arr[i]->disk_addr;
-         cache_unlock(cc, extent_page_arr[i]);
-         cache_unclaim(cc, extent_page_arr[i]);
-         cache_unget(cc, extent_page_arr[i]);
+         uint64       addr = base_addr + i * cfg->page_size;
+         page_handle *page = cache_alloc(cc, addr, PAGE_TYPE_MISC);
+         addr_arr[j * cfg->pages_per_extent + i] = addr;
+         cache_unlock(cc, page);
+         cache_unclaim(cc, page);
+         cache_unget(cc, page);
       }
    }
 


### PR DESCRIPTION
Separate Disk Allocation from Cache Allocation

    Breaks out the disk allocation from `cache_alloc`.

    The new API for cache_alloc takes a `disk_addr` and returns a new
    write-locked page.

    Allocation now happens in two steps:
    1. Allocate a new `disk_addr` using `allocator_alloc_extent` or
       `mini_allocator_alloc`.
    2. Allocate a new page for `disk_addr` using `cache_alloc`

    The second commit also includes some minor cleanup and reformatting of changed
    functions and definitions.