### PR TITLE
Move page alloc stats from cache to allocator

### DIFF
--- a/src/btree.c
+++ b/src/btree.c
@@ -997,7 +997,7 @@ btree_init(cache          *cc,
    page_type type = is_packed ? PAGE_TYPE_BRANCH : PAGE_TYPE_MEMTABLE;
    allocator *     al   = cache_allocator(cc);
    uint64          base_addr;
-   platform_status rc = allocator_alloc_extent(al, &base_addr);
+   platform_status rc = allocator_alloc(al, &base_addr, type);
    platform_assert_status_ok(rc);
    page_handle *root_page = cache_alloc(cc, base_addr, type);
 
@@ -1077,9 +1077,8 @@ btree_zap_range(cache        *cc,
    }
 
    uint64 meta_head = btree_root_to_meta_addr(cc, cfg, root_addr, 0);
-   mini_keyed_dec_ref(
+   return mini_keyed_dec_ref(
       cc, cfg->data_cfg, PAGE_TYPE_BRANCH, meta_head, start_key, end_key);
-   return TRUE;
 }
 
 // FIXME: [aconway 2021-08-21]

--- a/src/cache.h
+++ b/src/cache.h
@@ -21,24 +21,10 @@ typedef struct page_handle {
 
 typedef struct cache cache;
 
-typedef enum page_type {
-   PAGE_TYPE_TRUNK,
-   PAGE_TYPE_BRANCH,
-   PAGE_TYPE_MEMTABLE,
-   PAGE_TYPE_FILTER,
-   PAGE_TYPE_LOG,
-   PAGE_TYPE_MISC,
-   PAGE_TYPE_LOCK_NO_DATA,
-   NUM_PAGE_TYPES,
-   PAGE_TYPE_INVALID,
-} page_type;
-
 typedef struct cache_stats {
    uint64 cache_hits[NUM_PAGE_TYPES];
    uint64 cache_misses[NUM_PAGE_TYPES];
    uint64 cache_miss_time_ns[NUM_PAGE_TYPES];
-   uint64 page_allocs[NUM_PAGE_TYPES];
-   uint64 page_deallocs[NUM_PAGE_TYPES];
    uint64 page_writes[NUM_PAGE_TYPES];
    uint64 page_reads[NUM_PAGE_TYPES];
    uint64 prefetches_issued[NUM_PAGE_TYPES];
@@ -160,7 +146,6 @@ typedef struct cache_ops {
    cache_generic_fn        cleanup;
    assert_ungot_fn         assert_ungot;
    cache_generic_fn        assert_free;
-   cache_generic_fn        assert_noleaks;
    page_valid_fn           page_valid;
    validate_page_fn        validate_page;
    cache_present_fn        cache_present;
@@ -334,12 +319,6 @@ static inline void
 cache_assert_free(cache *cc)
 {
    return cc->ops->assert_free(cc);
-}
-
-static inline void
-cache_assert_noleaks(cache *cc)
-{
-   return cc->ops->assert_noleaks(cc);
 }
 
 static inline void

--- a/src/memtable.h
+++ b/src/memtable.h
@@ -51,24 +51,11 @@ typedef struct memtable_tree {
 #endif
 
 typedef struct memtable {
-   // FIXME: [aconway 2020-08-26] need to implement:
    volatile memtable_state state;
    uint64                  generation;
-
-#if 1
-   // the core memtable stuff
-   // "a memtable tree"
-   // FIXME: [yfogel 2020-08-26] do we need num_trees anymore?
-   // size_t         num_trees;
-   // FIXME: [yfogel 2020-08-26] refactor into:
-   // memtable_tree  trees[NUM_DATA_TYPES];
    uint64          root_addr;
    mini_allocator  mini;
    btree_config   *cfg;
-#else
-   memtable_tree trees[NUM_DATA_TYPES];
-#endif
-
 } PLATFORM_CACHELINE_ALIGNED memtable;
 
 // FIXME: [aconway 2020-09-01] MUST_CHECK_RETURN

--- a/src/mini_allocator.h
+++ b/src/mini_allocator.h
@@ -65,7 +65,7 @@ mini_keyed_inc_ref(cache *      cc,
                    uint64       meta_head,
                    const char * start_key,
                    const char * end_key);
-void
+bool
 mini_keyed_dec_ref(cache *      cc,
                    data_config *data_cfg,
                    page_type    type,

--- a/src/rc_allocator.c
+++ b/src/rc_allocator.c
@@ -30,43 +30,169 @@
  */
 
 // allocator.h functions
-platform_status      rc_allocator_alloc_extent         (rc_allocator *al, uint64 *addr_arr);
-uint8                rc_allocator_inc_ref              (rc_allocator *al, uint64 addr);
-uint8                rc_allocator_dec_ref              (rc_allocator *al, uint64 addr);
-uint8                rc_allocator_get_ref              (rc_allocator *al, uint64 addr);
-uint64               rc_allocator_get_capacity         (rc_allocator *al);
-platform_status      rc_allocator_get_super_addr       (rc_allocator *al,
-                                                        allocator_root_id spl_id,
-                                                        uint64 *addr);
-platform_status      rc_allocator_alloc_super_addr     (rc_allocator *al,
-                                                        allocator_root_id spl_id,
-                                                        uint64 *addr);
-void                 rc_allocator_remove_super_addr    (rc_allocator *al,
-                                                        allocator_root_id spl_id);
-uint64               rc_allocator_extent_size          (rc_allocator *al);
-uint64               rc_allocator_page_size            (rc_allocator *al);
-void                 rc_allocator_print_allocated      (rc_allocator *al);
-uint64               rc_allocator_max_allocated        (rc_allocator *al);
-uint64               rc_allocator_in_use               (rc_allocator *al);
+platform_status
+rc_allocator_alloc(rc_allocator *al, uint64 *addr, page_type type);
 
-// other functions
+platform_status
+rc_allocator_alloc_virtual(allocator *a, uint64 *addr, page_type type)
+{
+   rc_allocator *al = (rc_allocator *)a;
+   return rc_allocator_alloc(al, addr, type);
+}
+
+uint8
+rc_allocator_inc_ref(rc_allocator *al, uint64 addr);
+
+uint8
+rc_allocator_inc_ref_virtual(allocator *a, uint64 addr)
+{
+   rc_allocator *al = (rc_allocator *)a;
+   return rc_allocator_inc_ref(al, addr);
+}
+
+uint8
+rc_allocator_dec_ref(rc_allocator *al, uint64 addr, page_type type);
+
+uint8
+rc_allocator_dec_ref_virtual(allocator *a, uint64 addr, page_type type)
+{
+   rc_allocator *al = (rc_allocator *)a;
+   return rc_allocator_dec_ref(al, addr, type);
+}
+
+uint8
+rc_allocator_get_ref(rc_allocator *al, uint64 addr);
+
+uint8
+rc_allocator_get_ref_virtual(allocator *a, uint64 addr)
+{
+   rc_allocator *al = (rc_allocator *)a;
+   return rc_allocator_get_ref(al, addr);
+}
+
+platform_status
+rc_allocator_get_super_addr(rc_allocator *    al,
+                            allocator_root_id spl_id,
+                            uint64 *          addr);
+
+platform_status
+rc_allocator_get_super_addr_virtual(allocator *       a,
+                                    allocator_root_id spl_id,
+                                    uint64 *          addr)
+{
+   rc_allocator *al = (rc_allocator *)a;
+   return rc_allocator_get_super_addr(al, spl_id, addr);
+}
+
+platform_status
+rc_allocator_alloc_super_addr(rc_allocator *    al,
+                              allocator_root_id spl_id,
+                              uint64 *          addr);
+
+platform_status
+rc_allocator_alloc_super_addr_virtual(allocator *       a,
+                                      allocator_root_id spl_id,
+                                      uint64 *          addr)
+{
+   rc_allocator *al = (rc_allocator *)a;
+   return rc_allocator_alloc_super_addr(al, spl_id, addr);
+}
+
+void
+rc_allocator_remove_super_addr(rc_allocator *al, allocator_root_id spl_id);
+
+void
+rc_allocator_remove_super_addr_virtual(allocator *a, allocator_root_id spl_id)
+{
+   rc_allocator *al = (rc_allocator *)a;
+   rc_allocator_remove_super_addr(al, spl_id);
+}
+
+uint64
+rc_allocator_in_use(rc_allocator *al);
+
+uint64
+rc_allocator_in_use_virtual(allocator *a)
+{
+   rc_allocator *al = (rc_allocator *)a;
+   return rc_allocator_in_use(al);
+}
+
+uint64
+rc_allocator_get_capacity(rc_allocator *al);
+
+uint64
+rc_allocator_get_capacity_virtual(allocator *a)
+{
+   rc_allocator *al = (rc_allocator *)a;
+   return rc_allocator_get_capacity(al);
+}
+
+uint64
+rc_allocator_extent_size(rc_allocator *al);
+
+uint64
+rc_allocator_extent_size_virtual(allocator *a)
+{
+   rc_allocator *al = (rc_allocator *)a;
+   return rc_allocator_extent_size(al);
+}
+
+uint64
+rc_allocator_page_size(rc_allocator *al);
+
+uint64
+rc_allocator_page_size_virtual(allocator *a)
+{
+   rc_allocator *al = (rc_allocator *)a;
+   return rc_allocator_page_size(al);
+}
+
+void
+rc_allocator_assert_noleaks(rc_allocator *al);
+
+void
+rc_allocator_assert_noleaks_virtual(allocator *a)
+{
+   rc_allocator *al = (rc_allocator *)a;
+   rc_allocator_assert_noleaks(al);
+}
+
+void
+rc_allocator_print_stats(rc_allocator *al);
+
+void
+rc_allocator_print_stats_virtual(allocator *a)
+{
+   rc_allocator *al = (rc_allocator *)a;
+   rc_allocator_print_stats(al);
+}
+
+void
+rc_allocator_debug_print(rc_allocator *al);
+
+void
+rc_allocator_debug_print_virtual(allocator *a)
+{
+   rc_allocator *al = (rc_allocator *)a;
+   rc_allocator_debug_print(al);
+}
 
 const static allocator_ops rc_allocator_ops = {
-   .alloc_extent      = (alloc_extent_fn)      rc_allocator_alloc_extent,
-   .inc_refcount      = (inc_refcount_fn)      rc_allocator_inc_ref,
-   .dec_refcount      = (dec_refcount_fn)      rc_allocator_dec_ref,
-   .get_refcount      = (get_refcount_fn)      rc_allocator_get_ref,
-   .get_capacity      = (get_capacity_fn)      rc_allocator_get_capacity,
-   .get_super_addr    = (get_super_addr_fn)    rc_allocator_get_super_addr,
-   .alloc_super_addr  = (alloc_super_addr_fn)  rc_allocator_alloc_super_addr,
-   .remove_super_addr = (remove_super_addr_fn) rc_allocator_remove_super_addr,
-   .in_use            = (in_use_fn)            rc_allocator_in_use,
-   .get_extent_size   = (get_size_fn)          rc_allocator_extent_size,
-   .get_page_size     = (get_size_fn)          rc_allocator_page_size,
-   .print_allocated   = (print_allocated_fn)   rc_allocator_print_allocated,
-   .max_allocated     = (max_allocated_fn)     rc_allocator_max_allocated,
+   .alloc             = rc_allocator_alloc_virtual,
+   .inc_ref           = rc_allocator_inc_ref_virtual,
+   .dec_ref           = rc_allocator_dec_ref_virtual,
+   .get_ref           = rc_allocator_get_ref_virtual,
+   .get_super_addr    = rc_allocator_get_super_addr_virtual,
+   .alloc_super_addr  = rc_allocator_alloc_super_addr_virtual,
+   .remove_super_addr = rc_allocator_remove_super_addr_virtual,
+   .get_capacity      = rc_allocator_get_capacity_virtual,
+   .get_extent_size   = rc_allocator_extent_size_virtual,
+   .get_page_size     = rc_allocator_page_size_virtual,
+   .assert_noleaks    = rc_allocator_assert_noleaks_virtual,
+   .print_stats       = rc_allocator_print_stats_virtual,
+   .debug_print       = rc_allocator_debug_print_virtual,
 };
-
 
 static platform_status
 rc_allocator_init_meta_page(rc_allocator *al)
@@ -185,7 +311,7 @@ rc_allocator_init(rc_allocator         *al,
    memset(al->ref_count, 0, buffer_size);
 
    // allocate the super block
-   allocator_alloc_extent(&al->super, &addr);
+   allocator_alloc(&al->super, &addr, PAGE_TYPE_MISC);
    // super block extent should always start from address 0.
    platform_assert(addr == RC_ALLOCATOR_BASE_OFFSET);
 
@@ -196,7 +322,7 @@ rc_allocator_init(rc_allocator         *al,
    rc_extent_count = (buffer_size + al->cfg->extent_size - 1)
       / al->cfg->extent_size;
    for (uint64 i = 0; i < rc_extent_count; i++) {
-      allocator_alloc_extent(&al->super, &addr);
+      allocator_alloc(&al->super, &addr, PAGE_TYPE_MISC);
       platform_assert(addr == cfg->extent_size * (i + 1));
    }
 
@@ -281,11 +407,11 @@ rc_allocator_mount(rc_allocator         *al,
    platform_assert_status_ok(status);
    for (uint64 i = 0; i < al->cfg->extent_capacity; i++) {
       if (al->ref_count[i] != 0) {
-         al->allocated++;
+         al->stats.curr_allocated++;
       }
    }
    platform_log("Allocated at mount: %lu MiB\n",
-         B_TO_MiB(al->allocated * cfg->extent_size));
+                B_TO_MiB(al->stats.curr_allocated * cfg->extent_size));
    return STATUS_OK;
 }
 
@@ -296,7 +422,7 @@ rc_allocator_dismount(rc_allocator *al)
    platform_status status;
 
    platform_log("Allocated at dismount: %lu MiB\n",
-         B_TO_MiB(al->allocated * al->cfg->extent_size));
+                B_TO_MiB(al->stats.curr_allocated * al->cfg->extent_size));
    // persist the ref counts upon dismount.
    uint32 io_size = ROUNDUP(al->cfg->extent_capacity, al->cfg->page_size);
    status = io_write(al->io, al->ref_count, io_size, al->cfg->extent_size);
@@ -308,9 +434,11 @@ rc_allocator_dismount(rc_allocator *al)
 /*
  *----------------------------------------------------------------------
  *
- * rc_allocator_inc_ref --
+ * rc_allocator_[inc,dec,get]_ref --
  *
- *      Increments the ref count of the given address and returns the new one.
+ *      Increments/decrements/fetches the ref count of the given address and
+ *      returns the new one. If the ref_count goes to 0, then the extent is
+ *      freed.
  *
  *----------------------------------------------------------------------
  */
@@ -328,15 +456,22 @@ rc_allocator_inc_ref(rc_allocator *al, uint64 addr)
    return ref_count;
 }
 
-/*
- *----------------------------------------------------------------------
- *
- * rc_allocator_get_ref --
- *
- *      Returns the ref count of the given address.
- *
- *----------------------------------------------------------------------
- */
+uint8
+rc_allocator_dec_ref(rc_allocator *al, uint64 addr, page_type type)
+{
+   debug_assert(addr % al->cfg->extent_size == 0);
+
+   uint64 extent_no = addr / al->cfg->extent_size;
+   debug_assert(extent_no < al->cfg->extent_capacity);
+
+   uint8 ref_count = __sync_sub_and_fetch(&al->ref_count[extent_no], 1);
+   platform_assert(ref_count != UINT8_MAX);
+   if (ref_count == 0) {
+      __sync_sub_and_fetch(&al->stats.curr_allocated, 1);
+      __sync_add_and_fetch(&al->stats.extent_deallocs[type], 1);
+   }
+   return ref_count;
+}
 
 uint8
 rc_allocator_get_ref(rc_allocator *al, uint64 addr)
@@ -347,33 +482,6 @@ rc_allocator_get_ref(rc_allocator *al, uint64 addr)
    extent_no = addr / al->cfg->extent_size;
    debug_assert(extent_no < al->cfg->extent_capacity);
    return al->ref_count[extent_no];
-}
-
-/*
- *----------------------------------------------------------------------
- *
- * rc_allocator_dec_ref --
- *
- *      Decrements the ref count and returns the new one. If the ref_count
- *      is 0, then the extent is free.
- *
- *----------------------------------------------------------------------
- */
-
-uint8
-rc_allocator_dec_ref(rc_allocator *al, uint64 addr)
-{
-   debug_assert(addr % al->cfg->extent_size == 0);
-
-   uint64 extent_no = addr / al->cfg->extent_size;
-   debug_assert(extent_no < al->cfg->extent_capacity);
-
-   uint8 ref_count = __sync_sub_and_fetch(&al->ref_count[extent_no], 1);
-   platform_assert(ref_count != UINT8_MAX);
-   if (ref_count == 0) {
-      __sync_sub_and_fetch(&al->allocated, 1);
-   }
-   return ref_count;
 }
 
 
@@ -414,16 +522,6 @@ rc_allocator_get_super_addr(rc_allocator *al,
    platform_mutex_unlock(&al->lock);
    return status;
 
-}
-
-uint64 rc_allocator_in_use(rc_allocator *al)
-{
-   return al->allocated * al->cfg->extent_size;
-}
-
-uint64 rc_allocator_max_allocated(rc_allocator *al)
-{
-   return al->max_allocated * al->cfg->extent_size;
 }
 
 platform_status
@@ -505,7 +603,7 @@ rc_allocator_page_size(rc_allocator *al)
 /*
  *----------------------------------------------------------------------
  *
- * rc_allocator_alloc_extent --
+ * rc_allocator_alloc--
  *
  *      Allocate an extent
  *
@@ -513,8 +611,9 @@ rc_allocator_page_size(rc_allocator *al)
  */
 
 platform_status
-rc_allocator_alloc_extent(rc_allocator *al,         /* IN  */
-                          uint64       *addr)       /* OUT */
+rc_allocator_alloc(rc_allocator *al,   // IN
+                   uint64 *      addr, // OUT
+                   page_type     type)     // IN
 {
    uint64 first_hand = al->hand % al->cfg->extent_capacity;
    uint64 hand;
@@ -526,17 +625,19 @@ rc_allocator_alloc_extent(rc_allocator *al,         /* IN  */
          extent_is_free = __sync_bool_compare_and_swap(&al->ref_count[hand], 0, 2);
    } while (!extent_is_free && (hand + 1) % al->cfg->extent_capacity != first_hand);
    if (!extent_is_free) {
-      platform_log ("Out of Space: allocated %lu out of %lu addrs.\n",
-            al->allocated, al->cfg->extent_capacity);
+      platform_log("Out of Space: allocated %lu out of %lu addrs.\n",
+                   al->stats.curr_allocated,
+                   al->cfg->extent_capacity);
       return STATUS_NO_SPACE;
    }
-   int64 curr_allocated =__sync_add_and_fetch(&al->allocated, 1);
-   int64 max_allocated = al->max_allocated;
+   int64 curr_allocated = __sync_add_and_fetch(&al->stats.curr_allocated, 1);
+   int64 max_allocated  = al->stats.max_allocated;
    while (curr_allocated > max_allocated) {
-      __sync_bool_compare_and_swap(&al->max_allocated, max_allocated,
-                                   curr_allocated);
-      max_allocated = al->max_allocated;
+      __sync_bool_compare_and_swap(
+         &al->stats.max_allocated, max_allocated, curr_allocated);
+      max_allocated = al->stats.max_allocated;
    }
+   __sync_add_and_fetch(&al->stats.extent_allocs[type], 1);
    *addr = hand * al->cfg->extent_size;
 
    return STATUS_OK;
@@ -545,7 +646,107 @@ rc_allocator_alloc_extent(rc_allocator *al,         /* IN  */
 /*
  *----------------------------------------------------------------------
  *
- * rc_allocator_print_allocated --
+ * rc_allocator_in_use --
+ *
+ *      Returns the number of extents currently allocated
+ *
+ *----------------------------------------------------------------------
+ */
+
+uint64
+rc_allocator_in_use(rc_allocator *al)
+{
+   return al->stats.curr_allocated;
+}
+
+/*
+ *----------------------------------------------------------------------
+ *
+ * rc_allocator_assert_noleaks --
+ *
+ *      Asserts that the allocations of each type are completely matched by
+ *      deallocations.
+ *
+ *----------------------------------------------------------------------
+ */
+
+void
+rc_allocator_assert_noleaks(rc_allocator *al)
+{
+   for (page_type type = PAGE_TYPE_TRUNK; type != NUM_PAGE_TYPES; type++) {
+      if (type == PAGE_TYPE_LOG || type == PAGE_TYPE_MISC) {
+         continue;
+      }
+      if (al->stats.extent_allocs[type] != al->stats.extent_deallocs[type]) {
+         platform_default_log("assert_noleaks: leak found\n");
+         platform_default_log("\n");
+         rc_allocator_print_stats(al);
+         rc_allocator_debug_print(al);
+         platform_assert(0);
+      }
+   }
+}
+
+
+/*
+ *----------------------------------------------------------------------
+ *
+ * rc_allocator_print_stats --
+ *
+ *      Prints basic statistics about the allocator state.
+ *
+ *      Max allocations, and page type stats are since last mount.
+ *
+ *----------------------------------------------------------------------
+ */
+
+void
+rc_allocator_print_stats(rc_allocator *al)
+{
+   int64 divider = GiB / al->cfg->extent_size;
+   platform_default_log(
+      "----------------------------------------------------------------\n");
+   platform_default_log(
+      "| Allocator Stats                                              |\n");
+   platform_default_log(
+      "|--------------------------------------------------------------|\n");
+   uint64 curr_gib = al->stats.curr_allocated / divider;
+   platform_default_log(
+      "| Currently Allocated: %12lu extents (%4luGiB)          |\n",
+      al->stats.curr_allocated,
+      curr_gib);
+   uint64 max_gib = al->stats.max_allocated / divider;
+   platform_default_log(
+      "| Max Allocated:       %12lu extents (%4luGiB)          |\n",
+      al->stats.max_allocated,
+      max_gib);
+   platform_default_log(
+      "|--------------------------------------------------------------|\n");
+   platform_default_log(
+      "| Page Type | Allocations | Deallocations | Footprint (bytes)  |\n");
+   platform_default_log(
+      "|--------------------------------------------------------------|\n");
+   for (page_type type = PAGE_TYPE_TRUNK; type != NUM_PAGE_TYPES; type++) {
+      const char *str           = page_type_str[type];
+      int64       allocs        = al->stats.extent_allocs[type];
+      int64       deallocs      = al->stats.extent_deallocs[type];
+      int64       footprint     = allocs - deallocs;
+      int64       footprint_gib = footprint / divider;
+      platform_default_log("| %9s | %11ld | %13ld | %8ld (%4ldGiB) |\n",
+                           str,
+                           allocs,
+                           deallocs,
+                           footprint,
+                           footprint_gib);
+   }
+   platform_default_log(
+      "----------------------------------------------------------------\n");
+}
+
+/*
+ *----------------------------------------------------------------------
+ *
+ * rc_allocator_debug_print --
  *
  *      Prints the base addrs of all allocated extents.
  *
@@ -553,14 +754,14 @@ rc_allocator_alloc_extent(rc_allocator *al,         /* IN  */
  */
 
 void
-rc_allocator_print_allocated(rc_allocator *al)
+rc_allocator_debug_print(rc_allocator *al)
 {
    uint64 i;
    uint8  ref;
-   platform_log("Allocated: %lu\n", al->allocated);
+   platform_default_log("Allocated: %lu\n", al->stats.curr_allocated);
    for (i = 0; i < al->cfg->extent_capacity; i++) {
       ref = al->ref_count[i];
       if (ref != 0)
-         platform_log("%lu -- %u\n", i * al->cfg->extent_size, ref);
+         platform_default_log("%lu -- %u\n", i * al->cfg->extent_size, ref);
    }
 }

--- a/src/routing_filter.c
+++ b/src/routing_filter.c
@@ -426,7 +426,7 @@ routing_filter_add(cache            *cc,
    // we use a mini_allocator to obtain pages
    allocator *     al = cache_allocator(cc);
    uint64          meta_head;
-   platform_status rc = allocator_alloc_extent(al, &meta_head);
+   platform_status rc = allocator_alloc(al, &meta_head, PAGE_TYPE_FILTER);
    platform_assert_status_ok(rc);
    filter->meta_head = meta_head;
    // filters use an unkeyed mini allocator

--- a/src/shard_log.c
+++ b/src/shard_log.c
@@ -81,7 +81,7 @@ shard_log_init(shard_log        *log,
    log->magic = platform_checksum64(&magic_idx, sizeof(uint64), cfg->seed);
 
    allocator *     al = cache_allocator(cc);
-   platform_status rc = allocator_alloc_extent(al, &log->meta_head);
+   platform_status rc = allocator_alloc(al, &log->meta_head, PAGE_TYPE_LOG);
    platform_assert_status_ok(rc);
 
    for (threadid thr_i = 0; thr_i < MAX_THREADS; thr_i++) {

--- a/tests/cache_test.c
+++ b/tests/cache_test.c
@@ -60,16 +60,16 @@ out:
 }
 
 static platform_status
-cache_test_alloc_extents(cache *cc,
+cache_test_alloc_extents(cache *            cc,
                          clockcache_config *cfg,
-                         uint64 addr_arr[],
-                         uint32 extents_to_allocate)
+                         uint64             addr_arr[],
+                         uint32             extents_to_allocate)
 {
    allocator *     al = cache_allocator(cc);
    platform_status rc;
    for (uint32 j = 0; j < extents_to_allocate; j++) {
       uint64 base_addr;
-      rc = allocator_alloc_extent(al, &base_addr);
+      rc = allocator_alloc(al, &base_addr, PAGE_TYPE_MISC);
       if (!SUCCESS(rc)) {
          platform_error_log("Expected to be able to allocate %u entries,"
                             "but only allocated: %u",
@@ -267,10 +267,10 @@ test_cache_basic(cache             *cc,
    for (uint32 i = 0; i < extents_to_allocate; i++) {
       uint64     addr = addr_arr[i * cfg->pages_per_extent];
       allocator *al   = cache_allocator(cc);
-      uint8      ref  = allocator_dec_refcount(al, addr);
+      uint8      ref  = allocator_dec_ref(al, addr, PAGE_TYPE_MISC);
       platform_assert(ref == AL_NO_REFS);
       cache_hard_evict_extent(cc, addr, PAGE_TYPE_MISC);
-      ref = allocator_dec_refcount(al, addr);
+      ref = allocator_dec_ref(al, addr, PAGE_TYPE_MISC);
       platform_assert(ref == AL_FREE);
    }
 
@@ -516,10 +516,10 @@ test_cache_flush(cache             *cc,
    for (uint32 i = 0; i < extents_to_allocate; i++) {
       uint64     addr = addr_arr[i * cfg->pages_per_extent];
       allocator *al   = cache_allocator(cc);
-      uint8      ref  = allocator_dec_refcount(al, addr);
+      uint8      ref  = allocator_dec_ref(al, addr, PAGE_TYPE_MISC);
       platform_assert(ref == AL_NO_REFS);
       cache_hard_evict_extent(cc, addr, PAGE_TYPE_MISC);
-      ref = allocator_dec_refcount(al, addr);
+      ref = allocator_dec_ref(al, addr, PAGE_TYPE_MISC);
       platform_assert(ref == AL_FREE);
    }
    platform_log("Dealloc took %lu secs\n",
@@ -891,10 +891,10 @@ test_cache_async(cache             *cc,
    for (uint32 i = 0; i < extents_to_allocate; i++) {
       uint64     addr = addr_arr[i * cfg->pages_per_extent];
       allocator *al   = cache_allocator(cc);
-      uint8      ref  = allocator_dec_refcount(al, addr);
+      uint8      ref  = allocator_dec_ref(al, addr, PAGE_TYPE_MISC);
       platform_assert(ref == AL_NO_REFS);
       cache_hard_evict_extent(cc, addr, PAGE_TYPE_MISC);
-      ref = allocator_dec_refcount(al, addr);
+      ref = allocator_dec_ref(al, addr, PAGE_TYPE_MISC);
       platform_assert(ref == AL_FREE);
    }
    platform_free(hid, addr_arr);

--- a/tests/splinter_test.c
+++ b/tests/splinter_test.c
@@ -2707,6 +2707,7 @@ splinter_test(int argc, char *argv[])
    }
    platform_free(hid, caches);
    platform_free(hid, cc);
+   allocator_assert_noleaks(alp);
    rc_allocator_deinit(&al);
    test_deinit_splinter(hid, ts);
 handle_deinit:


### PR DESCRIPTION
Breaking out the disk [de]allocation from the cache causes allocation
statistics to be inaccurate. This commit moves them to the allocator,
which now tracks extent allocations and deallocations by page_type.

Moves cache_assert_noleaks to allocator_assert_noleaks. Puts this check
in the destruction phase of splinter_test.

Adds proper virtualization to rc_allocator.