### PR TITLE
docs refactor

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,7 @@ Before you submit a bug report about the code in the repository, please check th
 Feature requests should fall within the scope of the project.
 
 ## Pull Requests
+See [docs/build.md](docs/build.md) for instructions on building from source.
 
 Before submitting a pull request, please ensure that:
 - code builds: `make`

--- a/README.md
+++ b/README.md
@@ -7,63 +7,8 @@ See
 > Alexander Conway, Abhishek Gupta, Vijay Chidambaram, Martin Farach-Colton, Richard P. Spillane, Amy Tai, Rob Johnson:
 [SplinterDB: Closing the Bandwidth Gap for NVMe Key-Value Stores](https://www.usenix.org/conference/atc20/presentation/conway). USENIX Annual Technical Conference 2020: 49-63
 
-## Build and test workflows
+## Usage
+SplinterDB is a library intended to be embedded within another program.  See [Usage](docs/usage.md) for a guide on how to integrate SplinterDB into an application.
 
-### Test a pre-built library with Docker
-Our Continuous Integration (CI) system builds the latest commit on `main`
-into a container image suitable for running tests and integrating SplinterDB
-into other applications.  To run tests:
-```shell
-$ docker run --rm projects.registry.vmware.com/splinterdb/splinterdb
-```
-Or add `/bin/bash` to get a shell in the container:
-```shell
-$ docker run -it --rm projects.registry.vmware.com/splinterdb/splinterdb /bin/bash
-```
-
-The `projects.registry.vmware.com/splinterdb/splinterdb` image contains runtime
-dependencies, the built shared library, test binary, and header files for the
-public API.  It does not include tools to build SplinterDB itself from source.
-See [`Dockerfile`](Dockerfile) for details.
-
-
-### Build from source with Docker
-To build and test from source, change into the
-directory containing this repository and then use our
-`projects.registry.vmware.com/splinterdb/build-env` image:
-```shell
-$ docker run -it --rm --mount type=bind,source="$PWD",target=/splinterdb \
-     projects.registry.vmware.com/splinterdb/build-env /bin/bash
-```
-
-Inside that shell, you can build and test with either GCC or Clang:
-```shell
-docker$ cd /splinterdb
-docker$ export CC=clang  # or gcc
-docker$ export LD=clang
-docker$ make
-docker$ make test
-```
-
-Unlike the `splinterdb/splinterdb` image, the `splinterdb/build-env` image
-contains everything needed to build from source with either GCC or Clang.
-See [`Dockerfile.build-env`](Dockerfile.build-env) for details.
-
-### Build from source on Linux
-Builds are known to work on Ubuntu using recent versions of GCC and Clang.
-
-In CI, we test against the versions that Ubuntu "focal" 20.04 provides by
-default, currently GCC 9 and Clang 10.
-
-```shell
-$ export COMPILER=gcc-9
-$ sudo apt update -y
-$ sudo apt install -y libaio-dev libconfig-dev libxxhash-dev $COMPILER
-$ export CC=$COMPILER
-$ export LD=$COMPILER
-$ make
-$ make test
-```
-
-## Test configuration
-By default the configuration file `default.cfg` is used. This creates a `db` file in the working directory to use as back end. To modify this configuration, copy to `splinter_test.cfg` and make changes.
+## Build
+See [Build](docs/build.md) for instructions on building SplinterDB from source.

--- a/docs/build.md
+++ b/docs/build.md
@@ -1,0 +1,45 @@
+# Building from source
+This document is about how to build and test SplinterDB itself.
+To integrate SplinterDB into another application, see [Usage](usage.md).
+
+## On Linux
+Builds are known to work on Ubuntu using recent versions of GCC and Clang.
+
+In CI, we test against the versions that Ubuntu "focal" 20.04 provides by
+default, currently GCC 9 and Clang 10.
+
+```shell
+$ export COMPILER=gcc-9
+$ sudo apt update -y
+$ sudo apt install -y libaio-dev libconfig-dev libxxhash-dev $COMPILER
+$ export CC=$COMPILER
+$ export LD=$COMPILER
+$ make
+$ make test
+```
+
+### Using Docker
+Docker can be used to build from source on many platforms, including Mac and Windows.
+
+Change into the directory containing this repository and then do
+```shell
+$ docker run -it --rm --mount type=bind,source="$PWD",target=/splinterdb \
+     projects.registry.vmware.com/splinterdb/build-env /bin/bash
+```
+
+> Note: the `build-env` image contains a working build environment, but does not
+contain the SplinterDB source code.  That must be mounted into the running
+container, e.g. the `--mount` command shown above.
+
+Inside the container is a Linux environment with 
+[all dependencies for building and testing](../Dockerfile.build-env)
+with either GCC or Clang.
+
+For example, from inside the running container:
+```shell
+docker$ cd /splinterdb
+docker$ export CC=clang  # or gcc
+docker$ export LD=clang
+docker$ make
+docker$ make test
+```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,79 @@
+# Using SplinterDB
+
+_A rough guide for how to integrate SplinterDB into a program._
+
+## 1. Get the SplinterDB library and headers
+
+### Option 1: from source
+Follow instructions to [build SplinterDB from source](build.md).
+
+### Option 2: using Docker
+Our Continuous Integration system publishes [Docker images](../Dockerfile)
+that are sufficient for linking SplinterDB into another program.
+
+Example usage:
+```shell
+$ docker run -it --rm projects.registry.vmware.com/splinterdb/splinterdb /bin/bash
+```
+
+The container includes the SplinterDB runtime dependencies, shared library,
+test binary, and the header files for SplinterDB's public API.
+
+```shell
+docker$ find /splinterdb
+/splinterdb
+/splinterdb/bin
+/splinterdb/bin/driver_test
+/splinterdb/bin/splinterdb.so
+/splinterdb/include
+/splinterdb/include/platform_public.h
+/splinterdb/include/data.h
+/splinterdb/include/kvstore.h
+/splinterdb/test.sh
+
+docker$ ldd /splinterdb/bin/splinterdb.so
+   linux-vdso.so.1 (0x00007ffc57fa4000)
+   libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007fefbd0dd000)
+   libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007fefbd0ba000)
+   libaio.so.1 => /lib/x86_64-linux-gnu/libaio.so.1 (0x00007fefbd0b5000)
+   libxxhash.so.0 => /lib/x86_64-linux-gnu/libxxhash.so.0 (0x00007fefbd0ab000)
+   libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007fefbceb9000)
+   /lib64/ld-linux-x86-64.so.2 (0x00007fefbd2a9000)
+```
+
+> Note: this image does not include tools to build SplinterDB itself
+from source.  See [our build docs](build.md) for that.
+
+Docker-based development is beyond the scope of this doc, but consider
+using bind mounts to access source code on your host OS:
+```shell
+$ docker run -it --rm \
+    --mount type=bind,source="$PWD/my-app-src",target=/my-app-src \
+    projects.registry.vmware.com/splinterdb/splinterdb /bin/bash
+```
+
+
+## 2. Include SplinterDB in your program
+
+For example, a C linker would need the flag `-lsplinterdb`.  You may also need to configure include and library directories.
+
+
+## 3. Call SplinterDB APIs from your program
+
+For basic key-value store use cases, [`kvstore_basic.h`](../src/kvstore_basic.h) should suffice.
+
+- Set the fields in `kvstore_basic_cfg`
+
+- `kvstore_basic_init()` will open a database and `kvstore_basic_deinit()` closes it.
+   Concurrent access to that database must go through the `kvstore_basic*` object
+   returned by `kvstore_basic_init()`.
+
+    > For example, a RDBMS using SplinterDB as a storage layer might consolidate all "table open" and "table close" operations across different client connections into a shared, per-table, reference-counted resource which internally calls `kvstore_basic_init()` in its constructor and `kvstore_basic_deinit()` in its destructor.
+
+- `kvstore_basic_register_thread()` must be called once for each thread that needs to use the database.  Note this may be non-trivial for languages with [runtime-managed threading](https://en.wikipedia.org/wiki/Green_threads).
+
+- Once registered, a thread may insert, delete, lookup and iterate.
+
+- A range query should use the iterator workflow described in `kvstore_basic.h`.
+
+A complete (single-threaded) example is in [`tests/kvstore_basic_test.c`](../tests/kvstore_basic_test.c).

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,4 @@
+# Benchmarking scripts
+
+## Test configuration
+By default the configuration file `default.cfg` is used. This creates a `db` file in the working directory to use as back end. To modify this configuration, copy to `splinter_test.cfg` and make changes.


### PR DESCRIPTION
Simplify README, pull out a few smaller docs

-  docs/build.md: from-source building, previously in README.md
 
-  docs/usage.md: how to use SplinterDB in an application

-  scripts/README.md: note about config for those scripts