### PR TITLE
Clang Format: Do not sort #includes alphabetically

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -60,15 +60,6 @@ ForEachMacros:
   - foreach
   - Q_FOREACH
   - BOOST_FOREACH
-IncludeBlocks:   Preserve
-IncludeCategories:
-#   - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
-#     Priority:        2
-#   - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
-#     Priority:        3
-  - Regex:           '.*'
-    Priority:        1
-IncludeIsMainRegex: '$'
 IndentCaseLabels: true
 IndentPPDirectives: AfterHash
 IndentWidth:     3
@@ -93,7 +84,7 @@ PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 120
 PointerAlignment: Right
 ReflowComments:  true
-SortIncludes:    true
+SortIncludes:    false
 SortUsingDeclarations: true
 SpaceAfterCStyleCast: false
 SpaceAfterTemplateKeyword: false


### PR DESCRIPTION
This is a change to the formatter only. It disables the check that `#include` statements are ordered alphabetically.