### PR TITLE
(#106) Add tests for kvstore_iterator() with non-NULL start key

### DIFF
--- a/include/splinterdb/kvstore_basic.h
+++ b/include/splinterdb/kvstore_basic.h
@@ -162,7 +162,7 @@ kvstore_basic_iter_init(const kvstore_basic *    kvsb,         // IN
 );
 
 void
-kvstore_basic_iter_deinit(kvstore_basic_iterator *iter);
+kvstore_basic_iter_deinit(kvstore_basic_iterator **iterpp);
 
 // checks that the iterator status is OK (no errors) and that get_current will
 // succeed If false, there are two possibilities:

--- a/src/kvstore_basic.c
+++ b/src/kvstore_basic.c
@@ -483,10 +483,12 @@ kvstore_basic_iter_init(const kvstore_basic *    kvsb,         // IN
 }
 
 void
-kvstore_basic_iter_deinit(kvstore_basic_iterator *iter)
+kvstore_basic_iter_deinit(kvstore_basic_iterator **iterpp)
 {
+   kvstore_basic_iterator *iter = *iterpp;
    kvstore_iterator_deinit(iter->super);
    platform_free(iter->heap_id, iter);
+   *iterpp = NULL;
 }
 
 _Bool

--- a/src/platform_linux/platform.h
+++ b/src/platform_linux/platform.h
@@ -572,15 +572,17 @@ platform_strtok_r(char *str, const char *delim, platform_strtok_ctx *ctx);
  * (which may or may not end up inlined)
  * Wrap free and free_volatile:
  */
-#define platform_free(id, p) do {        \
-      platform_free_from_heap(id, (p));  \
-      (p) = NULL;                        \
-   } while (0);
+#define platform_free(id, p)                                                   \
+   do {                                                                        \
+      platform_free_from_heap(id, (p));                                        \
+      (p) = NULL;                                                              \
+   } while (0)
 
-#define platform_free_volatile(id, p) do {        \
-      platform_free_volatile_from_heap(id, (p));  \
-      (p) = NULL;                                 \
-   } while (0);
+#define platform_free_volatile(id, p)                                          \
+   do {                                                                        \
+      platform_free_volatile_from_heap(id, (p));                               \
+      (p) = NULL;                                                              \
+   } while (0)
 
 // Convenience function to free something volatile
 static inline void


### PR DESCRIPTION
This commit adds couple of small test cases to exercise the
kvstore_basic_iter_init(), with a non-NULL start_key, to
validate that we are correctly positioning the start scan
on the requested key. Also, verify that if the specified start_key
does not exist that the scan is positioned on the 1st key.

Minor miscellaneous cleanup:
 - kvstore_basic_iter_deinit() now takes address of iterator,
   so it can be Zero'ed out before return.
 - Mildly refactor existing test cases to consolidate rc handling,
   and inject PASS / FAILED message lines (for consistency).