### PR TITLE
Mini Allocator Cleanup

### DIFF
--- a/include/splinterdb/limits.h
+++ b/include/splinterdb/limits.h
@@ -13,5 +13,6 @@
 
 #define MAX_KEY_SIZE     24
 #define MAX_MESSAGE_SIZE 128
+#define MAX_KEY_STR_LEN  128
 
 #endif // __LIMITS_H__

--- a/src/allocator.h
+++ b/src/allocator.h
@@ -16,6 +16,9 @@
 typedef uint64 allocator_root_id;
 #define INVALID_ALLOCATOR_ROOT_ID (0)
 
+#define AL_NO_REFS 1
+#define AL_FREE    0
+
 typedef struct allocator allocator;
 
 typedef platform_status

--- a/src/btree.c
+++ b/src/btree.c
@@ -88,7 +88,7 @@ btree_alloc(cache *         cc,
             page_type       type,
             btree_node *    node)
 {
-   node->addr = mini_allocator_alloc(mini, height, key, next_extent);
+   node->addr = mini_alloc(mini, height, key, next_extent);
    debug_assert(node->addr != 0);
    node->page = cache_alloc(cc, node->addr, type);
    node->hdr  = (btree_hdr *)(node->page->data);
@@ -1028,65 +1028,22 @@ btree_init(cache          *cc,
    cache_unget(cc, root_page);
 
    // set up the mini allocator
-   mini_allocator_init(mini, cc, cfg->data_cfg, root.addr + cfg->page_size, 0,
-         BTREE_MAX_HEIGHT, type);
+   uint64 meta_head = root.addr + cfg->page_size;
+   if (is_packed) {
+      // use keyed mini allocator for branches
+      mini_init(
+         mini, cc, cfg->data_cfg, meta_head, 0, BTREE_MAX_HEIGHT, type, TRUE);
+   } else {
+      // use unkeyed mini allocator for memtables
+      mini_init(mini, cc, NULL, meta_head, 0, BTREE_MAX_HEIGHT, type, FALSE);
+   }
 
    return root.addr;
 }
 
-/*
- * By separating should_zap and zap, this allows us to use a single
- * refcount to control multiple b-trees.  For example a branch
- * in splinter that has a point tree and range-delete tree
- */
-bool
-btree_should_zap_dec_ref(cache        *cc,
-                         btree_config *cfg,
-                         uint64        root_addr,
-                         page_type     type)
-{
-   // FIXME: [yfogel 2020-07-06] Should we assert that both cfgs provide
-   //       work the same w.r.t. root_to_meta_addr?
-   //       Right now we're always passing in the point config
-   uint64       meta_page_addr = btree_root_to_meta_addr(cc, cfg, root_addr, 0);
-   page_handle *meta_page;
-   uint64       wait = 1;
-
-   debug_assert(type == PAGE_TYPE_MEMTABLE || type == PAGE_TYPE_BRANCH);
-   while (1) {
-      meta_page = cache_get(cc, meta_page_addr, TRUE, type);
-      if (cache_claim(cc, meta_page))
-         break;
-      cache_unget(cc, meta_page);
-      platform_sleep(wait);
-      wait *= 2;
-   }
-   cache_lock(cc, meta_page);
-
-   // ALEX: We don't hold the root lock, but we only dealloc from here
-   // so there shouldn't be a race between this refcount check and the
-   // dealloc
-   uint64 ref = cache_get_ref(cc, root_addr);
-   //if (ref != 2)
-   //   platform_log("dec_ref %lu; %u\n", root_addr, ref - 1);
-   //else
-   //   platform_log("dec_ref %lu; %u\n", root_addr, 0);
-
-   bool should_zap;
-   if (ref > 2) {
-      cache_dealloc(cc, root_addr, type);
-      should_zap = FALSE;
-   } else {
-      // we are responsible for zapping the whole tree
-      // If we're talking about a branch we should zap the whole branch
-      should_zap = TRUE;
-   }
-   cache_unlock(cc, meta_page);
-   cache_unclaim(cc, meta_page);
-   cache_unget(cc, meta_page);
-   return should_zap;
-}
-
+// FIXME: [aconway 2021-08-21]
+// Functions like this probably should have branch_ prefixes to indicate they
+// are only for branches and not memtables.
 void
 btree_inc_range(cache        *cc,
                 btree_config *cfg,
@@ -1094,14 +1051,17 @@ btree_inc_range(cache        *cc,
                 const char   *start_key,
                 const char   *end_key)
 {
-   uint64 meta_page_addr = btree_root_to_meta_addr(cc, cfg, root_addr, 0);
+   uint64 meta_head = btree_root_to_meta_addr(cc, cfg, root_addr, 0);
    if (start_key != NULL && end_key != NULL) {
       debug_assert(btree_key_compare(cfg, start_key, end_key) < 0);
    }
-   mini_allocator_inc_range(cc, cfg->data_cfg, PAGE_TYPE_BRANCH,
-         meta_page_addr, start_key, end_key);
+   mini_keyed_inc_ref(
+      cc, cfg->data_cfg, PAGE_TYPE_BRANCH, meta_head, start_key, end_key);
 }
 
+// FIXME: [aconway 2021-08-21]
+// branch only function
+// should return void
 bool
 btree_zap_range(cache        *cc,
                 btree_config *cfg,
@@ -1110,25 +1070,27 @@ btree_zap_range(cache        *cc,
                 const char   *end_key,
                 page_type     type)
 {
-   debug_assert(type == PAGE_TYPE_BRANCH || type == PAGE_TYPE_MEMTABLE);
-   debug_assert(type == PAGE_TYPE_BRANCH || start_key == NULL);
+   debug_assert(type == PAGE_TYPE_BRANCH);
 
    if (start_key != NULL && end_key != NULL) {
       platform_assert(btree_key_compare(cfg, start_key, end_key) < 0);
    }
 
-   uint64 meta_page_addr = btree_root_to_meta_addr(cc, cfg, root_addr, 0);
-   bool fully_zapped = mini_allocator_zap(cc, cfg->data_cfg, meta_page_addr,
-         start_key, end_key, type);
-   return fully_zapped;
+   uint64 meta_head = btree_root_to_meta_addr(cc, cfg, root_addr, 0);
+   mini_keyed_dec_ref(
+      cc, cfg->data_cfg, PAGE_TYPE_BRANCH, meta_head, start_key, end_key);
+   return TRUE;
 }
 
-bool btree_zap(cache        *cc,
-               btree_config *cfg,
-               uint64        root_addr,
-               page_type     type)
+// FIXME: [aconway 2021-08-21]
+// memtable function only
+bool
+btree_zap(cache *cc, btree_config *cfg, uint64 root_addr, page_type type)
 {
-   return btree_zap_range(cc, cfg, root_addr, NULL, NULL, type);
+   platform_assert(type == PAGE_TYPE_MEMTABLE);
+   uint64 meta_head = btree_root_to_meta_addr(cc, cfg, root_addr, 0);
+   uint8  ref       = mini_unkeyed_dec_ref(cc, meta_head, type);
+   return ref == 0;
 }
 
 page_handle *
@@ -1137,9 +1099,13 @@ btree_blind_inc(cache        *cc,
                 uint64        root_addr,
                 page_type     type)
 {
-   //platform_log("(%2lu)blind inc %14lu\n", platform_get_tid(), root_addr);
-   uint64 meta_page_addr = btree_root_to_meta_addr(cc, cfg, root_addr, 0);
-   return mini_allocator_blind_inc(cc, meta_page_addr);
+   // FIXME: [aconway 2021-08-21]
+   // This is broken in this commit, fixing later.
+   //
+   // platform_log("(%2lu)blind inc %14lu\n", platform_get_tid(), root_addr);
+   // uint64 meta_page_addr = btree_root_to_meta_addr(cc, cfg, root_addr, 0);
+   // return mini_allocator_blind_inc(cc, meta_page_addr);
+   return NULL;
 }
 
 void
@@ -1148,8 +1114,11 @@ btree_blind_zap(cache        *cc,
                 page_handle  *meta_page,
                 page_type     type)
 {
-   //platform_log("(%2lu)blind zap %14lu\n", platform_get_tid(), root_addr);
-   mini_allocator_blind_zap(cc, type, meta_page);
+   // FIXME: [aconway 2021-08-21]
+   // This is broken in this commit, fixing later.
+   //
+   // platform_log("(%2lu)blind zap %14lu\n", platform_get_tid(), root_addr);
+   // mini_allocator_blind_zap(cc, type, meta_page);
 }
 
 
@@ -2387,11 +2356,12 @@ btree_pack_post_loop(btree_pack_internal *tree)
 
    char last_key[MAX_KEY_SIZE];
    memmove(last_key, tree->cfg->data_cfg->max_key, MAX_KEY_SIZE);
-   mini_allocator_release(&tree->mini, last_key);
+   mini_release(&tree->mini, last_key);
 
    // if output tree is empty, zap the tree
    if (*(tree->num_tuples) == 0) {
-      btree_zap(tree->cc, tree->cfg, *(tree->root_addr), PAGE_TYPE_BRANCH);
+      btree_zap_range(
+         tree->cc, tree->cfg, *(tree->root_addr), NULL, NULL, PAGE_TYPE_BRANCH);
       *(tree->root_addr) = 0;
    }
 }
@@ -2652,9 +2622,10 @@ btree_space_use_in_range(cache        *cc,
                          const char   *start_key,
                          const char   *end_key)
 {
+   platform_assert(type == PAGE_TYPE_BRANCH);
    uint64 meta_head = btree_root_to_meta_addr(cc, cfg, root_addr, 0);
-   uint64 extents_used = mini_allocator_count_extents_in_range(cc,
-         cfg->data_cfg, type, meta_head, start_key, end_key);
+   uint64 extents_used = mini_keyed_extent_count(
+      cc, cfg->data_cfg, PAGE_TYPE_BRANCH, meta_head, start_key, end_key);
    return extents_used * cfg->extent_size;
 }
 
@@ -2829,15 +2800,6 @@ btree_print_lookup(cache *cc,            // IN
    uint16 idx = btree_find_tuple(cfg, &node, key, greater_than_or_equal);
    platform_log("Matching index: %u of %u\n", idx, node.hdr->num_entries);
    btree_node_unget(cc, cfg, &node);
-}
-
-uint64
-btree_extent_count(cache        *cc,
-                   btree_config *cfg,
-                   uint64        root_addr)
-{
-   uint64 meta_head = btree_root_to_meta_addr(cc, cfg, root_addr, 0);
-   return mini_allocator_extent_count(cc, PAGE_TYPE_BRANCH, meta_head);
 }
 
 /*

--- a/src/btree.h
+++ b/src/btree.h
@@ -240,12 +240,6 @@ btree_zap(cache        *cc,
           uint64        root_addr,
           page_type     type);
 
-bool
-btree_should_zap_dec_ref(cache        *cc,
-                         btree_config *cfg,
-                         uint64        root_addr,
-                         page_type     type);
-
 void
 btree_inc_range(cache        *cc,
                 btree_config *cfg,
@@ -369,11 +363,6 @@ btree_verify_tree(cache *cc,
                   btree_config *cfg,
                   uint64 addr,
                   page_type type);
-
-uint64
-btree_extent_count(cache        *cc,
-                   btree_config *cfg,
-                   uint64        root_addr);
 
 uint64
 btree_space_use_in_range(cache        *cc,

--- a/src/mini_allocator.c
+++ b/src/mini_allocator.c
@@ -10,518 +10,952 @@
 
 #include "platform.h"
 
-#include "util.h"
-#include "mini_allocator.h"
 #include "allocator.h"
 #include "cache.h"
 #include "splinterdb/data.h"
+#include "mini_allocator.h"
+#include "util.h"
 
 #include "poison.h"
 
+// MINI_WAIT is a lock token used to lock a batch
 #define MINI_WAIT 1
+// MINI_NO_REFS is the ref count of an unkeyed mini allocator with no external
+// refs
+#define MINI_NO_REFS 2
 
-typedef struct mini_allocator_meta_entry {
-   uint64 extent_addr;
-   bool   zapped;
-   char   start_key[MAX_KEY_SIZE];
-   char   end_key[MAX_KEY_SIZE];
-} mini_allocator_meta_entry;
+/*
+ *-----------------------------------------------------------------------------
+ *
+ * mini_meta_hdr --
+ *
+ *      The header of a meta_page in a mini_allocator. Keyed mini_allocators
+ *      use entry_buffer and unkeyed ones use entry.
+ *
+ *-----------------------------------------------------------------------------
+ */
 
-typedef struct mini_allocator_meta_hdr {
-   uint64                    next_meta_addr;
-   uint64                    pos;
-   mini_allocator_meta_entry entry[];
-} mini_allocator_meta_hdr;
+typedef struct mini_meta_hdr {
+   uint64 next_meta_addr;
+   uint64 pos;
+   char   entry_buffer[];
+} mini_meta_hdr;
+
+/*
+ *-----------------------------------------------------------------------------
+ *
+ * mini_init_meta_page --
+ *
+ *      Initializes the header of the given meta_page.
+ *
+ * Results:
+ *      None.
+ *
+ * Side effects:
+ *      None.
+ *
+ *-----------------------------------------------------------------------------
+ */
+
+void
+mini_init_meta_page(mini_allocator *mini, page_handle *meta_page)
+{
+   mini_meta_hdr *hdr  = (mini_meta_hdr *)meta_page->data;
+   hdr->pos            = 0;
+   hdr->next_meta_addr = 0;
+}
+
+/*
+ *-----------------------------------------------------------------------------
+ *
+ * mini_full_[lock,unlock]_meta_[page,tail] --
+ *
+ *      Convenience functions to write lock/unlock the given meta_page or
+ *      meta_tail.
+ *
+ * Results:
+ *      lock: the page_handle of the locked page
+ *      unlock: None.
+ *
+ * Side effects:
+ *      Disk allocation, standard cache side effects.
+ *
+ *-----------------------------------------------------------------------------
+ */
+
+page_handle *
+mini_full_lock_meta_page(mini_allocator *mini, uint64 meta_addr)
+{
+   page_handle *meta_page;
+   uint64       wait = 1;
+   while (1) {
+      meta_page = cache_get(mini->cc, meta_addr, TRUE, mini->type);
+      if (cache_claim(mini->cc, meta_page)) {
+         break;
+      }
+      cache_unget(mini->cc, meta_page);
+      platform_sleep(wait);
+      wait = wait > 1024 ? wait : 2 * wait;
+   }
+   cache_lock(mini->cc, meta_page);
+   return meta_page;
+}
+
+page_handle *
+mini_full_lock_meta_tail(mini_allocator *mini)
+{
+   /*
+    * This loop follows the standard idiom for obtaining a claim.  Note that
+    * mini is shared, so the value of mini->meta_tail can change before we
+    * obtain the lock, thus we must check after the get.
+    */
+   page_handle *meta_page;
+   uint64       wait = 1;
+   while (1) {
+      uint64 meta_tail = mini->meta_tail;
+      meta_page        = cache_get(mini->cc, meta_tail, TRUE, mini->type);
+      if (meta_tail == mini->meta_tail && cache_claim(mini->cc, meta_page)) {
+         break;
+      }
+      cache_unget(mini->cc, meta_page);
+      platform_sleep(wait);
+      wait = wait > 1024 ? wait : 2 * wait;
+   }
+   cache_lock(mini->cc, meta_page);
+
+   return meta_page;
+}
+
+void
+mini_full_unlock_meta_page(mini_allocator *mini, page_handle *meta_page)
+{
+   cache_mark_dirty(mini->cc, meta_page);
+   cache_unlock(mini->cc, meta_page);
+   cache_unclaim(mini->cc, meta_page);
+   cache_unget(mini->cc, meta_page);
+}
+
+/*
+ *-----------------------------------------------------------------------------
+ *
+ * mini_(un)get_(un)claim_meta_page --
+ *
+ *      Convenience functions to read lock and claim the given meta_page.
+ *
+ * Results:
+ *      get_claim; the page_handle of the locked page
+ *      unget_unclaim: None.
+ *
+ * Side effects:
+ *      Disk allocation, standard cache side effects.
+ *
+ *-----------------------------------------------------------------------------
+ */
+
+page_handle *
+mini_get_claim_meta_page(cache *cc, uint64 meta_addr, page_type type)
+{
+   page_handle *meta_page;
+   uint64       wait = 1;
+   while (1) {
+      meta_page = cache_get(cc, meta_addr, TRUE, type);
+      if (cache_claim(cc, meta_page)) {
+         break;
+      }
+      cache_unget(cc, meta_page);
+      platform_sleep(wait);
+      wait = wait > 1024 ? wait : 2 * wait;
+   }
+   return meta_page;
+}
+
+void
+mini_unget_unclaim_meta_page(cache *cc, page_handle *meta_page)
+{
+   cache_unclaim(cc, meta_page);
+   cache_unget(cc, meta_page);
+}
+
+/*
+ *-----------------------------------------------------------------------------
+ *
+ * mini_init --
+ *
+ *      Initialize a new mini allocator.
+ *
+ *      There are two types of mini allocator, keyed and unkeyed. A keyed
+ *      allocator stores a key range for each extent and allows incrementing
+ *      and decrementing key ranges. An unkeyed allocator has a single refcount
+ *      for the whole allocator which is overloaded onto the meta_head
+ *      disk-allocator ref count.
+ *
+ * Results:
+ *      The 0th batch next address to be allocated.
+ *
+ * Side effects:
+ *      None.
+ *
+ *-----------------------------------------------------------------------------
+ */
 
 uint64
-mini_allocator_init(mini_allocator *mini,
-                    cache          *cc,
-                    data_config    *data_cfg,
-                    uint64          meta_head,
-                    uint64          meta_tail,
-                    uint64          num_batches,
-                    page_type       type)
+mini_init(mini_allocator *mini,
+          cache *         cc,
+          data_config *   cfg,
+          uint64          meta_head,
+          uint64          meta_tail,
+          uint64          num_batches,
+          page_type       type,
+          bool            keyed)
 {
    platform_assert(num_batches <= MINI_MAX_BATCHES);
+   platform_assert(num_batches != 0);
+   platform_assert(mini != NULL);
+   platform_assert(cc != NULL);
+   platform_assert(!keyed || cfg != NULL);
 
-   memset(mini, 0, sizeof(mini_allocator));
-
+   ZERO_CONTENTS(mini);
    mini->cc          = cc;
    mini->al          = cache_allocator(cc);
-   mini->data_cfg    = data_cfg;
+   mini->data_cfg    = cfg;
+   mini->keyed       = keyed;
    mini->meta_head   = meta_head;
-   mini->type        = type;
    mini->num_batches = num_batches;
-   platform_assert(num_batches <= MINI_MAX_BATCHES);
+   mini->type        = type;
 
    page_handle *meta_page;
    if (meta_tail == 0) {
       // new mini allocator
       mini->meta_tail = meta_head;
       meta_page       = cache_alloc(cc, mini->meta_head, type);
+      mini_init_meta_page(mini, meta_page);
+
+      if (!keyed) {
+         // meta_page gets an extra ref
+         uint64 base_addr = cache_base_addr(cc, mini->meta_head);
+         uint8  ref       = allocator_inc_refcount(mini->al, base_addr);
+         platform_assert(ref == MINI_NO_REFS + 1);
+      }
+
+      mini_full_unlock_meta_page(mini, meta_page);
    } else {
       // load mini allocator
       mini->meta_tail = meta_tail;
-      meta_page       = cache_get(cc, mini->meta_tail, TRUE, type);
-      uint64 wait     = 1;
-      while (!cache_claim(cc, meta_page)) {
-         // should never happen
-         platform_sleep(wait);
-         wait = wait > 1024 ? wait : 2 * wait;
-      }
-      cache_lock(cc, meta_page);
-   }
-   mini_allocator_meta_hdr *hdr = (mini_allocator_meta_hdr *)meta_page->data;
-   if (meta_tail == 0) {
-      hdr->next_meta_addr = 0;
-      hdr->pos = 0;
    }
 
    for (uint64 batch = 0; batch < num_batches; batch++) {
+      // because we recover ref counts from the mini allocators on recovery, we
+      // don't need to store these in the mini allocator until we consume them.
       platform_status rc =
          allocator_alloc_extent(mini->al, &mini->next_extent[batch]);
       platform_assert_status_ok(rc);
-      //platform_log("mini_allocator_alloc %lu-%lu.%lu : %lu\n",
-      //      mini->meta_head, mini->meta_tail, hdr->pos, mini->next_extent[batch]);
-      if (hdr->pos == (cache_page_size(mini->cc)
-            - sizeof(mini_allocator_meta_hdr)) / sizeof(uint64)) {
-         // need a new meta page
-         mini->meta_tail += cache_page_size(mini->cc);
-         if (mini->meta_tail % cache_extent_size(mini->cc) == 0) {
-            // need to allocate the next meta extent
-            rc = allocator_alloc_extent(mini->al, (uint64 *)&mini->meta_tail);
-            platform_assert_status_ok(rc);
-         }
-         hdr->next_meta_addr = mini->meta_tail;
-         page_handle *last_meta_page = meta_page;
-         meta_page = cache_alloc(mini->cc, mini->meta_tail, type);
-         cache_unlock(mini->cc, last_meta_page);
-         cache_unclaim(mini->cc, last_meta_page);
-         cache_unget(mini->cc, last_meta_page);
-         hdr = (mini_allocator_meta_hdr *)meta_page->data;
-         hdr->pos = 0;
-         hdr->next_meta_addr = 0;
-      }
    }
-
-   cache_mark_dirty(cc, meta_page);
-   cache_unlock(cc, meta_page);
-   cache_unclaim(cc, meta_page);
-   cache_unget(cc, meta_page);
 
    return mini->next_extent[0];
 }
 
+/*
+ *-----------------------------------------------------------------------------
+ *
+ * mini_meta_page_is_full --
+ *
+ * Results:
+ *      TRUE is meta_page is full, FALSE otherwise
+ *
+ * Side effects:
+ *      None.
+ *
+ *-----------------------------------------------------------------------------
+ */
+
 uint64
-mini_allocator_alloc(mini_allocator *mini,
-                     uint64          batch,
-                     char           *key,
-                     uint64         *next_extent)
+mini_num_entries(page_handle *meta_page)
 {
-   platform_assert(batch < mini->num_batches);
+   mini_meta_hdr *hdr = (mini_meta_hdr *)meta_page->data;
+   return hdr->pos;
+}
 
-   platform_status rc        = STATUS_OK;
-   uint64          next_addr = mini->next_addr[batch];
+uint64
+mini_unkeyed_entries_per_page(cache *cc)
+{
+   return (cache_page_size(cc) - sizeof(mini_meta_hdr)) / sizeof(uint64);
+}
 
-   // wait until we hold the lock for our batch
-   uint64 wait = 1;
-   while (0 || next_addr == MINI_WAIT
-            || !__sync_bool_compare_and_swap(&mini->next_addr[batch],
-                                             next_addr, MINI_WAIT))
-   {
+uint64
+mini_keyed_entry_size(data_config *cfg)
+{
+   return sizeof(uint64) + 2 * cfg->key_size;
+}
+
+uint64
+mini_keyed_entries_per_page(cache *cc, data_config *cfg)
+{
+   return (cache_page_size(cc) - sizeof(mini_meta_hdr)) /
+          mini_keyed_entry_size(cfg);
+}
+
+bool
+mini_meta_page_is_full(mini_allocator *mini, page_handle *meta_page)
+{
+   if (mini->keyed) {
+      debug_assert(mini_num_entries(meta_page) <=
+                   mini_keyed_entries_per_page(mini->cc, mini->data_cfg));
+      return mini_num_entries(meta_page) ==
+             mini_keyed_entries_per_page(mini->cc, mini->data_cfg);
+   }
+   // unkeyed
+   debug_assert(mini_num_entries(meta_page) <=
+                mini_unkeyed_entries_per_page(mini->cc));
+   return mini_num_entries(meta_page) ==
+          mini_unkeyed_entries_per_page(mini->cc);
+}
+
+/*
+ *-----------------------------------------------------------------------------
+ *
+ * mini_keyed_[get,set]_entry --
+ * mini_keyed_set_last_end_key --
+ * mini_unkeyed_[get,set]_entry --
+ *
+ *      Allocator functions for adding new extents to the meta_page or getting
+ *      the metadata of the pos-th extent in the given meta_page.
+ *
+ *      For keyed allocators, when setting an entry, only the start key is
+ *      known. When a new extent is allocated, its start key becomes the
+ *      previous extent's end_key (within a batch). This is set by calling
+ *      mini_keyed_set_last_end_key.
+ *
+ *      Unkeyed allocators simply add/fetch the extent_addr as an entry by
+ *      itself.
+ *
+ * Results:
+ *      get: the extent_addr, start_key and end_key of the entry
+ *      set: None.
+ *
+ * Side effects:
+ *      None.
+ *
+ *-----------------------------------------------------------------------------
+ */
+
+void
+mini_keyed_get_entry(cache *      cc,
+                     data_config *cfg,
+                     page_handle *meta_page,
+                     uint64       pos,
+                     uint64 *     extent_addr,
+                     const char **start_key,
+                     const char **end_key)
+{
+   mini_meta_hdr *hdr = (mini_meta_hdr *)meta_page->data;
+
+   uint64 entry_size   = mini_keyed_entry_size(cfg);
+   char * entry_cursor = hdr->entry_buffer + pos * entry_size;
+
+   *extent_addr = *(uint64 *)entry_cursor;
+   *start_key   = entry_cursor + sizeof(uint64);
+   *end_key     = *start_key + cfg->key_size;
+}
+
+void
+mini_keyed_set_entry(mini_allocator *mini,
+                     uint64          batch,
+                     page_handle *   meta_page,
+                     uint64          extent_addr,
+                     const char *    key)
+{
+   debug_assert(mini->keyed);
+   debug_assert(batch < mini->num_batches);
+   debug_assert(key != NULL);
+   debug_assert(extent_addr != 0);
+   debug_assert(extent_addr % cache_page_size(mini->cc) == 0);
+
+   mini_meta_hdr *hdr = (mini_meta_hdr *)meta_page->data;
+
+   uint64 pos = hdr->pos++;
+   char * entry_cursor =
+      hdr->entry_buffer + pos * mini_keyed_entry_size(mini->data_cfg);
+   uint64 *entry_extent_addr = (uint64 *)entry_cursor;
+   char *  entry_start_key   = entry_cursor + sizeof(uint64);
+
+   *entry_extent_addr = extent_addr;
+   data_key_copy(mini->data_cfg, entry_start_key, key);
+
+   // set last_meta_[addr,pos]
+   mini->last_meta_addr[batch] = meta_page->disk_addr;
+   mini->last_meta_pos[batch]  = pos;
+}
+
+void
+mini_keyed_set_last_end_key(mini_allocator *mini,
+                            uint64          batch,
+                            page_handle *   meta_page,
+                            const char *    key)
+{
+   debug_assert(mini->keyed);
+   debug_assert(batch < mini->num_batches);
+   debug_assert(key != NULL);
+
+   if (mini->last_meta_addr[batch] == 0) {
+      return;
+   }
+
+   page_handle *last_meta_page = NULL;
+   bool         need_unlock;
+   if (meta_page != NULL &&
+       mini->last_meta_addr[batch] == meta_page->disk_addr) {
+      last_meta_page = meta_page;
+      need_unlock    = FALSE;
+   } else {
+      last_meta_page =
+         mini_full_lock_meta_page(mini, mini->last_meta_addr[batch]);
+      need_unlock = TRUE;
+   }
+   mini_meta_hdr *last_hdr = (mini_meta_hdr *)last_meta_page->data;
+
+   uint64 pos = mini->last_meta_pos[batch];
+   debug_assert(pos < last_hdr->pos);
+   char *entry_cursor =
+      last_hdr->entry_buffer + pos * mini_keyed_entry_size(mini->data_cfg);
+   char *entry_end_key =
+      entry_cursor + sizeof(uint64) + mini->data_cfg->key_size;
+   data_key_copy(mini->data_cfg, entry_end_key, key);
+
+   if (need_unlock) {
+      mini_full_unlock_meta_page(mini, last_meta_page);
+   }
+}
+
+void
+mini_unkeyed_set_entry(mini_allocator *mini,
+                       page_handle *   meta_page,
+                       uint64          extent_addr)
+{
+   debug_assert(!mini->keyed);
+
+   mini_meta_hdr *hdr   = (mini_meta_hdr *)meta_page->data;
+   uint64         pos   = hdr->pos++;
+   uint64 *       entry = (uint64 *)hdr->entry_buffer;
+   entry[pos]           = extent_addr;
+}
+
+uint64
+mini_unkeyed_get_entry(cache *cc, page_handle *meta_page, uint64 pos)
+{
+   debug_assert(pos < mini_unkeyed_entries_per_page(cc));
+
+   mini_meta_hdr *hdr = (mini_meta_hdr *)meta_page->data;
+   debug_assert(pos < hdr->pos);
+   uint64 *entry = (uint64 *)hdr->entry_buffer;
+   return entry[pos];
+}
+
+/*
+ *-----------------------------------------------------------------------------
+ *
+ * mini_release --
+ *
+ *      Called to finalize the mini_allocator. After calling, no more
+ *      allocations can be made, but the mini_allocator linked list containing
+ *      the extents allocated and their metadata can be accessed by functions
+ *      using its meta_head.
+ *
+ *      Keyed allocators use this to set the final end keys of the batches.
+ *
+ * Results:
+ *      None.
+ *
+ * Side effects:
+ *      Disk deallocation, standard cache side effects.
+ *
+ *-----------------------------------------------------------------------------
+ */
+
+void
+mini_release(mini_allocator *mini, const char *key)
+{
+   debug_assert(!mini->keyed || key != NULL);
+
+   for (uint64 batch = 0; batch < mini->num_batches; batch++) {
+      // Dealloc the next extent
+      uint8 ref = allocator_dec_refcount(mini->al, mini->next_extent[batch]);
+      platform_assert(ref == AL_NO_REFS);
+      ref = allocator_dec_refcount(mini->al, mini->next_extent[batch]);
+      platform_assert(ref == AL_FREE);
+
+      if (mini->keyed) {
+         // Set the end_key of the last extent from this batch
+         mini_keyed_set_last_end_key(mini, batch, NULL, key);
+      }
+   }
+}
+
+/*
+ *-----------------------------------------------------------------------------
+ *
+ * mini_[lock,unlock]_batch_[get,set]next_addr --
+ *
+ *      Lock locks allocation on the given batch by replacing its next_addr
+ *      with a lock token.
+ *
+ *      Unlock unlocks allocation on the given batch by replacing the lock
+ *      token with the next free disk address to allocate.
+ *
+ * Results:
+ *      Lock: the next disk address to allocate
+ *      Unlock: None.
+ *
+ * Side effects:
+ *      None.
+ *
+ *-----------------------------------------------------------------------------
+ */
+
+uint64
+mini_lock_batch_get_next_addr(mini_allocator *mini, uint64 batch)
+{
+   uint64 next_addr = mini->next_addr[batch];
+   uint64 wait      = 1;
+   while (next_addr == MINI_WAIT ||
+          !__sync_bool_compare_and_swap(
+             &mini->next_addr[batch], next_addr, MINI_WAIT)) {
       platform_sleep(wait);
-      wait = wait > 1024 ? wait : 2 * wait;
+      wait      = wait > 1024 ? wait : 2 * wait;
       next_addr = mini->next_addr[batch];
    }
-   wait = 1;
+   return next_addr;
+}
+
+void
+mini_unlock_batch_set_next_addr(mini_allocator *mini,
+                                uint64          batch,
+                                uint64          next_addr)
+{
+   debug_assert(batch < mini->num_batches);
+   debug_assert(mini->next_addr[batch] == MINI_WAIT);
+
+   mini->next_addr[batch] = next_addr;
+}
+
+/*
+ *-----------------------------------------------------------------------------
+ *
+ * mini_[get,set]_next_meta_addr --
+ *
+ *      Sets the next_meta_addr on meta_page to next_meta_addr. This links
+ *      next_meta_addr in the linked list where meta_page is the current
+ *      meta_tail.
+ *
+ * Results:
+ *      None.
+ *
+ * Side effects:
+ *      None.
+ *
+ *-----------------------------------------------------------------------------
+ */
+
+uint64
+mini_get_next_meta_addr(page_handle *meta_page)
+{
+   // works for keyed and unkeyed
+   mini_meta_hdr *hdr = (mini_meta_hdr *)meta_page->data;
+   return hdr->next_meta_addr;
+}
+
+void
+mini_set_next_meta_addr(mini_allocator *mini,
+                        page_handle *   meta_page,
+                        uint64          next_meta_addr)
+{
+   // works for keyed and unkeyed
+   mini_meta_hdr *hdr  = (mini_meta_hdr *)meta_page->data;
+   hdr->next_meta_addr = next_meta_addr;
+}
+
+/*
+ *-----------------------------------------------------------------------------
+ *
+ * mini_alloc --
+ *
+ *      Allocate a next disk address from the mini_allocator.
+ *
+ *      If the allocator is keyed, then the extent from which the allocation is
+ *      made will include the given key.
+ *      NOTE: This requires keys provided be monotonically increasing.
+ *
+ *      If next_extent is not NULL, then the successor extent to the allocated
+ *      addr will be copied to it.
+ *
+ * Results:
+ *      A newly allocated disk address.
+ *
+ * Side effects:
+ *      Disk allocation, standard cache side effects.
+ *
+ *-----------------------------------------------------------------------------
+ */
+
+uint64
+mini_alloc(mini_allocator *mini,
+           uint64          batch,
+           const char *    key,
+           uint64 *        next_extent)
+{
+   debug_assert(batch < mini->num_batches);
+   debug_assert(!mini->keyed || key != NULL);
+
+   uint64 next_addr = mini_lock_batch_get_next_addr(mini, batch);
 
    if (next_addr % cache_extent_size(mini->cc) == 0) {
       // need to allocate the next extent
 
-      uint64 next_extent_addr = mini->next_extent[batch];
-      rc = allocator_alloc_extent(mini->al, &mini->next_extent[batch]);
+      uint64          extent_addr = mini->next_extent[batch];
+      platform_status rc =
+         allocator_alloc_extent(mini->al, &mini->next_extent[batch]);
       platform_assert_status_ok(rc);
-      next_addr = next_extent_addr;
-      if (next_extent) {
-         *next_extent = mini->next_extent[batch];
-      }
-      // platform_log("meta_head %lu next_extent %lu new_extent %lu\n",
-      //       mini->meta_head, mini->next_extent[batch],
-      //       new_pages[0]->disk_addr);
-      mini->next_addr[batch] = next_extent_addr + cache_page_size(mini->cc);
+      next_addr = extent_addr;
 
-      page_handle *meta_page;
-
-      /*
-       * need to get, claim and lock mini->meta_tail in order to add the new
-       * extent. The loop follows the standard idiom for obtaining a claim.
-       * Note that mini is shared, so the value of mini->meta_tail can change
-       * before we obtain the lock, thus we must check after the get.
-       */
-      while (1) {
-         uint64 meta_tail = mini->meta_tail;
-         meta_page        = cache_get(mini->cc, meta_tail, TRUE, mini->type);
-         if (meta_tail == mini->meta_tail && cache_claim(mini->cc, meta_page)) {
-            break;
-         }
-         cache_unget(mini->cc, meta_page);
-         platform_sleep(wait);
-         wait = wait > 1024 ? wait : 2 * wait;
-      }
-      wait = 1;
-      cache_lock(mini->cc, meta_page);
-      // FIXME: [aconway 2021-05-10] This is residual, delete eventually:
-      debug_assert(meta_page->disk_addr == mini->meta_tail);
-
-      mini_allocator_meta_hdr *hdr = (mini_allocator_meta_hdr *)meta_page->data;
-      if (hdr->pos == (cache_page_size(mini->cc)
-            - sizeof(mini_allocator_meta_hdr))
-            / sizeof(mini_allocator_meta_entry)) {
-         // need a new meta page
+      page_handle *meta_page = mini_full_lock_meta_tail(mini);
+      if (mini_meta_page_is_full(mini, meta_page)) {
+         // need to allocate a new meta page
          uint64 new_meta_tail = mini->meta_tail + cache_page_size(mini->cc);
          if (new_meta_tail % cache_extent_size(mini->cc) == 0) {
             // need to allocate the next meta extent
             rc = allocator_alloc_extent(mini->al, &new_meta_tail);
             platform_assert_status_ok(rc);
          }
-         hdr->next_meta_addr = new_meta_tail;
+
+         mini_set_next_meta_addr(mini, meta_page, new_meta_tail);
+
          page_handle *last_meta_page = meta_page;
          meta_page       = cache_alloc(mini->cc, new_meta_tail, mini->type);
          mini->meta_tail = new_meta_tail;
-         cache_mark_dirty(mini->cc, last_meta_page);
-         cache_unlock(mini->cc, last_meta_page);
-         cache_unclaim(mini->cc, last_meta_page);
-         cache_unget(mini->cc, last_meta_page);
-         hdr = (mini_allocator_meta_hdr *)meta_page->data;
-         hdr->pos = 0;
-         hdr->next_meta_addr = 0;
+         mini_full_unlock_meta_page(mini, last_meta_page);
+         mini_init_meta_page(mini, meta_page);
       }
-
-      //platform_log("mini_allocator_alloc %lu-%lu.%lu : %lu\n",
-      //      mini->meta_head, mini->meta_tail, hdr->pos, new_extent_addr);
-
-      platform_assert(hdr == (mini_allocator_meta_hdr *)meta_page->data);
-      uint64 new_pos = hdr->pos;
-      uint64 new_meta_addr = meta_page->disk_addr;
-      mini_allocator_meta_entry *entry = &hdr->entry[hdr->pos++];
-      if (key != NULL) {
-         data_key_copy(mini->data_cfg, entry->start_key, key);
-
-         // Set the end_key of the last extent from this batch
-         if (mini->last_meta_addr[batch] != 0) {
-            page_handle *last_meta_page = NULL;
-            if (mini->last_meta_addr[batch] == mini->meta_tail) {
-               last_meta_page = meta_page;
-            } else {
-               last_meta_page =
-                  cache_get(mini->cc, mini->last_meta_addr[batch], TRUE, mini->type);
-               while (!cache_claim(mini->cc, last_meta_page)) {
-                  // should never happen
-                  platform_sleep(wait);
-                  wait = wait > 1024 ? wait : 2 * wait;
-               }
-               wait = 1;
-               cache_lock(mini->cc, last_meta_page);
-            }
-            mini_allocator_meta_hdr *last_hdr =
-               (mini_allocator_meta_hdr *)last_meta_page->data;
-            mini_allocator_meta_entry *last_entry =
-               &last_hdr->entry[mini->last_meta_pos[batch]];
-            data_key_copy(mini->data_cfg, last_entry->end_key, key);
-            cache_mark_dirty(mini->cc, last_meta_page);
-            if (mini->last_meta_addr[batch] != mini->meta_tail) {
-               cache_unlock(mini->cc, last_meta_page);
-               cache_unclaim(mini->cc, last_meta_page);
-               cache_unget(mini->cc, last_meta_page);
-            }
-         }
-         mini->last_meta_pos[batch] = new_pos;
-         mini->last_meta_addr[batch] = new_meta_addr;
+      if (mini->keyed) {
+         mini_keyed_set_last_end_key(mini, batch, meta_page, key);
+         mini_keyed_set_entry(mini, batch, meta_page, next_addr, key);
       } else {
-         memset(entry->start_key, 0, MAX_KEY_SIZE);
-         memset(entry->end_key, 0, MAX_KEY_SIZE);
+         // unkeyed
+         mini_unkeyed_set_entry(mini, meta_page, next_addr);
       }
-      entry->extent_addr = next_extent_addr;
-      entry->zapped = FALSE;
-      //if (key != NULL) {
-      //   char key_str[256];
-      //   data_key_to_string(key, key_str, 24);
-      //   platform_log("alloc %12lu %12lu %2lu %s\n",
-      //         next_extent_addr, new_meta_addr, new_pos, key_str);
-      //} else {
-      //   platform_log("alloc %12lu %12lu %2lu NULL\n",
-      //         next_extent_addr, new_meta_addr, new_pos);
-      //}
-      cache_mark_dirty(mini->cc, meta_page);
-      cache_unlock(mini->cc, meta_page);
-      cache_unclaim(mini->cc, meta_page);
-      cache_unget(mini->cc, meta_page);
 
-      return next_addr;
+      mini_full_unlock_meta_page(mini, meta_page);
    }
 
-   // we got a valid new addr
    if (next_extent) {
       *next_extent = mini->next_extent[batch];
    }
-   mini->next_addr[batch] = next_addr + cache_page_size(mini->cc);
+
+   uint64 new_next_addr = next_addr + cache_page_size(mini->cc);
+   mini_unlock_batch_set_next_addr(mini, batch, new_next_addr);
    return next_addr;
 }
 
-void
-mini_allocator_release(mini_allocator *mini,
-                       char           *key)
-{
-   for (uint64 batch = 0; batch < mini->num_batches; batch++) {
-      // Dealloc the next extent
-      cache_dealloc(mini->cc, mini->next_extent[batch], mini->type);
+/*
+ *-----------------------------------------------------------------------------
+ *
+ * mini_[keyed,unkeyed]_for_each(_self_exclusive) --
+ *
+ *      Calls func on each extent_addr in the mini_allocator.
+ *
+ *      If the allocator is keyed and a single key or key range is given, calls
+ *      it only on the extent_addrs with intersecting key ranges.
+ *
+ *      The self-exclusive version does hand-over-hand locking with claims to
+ *      prevent races among callers. This is used for mini_keyed_dec_ref so
+ *      that an order is enforced and the last caller can deinit the
+ *      meta_pages.
+ *
+ *      NOTE: Should not be called if there are no intersecting ranges.
+ *
+ * Results:
+ *      unkeyed: None
+ *      keyed: TRUE if every call to func returns true, FALSE otherwise.
+ *
+ * Side effects:
+ *      func may store output in out.
+ *
+ *-----------------------------------------------------------------------------
+ */
 
-      // Set the end_key of the last extent from this batch
-      if (key != NULL && mini->last_meta_addr[batch] != 0) {
-         page_handle *last_meta_page =
-            cache_get(mini->cc, mini->last_meta_addr[batch], TRUE, mini->type);
-         uint64 wait = 1;
-         while (!cache_claim(mini->cc, last_meta_page)) {
-            // should never happen
-            platform_sleep(wait);
-            wait = wait > 1024 ? wait : 2 * wait;
-         }
-         wait = 1;
-         cache_lock(mini->cc, last_meta_page);
-         mini_allocator_meta_hdr *last_hdr =
-            (mini_allocator_meta_hdr *)last_meta_page->data;
-         mini_allocator_meta_entry *last_entry =
-            &last_hdr->entry[mini->last_meta_pos[batch]];
-         data_key_copy(mini->data_cfg, last_entry->end_key, key);
-         cache_mark_dirty(mini->cc, last_meta_page);
-         cache_unlock(mini->cc, last_meta_page);
-         cache_unclaim(mini->cc, last_meta_page);
-         cache_unget(mini->cc, last_meta_page);
+
+typedef bool (*mini_for_each_fn)(cache *   cc,
+                                 page_type type,
+                                 uint64    base_addr,
+                                 void *    out);
+
+void
+mini_unkeyed_for_each(cache *          cc,
+                      uint64           meta_head,
+                      page_type        type,
+                      mini_for_each_fn func,
+                      void *           out)
+{
+   uint64 meta_addr = meta_head;
+   do {
+      page_handle *meta_page = cache_get(cc, meta_addr, TRUE, type);
+
+      uint64 num_meta_entries = mini_num_entries(meta_page);
+      for (uint64 i = 0; i < num_meta_entries; i++) {
+         uint64 extent_addr = mini_unkeyed_get_entry(cc, meta_page, i);
+         func(cc, type, extent_addr, out);
       }
-   }
+      meta_addr = mini_get_next_meta_addr(meta_page);
+      cache_unget(cc, meta_page);
+   } while (meta_addr != 0);
 }
 
-typedef bool
-(*mini_allocator_for_each_fn)(cache *cc,
-                              page_type type,
-                              uint64 base_addr,
-                              uint64 *pages_outstanding);
-
-void
-mini_allocator_print(cache                      *cc,
-                     data_config                *data_cfg,
-                     page_type                   type,
-                     uint64                      meta_head)
+bool
+mini_keyed_extent_in_range(data_config *cfg,
+                           const char * entry_start_key,
+                           const char * entry_end_key,
+                           const char * start_key,
+                           const char * end_key)
 {
-   page_handle             *meta_page;
-   uint64                   i;
-   mini_allocator_meta_hdr *hdr;
-   uint64                   next_meta_addr = meta_head;
+   /*
+    * extent is in range if
+    * 1. full range (start_key == NULL and end_key == NULL)
+    * 2. extent in range (start_key_[1,2] < end_key_[2,1])
+    * 3. range is a point (end_key == NULL) and point is in extent
+    */
+   if (start_key == NULL && end_key == NULL) {
+      // case 1
+      return TRUE;
+   }
+   if (end_key == NULL) {
+      // case 3
+      return data_key_compare(cfg, start_key, entry_end_key) <= 0 &&
+             data_key_compare(cfg, entry_start_key, start_key) <= 0;
+   } else {
+      // case 2
+      return data_key_compare(cfg, start_key, entry_end_key) <= 0 &&
+             data_key_compare(cfg, entry_start_key, end_key) <= 0;
+   }
+   platform_assert(0);
+}
+
+bool
+mini_keyed_for_each(cache *          cc,
+                    data_config *    cfg,
+                    uint64           meta_head,
+                    page_type        type,
+                    const char *     start_key,
+                    const char *     end_key,
+                    mini_for_each_fn func,
+                    void *           out)
+{
+   // We return true for cleanup if every call to func returns TRUE.
+   bool should_cleanup = TRUE;
+   // Should not be called if there are no intersecting ranges, we track with
+   // did_work.
+   debug_only bool did_work = FALSE;
+
+   uint64 meta_addr = meta_head;
 
    do {
-      meta_page = cache_get(cc, next_meta_addr, TRUE, PAGE_TYPE_MISC);
-      hdr = (mini_allocator_meta_hdr *)meta_page->data;
-
-      platform_log("meta addr %12lu\n", next_meta_addr);
-      for (i = 0; i < hdr->pos; i++) {
-         mini_allocator_meta_entry *entry = &hdr->entry[i];
-         char start_key_str[256];
-         data_key_to_string(data_cfg, entry->start_key, start_key_str, 24);
-         char end_key_str[256];
-         data_key_to_string(data_cfg, entry->end_key, end_key_str, 24);
-         allocator *al = cache_allocator(cc);
-         uint8 ref_count = allocator_get_refcount(al, entry->extent_addr);
-         platform_log("%2lu %12lu %s %s %d (%u)\n",
-               i, entry->extent_addr, start_key_str, end_key_str,
-               entry->zapped, ref_count);
+      page_handle *meta_page = cache_get(cc, meta_addr, TRUE, type);
+      for (uint64 i = 0; i < mini_num_entries(meta_page); i++) {
+         uint64      extent_addr;
+         const char *entry_start_key, *entry_end_key;
+         mini_keyed_get_entry(cc,
+                              cfg,
+                              meta_page,
+                              i,
+                              &extent_addr,
+                              &entry_start_key,
+                              &entry_end_key);
+         if (mini_keyed_extent_in_range(
+                cfg, entry_start_key, entry_end_key, start_key, end_key)) {
+            debug_code(did_work = TRUE);
+            bool entry_should_cleanup = func(cc, type, extent_addr, out);
+            should_cleanup            = should_cleanup && entry_should_cleanup;
+         }
       }
 
-      next_meta_addr = hdr->next_meta_addr;
-
+      meta_addr = mini_get_next_meta_addr(meta_page);
       cache_unget(cc, meta_page);
-   } while (next_meta_addr != 0);
+   } while (meta_addr != 0);
+
+
+   debug_assert(did_work);
+   return should_cleanup;
+}
+
+bool
+mini_keyed_for_each_self_exclusive(cache *          cc,
+                                   data_config *    cfg,
+                                   uint64           meta_head,
+                                   page_type        type,
+                                   const char *     start_key,
+                                   const char *     end_key,
+                                   mini_for_each_fn func,
+                                   void *           out)
+{
+   // We return true for cleanup if every call to func returns TRUE.
+   bool should_cleanup = TRUE;
+   // Should not be called if there are no intersecting ranges, we track with
+   // did_work.
+   debug_only bool did_work = FALSE;
+
+   uint64       meta_addr = meta_head;
+   page_handle *meta_page = mini_get_claim_meta_page(cc, meta_head, type);
+
+   do {
+      for (uint64 i = 0; i < mini_num_entries(meta_page); i++) {
+         uint64      extent_addr;
+         const char *entry_start_key, *entry_end_key;
+         mini_keyed_get_entry(cc,
+                              cfg,
+                              meta_page,
+                              i,
+                              &extent_addr,
+                              &entry_start_key,
+                              &entry_end_key);
+         if (mini_keyed_extent_in_range(
+                cfg, entry_start_key, entry_end_key, start_key, end_key)) {
+            debug_code(did_work = TRUE);
+            bool entry_should_cleanup = func(cc, type, extent_addr, out);
+            should_cleanup            = should_cleanup && entry_should_cleanup;
+         }
+      }
+
+      meta_addr = mini_get_next_meta_addr(meta_page);
+      if (meta_addr != 0) {
+         page_handle *next_meta_page =
+            mini_get_claim_meta_page(cc, meta_addr, type);
+         mini_unget_unclaim_meta_page(cc, meta_page);
+         meta_page = next_meta_page;
+      }
+   } while (meta_addr != 0);
+
+   mini_unget_unclaim_meta_page(cc, meta_page);
+
+   debug_assert(did_work);
+   return should_cleanup;
+}
+
+/*
+ *-----------------------------------------------------------------------------
+ *
+ * mini_unkeyed_[inc,dec]_ref --
+ *
+ *      Increments or decrements the ref count of the unkeyed allocator. When
+ *      the external ref count reaches 0 (actual ref count reachs
+ *      MINI_NO_REFS), the mini allocator is destroyed.
+ *
+ * Results:
+ *      Prior external ref count (internal ref count - MINI_NO_REFS)
+ *
+ * Side effects:
+ *      Deallocation/cache side effects when external ref count hits 0
+ *
+ *-----------------------------------------------------------------------------
+ */
+
+
+uint8
+mini_unkeyed_inc_ref(cache *cc, uint64 meta_head)
+{
+   allocator *al        = cache_allocator(cc);
+   uint64     base_addr = cache_base_addr(cc, meta_head);
+   uint8      ref       = allocator_inc_refcount(al, base_addr);
+   platform_assert(ref > MINI_NO_REFS);
+   return ref - MINI_NO_REFS;
 }
 
 static inline bool
-mini_allocator_addrs_share_extent(cache  *cc,
-                                  uint64  left_addr,
-                                  uint64  right_addr)
+mini_addrs_share_extent(cache *cc, uint64 left_addr, uint64 right_addr)
 {
    uint64 extent_size = cache_extent_size(cc);
    return right_addr / extent_size == left_addr / extent_size;
 }
 
-bool
-mini_allocator_for_each(cache                      *cc,
-                        data_config                *data_cfg,
-                        page_type                   type,
-                        uint64                      meta_head,
-                        mini_allocator_for_each_fn  func,
-                        const char                 *start_key,
-                        const char                 *end_key,
-                        uint64                     *pages_outstanding)
+void
+mini_deinit(cache *cc, uint64 meta_head, page_type type)
 {
-   page_handle             *meta_page;
-   uint64                   i;
-   mini_allocator_meta_hdr *hdr;
-   uint64                   next_meta_addr = meta_head;
-   uint64                   last_meta_addr;
-   uint64                   wait = 1;
-
-   debug_assert(IMPLIES(data_cfg == NULL, start_key == NULL));
-
-   bool fully_zapped = TRUE;
+   allocator *al        = cache_allocator(cc);
+   uint64     meta_addr = meta_head;
    do {
-      meta_page = cache_get(cc, next_meta_addr, TRUE, PAGE_TYPE_MISC);
-      while (!cache_claim(cc, meta_page)) {
-         cache_unget(cc, meta_page);
-         meta_page = NULL;
-         platform_sleep(wait);
-         wait = wait > 1024 ? wait : 2 * wait;
-         meta_page = cache_get(cc, next_meta_addr, TRUE, PAGE_TYPE_MISC);
-      }
-      wait = 1;
-      cache_lock(cc, meta_page);
-
-      hdr = (mini_allocator_meta_hdr *)meta_page->data;
-
-      for (i = 0; i < hdr->pos; i++) {
-         mini_allocator_meta_entry *entry = &hdr->entry[i];
-         /*
-          * extent is in range if
-          * 1. full range (start_key == NULL and end_key == NULL)
-          * 2. extent in range (start_key_[1,2] < end_key_[2,1])
-          * 3. range is a point (end_key == NULL) and point is in extent
-          */
-         bool extent_in_range = FALSE;
-         if (start_key == NULL && end_key == NULL) {
-            // case 1
-            extent_in_range = TRUE;
-         } else if (end_key == NULL) {
-            // case 3
-            extent_in_range =
-                  1
-               && data_key_compare(data_cfg, start_key, entry->end_key) <= 0
-               && data_key_compare(data_cfg, entry->start_key, start_key) <= 0;
-         } else {
-            // case 2
-            extent_in_range =
-                  1
-               && data_key_compare(data_cfg, start_key, entry->end_key) <= 0
-               && data_key_compare(data_cfg, entry->start_key, end_key) <= 0;
-         }
-         if (extent_in_range) {
-            if (entry->zapped) {
-               platform_log("ERROR: entry %lu already_zapped\n",
-                     entry->extent_addr);
-            }
-            platform_assert(!entry->zapped);
-            entry->zapped = func(cc, type, entry->extent_addr, pages_outstanding);
-         }
-         fully_zapped = fully_zapped && entry->zapped;
-      }
-
-      last_meta_addr = next_meta_addr;
-      next_meta_addr = hdr->next_meta_addr;
-
-      cache_mark_dirty(cc, meta_page);
-      cache_unlock(cc, meta_page);
-      cache_unclaim(cc, meta_page);
+      page_handle *meta_page      = cache_get(cc, meta_addr, TRUE, type);
+      uint64       last_meta_addr = meta_addr;
+      meta_addr                   = mini_get_next_meta_addr(meta_page);
       cache_unget(cc, meta_page);
-   } while (next_meta_addr != 0);
-   if (fully_zapped) {
-      //platform_log("fully zapped %lu\n", meta_head - 4096);
-      uint64 next_meta_addr = meta_head;
-      do {
-         meta_page = cache_get(cc, next_meta_addr, TRUE, PAGE_TYPE_MISC);
-         hdr = (mini_allocator_meta_hdr *)meta_page->data;
-         last_meta_addr = next_meta_addr;
-         next_meta_addr = hdr->next_meta_addr;
-         cache_unget(cc, meta_page);
-         if (!mini_allocator_addrs_share_extent(cc, last_meta_addr, next_meta_addr)) {
-            uint64 last_meta_base_addr =
-               last_meta_addr / cache_extent_size(cc) * cache_extent_size(cc);
-            func(cc, type, last_meta_base_addr, pages_outstanding);
-         }
-      } while (next_meta_addr != 0);
+
+      if (!mini_addrs_share_extent(cc, last_meta_addr, meta_addr)) {
+         uint64 last_meta_base_addr = cache_base_addr(cc, last_meta_addr);
+         uint8  ref = allocator_dec_refcount(al, last_meta_base_addr);
+         platform_assert(ref == AL_NO_REFS);
+         cache_hard_evict_extent(cc, last_meta_base_addr, type);
+         ref = allocator_dec_refcount(al, last_meta_base_addr);
+         platform_assert(ref == AL_FREE);
+      }
+   } while (meta_addr != 0);
+}
+
+bool
+mini_dealloc_extent(cache *cc, page_type type, uint64 base_addr, void *out)
+{
+   allocator *al  = cache_allocator(cc);
+   uint8      ref = allocator_dec_refcount(al, base_addr);
+   platform_assert(ref == AL_NO_REFS);
+   cache_hard_evict_extent(cc, base_addr, type);
+   ref = allocator_dec_refcount(al, base_addr);
+   platform_assert(ref == AL_FREE);
+   return TRUE;
+}
+
+uint8
+mini_unkeyed_dec_ref(cache *cc, uint64 meta_head, page_type type)
+{
+   allocator *al        = cache_allocator(cc);
+   uint64     base_addr = cache_base_addr(cc, meta_head);
+   uint8      ref       = allocator_dec_refcount(al, base_addr);
+   if (ref != MINI_NO_REFS) {
+      debug_assert(ref != AL_NO_REFS);
+      debug_assert(ref != AL_FREE);
+      return ref - MINI_NO_REFS;
    }
 
-   return fully_zapped;
+   // need to deallocate and clean up the mini allocator
+   mini_unkeyed_for_each(cc, meta_head, type, mini_dealloc_extent, NULL);
+   mini_deinit(cc, meta_head, type);
+   return 0;
 }
 
+/*
+ *-----------------------------------------------------------------------------
+ *
+ * mini_keyed_[inc,dec]_ref --
+ *
+ *      In keyed mini allocators, ref counts are kept on a per-extent basis,
+ *      and ref count increments and decrements are performed on key ranges.
+ *
+ *      See mini_keyed_for_each for key range intersection rules.
+ *
+ *      In SplinterDB, keyed mini allocators are used for branches, which have
+ *      at least one extent (the extent containing the root) whose key range
+ *      covers the key range of the branch itself (and therefore the mini
+ *      allocator). Therefore, a dec_ref which deallocates every extent it
+ *      intersects must have deallocated this extent as well, and therefore
+ *      there are no refs in the allocator and it can be cleaned up.
+ *
+ * Results:
+ *      None
+ *
+ * Side effects:
+ *      Deallocation/cache side effects.
+ *
+ *-----------------------------------------------------------------------------
+ */
+
 bool
-mini_allocator_zap_extent(cache  *cc,
+mini_keyed_inc_ref_extent(cache *   cc,
                           page_type type,
-                          uint64  base_addr,
-                          uint64 *pages_outstanding)
-{
-   return cache_dealloc(cc, base_addr, type);
-}
-
-bool
-mini_allocator_zap(cache       *cc,
-                   data_config *data_cfg,
-                   uint64       meta_head,
-                   const char  *start_key,
-                   const char  *end_key,
-                   page_type    type)
-{
-   //if (start_key != NULL) {
-   //   char start_key_str[256];
-   //   if (start_key != NULL) {
-   //      data_key_to_string(start_key, start_key_str, 24);
-   //   }
-   //   if (end_key == NULL) {
-   //      platform_log("mini_allocator_zap %12lu %s\n",
-   //            meta_head, start_key_str);
-   //   } else {
-   //      char end_key_str[256];
-   //      data_key_to_string(end_key, end_key_str, 24);
-   //      platform_log("mini_allocator_zap %12lu %s %s\n",
-   //            meta_head, start_key_str, end_key_str);
-   //   }
-   //} else {
-   //   platform_log("mini_allocator_zap %12lu full\n", meta_head);
-   //}
-   //mini_allocator_print(cc, data_cfg, type, meta_head);
-   bool fully_zapped = mini_allocator_for_each(cc, data_cfg, type, meta_head,
-         mini_allocator_zap_extent, start_key, end_key, NULL);
-   //if (fully_zapped) {
-   //   platform_log("fully zapped\n");
-   //}
-   //} else {
-   //   platform_log("mini allocator after zap\n");
-   //   mini_allocator_print(cc, data_cfg, type, meta_head);
-   //}
-   return fully_zapped;
-}
-
-bool
-mini_allocator_sync_extent(cache     *cc,
-                           page_type  type,
-                           uint64     base_addr,
-                           uint64    *pages_outstanding)
-{
-   cache_extent_sync(cc, base_addr, pages_outstanding);
-   return FALSE;
-}
-
-
-void
-mini_allocator_sync(cache     *cc,
-                    page_type  type,
-                    uint64     meta_head,
-                    uint64    *pages_outstanding)
-{
-   mini_allocator_for_each(cc, NULL, type, meta_head, mini_allocator_sync_extent,
-         NULL, NULL, pages_outstanding);
-}
-
-bool
-mini_allocator_inc_extent(cache     *cc,
-                          page_type  type,
-                          uint64     base_addr,
-                          uint64    *pages_outstanding)
+                          uint64    base_addr,
+                          void *    out)
 {
    allocator *al = cache_allocator(cc);
    allocator_inc_refcount(al, base_addr);
@@ -529,191 +963,236 @@ mini_allocator_inc_extent(cache     *cc,
 }
 
 void
-mini_allocator_inc_range(cache       *cc,
-                         data_config *data_cfg,
-                         page_type    type,
-                         uint64       meta_head,
-                         const char  *start_key,
-                         const char  *end_key)
+mini_keyed_inc_ref(cache *      cc,
+                   data_config *data_cfg,
+                   page_type    type,
+                   uint64       meta_head,
+                   const char * start_key,
+                   const char * end_key)
 {
-   //if (start_key != NULL) {
-   //   char start_key_str[256];
-   //   if (start_key != NULL) {
-   //      data_key_to_string(start_key, start_key_str, 24);
-   //   }
-   //   if (end_key == NULL) {
-   //      platform_log("mini_allocator_inc_range %12lu %s\n",
-   //            meta_head, start_key_str);
-   //   } else {
-   //      char end_key_str[256];
-   //      data_key_to_string(end_key, end_key_str, 24);
-   //      platform_log("mini_allocator_inc_range %12lu %s %s\n",
-   //            meta_head, start_key_str, end_key_str);
-   //   }
-   //} else {
-   //   platform_log("mini_allocator_inc_range %12lu full\n", meta_head);
-   //}
-   //mini_allocator_print(cc, data_cfg, type, meta_head);
-   mini_allocator_for_each(cc, data_cfg, type, meta_head,
-         mini_allocator_inc_extent, start_key, end_key, NULL);
-   //platform_log("mini allocator after inc\n");
-   //mini_allocator_print(cc, data_cfg, type, meta_head);
+   mini_keyed_for_each(cc,
+                       data_cfg,
+                       meta_head,
+                       type,
+                       start_key,
+                       end_key,
+                       mini_keyed_inc_ref_extent,
+                       NULL);
 }
 
-uint64
-mini_allocator_extent_count(cache     *cc,
-                            page_type  type,
-                            uint64     meta_head)
+bool
+mini_keyed_dec_ref_extent(cache *   cc,
+                          page_type type,
+                          uint64    base_addr,
+                          void *    out)
 {
-   page_handle *meta_page;
-   uint64 next_meta_addr = meta_head;
-   uint64 num_extents = 0;
-
-   do {
-      meta_page = cache_get(cc, next_meta_addr, TRUE, PAGE_TYPE_MISC);
-      num_extents++;
-
-      mini_allocator_meta_hdr *hdr = (mini_allocator_meta_hdr *)meta_page->data;
-
-      for (uint64 i = 0; i < hdr->pos; i++) {
-         mini_allocator_meta_entry *entry = &hdr->entry[i];
-         if (!entry->zapped) {
-            num_extents++;
-         }
-      }
-      next_meta_addr = hdr->next_meta_addr;
-      cache_unget(cc, meta_page);
-   } while (next_meta_addr != 0);
-
-   return num_extents;
+   allocator *al  = cache_allocator(cc);
+   uint8      ref = allocator_dec_refcount(al, base_addr);
+   if (ref == AL_NO_REFS) {
+      cache_hard_evict_extent(cc, base_addr, type);
+      ref = allocator_dec_refcount(al, base_addr);
+      platform_assert(ref == AL_FREE);
+      return TRUE;
+   }
+   return FALSE;
 }
 
-bool mini_allocator_count_extent(cache     *cc,
-                                 page_type  type,
-                                 uint64     base_addr,
-                                 uint64    *count)
+void
+mini_keyed_dec_ref(cache *      cc,
+                   data_config *data_cfg,
+                   page_type    type,
+                   uint64       meta_head,
+                   const char * start_key,
+                   const char * end_key)
 {
+   bool should_cleanup =
+      mini_keyed_for_each_self_exclusive(cc,
+                                         data_cfg,
+                                         meta_head,
+                                         type,
+                                         start_key,
+                                         end_key,
+                                         mini_keyed_dec_ref_extent,
+                                         NULL);
+   if (should_cleanup) {
+      mini_deinit(cc, meta_head, type);
+   }
+}
+
+/*
+ *-----------------------------------------------------------------------------
+ *
+ * mini_keyed_count_extents --
+ *
+ *      Returns the number of extents in the mini allocator intersecting the
+ *      given key range (see mini_keyed_for_each for intersection rules).
+ *
+ * Results:
+ *      The extent count.
+ *
+ * Side effects:
+ *      None.
+ *
+ *-----------------------------------------------------------------------------
+ */
+
+bool
+mini_keyed_count_extents(cache *cc, page_type type, uint64 base_addr, void *out)
+{
+   uint64 *count = (uint64 *)out;
    (*count)++;
    return FALSE;
 }
 
 uint64
-mini_allocator_count_extents_in_range(cache       *cc,
-                                      data_config *data_cfg,
-                                      page_type    type,
-                                      uint64       meta_head,
-                                      const char  *start_key,
-                                      const char  *end_key)
+mini_keyed_extent_count(cache *      cc,
+                        data_config *data_cfg,
+                        page_type    type,
+                        uint64       meta_head,
+                        const char * start_key,
+                        const char * end_key)
 {
-   uint64 num_extents = 0;
-   mini_allocator_for_each(cc, data_cfg, type, meta_head,
-         mini_allocator_count_extent, start_key, end_key, &num_extents);
-   return num_extents;
+   uint64 count = 0;
+   mini_keyed_for_each(cc,
+                       data_cfg,
+                       meta_head,
+                       type,
+                       start_key,
+                       end_key,
+                       mini_keyed_count_extents,
+                       &count);
+   return count;
 }
 
+/*
+ *-----------------------------------------------------------------------------
+ *
+ * mini_unkeyed_prefetch --
+ *
+ *      Prefetches all extents in the (unkeyed) mini allocator.
+ *
+ * Results:
+ *      None.
+ *
+ * Side effects:
+ *      Standard cache side effects.
+ *
+ *-----------------------------------------------------------------------------
+ */
+
 bool
-mini_allocator_prefetch_extent(cache     *cc,
-                               page_type  type,
-                               uint64     base_addr,
-                               uint64    *pages_outstanding)
+mini_prefetch_extent(cache *cc, page_type type, uint64 base_addr, void *out)
 {
    cache_prefetch(cc, base_addr, type);
    return FALSE;
 }
 
 void
-mini_allocator_prefetch(cache     *cc,
-                        page_type  type,
-                        uint64     meta_head)
+mini_unkeyed_prefetch(cache *cc, page_type type, uint64 meta_head)
 {
-   mini_allocator_for_each(cc, NULL, type, meta_head,
-         mini_allocator_prefetch_extent, NULL, NULL,
-         NULL);
+   mini_unkeyed_for_each(cc, meta_head, type, mini_prefetch_extent, NULL);
 }
 
-page_handle *
-mini_allocator_blind_inc(cache *cc,
-                         uint64 meta_head)
+/*
+ *-----------------------------------------------------------------------------
+ *
+ * mini_[keyed,unkeyed]_print --
+ *
+ *      Prints each meta_page together with all its entries to
+ *      PLATFORM_DEFAULT_LOG.
+ *
+ *      Keyed allocators print each extent addr together with start and end
+ *      keys, unkeyed allocators only print the extent addr.
+ *
+ * Results:
+ *      None.
+ *
+ * Side effects:
+ *      None.
+ *
+ *-----------------------------------------------------------------------------
+ */
+
+void
+mini_unkeyed_print(cache *cc, uint64 meta_head, page_type type)
 {
-   return cache_get(cc, meta_head, TRUE, PAGE_TYPE_MISC);
-   //uint64 next_meta_addr = meta_head;
-   //do {
-   //   page_handle *meta_page = cache_get(cc, next_meta_addr, TRUE, PAGE_TYPE_MISC);
-   //   mini_allocator_meta_hdr *hdr = (mini_allocator_meta_hdr *)meta_page->data;
-   //   allocator *al = cache_allocator(cc);
-   //   for (uint64 i = 0; i < hdr->pos; i++) {
-   //      mini_allocator_meta_entry *entry = &hdr->entry[i];
-   //      if (!entry->zapped) {
-   //         allocator_inc_refcount(al, entry->extent_addr);
-   //      }
-   //   }
-   //   next_meta_addr = hdr->next_meta_addr;
-   //   cache_unget(cc, meta_page);
-   //} while (next_meta_addr != 0);
+   uint64 next_meta_addr = meta_head;
+
+   platform_log("---------------------------------------------\n");
+   platform_log("| Mini Allocator -- meta_head: %12lu |\n", meta_head);
+   platform_log("|-------------------------------------------|\n");
+   platform_log("| idx | %35s |\n", "extent_addr");
+   platform_log("|-------------------------------------------|\n");
+
+   do {
+      page_handle *meta_page = cache_get(cc, next_meta_addr, TRUE, type);
+
+      platform_log("| meta addr %31lu |\n", next_meta_addr);
+      platform_log("|-------------------------------------------|\n");
+
+      uint64 num_entries = mini_num_entries(meta_page);
+      for (uint64 i = 0; i < num_entries; i++) {
+         uint64 extent_addr = mini_unkeyed_get_entry(cc, meta_page, i);
+         platform_log("| %3lu | %35lu |\n", i, extent_addr);
+      }
+      platform_log("|-------------------------------------------|\n");
+
+      next_meta_addr = mini_get_next_meta_addr(meta_page);
+      cache_unget(cc, meta_page);
+   } while (next_meta_addr != 0);
+   platform_log("\n");
 }
 
 void
-mini_allocator_blind_zap(cache       *cc,
-                         page_type    type,
-                         page_handle *meta_page)
+mini_keyed_print(cache *      cc,
+                 data_config *data_cfg,
+                 uint64       meta_head,
+                 page_type    type)
 {
-   cache_unget(cc, meta_page);
-   //uint64 next_meta_addr = meta_head;
-   //bool fully_zapped = TRUE;
-   //bool did_a_zap = FALSE;
-   //do {
-   //   bool locked = FALSE;
-   //   page_handle *meta_page = cache_get(cc, next_meta_addr, TRUE, PAGE_TYPE_MISC);
+   uint64 next_meta_addr = meta_head;
 
-   //   mini_allocator_meta_hdr *hdr = (mini_allocator_meta_hdr *)meta_page->data;
-   //   for (uint64 i = 0; i < hdr->pos; i++) {
-   //      mini_allocator_meta_entry *entry = &hdr->entry[i];
-   //      if (!entry->zapped) {
-   //         bool just_zapped = cache_dealloc(cc, entry->extent_addr, type);
-   //         if (just_zapped) {
-   //            if (!locked) {
-   //               uint64 wait = 1;
-   //               while (!cache_claim(cc, meta_page)) {
-   //                  cache_unget(cc, meta_page);
-   //                  meta_page = NULL;
-   //                  platform_sleep(wait);
-   //                  wait = wait > 1024 ? wait : 2 * wait;
-   //                  meta_page = cache_get(cc, next_meta_addr, TRUE, PAGE_TYPE_MISC);
-   //               }
-   //               cache_lock(cc, meta_page);
-   //               locked = TRUE;
-   //            }
-   //            entry->zapped = TRUE;
-   //            did_a_zap = TRUE;
-   //         }
-   //      }
-   //      fully_zapped = fully_zapped && entry->zapped;
-   //   }
-   //   if (hdr->pos == 0 && next_meta_addr == meta_head) {
-   //      fully_zapped = FALSE;
-   //   }
-   //   next_meta_addr = hdr->next_meta_addr;
-   //   if (locked) {
-   //      cache_mark_dirty(cc, meta_page);
-   //      cache_unlock(cc, meta_page);
-   //      cache_unclaim(cc, meta_page);
-   //   }
-   //   cache_unget(cc, meta_page);
-   //} while (next_meta_addr != 0);
-   //if (fully_zapped && did_a_zap) {
-   //   //platform_log("fully zapped %lu\n", meta_head - 4096);
-   //   uint64 next_meta_addr = meta_head;
-   //   do {
-   //      page_handle *meta_page = cache_get(cc, next_meta_addr, TRUE, PAGE_TYPE_MISC);
-   //      mini_allocator_meta_hdr *hdr = (mini_allocator_meta_hdr *)meta_page->data;
-   //      uint64 last_meta_addr = next_meta_addr;
-   //      next_meta_addr = hdr->next_meta_addr;
-   //      cache_unget(cc, meta_page);
-   //      if (!mini_allocator_addrs_share_extent(cc, last_meta_addr, next_meta_addr)) {
-   //         uint64 last_meta_base_addr =
-   //            last_meta_addr / cache_extent_size(cc) * cache_extent_size(cc);
-   //         cache_dealloc(cc, last_meta_base_addr, type);
-   //      }
-   //   } while (next_meta_addr != 0);
-   //}
+   platform_log(
+      "----------------------------------------------------------------\n");
+   platform_log("| Mini Keyed Allocator -- meta_head: %12lu              |\n",
+                meta_head);
+   platform_log(
+      "|--------------------------------------------------------------|\n");
+   platform_log(
+      "| idx | %12s | %18s | %18s |\n", "extent_addr", "start_key", "end_key");
+   platform_log(
+      "|--------------------------------------------------------------|\n");
+
+   do {
+      page_handle *meta_page = cache_get(cc, next_meta_addr, TRUE, type);
+
+      platform_log(
+         "| meta addr: %12lu                                      |\n",
+         next_meta_addr);
+      platform_log(
+         "|--------------------------------------------------------------|\n");
+
+      uint64 num_entries = mini_num_entries(meta_page);
+      for (uint64 i = 0; i < num_entries; i++) {
+         const char *start_key, *end_key;
+         uint64      extent_addr;
+         mini_keyed_get_entry(
+            cc, data_cfg, meta_page, i, &extent_addr, &start_key, &end_key);
+         char start_key_str[MAX_KEY_STR_LEN];
+         data_key_to_string(
+            data_cfg, start_key, start_key_str, MAX_KEY_STR_LEN);
+         char end_key_str[MAX_KEY_STR_LEN];
+         data_key_to_string(data_cfg, end_key, end_key_str, MAX_KEY_STR_LEN);
+         platform_log("| %3lu | %12lu | %18s | %18s |\n",
+                      i,
+                      extent_addr,
+                      start_key_str,
+                      end_key_str);
+      }
+      platform_log(
+         "|--------------------------------------------------------------|\n");
+
+      next_meta_addr = mini_get_next_meta_addr(meta_page);
+      cache_unget(cc, meta_page);
+   } while (next_meta_addr != 0);
+   platform_log("\n");
 }

--- a/src/mini_allocator.h
+++ b/src/mini_allocator.h
@@ -22,91 +22,77 @@ typedef struct mini_allocator {
    allocator *     al;
    cache *         cc;
    data_config *   data_cfg;
+   bool            keyed;
    uint64          meta_head;
    volatile uint64 meta_tail;
+   page_type       type;
+
    uint64          num_batches;
    volatile uint64 next_addr[MINI_MAX_BATCHES];
    uint64          next_extent[MINI_MAX_BATCHES];
    uint64          last_meta_addr[MINI_MAX_BATCHES];
    uint64          last_meta_pos[MINI_MAX_BATCHES];
-   page_type       type;
 } mini_allocator;
 
-typedef struct mini_allocator_sync_arg {
-   uint64 *pages_outstanding;
-   uint64  page_size;
-} mini_allocator_sync_arg;
+uint64
+mini_init(mini_allocator *mini,
+          cache *         cc,
+          data_config *   cfg,
+          uint64          meta_head,
+          uint64          meta_tail,
+          uint64          num_batches,
+          page_type       type,
+          bool            keyed);
+void
+mini_release(mini_allocator *mini, const char *key);
 
 uint64
-mini_allocator_init(mini_allocator *mini,
-                    cache          *cc,
-                    data_config    *cfg,
-                    uint64          meta_head,
-                    uint64          meta_tail,
-                    uint64          num_batches,
-                    page_type       type);
+mini_alloc(mini_allocator *mini,
+           uint64          batch,
+           const char *    key,
+           uint64 *        next_extent);
 
-uint64
-mini_allocator_alloc(mini_allocator *mini,
-                     uint64          batch,
-                     char           *key,
-                     uint64         *next_extent);
+
+uint8
+mini_unkeyed_inc_ref(cache *cc, uint64 meta_head);
+uint8
+mini_unkeyed_dec_ref(cache *cc, uint64 meta_head, page_type type);
 
 void
-mini_allocator_release(mini_allocator *mini,
-                       char           *key);
-
-bool
-mini_allocator_zap(cache       *cc,
+mini_keyed_inc_ref(cache *      cc,
                    data_config *data_cfg,
+                   page_type    type,
                    uint64       meta_head,
-                   const char  *start_key,
-                   const char  *end_key,
-                   page_type    type);
-
+                   const char * start_key,
+                   const char * end_key);
 void
-mini_allocator_sync(cache     *cc,
-                    page_type  type,
-                    uint64     meta_head,
-                    uint64    *pages_outstanding);
-
-void
-mini_allocator_inc_range(cache       *cc,
-                         data_config *data_cfg,
-                         page_type    type,
-                         uint64       meta_head,
-                         const char  *start_key,
-                         const char  *end_key);
-
-page_handle *
-mini_allocator_blind_inc(cache *cc,
-                         uint64 meta_head);
-
-void
-mini_allocator_blind_zap(cache       *cc,
-                         page_type    type,
-                         page_handle *meta_page);
+mini_keyed_dec_ref(cache *      cc,
+                   data_config *data_cfg,
+                   page_type    type,
+                   uint64       meta_head,
+                   const char * start_key,
+                   const char * end_key);
 
 uint64
-mini_allocator_extent_count(cache     *cc,
-                            page_type  type,
-                            uint64     meta_head);
-
-uint64
-mini_allocator_count_extents_in_range(cache       *cc,
-                                      data_config *data_cfg,
-                                      page_type    type,
-                                      uint64       meta_head,
-                                      const char  *start_key,
-                                      const char  *end_key);
+mini_keyed_extent_count(cache *      cc,
+                        data_config *data_cfg,
+                        page_type    type,
+                        uint64       meta_head,
+                        const char * start_key,
+                        const char * end_key);
+void
+mini_unkeyed_prefetch(cache *cc, page_type type, uint64 meta_head);
 
 void
-mini_allocator_prefetch(cache     *cc,
-                        page_type  type,
-                        uint64     meta_head);
+mini_unkeyed_print(cache *cc, uint64 meta_head, page_type type);
+void
+mini_keyed_print(cache *      cc,
+                 data_config *data_cfg,
+                 uint64       meta_head,
+                 page_type    type);
 
 static inline uint64
-mini_allocator_meta_tail(mini_allocator *mini)
+mini_meta_tail(mini_allocator *mini)
 {
    return mini->meta_tail;
 }

--- a/src/routing_filter.c
+++ b/src/routing_filter.c
@@ -350,7 +350,7 @@ routing_filter_add(cache            *cc,
    uint32 old_value_mask = 0;
    size_t old_remainder_and_value_size = 0;
    if (old_filter->addr != 0) {
-      mini_allocator_prefetch(cc, PAGE_TYPE_FILTER, old_filter->meta_head);
+      mini_unkeyed_prefetch(cc, PAGE_TYPE_FILTER, old_filter->meta_head);
       old_log_num_buckets = 31 - __builtin_clz(old_filter->num_fingerprints);
       if (old_log_num_buckets < cfg->log_index_size) {
          old_log_num_buckets = cfg->log_index_size;
@@ -429,28 +429,28 @@ routing_filter_add(cache            *cc,
    platform_status rc = allocator_alloc_extent(al, &meta_head);
    platform_assert_status_ok(rc);
    filter->meta_head = meta_head;
+   // filters use an unkeyed mini allocator
    mini_allocator mini;
-   mini_allocator_init(
-      &mini, cc, NULL, filter->meta_head, 0, 1, PAGE_TYPE_FILTER);
+   mini_init(&mini, cc, NULL, filter->meta_head, 0, 1, PAGE_TYPE_FILTER, FALSE);
 
    // set up the index pages
    uint64 addrs_per_page = page_size / sizeof(uint64);
    page_handle *index_page[MAX_PAGES_PER_EXTENT];
-   uint64 index_addr = mini_allocator_alloc(&mini, 0, NULL, NULL);
+   uint64       index_addr = mini_alloc(&mini, 0, NULL, NULL);
    platform_assert(index_addr % extent_size == 0);
    index_page[0] = cache_alloc(cc, index_addr, PAGE_TYPE_FILTER);
    for (uint64 i = 1; i < pages_per_extent; i++) {
-      uint64 next_index_addr = mini_allocator_alloc(&mini, 0, NULL, NULL);
+      uint64 next_index_addr = mini_alloc(&mini, 0, NULL, NULL);
       platform_assert(next_index_addr == index_addr + i * page_size);
       index_page[i] = cache_alloc(cc, next_index_addr, PAGE_TYPE_FILTER);
    }
    filter->addr = index_addr;
 
    // we write to the filter with the filter cursor
-   uint64 addr = mini_allocator_alloc(&mini, 0, NULL, NULL);
+   uint64       addr                    = mini_alloc(&mini, 0, NULL, NULL);
    page_handle *filter_page   = cache_alloc(cc, addr, PAGE_TYPE_FILTER);
-   char *filter_cursor = filter_page->data;
-   uint64 bytes_remaining_on_page = page_size;
+   char *       filter_cursor           = filter_page->data;
+   uint64       bytes_remaining_on_page = page_size;
 
    for (uint32 new_fp_no = 0; new_fp_no < num_new_fp; new_fp_no++) {
       new_fp_arr[new_fp_no] >>= 32 - cfg->fingerprint_size;
@@ -578,7 +578,7 @@ routing_filter_add(cache            *cc,
          uint32 header_size = encoding_size + sizeof(routing_hdr);
          if (header_size + remainder_block_size > bytes_remaining_on_page) {
             routing_unlock_and_unget_page(cc, filter_page);
-            addr = mini_allocator_alloc(&mini, 0, NULL, NULL);
+            addr        = mini_alloc(&mini, 0, NULL, NULL);
             filter_page = cache_alloc(cc, addr, PAGE_TYPE_FILTER);
 
             bytes_remaining_on_page = page_size;
@@ -621,7 +621,7 @@ routing_filter_add(cache            *cc,
       routing_unlock_and_unget_page(cc, index_page[i]);
    }
 
-   mini_allocator_release(&mini, NULL);
+   mini_release(&mini, NULL);
 
    platform_free(hid, temp);
 
@@ -1149,14 +1149,7 @@ routing_filter_zap(cache          *cc,
    }
 
    uint64 meta_head = filter->meta_head;
-   // If this returns 2, then we hold the only ref, i.e. it's safe to zap
-   uint64 ref = cache_get_ref(cc, meta_head);
-
-   if (ref == 2) {
-      mini_allocator_zap(cc, NULL, meta_head, NULL, NULL, PAGE_TYPE_FILTER);
-   } else {
-      cache_dealloc(cc, meta_head, PAGE_TYPE_FILTER);
-   }
+   mini_unkeyed_dec_ref(cc, meta_head, PAGE_TYPE_FILTER);
 }
 
 /*

--- a/tests/btree_test.c
+++ b/tests/btree_test.c
@@ -710,7 +710,8 @@ test_btree_basic(cache             *cc,
 
    btree_print_tree_stats(cc, btree_cfg, packed_root_addr);
 
-   btree_zap(cc, btree_cfg, packed_root_addr, PAGE_TYPE_BRANCH);
+   btree_zap_range(
+      cc, btree_cfg, packed_root_addr, NULL, NULL, PAGE_TYPE_BRANCH);
 
 destroy_btree:
    if (SUCCESS(rc))
@@ -905,8 +906,10 @@ test_btree_merge_basic(cache             *cc,
 
 destroy_btrees:
    for (uint64 tree_no = 0; tree_no < arity; tree_no++) {
-      btree_zap(cc, btree_cfg, root_addr[tree_no], PAGE_TYPE_BRANCH);
-      btree_zap(cc, btree_cfg, output_addr[tree_no], PAGE_TYPE_BRANCH);
+      btree_zap_range(
+         cc, btree_cfg, root_addr[tree_no], NULL, NULL, PAGE_TYPE_BRANCH);
+      btree_zap_range(
+         cc, btree_cfg, output_addr[tree_no], NULL, NULL, PAGE_TYPE_BRANCH);
    }
    if (SUCCESS(rc)) {
       platform_log("btree_test: btree merge test succeeded\n");
@@ -966,7 +969,7 @@ test_btree_count_in_range(cache             *cc,
    }
 
 destroy_btree:
-   btree_zap(cc, btree_cfg, root_addr, PAGE_TYPE_BRANCH);
+   btree_zap_range(cc, btree_cfg, root_addr, NULL, NULL, PAGE_TYPE_BRANCH);
 
    platform_free(hid, bound_key);
    if (SUCCESS(rc))

--- a/tests/cache_test.c
+++ b/tests/cache_test.c
@@ -265,7 +265,13 @@ test_cache_basic(cache             *cc,
     * Deallocate all the entries.
     */
    for (uint32 i = 0; i < extents_to_allocate; i++) {
-      cache_dealloc(cc, addr_arr[i * cfg->pages_per_extent], PAGE_TYPE_MISC);
+      uint64     addr = addr_arr[i * cfg->pages_per_extent];
+      allocator *al   = cache_allocator(cc);
+      uint8      ref  = allocator_dec_refcount(al, addr);
+      platform_assert(ref == AL_NO_REFS);
+      cache_hard_evict_extent(cc, addr, PAGE_TYPE_MISC);
+      ref = allocator_dec_refcount(al, addr);
+      platform_assert(ref == AL_FREE);
    }
 
 exit:
@@ -508,7 +514,13 @@ test_cache_flush(cache             *cc,
     * Deallocate all the entries.
     */
    for (uint32 i = 0; i < extents_to_allocate; i++) {
-      cache_dealloc(cc, addr_arr[i * cfg->pages_per_extent], PAGE_TYPE_MISC);
+      uint64     addr = addr_arr[i * cfg->pages_per_extent];
+      allocator *al   = cache_allocator(cc);
+      uint8      ref  = allocator_dec_refcount(al, addr);
+      platform_assert(ref == AL_NO_REFS);
+      cache_hard_evict_extent(cc, addr, PAGE_TYPE_MISC);
+      ref = allocator_dec_refcount(al, addr);
+      platform_assert(ref == AL_FREE);
    }
    platform_log("Dealloc took %lu secs\n",
                 NSEC_TO_SEC(platform_timestamp_elapsed(t_start)));
@@ -877,7 +889,13 @@ test_cache_async(cache             *cc,
    }
    // Deallocate all the entries.
    for (uint32 i = 0; i < extents_to_allocate; i++) {
-      cache_dealloc(cc, addr_arr[i * cfg->pages_per_extent], PAGE_TYPE_MISC);
+      uint64     addr = addr_arr[i * cfg->pages_per_extent];
+      allocator *al   = cache_allocator(cc);
+      uint8      ref  = allocator_dec_refcount(al, addr);
+      platform_assert(ref == AL_NO_REFS);
+      cache_hard_evict_extent(cc, addr, PAGE_TYPE_MISC);
+      ref = allocator_dec_refcount(al, addr);
+      platform_assert(ref == AL_FREE);
    }
    platform_free(hid, addr_arr);
    platform_free(hid, params);

--- a/tests/log_test.c
+++ b/tests/log_test.c
@@ -57,6 +57,8 @@ test_log_basic(cache            *cc,
       log_write(logh, key, data, i);
    }
 
+   mini_release(&log->mini, NULL);
+
    rc = shard_log_iterator_init(cc, cfg, hid, addr, magic, &itor);
    platform_assert_status_ok(rc);
    itorh = (iterator *)&itor;


### PR DESCRIPTION
Rewrite of the mini allocator.

Adds keyed and unkeyed versions of the mini allocator for the branches
and everything else, respectively. Keyed mini allocators pack keys
rather than using MAX_KEY_LEN, saving space. Unkeyed mini allocators
don't store keys at all.

Some minor API changes:
The mini_allocator_ prefix is now just mini_.
mini_keyed_ and mini_unkeyed_ are used when functions require one or the
   other.
Some unused functions have been removed, minor renaming and parameter
   reordering for consistency.

Unkeyed mini allocators now handle their own ref counts by overloading
the meta_head ref count. This replaces awkward external code in several
places which did a similar overloading.

This breaks two things, one major and one minor:
The major break is that range queries and branch destruction can race. A
   fix is coming in a future commit.
*** This break is fixed in #67 
The minor break is that it is no longer safe to count the extents in a
   branch, which was always sketchy because it counted all extents, not
   just those which are live for the branch.