### PR TITLE
Fix Overfull Leaves on Split

### DIFF
--- a/src/btree.c
+++ b/src/btree.c
@@ -2146,6 +2146,8 @@ typedef struct {
    uint32         *fingerprint_arr;
    unsigned int    seed;
 
+   uint64 max_tuples; // max tuples to output
+
    uint64         *root_addr;  // pointers to pack_req's root_addr
    uint64         *num_tuples; // pointers to pack_req's num_tuples
 
@@ -2187,6 +2189,7 @@ btree_pack_setup(btree_pack_req *req, btree_pack_internal *tree)
    tree->root_addr = &req->root_addr;
    tree->num_tuples = &req->num_tuples;
    *(tree->num_tuples) = 0;
+   tree->max_tuples      = req->max_tuples;
 
    cache *cc = tree->cc;
    btree_config *cfg = tree->cfg;
@@ -2244,7 +2247,8 @@ btree_pack_loop(btree_pack_internal *tree,   // IN/OUT
 #endif
       btree_add_tuple_at_pos(tree->cfg, &tree->edge[0], key, data, 0);
       tree->idx[0] = 1;
-      // FIXME: [nsarmicanic 2020-07-02] Not needed for range
+      platform_assert(tree->max_tuples == 0 ||
+                      *(tree->num_tuples) < tree->max_tuples);
       if (tree->hash) {
          tree->fingerprint_arr[*(tree->num_tuples)] =
             tree->hash(key, tree->cfg->data_cfg->key_size, tree->seed);

--- a/src/splinter.h
+++ b/src/splinter.h
@@ -119,6 +119,10 @@ typedef struct splinter_stats {
    uint64 leaf_split_time_ns;
    uint64 leaf_split_max_time_ns;
 
+   uint64 single_leaf_splits;
+   uint64 single_leaf_tuples;
+   uint64 single_leaf_max_tuples;
+
    uint64 root_filters_built;
    uint64 root_filter_tuples;
    uint64 root_filter_time_ns;


### PR DESCRIPTION
1. Tunes the threshold at which a leaf split results in a single leaf
from 90% full down to 80% full to prevent overfull leaves from
overzealous duplicate estimation.

2. Adds an assertion in btree_pack to detect and fail on overfull packs,
rather than segfaulting/corruption.