### PR TITLE
Update Makefile to add lib/ dir. Rename artifacts to libsplinterdb.{s…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,7 @@ CMakeLists.txt
 .debug
 bin/
 obj/
+lib/
 db
 cache-log
+tags


### PR DESCRIPTION
…o,a}.

This commit updates Makefile rules to:
 - Create lib/ dir
 - Artifacts produced are renamed: splinterdb.so -> libsplinterdb.so
 - make will now also produce lib/libsplinterdb.a
 - Cleaned up code under 'make install' to install .a, .so to appropriate
   system lib-dirs (/usr/local/lib).
 - Interface .h files installed at /usr/local/include/splinterdb/