### PR TITLE
Remove cache_(un)share

### DIFF
--- a/src/btree.c
+++ b/src/btree.c
@@ -827,11 +827,10 @@ btree_range_valid(cache        *cc,
  *
  * btree_split_node --
  *
- *      Splits the node at left_addr into a new node at right_addr. Uses
- *      anonymous pages for both and swaps in when complete.
+ *      Splits the node at left_addr into a new node at right_addr.
  *
- *      Assumes claim is held on left_node. Returns with write lock.
- *      Assumes right_node has a free addr, but isn't held
+ *      Assumes write locks are held on both left and right and returns with
+ *      both locks still held.
  *
  *-----------------------------------------------------------------------------
  */
@@ -885,14 +884,8 @@ btree_split_node(cache *cc,              // IN
 
    right_node->hdr->num_entries = target_right_entries;
    right_node->hdr->next_addr = left_node->hdr->next_addr;
-   //btree_node_lock(cc, cfg, left_node);
    left_node->hdr->num_entries = target_left_entries;
    left_node->hdr->next_addr = right_node->addr;
-
-   // unshare
-   cache_unshare(cc, right_node->page);
-   right_node->page = right_node->page;
-   right_node->hdr = right_node->hdr;
 }
 
 /*
@@ -905,12 +898,12 @@ btree_split_node(cache *cc,              // IN
  */
 
 void
-btree_add_shared_pivot(cache          *cc,
-                       btree_config   *cfg,
-                       mini_allocator *mini,
-                       btree_node     *parent,
-                       btree_node     *child,
-                       btree_node     *new_child)
+btree_add_split_pivot(cache *         cc,
+                      btree_config *  cfg,
+                      mini_allocator *mini,
+                      btree_node *    parent,
+                      btree_node *    child,
+                      btree_node *    new_child)
 {
    debug_assert(!btree_is_packed(cfg, parent));
    debug_assert(!btree_is_packed(cfg, child));
@@ -918,7 +911,6 @@ btree_add_shared_pivot(cache          *cc,
 
    uint16 height = btree_height(cfg, child);
    btree_alloc(cc, mini, height, NULL, NULL, PAGE_TYPE_MEMTABLE, new_child);
-   cache_share(cc, child->page, new_child->page);
    uint16 child_num_entries = btree_num_entries(cfg, child);
    uint16 new_entry_num = child_num_entries - child_num_entries / 2;
    char *pivot_key;
@@ -978,7 +970,7 @@ int btree_split_root(btree_config   *cfg,       // IN
    root_node->hdr->height++;
    btree_add_pivot_at_pos(cfg, root_node, &left_node, 0, TRUE);
    btree_node right_node;
-   btree_add_shared_pivot(cc, cfg, mini, root_node, &left_node, &right_node);
+   btree_add_split_pivot(cc, cfg, mini, root_node, &left_node, &right_node);
 
    // release root
    btree_node_unlock(cc, cfg, root_node);
@@ -1277,8 +1269,8 @@ start_over:
             btree_node_lock(cc, cfg, &parent_node);
             btree_node_lock(cc, cfg, &child_node);
             btree_node new_child_node;
-            btree_add_shared_pivot(cc, cfg, mini, &parent_node, &child_node,
-                  &new_child_node);
+            btree_add_split_pivot(
+               cc, cfg, mini, &parent_node, &child_node, &new_child_node);
             btree_node_full_unlock(cc, cfg, &parent_node);
 
             btree_split_node(cc, cfg, &child_node, &new_child_node);

--- a/src/cache.h
+++ b/src/cache.h
@@ -127,10 +127,6 @@ typedef void (*extent_sync_fn)(cache * cc,
                                uint64  addr,
                                uint64 *pages_outstanding);
 
-typedef void (*share_fn)(cache *      cc,
-                         page_handle *page_to_share,
-                         page_handle *anon_page);
-typedef void (*unshare_fn)(cache *cc, page_handle *anon_page);
 typedef void (*page_prefetch_fn)(cache *cc, uint64 addr, page_type type);
 typedef void (*page_mark_dirty_fn)(cache *cc, page_handle *page);
 typedef void (*flush_fn)(cache *cc);
@@ -164,8 +160,6 @@ typedef struct cache_ops {
    page_unclaim_fn      page_unclaim;
    page_lock_fn         page_lock;
    page_unlock_fn       page_unlock;
-   share_fn             share;
-   unshare_fn           unshare;
    page_prefetch_fn     page_prefetch;
    page_mark_dirty_fn   page_mark_dirty;
    page_pin_fn          page_pin;
@@ -278,18 +272,6 @@ static inline void
 cache_prefetch(cache *cc, uint64 addr, page_type type)
 {
    return cc->ops->page_prefetch(cc, addr, type);
-}
-
-static inline void
-cache_share(cache *cc, page_handle *page_to_share, page_handle *anon_page)
-{
-   return cc->ops->share(cc, page_to_share, anon_page);
-}
-
-static inline void
-cache_unshare(cache *cc, page_handle *anon_page)
-{
-   return cc->ops->unshare(cc, anon_page);
 }
 
 static inline void


### PR DESCRIPTION
This commit removes the cache_share and cache_unshare functions. These
were used in the memtable, and have been replaced with a simple page
allocation.

The cache_share and cache_unshare functions were designed to allow a
disk address to alias another disk address; i.e. after a share, the
second disk address would route to the same entry as the first. However,
due to the disk address checking done in cache_get, this alias didn't
work and a get to the alias would stall until cache_unshare was called.