### PR TITLE
Fix race between branch_dec_ref and range_iterators

### DIFF
--- a/src/allocator.h
+++ b/src/allocator.h
@@ -17,6 +17,7 @@
 typedef uint64 allocator_root_id;
 #define INVALID_ALLOCATOR_ROOT_ID (0)
 
+#define AL_ONE_REF 2
 #define AL_NO_REFS 1
 #define AL_FREE    0
 

--- a/src/btree.c
+++ b/src/btree.c
@@ -1092,34 +1092,19 @@ btree_zap(cache *cc, btree_config *cfg, uint64 root_addr, page_type type)
    return ref == 0;
 }
 
-page_handle *
-btree_blind_inc(cache        *cc,
-                btree_config *cfg,
-                uint64        root_addr,
-                page_type     type)
+void
+btree_block_dec_ref(cache *cc, btree_config *cfg, uint64 root_addr)
 {
-   // FIXME: [aconway 2021-08-21]
-   // This is broken in this commit, fixing later.
-   //
-   // platform_log("(%2lu)blind inc %14lu\n", platform_get_tid(), root_addr);
-   // uint64 meta_page_addr = btree_root_to_meta_addr(cc, cfg, root_addr, 0);
-   // return mini_allocator_blind_inc(cc, meta_page_addr);
-   return NULL;
+   uint64 meta_head = btree_root_to_meta_addr(cc, cfg, root_addr, 0);
+   mini_block_dec_ref(cc, meta_head);
 }
 
 void
-btree_blind_zap(cache        *cc,
-                btree_config *cfg,
-                page_handle  *meta_page,
-                page_type     type)
+btree_unblock_dec_ref(cache *cc, btree_config *cfg, uint64 root_addr)
 {
-   // FIXME: [aconway 2021-08-21]
-   // This is broken in this commit, fixing later.
-   //
-   // platform_log("(%2lu)blind zap %14lu\n", platform_get_tid(), root_addr);
-   // mini_allocator_blind_zap(cc, type, meta_page);
+   uint64 meta_head = btree_root_to_meta_addr(cc, cfg, root_addr, 0);
+   mini_unblock_dec_ref(cc, meta_head);
 }
-
 
 /*
  *-----------------------------------------------------------------------------

--- a/src/btree.h
+++ b/src/btree.h
@@ -247,17 +247,11 @@ btree_inc_range(cache        *cc,
                 const char   *start_key,
                 const char   *end_key);
 
-page_handle *
-btree_blind_inc(cache        *cc,
-                btree_config *cfg,
-                uint64        root_addr,
-                page_type     type);
+void
+btree_block_dec_ref(cache *cc, btree_config *cfg, uint64 root_addr);
 
 void
-btree_blind_zap(cache        *cc,
-                btree_config *cfg,
-                page_handle  *meta_page,
-                page_type     type);
+btree_unblock_dec_ref(cache *cc, btree_config *cfg, uint64 root_addr);
 
 void
 btree_iterator_init(cache *         cc,

--- a/src/mini_allocator.h
+++ b/src/mini_allocator.h
@@ -73,6 +73,12 @@ mini_keyed_dec_ref(cache *      cc,
                    const char * start_key,
                    const char * end_key);
 
+void
+mini_block_dec_ref(cache *cc, uint64 meta_head);
+
+void
+mini_unblock_dec_ref(cache *cc, uint64 meta_head);
+
 uint64
 mini_keyed_extent_count(cache *      cc,
                         data_config *data_cfg,

--- a/src/rc_allocator.c
+++ b/src/rc_allocator.c
@@ -467,6 +467,7 @@ rc_allocator_dec_ref(rc_allocator *al, uint64 addr, page_type type)
    uint8 ref_count = __sync_sub_and_fetch(&al->ref_count[extent_no], 1);
    platform_assert(ref_count != UINT8_MAX);
    if (ref_count == 0) {
+      platform_assert(type != PAGE_TYPE_INVALID);
       __sync_sub_and_fetch(&al->stats.curr_allocated, 1);
       __sync_add_and_fetch(&al->stats.extent_deallocs[type], 1);
    }

--- a/src/splinter.h
+++ b/src/splinter.h
@@ -216,7 +216,6 @@ typedef struct splinter_range_iterator {
    uint64           memtable_start_gen;
    uint64           memtable_end_gen;
    bool             compacted[SPLINTER_MAX_TOTAL_DEGREE];
-   page_handle     *meta_page[SPLINTER_MAX_TOTAL_DEGREE];
    merge_iterator  *merge_itor;
    bool             has_max_key;
    bool             at_end;


### PR DESCRIPTION
Re-adds coordination between `branch_dec_ref` and range_iterators that was
broken in #65 (Issue #158). Prior to #65 this was handling by using read/write
locks on the `meta_page` of the `meta_head`. This is not ideal, because those
write locks interfere with tiered memory transactions.

Coordination is achieved in this commit by overloading the ref count of the
meta head. A range query can "block" dec_refs on the mini_allocator by
increasing the ref count and "unblock" by decrementing it again.
`mini_keyed_dec_ref` callers must first wait for the ref count to go to
`AL_ONE_REF` before continuing, after which they are guaranteed that no
range queries can intersect their `dec_ref` range.
