### PR TITLE
Rearrange defines for key-/value-size limits; remove hard-coded values.

### DIFF
--- a/include/splinterdb/data.h
+++ b/include/splinterdb/data.h
@@ -11,11 +11,9 @@
 #ifndef __DATA_H
 #define __DATA_H
 
-#include "splinterdb/platform_public.h"
 #include <string.h> // for memmove
-
-#define MAX_KEY_SIZE     24
-#define MAX_MESSAGE_SIZE 128
+#include "splinterdb/limits.h"
+#include "splinterdb/platform_public.h"
 
 typedef enum message_type {
    MESSAGE_TYPE_INSERT,

--- a/include/splinterdb/kvstore_basic.h
+++ b/include/splinterdb/kvstore_basic.h
@@ -12,6 +12,26 @@
 #define _KVSTORE_BASIC_H_
 
 #include <stddef.h> // for size_t
+#include "splinterdb/limits.h"
+
+// Length-prefix encoding of a variable-sized key
+// Should be == sizeof(basic_key_encoding), which is enforced elsewhere
+#define KVSTORE_BASIC_KEY_HDR_SIZE ((int)sizeof(uint8_t))
+
+// Minimum size of a key, in bytes
+#define KVSTORE_BASIC_MIN_KEY_SIZE 2
+
+// Max size of a key, in bytes
+// Must always be = ( MAX_KEY_SIZE - sizeof(basic_key_encoding) )
+#define KVSTORE_BASIC_MAX_KEY_SIZE (MAX_KEY_SIZE - KVSTORE_BASIC_KEY_HDR_SIZE)
+
+// Should be == sizeof(basic_message), which is enforced elsewhere
+#define KVSTORE_BASIC_MSG_HDR_SIZE ((int)sizeof(void *))
+
+// Maximum size of a value, in bytes
+// Must always == ( MAX_MESSAGE_SIZE - sizeof(basic_message) )
+#define KVSTORE_BASIC_MAX_VALUE_SIZE                                           \
+   (MAX_MESSAGE_SIZE - KVSTORE_BASIC_MSG_HDR_SIZE)
 
 typedef int (*key_comparator_fn)(const void *context,
                                  const void *key1,
@@ -54,19 +74,6 @@ typedef struct {
 
 // Handle to a live instance of splinterdb
 typedef struct kvstore_basic kvstore_basic;
-
-// Minimum size of a key, in bytes
-#define KVSTORE_BASIC_MIN_KEY_SIZE 2
-
-// Max size of a key, in bytes
-//
-// Must always be = MAX_KEY_SIZE - sizeof(basic_key_encoding)
-#define KVSTORE_BASIC_MAX_KEY_SIZE 23
-
-// Maximum size of a value
-//
-// Must always = MAX_MESSAGE_SIZE - sizeof(basic_message)
-#define KVSTORE_BASIC_MAX_VALUE_SIZE 120
 
 // Create a new kvstore_basic from the provided config
 int

--- a/include/splinterdb/limits.h
+++ b/include/splinterdb/limits.h
@@ -1,0 +1,17 @@
+// Copyright 2018-2021 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+ * limits.h --
+ *
+ *     This file contains constants and functions the pertain to
+ *     limits of keys and messages supported by the Key Value Store.
+ */
+
+#ifndef __LIMITS_H__
+#define __LIMITS_H__
+
+#define MAX_KEY_SIZE     24
+#define MAX_MESSAGE_SIZE 128
+
+#endif // __LIMITS_H__


### PR DESCRIPTION
This commit does minor rearrangement of the #defines for key- and value-size
limits. No change in logic or existing limits is being done.

- Relocate KVSTORE_BASIC_KEY_HDR_SIZE, KVSTORE_BASIC_MSG_HDR_SIZE from
  .c to .h file. Adjust corresponding assertions accordingly.
- KVSTORE_BASIC_MAX_KEY_SIZE and KVSTORE_BASIC_MAX_VALUE_SIZE are now
  computed using above defines, rather than hard-coding the limits.

- Change error messages to report the key-size / limit and value-size / limit
  involved when a call fails.

- Refactor test cases: Add new ones:
  - Broke out test_kvstore_basic_large_keys() into
     - test_kvstore_basic_key_size_gt_max_key_size()
     - test_kvstore_basic_value_size_gt_max_value_size()