### PR TITLE
Remove Range Delete Scaffolding

### DIFF
--- a/src/btree.c
+++ b/src/btree.c
@@ -41,10 +41,14 @@ btree_root_to_meta_addr(cache *cc,
    return root_addr + (meta_page_no + 1) * cfg->page_size;
 }
 
-void            btree_iterator_get_curr (iterator *itor, char **key, char **data, data_type *type);
-platform_status btree_iterator_at_end   (iterator *itor, bool *at_end);
-platform_status btree_iterator_advance  (iterator *itor);
-void            btree_iterator_print    (iterator *itor);
+void
+btree_iterator_get_curr(iterator *itor, char **key, char **data);
+platform_status
+btree_iterator_at_end(iterator *itor, bool *at_end);
+platform_status
+btree_iterator_advance(iterator *itor);
+void
+btree_iterator_print(iterator *itor);
 
 const static iterator_ops btree_iterator_ops = {
    .get_curr = btree_iterator_get_curr,
@@ -1701,10 +1705,7 @@ btree_lookup_async_with_ref(cache *cc,              // IN
  */
 
 void
-btree_iterator_get_curr(iterator   *base_itor,
-                        char      **key,
-                        char      **data,
-                        data_type  *type)
+btree_iterator_get_curr(iterator *base_itor, char **key, char **data)
 {
    debug_assert(base_itor != NULL);
    btree_iterator *itor = (btree_iterator *)base_itor;
@@ -1722,7 +1723,6 @@ btree_iterator_get_curr(iterator   *base_itor,
    *key = itor->curr_key;
    debug_assert((itor->curr_data != NULL) == (itor->height == 0));
    *data = itor->curr_data;
-   *type = itor->cfg->type;
 }
 
 
@@ -1779,85 +1779,6 @@ btree_iterator_is_at_end(btree_iterator *itor)
    return itor->curr.addr == itor->end.addr && itor->idx == itor->end_idx;
 }
 
-static bool
-btree_iterator_is_last_tuple(btree_iterator *itor)
-{
-   debug_assert(!itor->at_end);
-   debug_assert(!btree_iterator_is_at_end(itor));
-   debug_assert(itor->height == 0);
-   debug_assert(itor->cfg->type == data_type_range);
-   debug_assert(itor->idx < itor->curr.hdr->num_entries);
-   btree_config *cfg = itor->cfg;
-   if (itor->is_live) {
-      if (itor->curr.hdr->next_addr == 0 &&
-          itor->idx + 1 == itor->curr.hdr->num_entries)
-      {
-         /*
-          * reached the very last element in entire tree
-          * This can happen if max_key == null or reached end before max key
-          */
-         return TRUE;
-      }
-      if (itor->max_key != NULL) {
-         char *next_key;
-         if (itor->idx + 1 == itor->curr.hdr->num_entries) {
-            // at last element of the leaf; get first element of next leaf
-            btree_node next = { .addr = itor->curr.hdr->next_addr };
-            btree_node_get(itor->cc, cfg, &next, itor->page_type);
-            next_key = btree_get_tuple(cfg, &next, 0);
-            btree_node_unget(itor->cc, cfg, &next);
-         } else {
-            // get next element of this leaf
-            next_key = btree_get_tuple(cfg, &itor->curr,
-                                       itor->idx + 1);
-         }
-         return btree_key_compare(cfg, itor->max_key, next_key) <= 0;
-      }
-      return FALSE;
-   } else {
-      if (itor->end.addr == 0) {
-         /*
-          * There is no max key
-          * It's the last tuple if we're in the last leaf and idx is the last
-          * tuple in the leaf.
-          */
-
-         debug_assert(itor->max_key == NULL);
-
-         return itor->curr.hdr->next_addr == 0 &&
-                itor->idx + 1 == itor->curr.hdr->num_entries;
-      }
-      // there is a max key
-      // FIXME: [yfogel 2020-07-14] when less_than is an available query
-      //    we only have one case.  We will always point to a REAL tuple
-      //    that is the last tuple included.
-      //    If nothing found that way, it means entire tree (or at least
-      //    entire iteration) is empty.
-      //    finding -1 in a leaf is impossible on any but 0th leaf (you'd
-      //    find instead the previous leaf)
-      //    Depends on if the less_than query for find_node is smart
-      //    it should be of course.
-      //    so -1 means iteration is 100% empty and you're done
-      //    (empty btree or no matches)
-      //    the "ugly" part of doing this, is that end becomes INCLUSIVE
-      //    we can workaround that by increasing index by 1
-      //    then we remove ALL rollovers except during advance going to next
-      //    (after the is_last test)
-
-      debug_assert(itor->max_key != NULL);
-
-      if (itor->end_idx) {
-         // It's the last tuple if on the end leaf and just before end_idx
-         return itor->curr.addr == itor->end.addr &&
-                itor->end_idx == itor->idx + 1;
-      } else {
-         // It's the last tuple if on 2nd-to-end leaf and last tuple on the leaf
-         return itor->curr.hdr->next_addr == itor->end.addr &&
-                itor->curr.hdr->num_entries == itor->idx + 1;
-      }
-   }
-}
-
 // Set curr_key and curr_data acording to height
 static void
 btree_iterator_set_curr_key_and_data(btree_iterator *itor)
@@ -1890,22 +1811,6 @@ debug_btree_iterator_validate_next_tuple(debug_only btree_iterator *itor)
    if (itor->max_key) {
       debug_assert(btree_key_compare(cfg, itor->curr_key, itor->max_key) < 0);
    }
-   if (itor->cfg->type == data_type_range) {
-      int cmp = btree_key_compare(cfg, itor->debug_prev_end_key, itor->curr_key);
-      if (itor->debug_is_packed) {
-         // Not a memtable, touching ranges are not allowed.
-         // FIXME: [nsarmicanic 2020-08-11] replace <= with <
-         //    once merge_iterator merges touching ranges
-         debug_assert(cmp <= 0);
-      } else {
-         // It is a memtable, touching ranges are allowed.
-         debug_assert(cmp <= 0);
-      }
-      if (itor->max_key) {
-         debug_assert(
-               btree_key_compare(cfg, itor->curr_data, itor->max_key) <= 0);
-      }
-   }
 #endif
 }
 
@@ -1917,24 +1822,7 @@ debug_btree_iterator_save_last_tuple(debug_only btree_iterator *itor)
 
    uint64 key_size = itor->cfg->data_cfg->key_size;
    memmove(itor->debug_prev_key, itor->curr_key, key_size);
-   if (itor->cfg->type == data_type_range) {
-      memmove(itor->debug_prev_end_key, itor->curr_data, key_size);
-   }
 #endif
-}
-
-static void
-btree_iterator_clamp_end(btree_iterator *itor)
-{
-   if (1
-       && itor->height == 0
-       && itor->cfg->type == data_type_range
-       && btree_iterator_is_last_tuple(itor)
-       && btree_key_compare(itor->cfg, itor->curr_data, itor->max_key) > 0)
-   {
-      // FIXME: [aconway 2020-09-11] Handle this better
-      itor->curr_data = (char *) itor->max_key;
-   }
 }
 
 platform_status
@@ -2022,8 +1910,6 @@ btree_iterator_advance(iterator *base_itor)
 
    btree_iterator_set_curr_key_and_data(itor);
 
-   btree_iterator_clamp_end(itor);
-
    debug_btree_iterator_validate_next_tuple(itor);
    debug_btree_iterator_save_last_tuple(itor);
 
@@ -2066,31 +1952,21 @@ btree_iterator_print(iterator *itor)
  * Caller must guarantee:
  *    min_key needs to be valid until the first call to advance() returns
  *    max_key (if not null) needs to be valid until at_end() returns true
- * If we are iterating over ranges
- *    (data_type == data_type_range && height == 0)
- *
- * btree_iterator on range_delete (leaves only) clamps the ranges outputted to
- *  the input min/max.  It also includes all ranges that overlap the [min,max)
- *  range, and not just keys that overlap it. (Potentially 1 extra range
- *  included in the iteration)
  *
  *-----------------------------------------------------------------------------
  */
 void
-btree_iterator_init(cache          *cc,
-                    btree_config   *cfg,
+btree_iterator_init(cache *         cc,
+                    btree_config *  cfg,
                     btree_iterator *itor,
                     uint64          root_addr,
                     page_type       page_type,
-                    const char     *min_key,
-                    const char     *max_key,
+                    const char *    min_key,
+                    const char *    max_key,
                     bool            do_prefetch,
                     bool            is_live,
-                    uint32          height,
-                    data_type       data_type)
+                    uint32          height)
 {
-   debug_assert(cfg->type == data_type);
-
    ZERO_CONTENTS(itor);
    itor->cc          = cc;
    itor->cfg         = cfg;
@@ -2191,18 +2067,6 @@ btree_iterator_init(cache          *cc,
    if (height == 0) {
       //FIXME: [yfogel 2020-07-08] no need for extra compare when less_than_or_equal is supproted
       itor->idx = btree_find_tuple(cfg, &itor->curr, min_key, greater_than_or_equal);
-      if (data_type == data_type_range && itor->idx > 0) {
-         char *end_data = btree_get_data(cfg, &itor->curr, itor->idx-1);
-         if (btree_key_compare(cfg, end_data, min_key) > 0) {
-            /*
-             * [start_key,end_data) overlaps min_key
-             * it MUST be on the leaf where that key would belong. So we have to
-             * look to the left on the same leaf, but only on the same leaf.
-             */
-            itor->idx--;
-            start_is_clamped = FALSE;
-         }
-      }
    } else {
       itor->idx = btree_find_pivot(cfg, &itor->curr, min_key, greater_than_or_equal);
    }
@@ -2263,8 +2127,6 @@ btree_iterator_init(cache          *cc,
    if (!start_is_clamped) {
       itor->curr_key = (char *)min_key;
    }
-
-   btree_iterator_clamp_end(itor);
 
    debug_assert(btree_key_compare(cfg, min_key, itor->curr_key) <= 0);
    debug_btree_iterator_save_last_tuple(itor);
@@ -2558,88 +2420,16 @@ btree_pack(btree_pack_req *req)
    btree_pack_setup(req, &tree);
 
    char *key, *data;
-   data_type type;
    bool at_end;
 
    iterator_at_end(tree.itor, &at_end);
    while (!at_end) {
-      iterator_get_curr(tree.itor, &key, &data, &type);
-      debug_assert(type == req->cfg->type);
+      iterator_get_curr(tree.itor, &key, &data);
       btree_pack_loop(&tree, key, data, &at_end);
-      // FIXME: [tjiaheng 2020-07-29] find out how we can use req->max_tuples
-      // here
-      // if (req->max_tuples != 0 && *(tree.num_tuples) == req->max_tuples) {
-      //    at_end = TRUE;
-      // }
    }
 
    btree_pack_post_loop(&tree);
    platform_assert(IMPLIES(req->num_tuples == 0, req->root_addr == 0));
-   return STATUS_OK;
-}
-
-/*
- *-----------------------------------------------------------------------------
- *
- * branch_pack --
- *
- *      Packs a branch (point and range btree) from an iterator source. Zaps the
- *      empty output tree.
- *
- *-----------------------------------------------------------------------------
- */
-
-platform_status
-branch_pack(platform_heap_id hid, branch_pack_req *req)
-{
-   btree_pack_internal *point_tree = TYPED_MALLOC(hid, point_tree);
-   btree_pack_internal *range_tree = TYPED_MALLOC(hid, range_tree);
-   ZERO_CONTENTS(point_tree);
-   ZERO_CONTENTS(range_tree);
-
-   btree_pack_setup(&req->point_req, point_tree);
-   btree_pack_setup(&req->range_req, range_tree);
-
-   btree_pack_internal *trees[NUM_DATA_TYPES];
-   trees[data_type_point] = point_tree;
-   trees[data_type_range] = range_tree;
-
-   char *key, *data;
-   data_type type;
-   bool at_end;
-
-   /*
-    * We are assuming point and range req have the same max_tuples and itor,
-    * thus using them interchangeably below
-    */
-   platform_assert(req->point_req.max_tuples == req->range_req.max_tuples);
-   platform_assert(req->point_req.itor == req->range_req.itor);
-
-   // FIXME: [tjiaheng 2020-07-29] find out how we can use req->max_tuples
-   // here
-   // uint64 max_tuples_per_tree = req->point_req.max_tuples;
-   iterator *itor = req->point_req.itor;
-
-   iterator_at_end(itor, &at_end);
-   while (!at_end) {
-      iterator_get_curr(itor, &key, &data, &type);
-      btree_pack_loop(trees[type], key, data, &at_end);
-      // FIXME: [tjiaheng 2020-07-29] find out how we can use req->max_tuples
-      // here
-      // if (max_tuples_per_tree != 0
-      //     && *(trees[type]->num_tuples) == max_tuples_per_tree) {
-      //    at_end = TRUE;
-      // }
-   }
-
-   btree_pack_post_loop(point_tree);
-   platform_assert(IMPLIES(req->point_req.num_tuples == 0, req->point_req.root_addr == 0));
-   btree_pack_post_loop(range_tree);
-   platform_assert(IMPLIES(req->range_req.num_tuples == 0, req->range_req.root_addr == 0));
-   platform_assert(req->range_req.root_addr == 0);
-
-   platform_free(hid, point_tree);
-   platform_free(hid, range_tree);
    return STATUS_OK;
 }
 
@@ -2694,8 +2484,16 @@ btree_count_in_range_by_iterator(cache        *cc,
 {
    btree_iterator btree_itor;
    iterator *itor = &btree_itor.super;
-   btree_iterator_init(cc, cfg, &btree_itor, root_addr, PAGE_TYPE_BRANCH,
-         min_key, max_key, TRUE, FALSE, 0, data_type_point);
+   btree_iterator_init(cc,
+                       cfg,
+                       &btree_itor,
+                       root_addr,
+                       PAGE_TYPE_BRANCH,
+                       min_key,
+                       max_key,
+                       TRUE,
+                       FALSE,
+                       0);
    bool at_end;
    uint64 count= 0;
    iterator_at_end(itor, &at_end);
@@ -3060,7 +2858,6 @@ btree_extent_count(cache        *cc,
 void
 btree_config_init(btree_config *btree_cfg,
                   data_config  *data_cfg,
-                  data_type     type,
                   uint64        rough_count_height,
                   uint64        page_size,
                   uint64        extent_size)
@@ -3106,6 +2903,4 @@ btree_config_init(btree_config *btree_cfg,
    if (btree_cfg->pivots_per_index > MAX_UNPACKED_IDX) {
       btree_cfg->pivots_per_index = MAX_UNPACKED_IDX;
    }
-
-   btree_cfg->type = type;
 }

--- a/src/btree.h
+++ b/src/btree.h
@@ -41,7 +41,6 @@ extern page_handle *trace_page;
  */
 
 typedef struct btree_config {
-   data_type    type;                // data type
    uint64       page_size;           // must match the cache/fs page_size
    uint64       extent_size;         // same
 
@@ -113,11 +112,6 @@ typedef struct btree_pack_req {
    uint64        num_tuples;  // no. of tuples in the output tree
    uint32       *fingerprint_arr; // hashes of the keys in the tree
 } btree_pack_req;
-
-typedef struct branch_pack_req {
-   btree_pack_req point_req;
-   btree_pack_req range_req;
-} branch_pack_req;
 
 struct btree_async_ctxt;
 typedef void (*btree_async_cb)(struct btree_async_ctxt *ctxt);
@@ -272,17 +266,16 @@ btree_blind_zap(cache        *cc,
                 page_type     type);
 
 void
-btree_iterator_init(cache *cc,
-                    btree_config *cfg,
+btree_iterator_init(cache *         cc,
+                    btree_config *  cfg,
                     btree_iterator *iterator,
-                    uint64 root_addr,
-                    page_type page_type,
-                    const char *min_key,
-                    const char *max_key,
-                    bool do_prefetch,
-                    bool is_live,
-                    uint32 height,
-                    data_type data_type);
+                    uint64          root_addr,
+                    page_type       page_type,
+                    const char *    min_key,
+                    const char *    max_key,
+                    bool            do_prefetch,
+                    bool            is_live,
+                    uint32          height);
 
 void
 btree_iterator_deinit(btree_iterator *itor);
@@ -320,9 +313,6 @@ btree_pack_req_deinit(btree_pack_req *req, platform_heap_id hid)
 
 platform_status
 btree_pack(btree_pack_req *req);
-
-platform_status
-branch_pack(platform_heap_id hid, branch_pack_req *req);
 
 uint64
 btree_count_in_range(cache        *cc,
@@ -396,7 +386,6 @@ btree_space_use_in_range(cache        *cc,
 void
 btree_config_init(btree_config *btree_cfg,
                   data_config  *data_cfg,
-                  data_type     type,
                   uint64        rough_count_height,
                   uint64        page_size,
                   uint64        extent_size);

--- a/src/iterator.h
+++ b/src/iterator.h
@@ -4,25 +4,10 @@
 #ifndef __ITERATOR_H
 #define __ITERATOR_H
 
-/*
- * DO NOT CHANGE definitions of data types without being absolutely certain
- * because they are reflected on disk.
- * All legitimate (e.g. non-error) data types must be 0-based and dense
- * because they are used as array indexes.
- *
- * Order of types should be "newest to oldest" (points are newer than ranges)
- */
-typedef enum data_type {
-   data_type_point = 0,
-   data_type_range = 1,
-   NUM_DATA_TYPES,
-   data_type_invalid,
-} data_type;
-
 typedef struct iterator iterator;
 
 // FIXME: [nsarmicanic 2020-07-16] Might be better to return type instead of void
-typedef void (*iterator_get_curr_fn)(iterator *itor, char **key, char **data, data_type *type);
+typedef void (*iterator_get_curr_fn)(iterator *itor, char **key, char **data);
 typedef platform_status (*iterator_at_end_fn)  (iterator *itor, bool *at_end);
 typedef platform_status (*iterator_advance_fn) (iterator *itor);
 typedef void  (*iterator_print_fn)   (iterator *itor);
@@ -41,9 +26,9 @@ struct iterator {
 };
 
 static inline void
-iterator_get_curr(iterator *itor, char **key, char **data, data_type *type)
+iterator_get_curr(iterator *itor, char **key, char **data)
 {
-   itor->ops->get_curr(itor, key, data, type);
+   itor->ops->get_curr(itor, key, data);
 }
 
 static inline platform_status

--- a/src/kvstore.c
+++ b/src/kvstore.c
@@ -469,9 +469,8 @@ kvstore_iterator_get_current(kvstore_iterator *kvi,    // IN
                              const char **     message // OUT
 )
 {
-   data_type type; // ignored
    iterator *itor = &(kvi->sri.super);
-   iterator_get_curr(itor, (char **)key, (char **)message, &type);
+   iterator_get_curr(itor, (char **)key, (char **)message);
    // TODO(gabe): casting away the const is gross
    // Maybe we can change the signature of iterator_get_curr?
 }

--- a/src/merge.c
+++ b/src/merge.c
@@ -11,8 +11,8 @@
 #include "poison.h"
 
 /* Function declarations and iterator_ops */
-void            merge_get_curr (iterator *itor, char **key, char **data,
-                                data_type *type);
+void
+                merge_get_curr(iterator *itor, char **key, char **data);
 platform_status merge_at_end   (iterator *itor, bool *at_end);
 platform_status merge_advance  (iterator *itor);
 
@@ -25,323 +25,6 @@ static iterator_ops merge_ops = {
    .at_end   = merge_at_end,
    .advance  = merge_advance,
 };
-
-
-// Range Stack Accessors and Mutators
-
-// Caller must zero this struct before init
-static void
-range_stack_init(range_stack *stack, int num_trees)
-{
-   // if stack is empty, index 0 will be -1
-   stack->seq[0] = -1;
-   stack->end_seq = -1;
-   stack->num_sequences = num_trees;
-}
-
-static inline bool
-range_stack_makes_point_redundant(range_stack *stack, message_type class)
-{
-   return stack->size > 0 && class == MESSAGE_TYPE_DELETE;
-}
-
-static inline bool
-range_stack_clobbers_point(range_stack *stack, int point_seq)
-{
-   debug_assert(point_seq >= 0);
-
-   /*
-    * merge_iterator takes homogenous input iterators so anything on the stack
-    * cannot share a sequence with a point.
-    * Also if stack is empty, index 0 will be -1
-    */
-   debug_assert(point_seq != stack->seq[0]);
-
-   return point_seq < stack->seq[0];
-}
-
-static inline char*
-range_stack_get_start_key(range_stack *stack)
-{
-   return stack->start_key;
-}
-
-// end_key is the data of range delete (key, data)
-static inline char*
-range_stack_get_end_key(range_stack *stack)
-{
-   debug_assert(stack->end_seq >= 0);
-   debug_assert(stack->end_seq < stack->num_sequences);
-   return stack->limits[stack->end_seq];
-}
-
-static int
-find_predecessor(range_stack *stack, int seq)
-{
-   /*
-    * FIXME: [yfogel 2020-06-11] maybe do binary search?  maybe do binary search
-    * iff stack size is big enough?
-    * You can do a binary search for highest index where stack[i].seq >= seq
-    * (note == should assert(FALSE))
-    * use linear scan for first run.. we can consider binary search later
-    * (including algo that decides on linear or binary depending on size)
-    * It's PROBABLY never worth it to do binary search
-    */
-
-   // find highest index i s.t. stack.seq[i] > seq
-   for (int i = stack->size - 1; i >= 0; --i) {
-      if (stack->seq[i] > seq) {
-         return i;
-      }
-   }
-   return -1;
-}
-
-
-/*
- *-----------------------------------------------------------------------------
- *
- * find_useful_successor --
- *
- *    This function looks for the lowest index i such that limit will be
- *    less than all limits in stack for starting index insert_position.
- *
- *    Precondition:
- *       seq > stack->seq[i] for all insert_position <= i < stack->size
- *
- *    Return found index i, otherwise return stack size
- *
- *-----------------------------------------------------------------------------
- */
-static int
-find_useful_successor(range_stack *stack,
-                      const char  *limit,
-                      int          seq,
-                      int          insert_position,
-                      data_config *cfg)
-{
-   /*
-    * While this COULD be done with binary search, it would actually be SLOWER
-    * in common cases than a linear scan!!!
-    * this particular function (in both callers) is amortized O(1) if you do a
-    * linear scan starting at the right position, so there's no point to do the
-    * more complicated binary search
-    */
-
-   /*
-    * Search for the lowest index i such that
-    * limits[stack.seq[i]] > limit
-    *    Note: don't search indexes lower than insert_position
-    */
-
-   for (int i = insert_position; i < stack->size; ++i) {
-      /*
-       * (seq[i] == seq) would mean range deletes from one sequence
-       *    overlap (which is illegal)
-       * (seq[i] > seq) would imply the precondition was violated
-       */
-      debug_assert(stack->seq[i] < seq);
-      // note that it's > and NOT >=
-      if (data_key_compare(cfg, stack->limits[stack->seq[i]], limit) > 0) {
-         // This index (and everything later) is useful to keep
-         return i;
-      }
-   }
-
-   return stack->size;
-}
-
-
-// FIXME: [nsarmicanic 2020-08-17] Right now there's no validating types of
-// config inside of merge_iterator. Move data_type from btree_config
-// to data_config so we can validate type
-static inline void
-debug_range_stack_check_invariants(debug_only range_stack *stack,
-                                   debug_only data_config *cfg)
-{
-#if SPLINTER_DEBUG
-    debug_assert(stack->size <= ARRAY_SIZE(stack->seq));
-    debug_assert(stack->num_sequences <= ARRAY_SIZE(stack->seq));
-
-    // has_start_key should only be set if there is something in the stack
-    debug_assert(stack->has_start_key == (stack->size > 0));
-
-    debug_assert(IMPLIES((stack->end_seq >= 0), (stack->size == 0)));
-    if (stack->end_seq >= 0) {
-       debug_assert(stack->end_seq < stack->num_sequences);
-    } else {
-       debug_assert(stack->end_seq == -1);
-    }
-
-    // Verify that sequence strictly decreases as index increases
-    for (int i = 1; i < stack->size; i++) {
-       debug_assert(stack->seq[i - 1] > stack->seq[i]);
-    }
-
-    if (stack->size > 0) {
-       // Verify all sequences are valid
-       for (int i = 0; i < stack->size; i++) {
-          debug_assert(stack->seq[i] >= 0);
-          debug_assert(stack->seq[i] < stack->num_sequences);
-       }
-       // Verify first limit is strictly greater than start_key
-       int seq = stack->seq[0];
-       debug_assert(data_key_compare(cfg, stack->start_key,
-                                     stack->limits[seq]) < 0);
-    } else {
-       debug_assert(stack->seq[0] == -1);
-    }
-
-    // Verify that end key is strictly increasing as index increases
-    for (int i = 1; i < stack->size; i++) {
-       int seq_lo = stack->seq[i - 1];
-       int seq_hi = stack->seq[i];
-       debug_assert(data_key_compare(cfg, stack->limits[seq_lo],
-                                     stack->limits[seq_hi]) < 0);
-    }
-#endif
-}
-
-
-static void
-add_new_range_delete_to_stack(range_stack *stack,
-                              const char  *startkey,
-                              const char  *limit,
-                              int          seq,
-                              data_config *cfg)
-{
-   debug_range_stack_check_invariants(stack, cfg);
-
-   if (stack->size == 0) {
-      debug_assert(!stack->has_start_key);
-      stack->has_start_key = TRUE;
-      memmove(stack->start_key, startkey, cfg->key_size);
-      stack->end_seq = -1;
-      stack->size = 1;
-      memmove(stack->limits[seq], limit, cfg->key_size);
-      stack->seq[0] = seq;
-      goto done;
-   }
-
-   /*
-    * Note: find_predecessor is NOT amortized O(1) here
-    *     It's actually possible to do find_useful_successor before
-    *     find_predecessor but it's not obvious that it would ever help
-    *     to do that.
-    *     Doing so would make find_useful_successor stop being amortized O(1)
-    *     and binary search on comparison functions is somewhat expensive
-    */
-   int predecessor = find_predecessor(stack, seq);
-   debug_assert(predecessor == -1 || stack->seq[predecessor] > seq);
-   if (predecessor >= 0 &&
-       data_key_compare(cfg, stack->limits[stack->seq[predecessor]],
-                        limit) >= 0) {
-      // The input range delete is redunant; throw it away.
-      goto done;
-   }
-
-   // We need to put the new range delete immediately after the predecessor
-   int insert_position = predecessor + 1;
-
-   // We are keeping the range delete; clone the limit key.
-   memmove(stack->limits[seq], limit, cfg->key_size);
-
-   int successor = find_useful_successor(stack, limit, seq,
-                                         insert_position, cfg);
-
-   int num_deleting = successor - insert_position;
-
-   /*
-    * limits are NOT stored in the array but instead per-sequence.
-    * This avoids an expensive memmove of the keys when we really only
-    * need (at most) one per sequence and thus don't care
-    *
-    * shift things
-    *    if nothing is being deleted this is shifting everything right by 1,
-    *    if 1 is being deleted it's a no-op
-    *    if more than 1 is being deleted it's a left shift
-    *    if we're deleting everything the memmove moves 0 bytes
-    */
-   int *dst = &stack->seq[insert_position + 1];
-   const int *src = &stack->seq[successor];
-   const int *end = &stack->seq[stack->size];
-   size_t bytes_to_move = (end - src) * sizeof(*src);
-   memmove(dst, src, bytes_to_move);
-
-   stack->size -= num_deleting;
-   // A new range is added to the stack, increment stack size
-   stack->size++;
-   stack->seq[insert_position] = seq;
-
-done:
-   debug_range_stack_check_invariants(stack, cfg);
-   return;
-}
-
-/*
- *-----------------------------------------------------------------------------
- *
- * maybe_remove_range_deletes --
- *
- *  Inform range stack that we have started processing a new key. Modifies
- *  the stack and removes any range deletes no longer necessary.
- *
- *  returns:
- *    TRUE if a range delete was generated to be outputted by the merge_iterator
- *    FALSE otherwise
- *
- *-----------------------------------------------------------------------------
- */
-static bool
-maybe_remove_range_deletes(range_stack *stack,
-                           char *next_key,
-                           data_config *cfg)
-{
-   bool r;
-   debug_range_stack_check_invariants(stack, cfg);
-   if (stack->size == 0) {
-      r = FALSE;
-      goto done;
-   }
-
-   // Find the first relevant/useful range_delete
-   int num_deleting =
-      find_useful_successor(stack, next_key,
-                            //passing a number bigger than anything on the stack
-                            stack->seq[0] + 1,
-                            0, cfg);
-   debug_assert(num_deleting >= 0);
-   debug_assert(num_deleting <= stack->size);
-
-   if (num_deleting == stack->size) {
-      // we are deleting EVERYTHING
-      debug_assert(stack->has_start_key);
-      stack->end_seq = stack->seq[stack->size - 1];
-      stack->has_start_key = FALSE;
-      stack->size = 0;
-      // if stack is empty, index 0 should be -1
-      stack->seq[0] = -1;
-      r = TRUE;
-      goto done;
-   }
-
-   /*
-    * we're shifting the ones we're keeping to left,
-    * and we don't care about clearing out the remainder
-    */
-   int *dest = &stack->seq[0];
-   const int *src = &stack->seq[num_deleting];
-   const int *end = &stack->seq[stack->size];
-   size_t bytes_to_move = (end - src) * sizeof(*src);
-   memmove(dest, src, bytes_to_move);
-
-   stack->size -= num_deleting;
-   r = FALSE;
-
-done:
-   debug_range_stack_check_invariants(stack, cfg);
-   return r;
-}
 
 /*
  * bsearch which returns insertion position
@@ -422,32 +105,13 @@ bsearch_insert(register const ordered_iterator *key,
 static inline void
 set_curr_ordered_iterator(ordered_iterator *itor)
 {
-   iterator_get_curr(itor->itor, &itor->key, &itor->data, &itor->type);
-}
-
-static inline void
-assert_data_config_valid(data_config *point_cfg,
-                         data_config *range_cfg)
-{
-   // FIXME: [nsarmicanic 2020-07-31] Should we add type to data_config?
-   //debug_assert(point_cfg->type = data_type_point);
-   //debug_assert(range_cfg->type = data_type_range);
-
-   debug_assert(point_cfg->key_size <= point_cfg->message_size);
-   debug_assert(range_cfg->key_size == range_cfg->message_size);
-   debug_assert(point_cfg->key_size == range_cfg->key_size);
-   debug_assert(point_cfg->key_size <= MAX_KEY_SIZE);
+   iterator_get_curr(itor->itor, &itor->key, &itor->data);
 }
 
 static inline void
 debug_assert_message_type_valid(debug_only merge_iterator *merge_itor)
 {
 #if SPLINTER_DEBUG
-   if (!merge_itor->at_end) {
-      debug_assert(merge_itor->type == data_type_point);
-   } else {
-      debug_assert(merge_itor->type == data_type_invalid);
-   }
    debug_code(char *data = merge_itor->data);
    debug_code(data_config *cfg = merge_itor->cfg);
    message_type type =
@@ -562,70 +226,14 @@ out:
    return STATUS_OK;
 }
 
-static void
-process_one_range_delete_or_clobber_one_point(merge_iterator *merge_itor)
-{
-   ordered_iterator *ordered_itor = merge_itor->ordered_iterators[0];
-   data_config *range_cfg = merge_itor->range_cfg;
-
-   switch (ordered_itor->type) {
-      case data_type_point:
-         // FIXME: [nsarmicanic 2020-07-31] remove if guard when this function
-         //        is not NULL
-         if (range_cfg->clobber_message_with_range_delete) {
-            data_clobber_message_with_range_delete(range_cfg, ordered_itor->key,
-                                                   ordered_itor->data);
-         }
-         break;
-      case data_type_range:
-         add_new_range_delete_to_stack(&merge_itor->stack,
-                                       ordered_itor->key,
-                                       ordered_itor->data,
-                                       ordered_itor->seq,
-                                       range_cfg);
-         break;
-      default:
-         debug_assert(FALSE);
-         break;
-   }
-}
-
-static platform_status
-process_remaining_range_deletes_and_clobber_points(merge_iterator *merge_itor)
-{
-#if SPLINTER_DEBUG
-   ordered_iterator *expected_itor = merge_itor->ordered_iterators[1];
-#endif
-   debug_assert(merge_itor->ordered_iterators[0]->next_key_equal);
-   do {
-      /*
-       * Need to maintain invariant that merge_itor->key points to a valid
-       * page; this means that this pointer must be updated before the 0th
-       * iterator is advanced
-       */
-      merge_itor->key = merge_itor->ordered_iterators[1]->key;
-      debug_assert(merge_itor->data != merge_itor->ordered_iterators[0]->data);
-      platform_status rc = advance_and_resort_min_ritor(merge_itor);
-      if (!SUCCESS(rc)) {
-         return rc;
-      }
-#if SPLINTER_DEBUG
-      debug_assert(expected_itor == merge_itor->ordered_iterators[0]);
-      expected_itor = merge_itor->ordered_iterators[1];
-#endif
-      process_one_range_delete_or_clobber_one_point(merge_itor);
-   } while (merge_itor->ordered_iterators[0]->next_key_equal);
-
-   return STATUS_OK;
-}
-
 /*
  * In the case where the two minimum iterators of the merge iterator have equal
  * keys, resolve_equal_keys will merge the data as necessary
  */
 
 static platform_status
-merge_resolve_equal_keys(merge_iterator *merge_itor, bool *retry) {
+merge_resolve_equal_keys(merge_iterator *merge_itor)
+{
    debug_assert(merge_itor->ordered_iterators[0]->next_key_equal);
    debug_assert(merge_itor->data != merge_itor->merge_buffer);
    debug_assert(merge_itor->key == merge_itor->ordered_iterators[0]->key);
@@ -636,116 +244,46 @@ merge_resolve_equal_keys(merge_iterator *merge_itor, bool *retry) {
    ordered_iterator *expected_itor = merge_itor->ordered_iterators[1];
 #endif
 
-   if (1
-       && merge_itor->ordered_iterators[0]->type == data_type_point
-       && !range_stack_clobbers_point(&merge_itor->stack,
-                                      merge_itor->ordered_iterators[0]->seq))
-   {
+   // there is more than one copy of the current key
+
+   memmove(merge_itor->merge_buffer, merge_itor->data, cfg->message_size);
+   merge_itor->data = merge_itor->merge_buffer;
+   do {
+      // Verify we don't fall off the end
+      debug_assert(merge_itor->num_remaining >= 2);
+      // Verify keys match
+      debug_assert(!data_key_compare(
+         cfg, merge_itor->key, merge_itor->ordered_iterators[1]->key));
+      debug_assert(merge_itor->data == merge_itor->merge_buffer);
+
+      data_merge_tuples(cfg,
+                        merge_itor->key,
+                        merge_itor->ordered_iterators[1]->data,
+                        merge_itor->data);
+      // FIXME: [yfogel 2020-01-11] handle class==MESSAGE_TYPE_INVALID
+      //    We should crash or cancel the entire compaction
+
       /*
-       * There is more than one copy of the current key, and the newest copy is
-       * a point that is not clobbered by range deletes.
+       * Need to maintain invariant that merge_itor->key points to a valid
+       * page; this means that this pointer must be updated before the 0th
+       * iterator is advanced
        */
-
-      memmove(merge_itor->merge_buffer, merge_itor->data, cfg->message_size);
-      merge_itor->data = merge_itor->merge_buffer;
-      do {
-         if (1
-             && merge_itor->ordered_iterators[1]->type == data_type_point
-             && !range_stack_clobbers_point(
-                                 &merge_itor->stack,
-                                 merge_itor->ordered_iterators[1]->seq))
-         {
-            /*
-             * There is at least one more point that is not clobbered by
-             * range deletes.
-             */
-
-            // Verify we don't fall off the end
-            debug_assert(merge_itor->num_remaining >= 2);
-            // Verify keys match
-            debug_assert(
-                  !data_key_compare(cfg,
-                     merge_itor->key,
-                     merge_itor->ordered_iterators[1]->key));
-            debug_assert(merge_itor->data == merge_itor->merge_buffer);
-
-            data_merge_tuples(cfg, merge_itor->key,
-                  merge_itor->ordered_iterators[1]->data,
-                  merge_itor->data);
-            // FIXME: [yfogel 2020-01-11] handle class==MESSAGE_TYPE_INVALID
-            //    We should crash or cancel the entire compaction
-
-            /*
-             * Need to maintain invariant that merge_itor->key points to a valid
-             * page; this means that this pointer must be updated before the 0th
-             * iterator is advanced
-             */
-            merge_itor->key = merge_itor->ordered_iterators[1]->key;
-            debug_assert(merge_itor->data == merge_itor->merge_buffer);
-            platform_status rc = advance_and_resort_min_ritor(merge_itor);
-            if (!SUCCESS(rc)) {
-               return rc;
-            }
+      merge_itor->key = merge_itor->ordered_iterators[1]->key;
+      debug_assert(merge_itor->data == merge_itor->merge_buffer);
+      platform_status rc = advance_and_resort_min_ritor(merge_itor);
+      if (!SUCCESS(rc)) {
+         return rc;
+      }
 #if SPLINTER_DEBUG
-            debug_assert(expected_itor == merge_itor->ordered_iterators[0]);
-            expected_itor = merge_itor->ordered_iterators[1];
+      debug_assert(expected_itor == merge_itor->ordered_iterators[0]);
+      expected_itor = merge_itor->ordered_iterators[1];
 #endif
+   } while (merge_itor->ordered_iterators[0]->next_key_equal);
 
-         } else {
-            /* Anything that's left over is either range deletes or points that
-             * are being clobbered.
-             * This deals with all duplicates so we break out of the loop once
-             * we are done.
-             */
-            debug_assert(merge_itor->data == merge_itor->merge_buffer);
-            process_remaining_range_deletes_and_clobber_points(merge_itor);
-            debug_assert(merge_itor->stack.size > 0);
-            break;
-         }
-      } while (merge_itor->ordered_iterators[0]->next_key_equal);
-
-      // Dealt with all duplicates, now pointing to last copy.
-      debug_assert(!merge_itor->ordered_iterators[0]->next_key_equal);
-
-      message_type class = data_message_class(cfg, merge_itor->data);
-      /*
-       * If retry is TRUE that means we threw away a point delete
-       * because we didn't need it because of range delete
-       *
-       * Point deletes on top of range deletes are redundant.
-       */
-      *retry = range_stack_makes_point_redundant(&merge_itor->stack, class);
-   } else {
-      merge_itor->data = NULL;
-      process_one_range_delete_or_clobber_one_point(merge_itor);
-      process_remaining_range_deletes_and_clobber_points(merge_itor);
-      *retry = TRUE;
-   }
+   // Dealt with all duplicates, now pointing to last copy.
+   debug_assert(!merge_itor->ordered_iterators[0]->next_key_equal);
 
    return STATUS_OK;
-}
-
-
-/*
- *-----------------------------------------------------------------------------
- *
- * discard_range_deletes--
- *
- * if merge_itor->discard_deletes:
- *    discards MESSAGE_TYPE_DELETE messages
- * return True if discarded a range delete
- *
- *-----------------------------------------------------------------------------
- */
-static inline bool
-discard_range_deletes(merge_iterator *merge_itor)
-{
-   debug_assert(merge_itor->type == data_type_range);
-   debug_assert(merge_itor->discard_deletes == !!merge_itor->discard_deletes);
-
-   // Increment stats iff discarded_deletes is true
-   merge_itor->discarded_deletes += merge_itor->discard_deletes;
-   return merge_itor->discard_deletes;
 }
 
 
@@ -764,7 +302,6 @@ discard_range_deletes(merge_iterator *merge_itor)
 static inline bool
 merge_resolve_updates_and_discard_deletes(merge_iterator *merge_itor)
 {
-   debug_assert(merge_itor->type == data_type_point);
    data_config *cfg = merge_itor->cfg;
    message_type class = data_message_class(cfg, merge_itor->data);
    // FIXME: [yfogel 2020-01-11] handle class==MESSAGE_TYPE_INVALID
@@ -794,72 +331,28 @@ advance_one_loop(merge_iterator *merge_itor, bool *retry)
    *retry= FALSE;
    // Determine whether we're at the end.
    if (merge_itor->num_remaining == 0) {
-      if (maybe_remove_range_deletes(&merge_itor->stack,
-                                     merge_itor->range_cfg->max_key,
-                                     merge_itor->range_cfg))
-      {
-         // We're at the end (modulo range in the stack)
-         merge_itor->type = data_type_range;
-         merge_itor->key = range_stack_get_start_key(&merge_itor->stack);
-         merge_itor->data = range_stack_get_end_key(&merge_itor->stack);
-         *retry = discard_range_deletes(merge_itor);
-         debug_assert(merge_itor->stack.size == 0);
-      } else {
-         merge_itor->type = data_type_invalid;
-         merge_itor->at_end = TRUE;
-      }
+      merge_itor->at_end = TRUE;
       return STATUS_OK;
    }
 
-   // set the next key/data/type from the min ritor
+   // set the next key/data from the min ritor
    merge_itor->key = merge_itor->ordered_iterators[0]->key;
-   data_type type = merge_itor->ordered_iterators[0]->type;
-   debug_assert(type == data_type_point || type == data_type_range);
    if (!merge_itor->has_data) {
       /*
        * We only have keys.  We COULD still merge (skip duplicates) the keys
        * but it would break callers.  Right now, rough estimates rely on the
        * duplicate keys outputted to improve the estimates.
        */
-      merge_itor->type = type;
       return STATUS_OK;
    }
    merge_itor->data = merge_itor->ordered_iterators[0]->data;
 
-   if (maybe_remove_range_deletes(&merge_itor->stack, merge_itor->key,
-                                  merge_itor->range_cfg))
-   {
-      merge_itor->type = data_type_range;
-      merge_itor->key = range_stack_get_start_key(&merge_itor->stack);
-      merge_itor->data = range_stack_get_end_key(&merge_itor->stack);
-      *retry = discard_range_deletes(merge_itor);
-      return STATUS_OK;
-   }
-
    if (merge_itor->ordered_iterators[0]->next_key_equal) {
-      platform_status rc = merge_resolve_equal_keys(merge_itor, retry);
+      platform_status rc = merge_resolve_equal_keys(merge_itor);
       if (!SUCCESS(rc)) {
          return rc;
       }
-      if (*retry) {
-         return STATUS_OK;
-      }
-   } else if (merge_itor->ordered_iterators[0]->type == data_type_range ||
-         range_stack_clobbers_point(&merge_itor->stack,
-                                    merge_itor->ordered_iterators[0]->seq))
-   {
-      /*
-       * We have no duplicates and have either
-       * - a point that gets clobbered or
-       * - one range delete.
-       */
-      process_one_range_delete_or_clobber_one_point(merge_itor);
-      *retry = TRUE;
-      return STATUS_OK;
    }
-
-   merge_itor->type = type;
-   debug_assert(merge_itor->type == data_type_point);
 
    if (merge_resolve_updates_and_discard_deletes(merge_itor)) {
       *retry = TRUE;
@@ -885,14 +378,9 @@ advance_one_loop(merge_iterator *merge_itor, bool *retry)
  *-----------------------------------------------------------------------------
  */
 
-// FIXME: [yfogel 2020-07-17] rename cfg to point_cfg
-// FIXME: [yfogel 2020-07-17] ADD data_type type; to data_config (dont' remove
-//       from btree_config (yet? maybe later)
-// FIXME: [yfogel 2020-08-24] Verify all input iterators are homogeneous for data_type
 platform_status
 merge_iterator_create(platform_heap_id  hid,
                       data_config      *cfg,
-                      data_config      *range_cfg,
                       int               num_trees,
                       iterator        **itor_arr,
                       bool              discard_deletes,
@@ -908,24 +396,14 @@ merge_iterator_create(platform_heap_id  hid,
    //        (also sanity functions WHEN FIRST NEEDED for splinterconfig and
    //         btree_config)
 
-   // FIXME: [nsarmicanic 2020-07-31] remove if guard once range_cfg is never passed as NULL
-   if (range_cfg) {
-      assert_data_config_valid(cfg, range_cfg);
-   }
-
-   // FIXME: [yfogel 2020-07-01] need to also err on missing range_cfg
-   //      but callers are currently passing NULL until callers
-   //      are fixed
-   if (0
-       || !out_itor
-       || !itor_arr
-       || !cfg
-       || num_trees < 0
-       || num_trees >= ARRAY_SIZE(merge_itor->ordered_iterator_stored))
-   {
+   if (!out_itor || !itor_arr || !cfg || num_trees < 0 ||
+       num_trees >= ARRAY_SIZE(merge_itor->ordered_iterator_stored)) {
       platform_log("merge_iterator_create: bad parameter merge_itor %p"
-            " num_trees %d itor_arr %p cfg %p range_cfg %p\n",
-            out_itor, num_trees, itor_arr, cfg, range_cfg);
+                   " num_trees %d itor_arr %p cfg %p\n",
+                   out_itor,
+                   num_trees,
+                   itor_arr,
+                   cfg);
       return STATUS_BAD_PARAM;
    }
 
@@ -951,22 +429,18 @@ merge_iterator_create(platform_heap_id  hid,
    //                            everywhere else)
    //                            maybe also copy data config locally?
    merge_itor->cfg = cfg;
-   merge_itor->range_cfg = range_cfg;
-
-   // Initialize range stack
-   range_stack_init(&merge_itor->stack, num_trees);
 
    // index -1 initializes the pad variable
    for (i = -1; i < num_trees; i++) {
-     merge_itor->ordered_iterator_stored[i] = (ordered_iterator) {
-        .seq = i,
-        .itor = i == -1 ? NULL : itor_arr[i],
-        .key = NULL,
-        .data = NULL,
-        .next_key_equal = FALSE,
-     };
-     merge_itor->ordered_iterators[i] =
-        &merge_itor->ordered_iterator_stored[i];
+      merge_itor->ordered_iterator_stored[i] = (ordered_iterator){
+         .seq            = i,
+         .itor           = i == -1 ? NULL : itor_arr[i],
+         .key            = NULL,
+         .data           = NULL,
+         .next_key_equal = FALSE,
+      };
+      merge_itor->ordered_iterators[i] =
+         &merge_itor->ordered_iterator_stored[i];
    }
 
    // Move all the dead iterators to the end and count how many are still alive.
@@ -1100,19 +574,13 @@ merge_at_end(iterator *itor,   // IN
  *-----------------------------------------------------------------------------
  */
 
-// FIXME: [tjiaheng 2020-07-17] should support data_type_range
 void
-merge_get_curr(iterator   *itor,
-               char      **key,
-               char      **data,
-               data_type  *type)
+merge_get_curr(iterator *itor, char **key, char **data)
 {
    merge_iterator *merge_itor = (merge_iterator *)itor;
    debug_assert(!merge_itor->at_end);
-   debug_assert(merge_itor->type != data_type_invalid);
    *key = merge_itor->key;
    *data = merge_itor->data;
-   *type = merge_itor->type;
 }
 
 /*
@@ -1139,14 +607,11 @@ merge_advance(iterator *itor)
    do {
       merge_itor->key = NULL;
       merge_itor->data = NULL;
-      if (merge_itor->type != data_type_range) {
-         // Advance one iterator
-         rc = advance_and_resort_min_ritor(merge_itor);
-         if (!SUCCESS(rc)) {
-            return rc;
-         }
+      // Advance one iterator
+      rc = advance_and_resort_min_ritor(merge_itor);
+      if (!SUCCESS(rc)) {
+         return rc;
       }
-      merge_itor->type = data_type_invalid;
 
       rc = advance_one_loop(merge_itor, &retry);
       if (!SUCCESS(rc)) {
@@ -1162,9 +627,8 @@ merge_iterator_print(merge_iterator *merge_itor)
 {
    uint64 i;
    char *key, *data, key_str[MAX_KEY_SIZE];
-   data_type type;
    data_config *data_cfg = merge_itor->cfg;
-   iterator_get_curr(&merge_itor->super, &key, &data, &type);
+   iterator_get_curr(&merge_itor->super, &key, &data);
    data_key_to_string(data_cfg, key, key_str, 32);
 
    platform_log("****************************************\n");
@@ -1181,7 +645,7 @@ merge_iterator_print(merge_iterator *merge_itor)
       else
          platform_log("_ : ");
       if (i < merge_itor->num_remaining) {
-         iterator_get_curr(merge_itor->ordered_iterators[i]->itor, &key, &data, &type);
+         iterator_get_curr(merge_itor->ordered_iterators[i]->itor, &key, &data);
          data_key_to_string(data_cfg, key, key_str, 32);
          platform_log("%s\n", key_str);
       } else {

--- a/src/merge.h
+++ b/src/merge.h
@@ -14,10 +14,6 @@
 #include "iterator.h"
 #include "platform.h"
 
-// FIXME: [nsarmicanic 2020-07-02] There is an inconsistency
-// with range iterator limit 128. What is that limit?
-// Should 128 increase?
-// Should 1024 increate or decrease?
 // Hard limit tall tree range query?
 #define MAX_MERGE_ARITY (1024)
 
@@ -26,26 +22,9 @@ typedef struct ordered_iterator {
    int seq;
    char *key;
    char *data;
-   data_type type;
    bool next_key_equal;
 } ordered_iterator;
 
-/*
- * range_stack structure is used by merge iterator to keep track
- * of range deletes.
- * For invariants of range stack take a look at: range_stack_check_invariants
- *
- */
-// FIXME: [nsarmicanic 2020-07-29] maybe move range_stack to scratch
-typedef struct range_stack {
-   uint32 size;
-   char   limits[MAX_MERGE_ARITY][MAX_KEY_SIZE];
-   char   start_key[MAX_KEY_SIZE];
-   int    end_seq;
-   int    seq[MAX_MERGE_ARITY];
-   int    num_sequences;
-   bool   has_start_key;
-} range_stack;
 
 typedef struct merge_iterator {
    iterator               super;           // handle for iterator.h API
@@ -55,12 +34,9 @@ typedef struct merge_iterator {
    bool                   has_data;        // Whether to look at data at all
    bool                   at_end;
    int                    num_remaining;   // number of ritors not at end
-   // FIXME: [yfogel 2020-07-01] rename cfg to point_cfg/delayed for paralelizem
    data_config           *cfg;             // point message tree data config
-   data_config           *range_cfg;       // range delete tree data config
    char                  *key;             // next key
    char                  *data;            // next data
-   data_type              type;            // next data type
 
    // FIXME: [nsarmicanic 2020-07-02] Maybe preallocate one of these sections
    // pre thread?
@@ -76,16 +52,10 @@ typedef struct merge_iterator {
    // Stats
    uint64                 discarded_deletes;
 
-   // FIXME: [yfogel 2020-07-01] these two are for use for merge_iterator
-   //       range delete changes.  Feel free to rename (not used at all yet)
-   char                   start_key_buffer[MAX_KEY_SIZE];
-   char                   end_key_buffer[MAX_KEY_SIZE];
-
-   range_stack stack;
-
    // space for merging data together
    char                   merge_buffer[MAX_MESSAGE_SIZE];
 } merge_iterator;
+
 // Statically enforce that the padding variables act as index -1 for both arrays
 _Static_assert(offsetof(merge_iterator, ordered_iterator_stored_pad) ==
                offsetof(merge_iterator, ordered_iterator_stored[-1]), "");
@@ -95,7 +65,6 @@ _Static_assert(offsetof(merge_iterator, ordered_iterators_pad) ==
 platform_status
 merge_iterator_create(platform_heap_id  hid,
                       data_config      *cfg,
-                      data_config      *range_cfg,
                       int               num_trees,
                       iterator        **itor_arr,
                       bool              discard_deletes,

--- a/src/routing_filter.c
+++ b/src/routing_filter.c
@@ -1216,8 +1216,7 @@ routing_filter_verify(cache          *cc,
    while (!at_end) {
       char *key;
       char *data;
-      data_type dummy_type;
-      iterator_get_curr(itor, &key, &data, &dummy_type);
+      iterator_get_curr(itor, &key, &data);
       uint64 found_values;
       platform_status rc =
          routing_filter_lookup(cc, cfg, filter, key, &found_values);

--- a/src/shard_log.c
+++ b/src/shard_log.c
@@ -18,7 +18,8 @@
 
 static uint64 shard_log_magic_idx = 0;
 
-int    shard_log_write     (log_handle *log, char *key, char *data, uint64 generation);
+int
+       shard_log_write(log_handle *log, char *key, char *data, uint64 generation);
 uint64 shard_log_addr      (log_handle *log);
 uint64 shard_log_meta_addr (log_handle *log);
 uint64 shard_log_magic     (log_handle *log);
@@ -30,9 +31,12 @@ static log_ops shard_log_ops = {
    .magic     = shard_log_magic,
 };
 
-void            shard_log_iterator_get_curr (iterator *itor, char **key, char **data, data_type *type);
-platform_status shard_log_iterator_at_end   (iterator *itor, bool *at_end);
-platform_status shard_log_iterator_advance  (iterator *itor);
+void
+shard_log_iterator_get_curr(iterator *itor, char **key, char **data);
+platform_status
+shard_log_iterator_at_end(iterator *itor, bool *at_end);
+platform_status
+shard_log_iterator_advance(iterator *itor);
 
 const static iterator_ops shard_log_iterator_ops = {
    .get_curr = shard_log_iterator_get_curr,
@@ -332,10 +336,7 @@ shard_log_iterator_deinit(platform_heap_id hid, shard_log_iterator *itor)
 //    shard log actually does (what are the types?)
 //    Do we also need a key_type?
 void
-shard_log_iterator_get_curr(iterator   *itorh,
-                            char      **key,
-                            char      **data,
-                            data_type  *type)
+shard_log_iterator_get_curr(iterator *itorh, char **key, char **data)
 {
    shard_log_iterator *itor = (shard_log_iterator *)itorh;
    char *cursor = itor->cursor;

--- a/src/splinter.c
+++ b/src/splinter.c
@@ -453,7 +453,6 @@ typedef struct PACKED splinter_trunk_hdr {
 
 typedef struct splinter_pivot_data {
    uint64         addr;         // PBN of the child
-   // FIXME: [tjiaheng 2020-07-23] do we want to also include range_num_tuples
    uint64         num_tuples;   // estimate of the # of tuples for this pivot
    uint64         generation;   // receives new higher number when pivot splits
    uint16         start_branch; // first branch live (not used in leaves)
@@ -640,8 +639,8 @@ int                                splinter_split_root                (splinter_
 void                               splinter_print                     (splinter_handle *spl);
 void                               splinter_print_node                (splinter_handle *spl, uint64 addr, platform_stream_handle stream);
 void                               splinter_print_locked_node         (splinter_handle *spl, page_handle *node, platform_stream_handle stream);
-static void                        splinter_btree_skiperator_init     (splinter_handle *spl, splinter_btree_skiperator *skip_itor, page_handle *node, uint16 branch_idx, data_type data_type, key_buffer pivots[static SPLINTER_MAX_PIVOTS]);
-void                               splinter_btree_skiperator_get_curr (iterator *itor, char **key, char **data, data_type *type);
+static void                        splinter_btree_skiperator_init     (splinter_handle *spl, splinter_btree_skiperator *skip_itor, page_handle *node, uint16 branch_idx, key_buffer pivots[static SPLINTER_MAX_PIVOTS]);
+void                               splinter_btree_skiperator_get_curr (iterator *itor, char **key, char **data);
 platform_status                    splinter_btree_skiperator_advance  (iterator *itor);
 platform_status                    splinter_btree_skiperator_at_end   (iterator *itor, bool *at_end);
 void                               splinter_btree_skiperator_print    (iterator *itor);
@@ -818,7 +817,6 @@ splinter_node_is_full(splinter_handle *spl,
    for (uint16 i = 0; i < splinter_num_children(spl, node); i++) {
       num_tuples += splinter_get_pivot_data(spl, node, i)->num_tuples;
    }
-   // FIXME: [tjiaheng 2020-07-23] do we want to also include range_num_tuples
    return num_tuples > spl->cfg.max_tuples_per_node;
 }
 
@@ -1403,7 +1401,6 @@ splinter_add_pivot_new_root(splinter_handle *spl,
    splinter_set_pivot_data_new_root(spl, parent, child_addr);
 }
 
-// FIXME: [tjiaheng 2020-07-23] do we want to also include range_num_tuples
 /*
  * update_num_tuples updates the estimate of the tuples (num_tuples) in each
  * pivot to include an estimate of those from new_branch.
@@ -1423,7 +1420,6 @@ splinter_update_num_tuples(splinter_handle *spl,
    }
 }
 
-// FIXME: [tjiaheng 2020-07-23] do we want to also include range_num_tuples
 /*
  * pivot_recount_num_tuples recounts num_tuples for the pivot at position
  * pivot_no using a rough count.
@@ -1445,8 +1441,6 @@ splinter_pivot_recount_num_tuples(splinter_handle *spl,
          splinter_pivot_tuples_in_branch(spl, node, pivot_no, branch_no);
    }
 }
-
-// FIXME: [tjiaheng 2020-07-23] do we want to also include range_num_tuples
 
 uint64
 splinter_pivot_num_tuples(splinter_handle *spl,
@@ -1642,7 +1636,6 @@ splinter_pivot_tuples_in_branch_slow(splinter_handle *spl,
  * a subsequent flush, the tuple count for the node must be updated to include
  * their tuples.
  */
-// FIXME: [tjiaheng 2020-07-23] do we want to also include range_num_tuples
 void
 splinter_leaf_count_num_tuples(splinter_handle *spl,
                                page_handle     *node,
@@ -2721,21 +2714,16 @@ splinter_zap_branch_range(splinter_handle *spl,
                           const char      *end_key,
                           page_type        type)
 {
-   platform_assert(type == PAGE_TYPE_BRANCH || type == PAGE_TYPE_MEMTABLE);
-   platform_assert(0 || (1 && start_key == NULL
-                           && end_key == NULL)
-                     || (1 && type != PAGE_TYPE_MEMTABLE
-                           && start_key != NULL));
-   if (branch->root_addr) {
-      btree_zap_range(spl->cc, &spl->cfg.btree_cfg, branch->root_addr,
-            start_key, end_key, PAGE_TYPE_BRANCH);
-   }
-   if (branch->range_root_addr) {
-      btree_zap_range(spl->cc, &spl->cfg.btree_cfg, branch->range_root_addr,
-            start_key, end_key, PAGE_TYPE_BRANCH);
-   }
-   // FIXME: [yfogel 2020-07-06] If/when we add range-delete filter
-   //    (e.g. on components) we should clean up the range filter here
+   platform_assert(type == PAGE_TYPE_BRANCH);
+   platform_assert((start_key == NULL && end_key == NULL) ||
+                   (type != PAGE_TYPE_MEMTABLE && start_key != NULL));
+   platform_assert(branch->root_addr != 0);
+   btree_zap_range(spl->cc,
+                   &spl->cfg.btree_cfg,
+                   branch->root_addr,
+                   start_key,
+                   end_key,
+                   PAGE_TYPE_BRANCH);
 }
 
 /*
@@ -2952,9 +2940,16 @@ splinter_memtable_iterator_init(splinter_handle *spl,
    if (inc_refcount) {
       allocator_inc_refcount(spl->al, root_addr);
    }
-   btree_iterator_init(spl->cc, &spl->cfg.btree_cfg, itor, root_addr,
-         PAGE_TYPE_MEMTABLE, min_key, max_key, FALSE, is_live, 0,
-         data_type_point);
+   btree_iterator_init(spl->cc,
+                       &spl->cfg.btree_cfg,
+                       itor,
+                       root_addr,
+                       PAGE_TYPE_MEMTABLE,
+                       min_key,
+                       max_key,
+                       FALSE,
+                       is_live,
+                       0);
 }
 
 static void
@@ -3023,8 +3018,6 @@ splinter_memtable_compact_and_build_filter(splinter_handle *spl,
 {
    timestamp comp_start = platform_get_timestamp();
 
-   // FIXME: [yfogel 2020-07-01] initialization needs to happen ~here
-   //    for range_root_addr
    memtable *mt = splinter_get_memtable(spl, generation);
 
    memtable_transition(mt, MEMTABLE_STATE_FINALIZED, MEMTABLE_STATE_COMPACTING);
@@ -3039,7 +3032,6 @@ splinter_memtable_compact_and_build_filter(splinter_handle *spl,
    btree_iterator  btree_itor;
    iterator       *itor = &btree_itor.super;
    const char     *min_key = spl->cfg.data_cfg->min_key;
-   // FIXME: [yfogel 2020-07-01] needs to also do the range tree.
 
    splinter_memtable_iterator_init(spl, &btree_itor, memtable_root_addr,
          min_key, NULL, FALSE, FALSE);
@@ -4225,46 +4217,14 @@ splinter_flush_fullest(splinter_handle *spl,
    return FALSE;
 }
 
-UNUSED_FUNCTION()
-static inline uint64
-branch_choose_root(splinter_branch *branch,
-                   data_type type)
-{
-   switch (type) {
-      case data_type_point:
-         return branch->root_addr;
-      case data_type_range:
-         return branch->range_root_addr;
-      case data_type_invalid:
-      default:
-         platform_assert(FALSE);
-   }
-}
-
-static inline btree_config*
-splinter_choose_btree_config(splinter_handle *spl,
-                             data_type type)
-{
-   switch (type) {
-      case data_type_point:
-         return &spl->cfg.btree_cfg;
-      case data_type_range:
-         return &spl->cfg.range_btree_cfg;
-      case data_type_invalid:
-      default:
-         platform_assert(FALSE);
-   }
-}
-
 void
 save_pivots_to_compact_bundle_scratch(splinter_handle        *spl,     // IN
                                       page_handle            *node,    // IN
-                                      data_type               type,    // IN
                                       compact_bundle_scratch *scratch) // IN/OUT
 {
    uint32 num_pivot_keys = splinter_num_pivot_keys(spl, node);
 
-   btree_config *cfg = splinter_choose_btree_config(spl, type);
+   btree_config *cfg = &spl->cfg.btree_cfg;
 
    debug_assert(num_pivot_keys < ARRAY_SIZE(scratch->saved_pivot_keys));
 
@@ -4287,19 +4247,24 @@ splinter_branch_iterator_init(splinter_handle *spl,
                               const char      *min_key,
                               const char      *max_key,
                               bool             do_prefetch,
-                              data_type        data_type,
                               bool             should_inc_ref)
 {
    cache *cc = spl->cc;
-   btree_config *btree_cfg = data_type == data_type_point ?
-      &spl->cfg.btree_cfg : &spl->cfg.range_btree_cfg;
-   uint64 root_addr = data_type == data_type_point ?
-      branch->root_addr : branch->range_root_addr;
+   btree_config *btree_cfg = &spl->cfg.btree_cfg;
+   uint64        root_addr = branch->root_addr;
    if (root_addr != 0 && should_inc_ref) {
       btree_inc_range(cc, btree_cfg, root_addr, min_key, max_key);
    }
-   btree_iterator_init(cc, btree_cfg, itor, root_addr, PAGE_TYPE_BRANCH,
-         min_key, max_key, do_prefetch, FALSE, 0, data_type);
+   btree_iterator_init(cc,
+                       btree_cfg,
+                       itor,
+                       root_addr,
+                       PAGE_TYPE_BRANCH,
+                       min_key,
+                       max_key,
+                       do_prefetch,
+                       FALSE,
+                       0);
 }
 
 void
@@ -4336,7 +4301,6 @@ splinter_btree_skiperator_init(
       splinter_btree_skiperator *skip_itor,
       page_handle               *node,
       uint16                     branch_idx,
-      data_type                  data_type,
       key_buffer                 pivots[static SPLINTER_MAX_PIVOTS])
 {
    ZERO_CONTENTS(skip_itor);
@@ -4365,8 +4329,13 @@ splinter_btree_skiperator_init(
             min_key : pivots[first_pivot].k;
          char *pivot_max_key = i == max_pivot_no ? max_key : pivots[i].k;
          btree_iterator *btree_itor = &skip_itor->itor[skip_itor->end++];
-         splinter_branch_iterator_init(spl, btree_itor, &skip_itor->branch,
-               pivot_min_key, pivot_max_key, TRUE, data_type, TRUE);
+         splinter_branch_iterator_init(spl,
+                                       btree_itor,
+                                       &skip_itor->branch,
+                                       pivot_min_key,
+                                       pivot_max_key,
+                                       TRUE,
+                                       TRUE);
          iterator_started = FALSE;
       }
    }
@@ -4386,14 +4355,11 @@ splinter_btree_skiperator_init(
 }
 
 void
-splinter_btree_skiperator_get_curr(iterator   *itor,
-                                   char      **key,
-                                   char      **data,
-                                   data_type  *type)
+splinter_btree_skiperator_get_curr(iterator *itor, char **key, char **data)
 {
    debug_assert(itor != NULL);
    splinter_btree_skiperator *skip_itor = (splinter_btree_skiperator *)itor;
-   iterator_get_curr(&skip_itor->itor[skip_itor->curr].super, key, data, type);
+   iterator_get_curr(&skip_itor->itor[skip_itor->curr].super, key, data);
 }
 
 platform_status
@@ -4461,35 +4427,19 @@ splinter_btree_skiperator_deinit(splinter_handle           *spl,
  */
 
 
-// FIXME: [yfogel 2020-07-02]
-// figureout if this need to support both or can just support one and
-// May want to add range_btree_pack
-// probably want this to handle the branch
-// and call the lower level pack_req_init twice
-// but may want to wrap this function in another that handles two.
-// API needs to change if you do that so yo ucan PASS IN filter cfg
-// (or hash/seed) for example
 static inline void
-splinter_branch_pack_req_init(splinter_handle *spl,
-                              iterator        *itor,
-                              branch_pack_req *req)
+splinter_btree_pack_req_init(splinter_handle *spl,
+                             iterator *       itor,
+                             btree_pack_req * req)
 {
-   btree_pack_req_init(&req->point_req, spl->cc, &spl->cfg.btree_cfg, itor,
-                       spl->cfg.max_tuples_per_node, spl->cfg.leaf_filter_cfg.hash,
-                       spl->cfg.leaf_filter_cfg.seed, spl->heap_id);
-   // only point tree uses filter for now
-   btree_pack_req_init(&req->range_req, spl->cc, &spl->cfg.range_btree_cfg,
-                       itor, spl->cfg.max_tuples_per_node, NULL, 0,
+   btree_pack_req_init(req,
+                       spl->cc,
+                       &spl->cfg.btree_cfg,
+                       itor,
+                       spl->cfg.max_tuples_per_node,
+                       spl->cfg.leaf_filter_cfg.hash,
+                       spl->cfg.leaf_filter_cfg.seed,
                        spl->heap_id);
-}
-
-__attribute__ ((unused))
-static inline void
-splinter_branch_pack_req_deinit(splinter_handle *spl,
-                                branch_pack_req *req)
-{
-   // only point tree uses filter for now
-   btree_pack_req_deinit(&req->point_req, spl->heap_id);
 }
 
 /*
@@ -4639,7 +4589,6 @@ splinter_compact_bundle(void *arg,
    uint16 bundle_start_branch = splinter_bundle_start_branch(spl, node, bundle);
    uint16 bundle_end_branch   = splinter_bundle_end_branch(spl, node, bundle);
    uint16 num_branches        = splinter_bundle_branch_count(spl, node, bundle);
-   uint16 num_trees           = num_branches * 2;
 
    /*
     * Update and delete messages need to be kept around until/unless they have
@@ -4658,48 +4607,25 @@ splinter_compact_bundle(void *arg,
    /*
     * 6. Build iterators
     */
-   // FIXME: [nsarmicanic 2020-07-02] calc num_trees and use it instead of
-   //  num_branches
-   //  Figure out num_itors or num_trees is a better name (For the entire func)
-   platform_assert(num_trees <= ARRAY_SIZE(scratch->skip_itor));
+   platform_assert(num_branches <= ARRAY_SIZE(scratch->skip_itor));
    splinter_btree_skiperator *skip_itor_arr = scratch->skip_itor;
    iterator **itor_arr = scratch->itor_arr;
 
-   save_pivots_to_compact_bundle_scratch(spl, node, data_type_point,
-                                         scratch);
+   save_pivots_to_compact_bundle_scratch(spl, node, scratch);
 
    uint16 tree_offset = 0;
    for (uint16 branch_no = bundle_start_branch; branch_no != bundle_end_branch;
          branch_no = splinter_branch_no_add(spl, branch_no, 1)) {
       /*
        * We are iterating from oldest to newest branch
-       *
-       * RangeDeleteTree is older than PointTree in the same branch
-       * therefor range_delete tree skiperator should be earlier
-       * than point_tree skiperator
        */
-      splinter_btree_skiperator_init(spl, &skip_itor_arr[tree_offset], node,
-                                     branch_no, data_type_range,
+      splinter_btree_skiperator_init(spl,
+                                     &skip_itor_arr[tree_offset],
+                                     node,
+                                     branch_no,
                                      scratch->saved_pivot_keys);
       itor_arr[tree_offset] = &skip_itor_arr[tree_offset].super;
       tree_offset++;
-
-      splinter_btree_skiperator_init(spl, &skip_itor_arr[tree_offset], node,
-                                     branch_no, data_type_point,
-                                     scratch->saved_pivot_keys);
-      itor_arr[tree_offset] = &skip_itor_arr[tree_offset].super;
-      tree_offset++;
-
-      // FIXME: [nsarmicanic 2020-07-02] Is it branch ref count or tree refcoutn?
-      //       refcount is per branch, but we should increment
-      //       the refcount for each iterator created
-      //       (it's two references)
-      //       on creation it's trivial to just add one refrence
-      //       but a little harder to only remove one reference at end
-      //       so if it's easy to clean up just 1, that's fine, otherwise
-      //       add one reference for EACH iterator created (each tree)
-      //       if you feel there is perf on the tabel, leave a FIXME explaining
-      //       the type of optimization before committing
    }
    splinter_log_node(spl, node);
 
@@ -4712,67 +4638,51 @@ splinter_compact_bundle(void *arg,
     * 8. Perform compaction
     */
    merge_iterator *merge_itor;
-   // FIXME: [yfogel 2020-07-01] Determine if we properly
-   // initialized range_cfg (probably since using standard inits?)
-   rc = merge_iterator_create(
-         spl->heap_id, spl->cfg.data_cfg, &spl->cfg.range_data_cfg,
-         num_trees, itor_arr, resolve_updates_and_discard_deletes,
-         resolve_updates_and_discard_deletes, TRUE, &merge_itor);
+   rc = merge_iterator_create(spl->heap_id,
+                              spl->cfg.data_cfg,
+                              num_branches,
+                              itor_arr,
+                              resolve_updates_and_discard_deletes,
+                              resolve_updates_and_discard_deletes,
+                              TRUE,
+                              &merge_itor);
    platform_assert_status_ok(rc);
-   branch_pack_req pack_req;
-   splinter_branch_pack_req_init(spl, &merge_itor->super, &pack_req);
-   req->fp_arr = pack_req.point_req.fingerprint_arr;
+   btree_pack_req pack_req;
+   splinter_btree_pack_req_init(spl, &merge_itor->super, &pack_req);
+   req->fp_arr = pack_req.fingerprint_arr;
    if (spl->cfg.use_stats) {
       pack_start = platform_get_timestamp();
    }
-   // FIXME: [yfogel 2020-07-06] is there a refcount inside here?
-   //    need to be carefull to make sure we have refcounts right
-   //    need to maybe kill one tree here if it's fully empty
-   //    and then make sure refcount is on the remaining one's
-   //    address
-   branch_pack(spl->heap_id, &pack_req);
+   btree_pack(&pack_req);
    if (spl->cfg.use_stats) {
       spl->stats[tid].compaction_pack_time_ns[height]
          += platform_timestamp_elapsed(pack_start);
    }
-   btree_pack_req *point_req = &pack_req.point_req;
-   btree_pack_req *range_req = &pack_req.range_req;
-   //platform_assert(point_req->num_tuples <= spl->cfg.max_tuples_per_node);
-   //platform_assert(range_req->num_tuples <= spl->cfg.max_tuples_per_node);
 
    splinter_branch new_branch;
-   new_branch.root_addr = point_req->root_addr;
-   // FIXME: [yfogel 2020-07-01] will need to initialize range root addr
-   //    ~here
-   new_branch.range_root_addr = range_req->root_addr;
+   new_branch.root_addr = pack_req.root_addr;
 
-   req->fp_arr = point_req->fingerprint_arr;
+   req->fp_arr = pack_req.fingerprint_arr;
 
-   splinter_log_stream("output: %lu\n", point_req->root_addr);
+   splinter_log_stream("output: %lu\n", req->root_addr);
    if (spl->cfg.use_stats) {
-      // FIXME: [aconway 2020-09-12] Need to check range as well at some point
-      if (point_req->num_tuples == 0) {
+      if (pack_req.num_tuples == 0) {
          spl->stats[tid].compactions_empty[height]++;
       }
-      spl->stats[tid].compaction_tuples[height] += point_req->num_tuples;
-      if (point_req->num_tuples > spl->stats[tid].compaction_max_tuples[height]) {
-         spl->stats[tid].compaction_max_tuples[height] = point_req->num_tuples;
+      spl->stats[tid].compaction_tuples[height] += pack_req.num_tuples;
+      if (pack_req.num_tuples > spl->stats[tid].compaction_max_tuples[height]) {
+         spl->stats[tid].compaction_max_tuples[height] = pack_req.num_tuples;
       }
    }
 
-   splinter_log_stream("output point: %lu\n", point_req->root_addr);
-   splinter_log_stream("output range: %lu\n", range_req->root_addr);
-   // FIXME: [aconway 2020-09-14] Can't deinit here, because build_filter will
-   // use the fp_arr
-   //splinter_branch_pack_req_deinit(spl, &pack_req);
+   splinter_log_stream("output point: %lu\n", pack_req.root_addr);
 
    /*
     * 10. Clean up
     */
    rc = merge_iterator_destroy(spl->heap_id, &merge_itor);
    platform_assert_status_ok(rc);
-   // FIXME: [nsarmicanic 2020-07-02] num_itors
-   for (uint64 i = 0; i < num_trees; i++) {
+   for (uint64 i = 0; i < num_branches; i++) {
       splinter_btree_skiperator_deinit(spl, &skip_itor_arr[i]);
    }
 
@@ -4821,7 +4731,7 @@ splinter_compact_bundle(void *arg,
       }
 
       if (splinter_bundle_live(spl, node, req->bundle_no)) {
-         if (point_req->num_tuples != 0) {
+         if (pack_req.num_tuples != 0) {
             splinter_replace_bundle_branches(spl, node, &new_branch, req);
             num_replacements++;
             splinter_log_stream("inserted %lu into %lu\n",
@@ -4847,9 +4757,8 @@ splinter_compact_bundle(void *arg,
       splinter_log_node(spl, node);
       debug_assert(splinter_verify_node(spl, node));
 
-      if (1 && num_replacements != 0
-            && point_req->num_tuples != 0
-            && start_generation == generation) {
+      if (num_replacements != 0 && pack_req.num_tuples != 0 &&
+          start_generation == generation) {
          const char *max_key = splinter_max_key(spl, node);
          splinter_zap_branch_range(spl, &new_branch, max_key, NULL,
                PAGE_TYPE_BRANCH);
@@ -5215,8 +5124,6 @@ splinter_split_leaf(splinter_handle *spl,
            splinter_key_size(spl));
 
    if (target_num_leaves != 1) {
-      // FIXME: [yfogel 2020-07-22] This entire function needs to support
-      //    range_delete trees and does not yet.
       /*
        * 1. Create a rough merge iterator on all the branches
        *
@@ -5234,38 +5141,43 @@ splinter_split_leaf(splinter_handle *spl,
        */
 
       platform_assert(num_branches <= ARRAY_SIZE(scratch->btree_itor));
-      btree_iterator  *rough_btree_itor = scratch->btree_itor;
-      iterator       **rough_itor = scratch->rough_itor;
+      btree_iterator *rough_btree_itor = scratch->btree_itor;
+      iterator **     rough_itor       = scratch->rough_itor;
       char            min_key[MAX_KEY_SIZE];
       char            max_key[MAX_KEY_SIZE];
-      memmove(min_key, splinter_get_pivot(spl, leaf, 0), splinter_key_size(spl));
-      memmove(max_key, splinter_get_pivot(spl, leaf, 1), splinter_key_size(spl));
+      memmove(
+         min_key, splinter_get_pivot(spl, leaf, 0), splinter_key_size(spl));
+      memmove(
+         max_key, splinter_get_pivot(spl, leaf, 1), splinter_key_size(spl));
 
-      for (uint64 branch_offset = 0;
-           branch_offset < num_branches;
+      for (uint64 branch_offset = 0; branch_offset < num_branches;
            branch_offset++) {
          uint64 branch_no =
             splinter_branch_no_add(spl, start_branch, branch_offset);
          debug_assert(branch_no != splinter_end_branch(spl, leaf));
          splinter_branch *branch = splinter_get_branch(spl, leaf, branch_no);
-         // FIXME: [yfogel 2020-07-22] need to also do the range_delete tree here
-         //        pivots are already saved (see above)
-         //        may need to increase size of scratch to 2x so room
-         //        for range delete trees
-         btree_iterator_init(
-               spl->cc, &spl->cfg.btree_cfg,
-               &rough_btree_itor[branch_offset], branch->root_addr,
-               PAGE_TYPE_BRANCH, min_key, max_key, TRUE, FALSE, 1,
-               data_type_point);
+         btree_iterator_init(spl->cc,
+                             &spl->cfg.btree_cfg,
+                             &rough_btree_itor[branch_offset],
+                             branch->root_addr,
+                             PAGE_TYPE_BRANCH,
+                             min_key,
+                             max_key,
+                             TRUE,
+                             FALSE,
+                             1);
          rough_itor[branch_offset] = &rough_btree_itor[branch_offset].super;
       }
 
       merge_iterator *rough_merge_itor;
-      platform_status rc =
-         merge_iterator_create(spl->heap_id, spl->cfg.data_cfg,
-                               &spl->cfg.range_data_cfg, num_branches,
-                               rough_itor, FALSE, FALSE, FALSE,
-                               &rough_merge_itor);
+      platform_status rc = merge_iterator_create(spl->heap_id,
+                                                 spl->cfg.data_cfg,
+                                                 num_branches,
+                                                 rough_itor,
+                                                 FALSE,
+                                                 FALSE,
+                                                 FALSE,
+                                                 &rough_merge_itor);
       platform_assert_status_ok(rc);
 
       /*
@@ -5288,9 +5200,7 @@ splinter_split_leaf(splinter_handle *spl,
 
          if (!at_end) {
             char *curr_key, *dummy_data;
-            data_type dummy_type;
-            iterator_get_curr(&rough_merge_itor->super, &curr_key,
-                              &dummy_data, &dummy_type);
+            iterator_get_curr(&rough_merge_itor->super, &curr_key, &dummy_data);
             // copy new pivot (in parent) of new leaf
             memmove(scratch->pivot[num_leaves + 1],
                     curr_key,
@@ -5302,9 +5212,6 @@ splinter_split_leaf(splinter_handle *spl,
       rc = merge_iterator_destroy(spl->heap_id, &rough_merge_itor);
       platform_assert_status_ok(rc);
       for (uint64 i = 0; i < num_branches; i++) {
-         // FIXME: [yfogel 2020-07-22] may need to modify for range_delete trees.
-         // FIXME: [yfogel 2020-07-22] need to change initialization of this branch
-         //    cause need both point and range initialized
          btree_iterator_deinit(&rough_btree_itor[i]);
       }
    } else {
@@ -5542,7 +5449,8 @@ splinter_split_root(splinter_handle *spl,
  *-----------------------------------------------------------------------------
  */
 
-void             splinter_range_iterator_get_curr (iterator *itor, char **key, char **data, data_type *type);
+void
+                 splinter_range_iterator_get_curr(iterator *itor, char **key, char **data);
 platform_status  splinter_range_iterator_at_end   (iterator *itor, bool *at_end);
 platform_status  splinter_range_iterator_advance  (iterator *itor);
 void             splinter_range_iterator_deinit   (splinter_range_iterator *range_itor);
@@ -5621,8 +5529,6 @@ splinter_range_iterator_init(splinter_handle         *spl,
       }
 
       range_itor->branch[range_itor->num_branches].root_addr = root_addr;
-      // FIXME: [yfogel 2020-07-06] need to init range root addr
-      range_itor->branch[range_itor->num_branches].range_root_addr = 0;
 
       range_itor->num_branches++;
    }
@@ -5697,9 +5603,13 @@ splinter_range_iterator_init(splinter_handle         *spl,
       if (range_itor->compacted[branch_no]) {
          bool do_prefetch = range_itor->compacted[branch_no] &&
             num_tuples > SPLINTER_PREFETCH_MIN ? TRUE : FALSE;
-         splinter_branch_iterator_init(spl, btree_itor, branch,
-               range_itor->min_key, range_itor->local_max_key, do_prefetch,
-               data_type_point, FALSE);
+         splinter_branch_iterator_init(spl,
+                                       btree_itor,
+                                       branch,
+                                       range_itor->min_key,
+                                       range_itor->local_max_key,
+                                       do_prefetch,
+                                       FALSE);
       } else {
          uint64 mt_root_addr = branch->root_addr;
          bool is_live = branch_no == 0;
@@ -5711,10 +5621,12 @@ splinter_range_iterator_init(splinter_handle         *spl,
 
    platform_status rc = merge_iterator_create(spl->heap_id,
                                               spl->cfg.data_cfg,
-                                              &spl->cfg.range_data_cfg,
                                               range_itor->num_branches,
-                                              range_itor->itor, TRUE, TRUE,
-                                              TRUE, &range_itor->merge_itor);
+                                              range_itor->itor,
+                                              TRUE,
+                                              TRUE,
+                                              TRUE,
+                                              &range_itor->merge_itor);
    if (!SUCCESS(rc)) {
       return rc;
    }
@@ -5748,14 +5660,11 @@ splinter_range_iterator_init(splinter_handle         *spl,
 }
 
 void
-splinter_range_iterator_get_curr(iterator   *itor,
-                                 char      **key,
-                                 char      **data,
-                                 data_type  *type)
+splinter_range_iterator_get_curr(iterator *itor, char **key, char **data)
 {
    debug_assert(itor != NULL);
    splinter_range_iterator *range_itor = (splinter_range_iterator *)itor;
-   iterator_get_curr(&range_itor->merge_itor->super, key, data, type);
+   iterator_get_curr(&range_itor->merge_itor->super, key, data);
 }
 
 platform_status
@@ -6852,13 +6761,12 @@ splinter_range(splinter_handle *spl,
       goto destroy_range_itor;
    }
 
-   data_type type;
    bool at_end;
    iterator_at_end(&range_itor->super, &at_end);
 
    for (*tuples_returned = 0; *tuples_returned < num_tuples && !at_end; (*tuples_returned)++) {
       char *key, *data;
-      iterator_get_curr(&range_itor->super, &key, &data, &type);
+      iterator_get_curr(&range_itor->super, &key, &data);
       char *next_key = out + *tuples_returned * (splinter_key_size(spl) + splinter_message_size(spl));
       char *next_data = next_key + splinter_key_size(spl);
       memmove(next_key, key, splinter_key_size(spl));
@@ -7620,12 +7528,14 @@ splinter_print_locked_node(splinter_handle        *spl,
                pdata->srq_idx, pdata->generation);
       }
    }
+   // clang-format off
    platform_log_stream("|-------------------------------------------------------------------------------------|\n");
    platform_log_stream("|                              BRANCHES AND [SUB]BUNDLES                              |\n");
    platform_log_stream("|-------------------------------------------------------------------------------------|\n");
-   platform_log_stream("|   # |  point addr  |  range addr  | filter1 addr | filter2 addr | filter3 addr |    |\n");
+   platform_log_stream("|   # |          point addr         | filter1 addr | filter2 addr | filter3 addr |    |\n");
    platform_log_stream("|     |    pivot/bundle/subbundle   |  num tuples  |              |              |    |\n");
    platform_log_stream("|-----|--------------|--------------|--------------|--------------|--------------|----|\n");
+   // clang-format on
    uint16 start_branch = splinter_start_branch(spl, node);
    uint16 end_branch = splinter_end_branch(spl, node);
    uint16 start_bundle = splinter_start_bundle(spl, node);
@@ -7641,7 +7551,10 @@ splinter_print_locked_node(splinter_handle        *spl,
            pivot_no++)
       {
          if (branch_no == splinter_pivot_start_branch(spl, node, pivot_no)) {
-            platform_log_stream("|     |        -- pivot %2u --       |              |              |              |    |\n", pivot_no);
+            // clang-format off
+            platform_log_stream("|     |        -- pivot %2u --       |              |              |              |    |\n",
+                                pivot_no);
+            // clang-format on
          }
       }
       for (uint16 bundle_no = start_bundle;
@@ -7671,7 +7584,11 @@ splinter_print_locked_node(splinter_handle        *spl,
       }
 
       splinter_branch *branch = splinter_get_branch(spl, node, branch_no);
-      platform_log_stream("| %3u | %12lu | %12lu |              |              |              |    |\n", branch_no, branch->root_addr, branch->range_root_addr);
+      // clang-format off
+      platform_log_stream("| %3u |         %12lu       |              |              |              |    |\n",
+                          branch_no,
+                          branch->root_addr);
+      // clang-format on
    }
    platform_log_stream("---------------------------------------------------------------------------------------\n");
    platform_log_stream("\n");
@@ -8386,37 +8303,7 @@ splinter_config_init(splinter_config *splinter_cfg,
    routing_config *leaf_filter_cfg = &splinter_cfg->leaf_filter_cfg;
 
    ZERO_CONTENTS(splinter_cfg);
-   // FIXME: [yfogel 2020-07-01] need to change splinter_cfg->data_cfg to a
-   //       struct from pointer (parameter to func here is still pointer)
    splinter_cfg->data_cfg = data_cfg;
-
-   // Calculate range data config from point data config.
-   // FIXME: [yfogel 2020-07-01] will we want this as a function (for tests?)
-   {
-      splinter_cfg->range_data_cfg = (data_config) {
-         .key_size = data_cfg->key_size,
-         .message_size = data_cfg->key_size, // data IS a key
-         // C Does not allow us to copy arrays; use a memmove outside
-         //.min_key = data_cfg->min_key,
-         //.max_key = data_cfg->max_key,
-         .key_compare = data_cfg->key_compare,
-         .key_to_string = data_cfg->key_to_string,
-         .message_to_string = data_cfg->key_to_string, // data IS a key
-         // FIXME: [yfogel 2020-07-01] These NULLs should be replaced by
-         //     stub implementations that immediate panic.
-         //     That will be easier to debug/understand it's intentional
-         //     and describing a massive bug rather than a crash you have
-         //     to reverse engineer
-         .merge_tuples = NULL,
-         .merge_tuples_final = NULL,
-         .message_class = NULL,
-         .clobber_message_with_range_delete = NULL,
-      };
-      memmove(splinter_cfg->range_data_cfg.min_key,
-              data_cfg->min_key, sizeof(data_cfg->min_key));
-      memmove(splinter_cfg->range_data_cfg.max_key,
-              data_cfg->max_key, sizeof(data_cfg->max_key));
-   }
 
    splinter_cfg->log_cfg = log_cfg;
 
@@ -8439,15 +8326,6 @@ splinter_config_init(splinter_config *splinter_cfg,
    // Initialize point message btree
    btree_config_init(&splinter_cfg->btree_cfg,
                      splinter_cfg->data_cfg,
-                     data_type_point,
-                     btree_rough_count_height,
-                     splinter_cfg->page_size, splinter_cfg->extent_size);
-   // Initialize range delete btree
-   // FIXME: [yfogel 2020-07-01] replace NULL with panic-immediately
-   //        hash function
-   btree_config_init(&splinter_cfg->range_btree_cfg,
-                     &splinter_cfg->range_data_cfg,
-                     data_type_range,
                      btree_rough_count_height,
                      splinter_cfg->page_size, splinter_cfg->extent_size);
 
@@ -8459,8 +8337,6 @@ splinter_config_init(splinter_config *splinter_cfg,
          SPLINTER_NUM_MEMTABLES, memtable_capacity);
 
    // Has to be set after btree_config_init is called
-   // FIXME: [yfogel 2020-07-01] re-evaluate if this calc needs to take
-   //        into account the range delete tree? (2x? 1x? what?)
    splinter_cfg->max_tuples_per_node
       = splinter_cfg->fanout * splinter_cfg->mt_cfg.max_tuples_per_memtable;
    splinter_cfg->target_leaf_tuples = splinter_cfg->max_tuples_per_node / 2;

--- a/tests/btree_test.c
+++ b/tests/btree_test.c
@@ -614,9 +614,16 @@ test_btree_basic(cache             *cc,
    uint64 root_addr = memtable_root_addr(mt);
    btree_iterator itor;
    start_time = platform_get_timestamp();
-   btree_iterator_init(cc, btree_cfg, &itor, root_addr, PAGE_TYPE_MEMTABLE,
-                       btree_min_key(btree_cfg), NULL, FALSE, FALSE, 0,
-                       data_type_point);
+   btree_iterator_init(cc,
+                       btree_cfg,
+                       &itor,
+                       root_addr,
+                       PAGE_TYPE_MEMTABLE,
+                       btree_min_key(btree_cfg),
+                       NULL,
+                       FALSE,
+                       FALSE,
+                       0);
    platform_log("btree iterator init time %luns\n", platform_timestamp_elapsed(start_time));
    btree_pack_req req;
    memset(&req, 0, sizeof(req));
@@ -744,9 +751,16 @@ test_btree_create_packed_trees(cache             *cc,
    for (uint64 tree_no = 0; tree_no < num_trees; tree_no++) {
       memtable *mt = &ctxt->mt_ctxt->mt[tree_no];
       btree_iterator itor;
-      btree_iterator_init(cc, btree_cfg, &itor, memtable_root_addr(mt),
-                          PAGE_TYPE_MEMTABLE, btree_min_key(btree_cfg), NULL,
-                          FALSE, FALSE, 0, data_type_point);
+      btree_iterator_init(cc,
+                          btree_cfg,
+                          &itor,
+                          memtable_root_addr(mt),
+                          PAGE_TYPE_MEMTABLE,
+                          btree_min_key(btree_cfg),
+                          NULL,
+                          FALSE,
+                          FALSE,
+                          0);
 
       btree_pack_req req;
       btree_pack_req_init(&req, cc, btree_cfg, &itor.super, 0, NULL, 0, hid);
@@ -820,16 +834,29 @@ test_btree_merge_basic(cache             *cc,
    for (uint64 pivot_no = 0; pivot_no < arity; pivot_no++) {
       char *max_key = pivot_no == arity - 1 ? NULL : pivot_key[pivot_no + 1].k;
       for (uint64 tree_no = 0; tree_no < arity; tree_no++) {
-         btree_iterator_init(cc, btree_cfg, &btree_itor_arr[tree_no],
-               root_addr[tree_no], PAGE_TYPE_BRANCH, pivot_key[pivot_no].k,
-               max_key, TRUE, FALSE, 0, data_type_point);
+         btree_iterator_init(cc,
+                             btree_cfg,
+                             &btree_itor_arr[tree_no],
+                             root_addr[tree_no],
+                             PAGE_TYPE_BRANCH,
+                             pivot_key[pivot_no].k,
+                             max_key,
+                             TRUE,
+                             FALSE,
+                             0);
          itor_arr[tree_no] = &btree_itor_arr[tree_no].super;
       }
       merge_iterator *merge_itor;
       // FIXME: [yfogel 2020-07-01] really not a good idea to pass in
       //        NULL for the range data config
-      rc = merge_iterator_create(hid, btree_cfg->data_cfg, NULL, arity,
-            itor_arr, TRUE, TRUE, TRUE, &merge_itor);
+      rc = merge_iterator_create(hid,
+                                 btree_cfg->data_cfg,
+                                 arity,
+                                 itor_arr,
+                                 TRUE,
+                                 TRUE,
+                                 TRUE,
+                                 &merge_itor);
       if (!SUCCESS(rc)) {
          goto destroy_btrees;
       }
@@ -983,16 +1010,29 @@ test_btree_rough_iterator(cache             *cc,
    platform_assert(rough_itor);
 
    for (uint64 tree_no = 0; tree_no < num_trees; tree_no++) {
-      btree_iterator_init(cc, btree_cfg, &rough_btree_itor[tree_no],
-            root_addr[tree_no], PAGE_TYPE_BRANCH, min_key, max_key, TRUE,
-            FALSE, 1, data_type_point);
+      btree_iterator_init(cc,
+                          btree_cfg,
+                          &rough_btree_itor[tree_no],
+                          root_addr[tree_no],
+                          PAGE_TYPE_BRANCH,
+                          min_key,
+                          max_key,
+                          TRUE,
+                          FALSE,
+                          1);
       rough_itor[tree_no] = &rough_btree_itor[tree_no].super;
    }
 
    merge_iterator *rough_merge_itor;
    //FIXME: [yfogel 2020-07-01] replace NULL
-   rc = merge_iterator_create(hid, btree_cfg->data_cfg, NULL, num_trees,
-                              rough_itor, TRUE, TRUE, FALSE, &rough_merge_itor);
+   rc = merge_iterator_create(hid,
+                              btree_cfg->data_cfg,
+                              num_trees,
+                              rough_itor,
+                              TRUE,
+                              TRUE,
+                              FALSE,
+                              &rough_merge_itor);
    platform_assert_status_ok(rc);
    //uint64 target_num_pivots =
    //   cfg->mt_cfg->max_tuples_per_memtable / btree_cfg->tuples_per_leaf;
@@ -1004,9 +1044,7 @@ test_btree_rough_iterator(cache             *cc,
    for (pivot_no = 0; !at_end; pivot_no++) {
       //uint64 rough_count_pivots = 0;
       char *curr_key, *dummy_data;
-      data_type PAGE_TYPE_BRANCH;
-      iterator_get_curr(&rough_merge_itor->super, &curr_key, &dummy_data,
-                        &PAGE_TYPE_BRANCH);
+      iterator_get_curr(&rough_merge_itor->super, &curr_key, &dummy_data);
       memmove(pivot[pivot_no].k, curr_key, btree_key_size(btree_cfg));
       at_end = TRUE;
       //char key_str[128];
@@ -1110,16 +1148,28 @@ test_btree_merge_perf(cache             *cc,
             pivot_no == arity - 1 ? NULL : pivot_key[pivot_no + 1].k;
          for (uint64 tree_no = 0; tree_no < arity; tree_no++) {
             uint64 global_tree_no = merge_no * num_merges + tree_no;
-            btree_iterator_init(cc, btree_cfg, &btree_itor_arr[tree_no],
-                  root_addr[global_tree_no], PAGE_TYPE_BRANCH,
-                  pivot_key[pivot_no].k, max_key, TRUE, FALSE, 0,
-                  data_type_point);
+            btree_iterator_init(cc,
+                                btree_cfg,
+                                &btree_itor_arr[tree_no],
+                                root_addr[global_tree_no],
+                                PAGE_TYPE_BRANCH,
+                                pivot_key[pivot_no].k,
+                                max_key,
+                                TRUE,
+                                FALSE,
+                                0);
             itor_arr[tree_no] = &btree_itor_arr[tree_no].super;
          }
          merge_iterator *merge_itor;
          // FIXME: [yfogel 2020-07-01] replaceNULL
-         rc = merge_iterator_create(hid, btree_cfg->data_cfg, NULL, arity,
-               itor_arr, TRUE, TRUE, TRUE, &merge_itor);
+         rc = merge_iterator_create(hid,
+                                    btree_cfg->data_cfg,
+                                    arity,
+                                    itor_arr,
+                                    TRUE,
+                                    TRUE,
+                                    TRUE,
+                                    &merge_itor);
          if (!SUCCESS(rc)) {
             goto destroy_btrees;
          }

--- a/tests/log_test.c
+++ b/tests/log_test.c
@@ -74,8 +74,7 @@ test_log_basic(cache            *cc,
    for (i = 0; i < num_entries && !at_end; i++) {
       test_key(key, TEST_RANDOM, i, 0, 0, cfg->data_cfg->key_size, 0);
       test_insert_data(data, 1, &dummy, 0, cfg->data_cfg->message_size, MESSAGE_TYPE_INSERT);
-      data_type type;
-      iterator_get_curr(itorh, &returned_key, &returned_data, &type);
+      iterator_get_curr(itorh, &returned_key, &returned_data);
       if (data_key_compare(cfg->data_cfg, key, returned_key) != 0
             || memcmp(data, returned_data, cfg->data_cfg->message_size) != 0) {
          platform_log("log_test_basic: key or data mismatch\n");
@@ -154,11 +153,10 @@ test_log_crash(clockcache           *cc,
    itorh = (iterator *)&itor;
 
    iterator_at_end(itorh, &at_end);
-   data_type type;
    for (i = 0; i < num_entries && !at_end; i++) {
       test_key(key, TEST_RANDOM, i, 0, 0, cfg->data_cfg->key_size, 0);
       test_insert_data(data, 1, &dummy, 0, cfg->data_cfg->message_size, MESSAGE_TYPE_INSERT);
-      iterator_get_curr(itorh, &returned_key, &returned_data, &type);
+      iterator_get_curr(itorh, &returned_key, &returned_data);
       if (data_key_compare(cfg->data_cfg, key, returned_key) != 0
             || memcmp(data, returned_data, cfg->data_cfg->message_size) != 0) {
          platform_log("log_test_basic: key or data mismatch\n");

--- a/tests/test.h
+++ b/tests/test.h
@@ -176,15 +176,14 @@ test_count_tuples_in_range(cache        *cc,
          btree_print_tree(cc, cfg, root_addr[i]);
          platform_assert(0);
       }
-      btree_iterator_init(cc, cfg, &itor, root_addr[i], type, low_key,
-                          high_key, TRUE, FALSE, 0, data_type_point);
+      btree_iterator_init(
+         cc, cfg, &itor, root_addr[i], type, low_key, high_key, TRUE, FALSE, 0);
       bool at_end;
       iterator_at_end(&itor.super, &at_end);
       while (!at_end) {
          char *key = NULL, *data, *last_key = NULL;
-         data_type type;
          last_key = key;
-         iterator_get_curr(&itor.super, &key, &data, &type);
+         iterator_get_curr(&itor.super, &key, &data);
          if (last_key != NULL && btree_key_compare(cfg, last_key, key) > 0) {
             char last_key_str[128], key_str[128];
             btree_key_to_string(cfg, last_key, last_key_str);
@@ -237,14 +236,13 @@ test_btree_print_all_keys(cache        *cc,
    uint64 i;
    for (i = 0; i < num_trees; i++) {
       platform_log("tree number %lu\n", i);
-      btree_iterator_init(cc, cfg, &itor, root_addr[i], type,
-            low_key, high_key, TRUE, FALSE, 0, data_type_point);
+      btree_iterator_init(
+         cc, cfg, &itor, root_addr[i], type, low_key, high_key, TRUE, FALSE, 0);
       bool at_end;
       iterator_at_end(&itor.super, &at_end);
       while (!at_end) {
          char *key = NULL, *data;
-         data_type type;
-         iterator_get_curr(&itor.super, &key, &data, &type);
+         iterator_get_curr(&itor.super, &key, &data);
          char key_str[128];
          btree_key_to_string(cfg, key, key_str);
          platform_log("%s\n", key_str);

--- a/tests/test_functionality.c
+++ b/tests/test_functionality.c
@@ -196,7 +196,6 @@ verify_range_against_shadow(splinter_handle            *spl,
       goto out;
    }
 
-   data_type type;
    for (i = start_index; i < end_index; i++) {
       uint64 shadow_key = sharr->keys[i];
       int8 shadow_refcount = sharr->ref_counts[i];
@@ -215,8 +214,8 @@ verify_range_against_shadow(splinter_handle            *spl,
       }
 
       iterator_get_curr((iterator *)range_itor,
-                        (char **)&splinter_keybuf, (char **)&splinter_data,
-                        &type);
+                        (char **)&splinter_keybuf,
+                        (char **)&splinter_data);
       splinter_key = be64toh(*splinter_keybuf);
 
       //platform_log("Range test %d: Shadow: 0x%08lx, Tree: 0x%08lx\n",
@@ -266,8 +265,8 @@ verify_range_against_shadow(splinter_handle            *spl,
           !at_end) {
       status = STATUS_LIMIT_EXCEEDED;
       iterator_get_curr((iterator *)range_itor,
-                        (char **)&splinter_keybuf, (char **)&splinter_data,
-                        &type);
+                        (char **)&splinter_keybuf,
+                        (char **)&splinter_data);
       splinter_key = be64toh(*splinter_keybuf);
 
       platform_log("Range iterator EXTRA KEY: %08lx \n"


### PR DESCRIPTION
Removes structs, functions and other code related to range delete. Range
delete was implemented by a different group and is not functional on
this fork. We do not plan to follow their implementation if we implement
it here.