### PR TITLE
Concurrent clockcache_prefetch bugfix

### DIFF
--- a/src/clockcache.c
+++ b/src/clockcache.c
@@ -2962,6 +2962,7 @@ clockcache_prefetch(clockcache *cc, uint64 base_addr, page_type type)
                 */
                entry->page.disk_addr = CC_UNMAPPED_ADDR;
                entry->status         = CC_FREE_STATUS;
+               page_off--;
             }
             break;
          }


### PR DESCRIPTION
Fixes the index of the retry when clockcache_prefetch races to load a
page.