### PR TITLE
renames

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -41,22 +41,22 @@ For example, a C linker would need the flag `-lsplinterdb`.  You may also need t
 
 ## 3. Call SplinterDB APIs from your program
 
-For basic key-value store use cases, [`kvstore_basic.h`](../src/kvstore_basic.h) should suffice.
+For basic key-value store use cases, [`splinterdb_kv.h`](../src/splinterdb_kv.h) should suffice.
 
-- Set the fields in `kvstore_basic_cfg`
+- Set the fields in `splinterdb_kv_cfg`
 
-- `kvstore_basic_create()` will create a new database and `kvstore_basic_close()` closes it.
-   Concurrent access to that database must go through the `kvstore_basic*` object
-   returned by `kvstore_basic_create()` (or `kvstore_basic_open()`).
+- `splinterdb_kv_create()` will create a new database and `splinterdb_kv_close()` closes it.
+   Concurrent access to that database must go through the `splinterdb_kv*` object
+   returned by `splinterdb_kv_create()` (or `splinterdb_kv_open()`).
 
     > For example, a RDBMS using SplinterDB as a storage layer might consolidate all "table open" and "table close"
       operations across different client connections into a shared, per-table, reference-counted resource which
-      internally calls `kvstore_basic_open()` in its constructor and `kvstore_basic_close()` in its destructor.
+      internally calls `splinterdb_kv_open()` in its constructor and `splinterdb_kv_close()` in its destructor.
 
-- `kvstore_basic_register_thread()` must be called once for each thread that needs to use the database.  Note this may be non-trivial for languages with [runtime-managed threading](https://en.wikipedia.org/wiki/Green_threads).
+- `splinterdb_kv_register_thread()` must be called once for each thread that needs to use the database.  Note this may be non-trivial for languages with [runtime-managed threading](https://en.wikipedia.org/wiki/Green_threads).
 
 - Once registered, a thread may insert, delete, lookup and iterate.
 
-- A range query should use the iterator workflow described in `kvstore_basic.h`.
+- A range query should use the iterator workflow described in `splinterdb_kv.h`.
 
-A complete (single-threaded) example is in [`tests/kvstore_basic_test.c`](../tests/kvstore_basic_test.c).
+A complete (single-threaded) example is in [`tests/splinterdb_kv_test.c`](../tests/splinterdb_kv_test.c).

--- a/include/splinterdb/platform_public.h
+++ b/include/splinterdb/platform_public.h
@@ -4,7 +4,7 @@
 /*
  * platform_public.h --
  *
- *     Minimal common header for both external users (e.g. kvstore) and internal
+ *     Minimal common header for both external users (e.g. splinterdb) and internal
  * use
  */
 

--- a/include/splinterdb/splinterdb.h
+++ b/include/splinterdb/splinterdb.h
@@ -2,19 +2,19 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /*
- * kvstore.h --
+ * splinterdb.h --
  *
- *     This file contains the external kvstore interfaces
+ *     This file contains the external splinterdb interfaces
  *     based on splinterdb.
  *     The user must provide a data_config that encodes
  *     values and message-types.
  *
- *     For simple use cases, start with kvstore_basic
+ *     For simple use cases, start with splinterdb_kv
  *
  */
 
-#ifndef _KVSTORE_H_
-#define _KVSTORE_H_
+#ifndef _SPLINTERDB_H_
+#define _SPLINTERDB_H_
 
 #include "splinterdb/data.h"
 
@@ -27,51 +27,51 @@ typedef struct {
 
    void *heap_handle;
    void *heap_id;
-} kvstore_config;
+} splinterdb_config;
 
-typedef struct kvstore kvstore;
+typedef struct splinterdb splinterdb;
 
-// Create a new kvstore from a given config
+// Create a new splinterdb from a given config
 //
-// The library will allocate and own the memory for kvstore
-// and will free it on kvstore_close
-//
-// It is ok for the caller to stack-allocate cfg, since it is not retained
-int
-kvstore_create(const kvstore_config *cfg, kvstore **kvs);
-
-// Open an existing kvstore, using the provided config
-//
-// The library will allocate and own the memory for kvstore
-// and will free it on kvstore_close
+// The library will allocate and own the memory for splinterdb
+// and will free it on splinterdb_close
 //
 // It is ok for the caller to stack-allocate cfg, since it is not retained
 int
-kvstore_open(const kvstore_config *cfg, kvstore **kvs);
+splinterdb_create(const splinterdb_config *cfg, splinterdb **kvs);
 
-// Close a kvstore
+// Open an existing splinterdb, using the provided config
+//
+// The library will allocate and own the memory for splinterdb
+// and will free it on splinterdb_close
+//
+// It is ok for the caller to stack-allocate cfg, since it is not retained
+int
+splinterdb_open(const splinterdb_config *cfg, splinterdb **kvs);
+
+// Close a splinterdb
 //
 // This will flush everything to disk and release all resources
 void
-kvstore_close(kvstore *kvs);
+splinterdb_close(splinterdb *kvs);
 
 // Register the current thread so that it can be used for
-// operations against the kvstore.
+// operations against the splinterdb.
 //
 // It must be called no more than once per thread, and before
-// any operation on the database, including kvstore_close.
+// any operation on the database, including splinterdb_close.
 //
-// Note: kvstore_create causes an implicit kvstore_register_thread
-// So it is safe to call kvstore_close from the same thread
-// that called kvstore_create without an exra kvstore_register_thread.
+// Note: splinterdb_create causes an implicit splinterdb_register_thread
+// So it is safe to call splinterdb_close from the same thread
+// that called splinterdb_create without an exra splinterdb_register_thread.
 void
-kvstore_register_thread(const kvstore *kvs);
+splinterdb_register_thread(const splinterdb *kvs);
 
 int
-kvstore_insert(const kvstore *kvs, char *key, char *message);
+splinterdb_insert(const splinterdb *kvs, char *key, char *message);
 
 int
-kvstore_lookup(const kvstore *kvs,     // IN
+splinterdb_lookup(const splinterdb *kvs,     // IN
                char *         key,     // IN
                char *         message, // OUT
                bool *         found    // OUT
@@ -102,50 +102,50 @@ It is always a good practice to check status() if the iterator is invalidated.
 
 Sample application code:
 
-   kvstore_iterator* it;
-   int rc = kvstore_iterator_init(kvs, &it, NULL);
+   splinterdb_iterator* it;
+   int rc = splinterdb_iterator_init(kvs, &it, NULL);
    if (rc != 0) { ... handle error ... }
 
    const char* key;
    const char* msg;
-   for(; kvstore_iterator_valid(it); kvstore_iterator_next(it)) {
-      kvstore_iterator_get_current(it, &key, &msg);
+   for(; splinterdb_iterator_valid(it); splinterdb_iterator_next(it)) {
+      splinterdb_iterator_get_current(it, &key, &msg);
       // read key and msg ...
    }
    // loop exit may mean error, or just that we've reached the end of the range
-   rc = kvstore_iterator_status(it);
+   rc = splinterdb_iterator_status(it);
    if (rc != 0) { ... handle error ... }
 */
 
-typedef struct kvstore_iterator kvstore_iterator;
+typedef struct splinterdb_iterator splinterdb_iterator;
 
 int
-kvstore_iterator_init(const kvstore *    kvs,      // IN
-                      kvstore_iterator **iter,     // OUT
+splinterdb_iterator_init(const splinterdb *    kvs,      // IN
+                      splinterdb_iterator **iter,     // OUT
                       char *             start_key // IN
 );
 
 void
-kvstore_iterator_deinit(kvstore_iterator *iter);
+splinterdb_iterator_deinit(splinterdb_iterator *iter);
 
 // checks that the iterator status is OK (no errors) and that get_current will
 // succeed If false, there are two possibilities:
 // 1. Iterator has passed the final item.  In this case, status() == 0
 // 2. Iterator has encountered an error.  In this case, status() != 0
 bool
-kvstore_iterator_valid(kvstore_iterator *iter);
+splinterdb_iterator_valid(splinterdb_iterator *iter);
 
 // attempts to advance the iterator to the next item
 // any error will cause valid() == false and be visible with status()
 void
-kvstore_iterator_next(kvstore_iterator *iter);
+splinterdb_iterator_next(splinterdb_iterator *iter);
 
 // Sets *key and *message to the locations of the current item
 // Callers must not modify that memory
 //
 // If valid() == false, then behavior is undefined.
 void
-kvstore_iterator_get_current(kvstore_iterator *iter,   // IN
+splinterdb_iterator_get_current(splinterdb_iterator *iter,   // IN
                              const char **     key,    // OUT
                              const char **     message // OUT
 );
@@ -154,6 +154,6 @@ kvstore_iterator_get_current(kvstore_iterator *iter,   // IN
 //
 // End-of-range is not an error
 int
-kvstore_iterator_status(const kvstore_iterator *iter);
+splinterdb_iterator_status(const splinterdb_iterator *iter);
 
-#endif // _KVSTORE_H_
+#endif // _SPLINTERDB_H_

--- a/include/splinterdb/splinterdb_kv.h
+++ b/include/splinterdb/splinterdb_kv.h
@@ -2,36 +2,36 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /*
- * kvstore_basic.h --
+ * splinterdb_kv.h --
  *
  *     Simplified key-value store interface
  *
  */
 
-#ifndef _KVSTORE_BASIC_H_
-#define _KVSTORE_BASIC_H_
+#ifndef _SPLINTERDB_KV_H_
+#define _SPLINTERDB_KV_H_
 
 #include <stddef.h> // for size_t
 #include "splinterdb/limits.h"
 
 // Length-prefix encoding of a variable-sized key
 // Should be == sizeof(basic_key_encoding), which is enforced elsewhere
-#define KVSTORE_BASIC_KEY_HDR_SIZE ((int)sizeof(uint8_t))
+#define SPLINTERDB_KV_KEY_HDR_SIZE ((int)sizeof(uint8_t))
 
 // Minimum size of a key, in bytes
-#define KVSTORE_BASIC_MIN_KEY_SIZE 2
+#define SPLINTERDB_KV_MIN_KEY_SIZE 2
 
 // Max size of a key, in bytes
 // Must always be = ( MAX_KEY_SIZE - sizeof(basic_key_encoding) )
-#define KVSTORE_BASIC_MAX_KEY_SIZE (MAX_KEY_SIZE - KVSTORE_BASIC_KEY_HDR_SIZE)
+#define SPLINTERDB_KV_MAX_KEY_SIZE (MAX_KEY_SIZE - SPLINTERDB_KV_KEY_HDR_SIZE)
 
 // Should be == sizeof(basic_message), which is enforced elsewhere
-#define KVSTORE_BASIC_MSG_HDR_SIZE ((int)sizeof(void *))
+#define SPLINTERDB_KV_MSG_HDR_SIZE ((int)sizeof(void *))
 
 // Maximum size of a value, in bytes
 // Must always == ( MAX_MESSAGE_SIZE - sizeof(basic_message) )
-#define KVSTORE_BASIC_MAX_VALUE_SIZE                                           \
-   (MAX_MESSAGE_SIZE - KVSTORE_BASIC_MSG_HDR_SIZE)
+#define SPLINTERDB_KV_MAX_VALUE_SIZE                                           \
+   (MAX_MESSAGE_SIZE - SPLINTERDB_KV_MSG_HDR_SIZE)
 
 typedef int (*key_comparator_fn)(const void *context,
                                  const void *key1,
@@ -70,34 +70,34 @@ typedef struct {
    // Reserved, set them to NULL
    void *heap_handle;
    void *heap_id;
-} kvstore_basic_cfg;
+} splinterdb_kv_cfg;
 
 // Handle to a live instance of splinterdb
-typedef struct kvstore_basic kvstore_basic;
+typedef struct splinterdb_kv splinterdb_kv;
 
-// Create a new kvstore_basic from the provided config
+// Create a new splinterdb_kv from the provided config
 int
-kvstore_basic_create(const kvstore_basic_cfg *cfg, // IN
-                     kvstore_basic **         kvsb // OUT
+splinterdb_kv_create(const splinterdb_kv_cfg *cfg, // IN
+                     splinterdb_kv **         kvsb // OUT
 );
 
-// Open an existing kvstore_basic using the provided config
+// Open an existing splinterdb_kv using the provided config
 int
-kvstore_basic_open(const kvstore_basic_cfg *cfg, // IN
-                   kvstore_basic **         kvsb // OUT
+splinterdb_kv_open(const splinterdb_kv_cfg *cfg, // IN
+                   splinterdb_kv **         kvsb // OUT
 );
 
 // De-init a handle and associated in-memory resources
 void
-kvstore_basic_close(kvstore_basic *kvsb);
+splinterdb_kv_close(splinterdb_kv *kvsb);
 
 // Call this once for each thread that needs to use the db
 void
-kvstore_basic_register_thread(const kvstore_basic *kvsb);
+splinterdb_kv_register_thread(const splinterdb_kv *kvsb);
 
 // Insert a key:value pair
 int
-kvstore_basic_insert(const kvstore_basic *kvsb,
+splinterdb_kv_insert(const splinterdb_kv *kvsb,
                      const char *         key,
                      size_t               key_len,
                      const char *         value,
@@ -105,7 +105,7 @@ kvstore_basic_insert(const kvstore_basic *kvsb,
 
 // Delete a given key and associated value
 int
-kvstore_basic_delete(const kvstore_basic *kvsb,
+splinterdb_kv_delete(const splinterdb_kv *kvsb,
                      const char *         key,
                      size_t               key_len);
 
@@ -115,7 +115,7 @@ kvstore_basic_delete(const kvstore_basic *kvsb,
 // Set val_max_len to the size of the val buffer
 // If found, val_bytes will hold the size of the value
 int
-kvstore_basic_lookup(const kvstore_basic *kvsb,
+splinterdb_kv_lookup(const splinterdb_kv *kvsb,
                      const char *         key,           // IN
                      size_t               key_len,       // IN
                      char *               val,           // OUT
@@ -128,60 +128,60 @@ kvstore_basic_lookup(const kvstore_basic *kvsb,
 /*
 KVStore Basic Iterator API
 
-See the doc comments in kvstore.h for details.
+See the doc comments in splinterdb.h for details.
 
 Sample application code:
 
-   kvstore_basic_iterator* it;
+   splinterdb_kv_iterator* it;
    const char* start_key = NULL;
-   int rc = kvstore_basic_iter_init(kvsb, &it, start_key);
+   int rc = splinterdb_kv_iter_init(kvsb, &it, start_key);
    if (rc != 0) { ... handle error ... }
 
    const char* key;
    const char* val;
    size_t key_len, val_len;
-   for(; kvstore_basic_iter_valid(it); kvstore_basic_iter_next(it)) {
-      kvstore_basic_iter_get_current(it, &key, &key_len, &val, &val_len);
+   for(; splinterdb_kv_iter_valid(it); splinterdb_kv_iter_next(it)) {
+      splinterdb_kv_iter_get_current(it, &key, &key_len, &val, &val_len);
 
       // read key and val, but do not modify them
       printf("key=%.*s val=%.*s", (int)(key_len), key, (int)(val_len), val);
    }
 
    // loop exit may mean error, or just that we've reached the end of the range
-   rc = kvstore_iter_status(it);
+   rc = splinterdb_iter_status(it);
    if (rc != 0) { ... handle error ... }
 */
 
-typedef struct kvstore_basic_iterator kvstore_basic_iterator;
+typedef struct splinterdb_kv_iterator splinterdb_kv_iterator;
 
 int
-kvstore_basic_iter_init(const kvstore_basic *    kvsb,         // IN
-                        kvstore_basic_iterator **iter,         // OUT
+splinterdb_kv_iter_init(const splinterdb_kv *    kvsb,         // IN
+                        splinterdb_kv_iterator **iter,         // OUT
                         const char *             start_key,    // IN
                         size_t                   start_key_len // IN
 );
 
 void
-kvstore_basic_iter_deinit(kvstore_basic_iterator **iterpp);
+splinterdb_kv_iter_deinit(splinterdb_kv_iterator **iterpp);
 
 // checks that the iterator status is OK (no errors) and that get_current will
 // succeed If false, there are two possibilities:
 // 1. Iterator has passed the final item.  In this case, status() == 0
 // 2. Iterator has encountered an error.  In this case, status() != 0
 _Bool
-kvstore_basic_iter_valid(kvstore_basic_iterator *iter);
+splinterdb_kv_iter_valid(splinterdb_kv_iterator *iter);
 
 // attempts to advance the iterator to the next item
 // any error will cause valid() == false and be visible with status()
 void
-kvstore_basic_iter_next(kvstore_basic_iterator *iter);
+splinterdb_kv_iter_next(splinterdb_kv_iterator *iter);
 
 // Sets *key and *message to the locations of the current item
 // Callers must not modify that memory
 //
 // If valid() == false, then behavior is undefined.
 void
-kvstore_basic_iter_get_current(kvstore_basic_iterator *iter,    // IN
+splinterdb_kv_iter_get_current(splinterdb_kv_iterator *iter,    // IN
                                const char **           key,     // OUT
                                size_t *                key_len, // OUT
                                const char **           value,   // OUT
@@ -192,6 +192,6 @@ kvstore_basic_iter_get_current(kvstore_basic_iterator *iter,    // IN
 //
 // End-of-range is not an error
 int
-kvstore_basic_iter_status(const kvstore_basic_iterator *iter);
+splinterdb_kv_iter_status(const splinterdb_kv_iterator *iter);
 
-#endif // _KVSTORE_BASIC_H_
+#endif // _SPLINTERDB_KV_H_

--- a/src/config.h
+++ b/src/config.h
@@ -15,7 +15,7 @@
 #include "io.h"
 #include "rc_allocator.h"
 #include "shard_log.h"
-#include "splinter.h"
+#include "trunk.h"
 #include "util.h"
 
 typedef struct master_config {

--- a/src/platform_linux/platform_inline.h
+++ b/src/platform_linux/platform_inline.h
@@ -302,8 +302,8 @@ platform_status_to_string(const platform_status status)
 #define platform_thread_cleanup_pop(exec) \
    pthread_cleanup_pop((exec))
 
-#define splinter_list_insert(...)
-#define splinter_list_remove(...)
+#define trunk_list_insert(...)
+#define trunk_list_remove(...)
 
 static inline void
 platform_histo_insert(platform_histo_handle histo, int64 datum)

--- a/src/splinterdb.c
+++ b/src/splinterdb.c
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /*
- * kvstore.c --
+ * splinterdb.c --
  *
- *     This file contains the implementation of external kvstore interfaces
+ *     This file contains the implementation of external splinterdb interfaces
  *     based on splinterdb
  */
 
@@ -12,13 +12,13 @@
 
 #include "clockcache.h"
 #include "config.h"
-#include "splinterdb/kvstore.h"
+#include "splinterdb/splinterdb.h"
 #include "rc_allocator.h"
-#include "splinter.h"
+#include "trunk.h"
 
 #include "poison.h"
 
-typedef struct kvstore {
+typedef struct splinterdb {
    task_system *        system;
    data_config          data_cfg;
    io_config            io_cfg;
@@ -27,12 +27,12 @@ typedef struct kvstore {
    rc_allocator         allocator_handle;
    clockcache_config    cache_cfg;
    clockcache           cache_handle;
-   allocator_root_id    splinter_id;
-   splinter_config      splinter_cfg;
-   splinter_handle *    spl;
+   allocator_root_id    trunk_id;
+   trunk_config      trunk_cfg;
+   trunk_handle *    spl;
    platform_heap_handle heap_handle; // for platform_buffer_create
    platform_heap_id     heap_id;
-} kvstore;
+} splinterdb;
 
 
 /*
@@ -51,9 +51,9 @@ platform_status_to_int(const platform_status status) // IN
 /*
  *-----------------------------------------------------------------------------
  *
- * kvstore_init_config --
+ * splinterdb_init_config --
  *
- *      Translate kvstore_config to configs for individual subsystems.
+ *      Translate splinterdb_config to configs for individual subsystems.
  *
  * Results:
  *      STATUS_OK on success, appopriate error on failure.
@@ -65,8 +65,8 @@ platform_status_to_int(const platform_status status) // IN
  */
 
 static platform_status
-kvstore_init_config(const kvstore_config *kvs_cfg, // IN
-                    kvstore *             kvs      // OUT
+splinterdb_init_config(const splinterdb_config *kvs_cfg, // IN
+                    splinterdb *             kvs      // OUT
 )
 {
    if (!data_validate_config(&kvs_cfg->data_cfg)) {
@@ -127,7 +127,7 @@ kvstore_init_config(const kvstore_config *kvs_cfg, // IN
                           masterCfg.cache_logfile,
                           masterCfg.use_stats);
 
-   splinter_config_init(&kvs->splinter_cfg,
+   trunk_config_init(&kvs->trunk_cfg,
                         &kvs->data_cfg,
                         NULL,
                         masterCfg.memtable_capacity,
@@ -147,12 +147,12 @@ kvstore_init_config(const kvstore_config *kvs_cfg, // IN
 
 // internal function for create or open
 int
-kvstore_create_or_open(const kvstore_config *kvs_cfg,      // IN
-                       kvstore **            kvs_out,      // OUT
+splinterdb_create_or_open(const splinterdb_config *kvs_cfg,      // IN
+                       splinterdb **            kvs_out,      // OUT
                        bool                  open_existing // IN
 )
 {
-   kvstore *       kvs;
+   splinterdb *       kvs;
    platform_status status;
 
    platform_assert(kvs_out != NULL);
@@ -163,7 +163,7 @@ kvstore_create_or_open(const kvstore_config *kvs_cfg,      // IN
       return platform_status_to_int(status);
    }
 
-   status = kvstore_init_config(kvs_cfg, kvs);
+   status = splinterdb_init_config(kvs_cfg, kvs);
    if (!SUCCESS(status)) {
       platform_error_log("Failed to init config: %s\n",
                          platform_status_to_string(status));
@@ -186,7 +186,7 @@ kvstore_create_or_open(const kvstore_config *kvs_cfg,      // IN
                                TRUE,
                                FALSE,
                                num_bg_threads,
-                               splinter_get_scratch_size());
+                               trunk_get_scratch_size());
    if (!SUCCESS(status)) {
       platform_error_log("Failed to init splinter state: %s\n",
                          platform_status_to_string(status));
@@ -229,20 +229,20 @@ kvstore_create_or_open(const kvstore_config *kvs_cfg,      // IN
       goto deinit_allocator;
    }
 
-   kvs->splinter_id = 1;
+   kvs->trunk_id = 1;
    if (open_existing) {
-      kvs->spl = splinter_mount(&kvs->splinter_cfg,
+      kvs->spl = trunk_mount(&kvs->trunk_cfg,
                                 (allocator *)&kvs->allocator_handle,
                                 (cache *)&kvs->cache_handle,
                                 kvs->system,
-                                kvs->splinter_id,
+                                kvs->trunk_id,
                                 kvs->heap_id);
    } else {
-      kvs->spl = splinter_create(&kvs->splinter_cfg,
+      kvs->spl = trunk_create(&kvs->trunk_cfg,
                                  (allocator *)&kvs->allocator_handle,
                                  (cache *)&kvs->cache_handle,
                                  kvs->system,
-                                 kvs->splinter_id,
+                                 kvs->trunk_id,
                                  kvs->heap_id);
    }
    if (kvs->spl == NULL) {
@@ -269,28 +269,28 @@ deinit_kvhandle:
 }
 
 int
-kvstore_create(const kvstore_config *cfg, // IN
-               kvstore **            kvs  // OUT
+splinterdb_create(const splinterdb_config *cfg, // IN
+               splinterdb **            kvs  // OUT
 )
 {
-   return kvstore_create_or_open(cfg, kvs, FALSE);
+   return splinterdb_create_or_open(cfg, kvs, FALSE);
 }
 
 int
-kvstore_open(const kvstore_config *cfg, // IN
-             kvstore **            kvs  // OUT
+splinterdb_open(const splinterdb_config *cfg, // IN
+             splinterdb **            kvs  // OUT
 )
 {
-   return kvstore_create_or_open(cfg, kvs, TRUE);
+   return splinterdb_create_or_open(cfg, kvs, TRUE);
 }
 
 
 /*
  *-----------------------------------------------------------------------------
  *
- * kvstore_close --
+ * splinterdb_close --
  *
- *      Close a kvstore, flushing to disk and releasing resources
+ *      Close a splinterdb, flushing to disk and releasing resources
  *
  * Results:
  *      None.
@@ -302,11 +302,11 @@ kvstore_open(const kvstore_config *cfg, // IN
  */
 
 void
-kvstore_close(kvstore *kvs) // IN
+splinterdb_close(splinterdb *kvs) // IN
 {
    platform_assert(kvs != NULL);
 
-   splinter_dismount(kvs->spl);
+   trunk_dismount(kvs->spl);
    clockcache_deinit(&kvs->cache_handle);
    rc_allocator_dismount(&kvs->allocator_handle);
    io_handle_deinit(&kvs->io_handle);
@@ -318,9 +318,9 @@ kvstore_close(kvstore *kvs) // IN
 /*
  *-----------------------------------------------------------------------------
  *
- * kvstore_register_thread --
+ * splinterdb_register_thread --
  *
- *      Register a thread for kvstore operations. Needs to be called from the
+ *      Register a thread for splinterdb operations. Needs to be called from the
  *      threads execution context.
  *
  *      This function must be called by a thread before it performs any
@@ -336,7 +336,7 @@ kvstore_close(kvstore *kvs) // IN
  */
 
 void
-kvstore_register_thread(const kvstore *kvs) // IN
+splinterdb_register_thread(const splinterdb *kvs) // IN
 {
    platform_assert(kvs != NULL);
    task_system_register_thread(kvs->system);
@@ -346,7 +346,7 @@ kvstore_register_thread(const kvstore *kvs) // IN
 /*
  *-----------------------------------------------------------------------------
  *
- * kvstore_insert --
+ * splinterdb_insert --
  *
  *      Insert a tuple into splinter
  *
@@ -360,7 +360,7 @@ kvstore_register_thread(const kvstore *kvs) // IN
  */
 
 int
-kvstore_insert(const kvstore *kvs,  // IN
+splinterdb_insert(const splinterdb *kvs,  // IN
                char *         key,  // IN
                char *         value // IN
 )
@@ -368,7 +368,7 @@ kvstore_insert(const kvstore *kvs,  // IN
    platform_status status;
 
    platform_assert(kvs != NULL);
-   status = splinter_insert(kvs->spl, key, value);
+   status = trunk_insert(kvs->spl, key, value);
    return platform_status_to_int(status);
 }
 
@@ -376,7 +376,7 @@ kvstore_insert(const kvstore *kvs,  // IN
 /*
  *-----------------------------------------------------------------------------
  *
- * kvstore_lookup --
+ * splinterdb_lookup --
  *
  *      Look up a key from splinter
  *
@@ -390,7 +390,7 @@ kvstore_insert(const kvstore *kvs,  // IN
  */
 
 int
-kvstore_lookup(const kvstore *kvs,   // IN
+splinterdb_lookup(const splinterdb *kvs,   // IN
                char *         key,   // IN
                char *         value, // OUT
                bool *         found  // OUT
@@ -399,37 +399,37 @@ kvstore_lookup(const kvstore *kvs,   // IN
    platform_status status;
 
    platform_assert(kvs != NULL);
-   status = splinter_lookup(kvs->spl, key, value, found);
+   status = trunk_lookup(kvs->spl, key, value, found);
    return platform_status_to_int(status);
 }
 
-struct kvstore_iterator {
-   splinter_range_iterator sri;
+struct splinterdb_iterator {
+   trunk_range_iterator sri;
    platform_status         last_rc;
 };
 
 int
-kvstore_iterator_init(const kvstore *    kvs,      // IN
-                      kvstore_iterator **iter,     // OUT
+splinterdb_iterator_init(const splinterdb *    kvs,      // IN
+                      splinterdb_iterator **iter,     // OUT
                       char *             start_key // IN
 )
 {
-   kvstore_iterator *it = TYPED_MALLOC(kvs->spl->heap_id, it);
+   splinterdb_iterator *it = TYPED_MALLOC(kvs->spl->heap_id, it);
    if (it == NULL) {
       platform_error_log("TYPED_MALLOC error\n");
       return platform_status_to_int(STATUS_NO_MEMORY);
    }
    it->last_rc = STATUS_OK;
 
-   splinter_range_iterator *range_itor = &(it->sri);
+   trunk_range_iterator *range_itor = &(it->sri);
 
-   platform_status rc = splinter_range_iterator_init(
+   platform_status rc = trunk_range_iterator_init(
       kvs->spl, range_itor, start_key, NULL, UINT64_MAX);
    if (!SUCCESS(rc)) {
-      // TODO(gabe): copied in from splinter.c::splinter_range
+      // TODO(gabe): copied in from trunk.c::trunk_range
       // but is this even right?  Like, if init fails, de-init
       // is typically a no-op?
-      splinter_range_iterator_deinit(range_itor);
+      trunk_range_iterator_deinit(range_itor);
       platform_free(kvs->spl->heap_id, *iter);
       return platform_status_to_int(rc);
    }
@@ -439,17 +439,17 @@ kvstore_iterator_init(const kvstore *    kvs,      // IN
 }
 
 void
-kvstore_iterator_deinit(kvstore_iterator *iter)
+splinterdb_iterator_deinit(splinterdb_iterator *iter)
 {
-   splinter_range_iterator *range_itor = &(iter->sri);
+   trunk_range_iterator *range_itor = &(iter->sri);
 
-   splinter_handle *spl = range_itor->spl;
-   splinter_range_iterator_deinit(range_itor);
+   trunk_handle *spl = range_itor->spl;
+   trunk_range_iterator_deinit(range_itor);
    platform_free(spl->heap_id, range_itor);
 }
 
 bool
-kvstore_iterator_valid(kvstore_iterator *kvi)
+splinterdb_iterator_valid(splinterdb_iterator *kvi)
 {
    if (!SUCCESS(kvi->last_rc)) {
       return FALSE;
@@ -464,14 +464,14 @@ kvstore_iterator_valid(kvstore_iterator *kvi)
 }
 
 void
-kvstore_iterator_next(kvstore_iterator *kvi)
+splinterdb_iterator_next(splinterdb_iterator *kvi)
 {
    iterator *itor = &(kvi->sri.super);
    kvi->last_rc   = iterator_advance(itor);
 }
 
 void
-kvstore_iterator_get_current(kvstore_iterator *kvi,    // IN
+splinterdb_iterator_get_current(splinterdb_iterator *kvi,    // IN
                              const char **     key,    // OUT
                              const char **     message // OUT
 )
@@ -483,7 +483,7 @@ kvstore_iterator_get_current(kvstore_iterator *kvi,    // IN
 }
 
 int
-kvstore_iterator_status(const kvstore_iterator *iter)
+splinterdb_iterator_status(const splinterdb_iterator *iter)
 {
    return platform_status_to_int(iter->last_rc);
 }

--- a/src/splinterdb_kv.c
+++ b/src/splinterdb_kv.c
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /*
- * kvstore_basic.c --
+ * splinterdb_kv.c --
  *
  *     Implementation for a simplified key-value store interface.
  *
@@ -11,8 +11,8 @@
 
 #include "platform.h"
 
-#include "splinterdb/kvstore.h"
-#include "splinterdb/kvstore_basic.h"
+#include "splinterdb/splinterdb.h"
+#include "splinterdb/splinterdb_kv.h"
 #include "util.h"
 
 #include "poison.h"
@@ -22,7 +22,7 @@ typedef struct {
    void *            key_comparator_context;
 } kvsb_data_config_context;
 
-struct kvstore_basic {
+struct splinterdb_kv {
    size_t max_app_key_size; // size of keys provided by app
    size_t max_app_val_size; // size of values provided by app
 
@@ -31,7 +31,7 @@ struct kvstore_basic {
 
    kvsb_data_config_context *data_config_context;
 
-   kvstore *kvs;
+   splinterdb *kvs;
 };
 
 // Length-prefix encoding of a variable-sized key
@@ -41,15 +41,15 @@ typedef struct PACKED {
    uint8 data[0]; // offset 1: 1st byte of value, aligned for 64-bit access
 } basic_key_encoding;
 
-static_assert((sizeof(basic_key_encoding) == KVSTORE_BASIC_KEY_HDR_SIZE),
+static_assert((sizeof(basic_key_encoding) == SPLINTERDB_KV_KEY_HDR_SIZE),
               "basic_key_encoding header should have length 1");
 
 static_assert(offsetof(basic_key_encoding, data[0]) == sizeof(uint8),
               "start of data should equal header size");
 
 static_assert((MAX_KEY_SIZE ==
-               (KVSTORE_BASIC_MAX_KEY_SIZE + KVSTORE_BASIC_KEY_HDR_SIZE)),
-              "KVSTORE_BASIC_MAX_KEY_SIZE should be updated when "
+               (SPLINTERDB_KV_MAX_KEY_SIZE + SPLINTERDB_KV_KEY_HDR_SIZE)),
+              "SPLINTERDB_KV_MAX_KEY_SIZE should be updated when "
               "MAX_KEY_SIZE changes");
 
 #define KVSB_PACK_PTR __attribute__((packed, aligned(__alignof__(void *))))
@@ -65,7 +65,7 @@ typedef struct KVSB_PACK_PTR {
    uint8  value[0]; // offset 8: 1st byte of value, aligned for 64-bit access
 } basic_message;
 
-static_assert(sizeof(basic_message) == KVSTORE_BASIC_MSG_HDR_SIZE,
+static_assert(sizeof(basic_message) == SPLINTERDB_KV_MSG_HDR_SIZE,
               "basic_message header should have the same size as a pointer");
 
 static_assert(offsetof(basic_message, value[0]) == sizeof(void *),
@@ -82,8 +82,8 @@ variable_len_compare(const void *context,
    // https://github.com/facebook/rocksdb/blob/2e062b222720d45d5a4f99b8de1824a2aae7b0c1/include/rocksdb/slice.h#L247-L258
    assert(key1 != NULL);
    assert(key2 != NULL);
-   assert(key1_len <= KVSTORE_BASIC_MAX_KEY_SIZE);
-   assert(key2_len <= KVSTORE_BASIC_MAX_KEY_SIZE);
+   assert(key1_len <= SPLINTERDB_KV_MAX_KEY_SIZE);
+   assert(key2_len <= SPLINTERDB_KV_MAX_KEY_SIZE);
    size_t min_len = (key1_len <= key2_len ? key1_len : key2_len);
    int    r       = memcmp(key1, key2, min_len);
    if (r == 0) {
@@ -105,8 +105,8 @@ basic_key_compare(const data_config *cfg,
    basic_key_encoding *key1 = (basic_key_encoding *)key1_raw;
    basic_key_encoding *key2 = (basic_key_encoding *)key2_raw;
 
-   assert(key1->length <= KVSTORE_BASIC_MAX_KEY_SIZE);
-   assert(key2->length <= KVSTORE_BASIC_MAX_KEY_SIZE);
+   assert(key1->length <= SPLINTERDB_KV_MAX_KEY_SIZE);
+   assert(key2->length <= SPLINTERDB_KV_MAX_KEY_SIZE);
 
    kvsb_data_config_context *ctx = (kvsb_data_config_context *)(cfg->context);
    return ctx->key_comparator(ctx->key_comparator_context,
@@ -157,7 +157,7 @@ encode_key(void *key_buffer, const void *key, size_t key_len)
 {
    basic_key_encoding *key_enc = (basic_key_encoding *)key_buffer;
    platform_assert(key_len <= UINT8_MAX &&
-                   key_len <= KVSTORE_BASIC_MAX_KEY_SIZE);
+                   key_len <= SPLINTERDB_KV_MAX_KEY_SIZE);
    key_enc->length = key_len;
    memmove(&(key_enc->data), key, key_len);
 }
@@ -171,7 +171,7 @@ encode_value(void *       msg_buffer,
    basic_message *msg = (basic_message *)msg_buffer;
    msg->type          = type;
    platform_assert(value_len <= UINT32_MAX &&
-                   value_len <= KVSTORE_BASIC_MAX_VALUE_SIZE);
+                   value_len <= SPLINTERDB_KV_MAX_VALUE_SIZE);
    msg->value_length = value_len;
    memmove(&(msg->value), value, value_len);
 }
@@ -198,7 +198,7 @@ static data_config _template_basic_data_config = {
    .key_size           = 0,
    .message_size       = 0,
    .min_key            = {0},
-   .max_key            = {0}, // kvstore_init_config sets this, we can ignore
+   .max_key            = {0}, // splinterdb_init_config sets this, we can ignore
    .key_compare        = basic_key_compare,
    .key_hash           = platform_hash32,
    .merge_tuples       = basic_merge_tuples,
@@ -214,30 +214,30 @@ new_basic_data_config(const size_t max_key_size,   // IN
                       data_config *out_cfg         // OUT
 )
 {
-   if (max_key_size > KVSTORE_BASIC_MAX_KEY_SIZE ||
-       max_key_size < KVSTORE_BASIC_MIN_KEY_SIZE) {
+   if (max_key_size > SPLINTERDB_KV_MAX_KEY_SIZE ||
+       max_key_size < SPLINTERDB_KV_MIN_KEY_SIZE) {
       platform_error_log("max key size %lu must be <= %lu and >= %lu\n",
                          max_key_size,
-                         (size_t)(KVSTORE_BASIC_MAX_KEY_SIZE),
-                         (size_t)(KVSTORE_BASIC_MIN_KEY_SIZE));
+                         (size_t)(SPLINTERDB_KV_MAX_KEY_SIZE),
+                         (size_t)(SPLINTERDB_KV_MIN_KEY_SIZE));
       return EINVAL;
    }
-   if (max_value_size > KVSTORE_BASIC_MAX_VALUE_SIZE) {
+   if (max_value_size > SPLINTERDB_KV_MAX_VALUE_SIZE) {
       platform_error_log("max value size %lu must be <= %lu\n",
                          max_value_size,
-                         (size_t)(KVSTORE_BASIC_MAX_VALUE_SIZE));
+                         (size_t)(SPLINTERDB_KV_MAX_VALUE_SIZE));
       return EINVAL;
    }
    // compute sizes for data_config, which are larger than the sizes the
    // application sees
-   const size_t key_size = max_key_size + KVSTORE_BASIC_KEY_HDR_SIZE;
-   const size_t msg_size = max_value_size + KVSTORE_BASIC_MSG_HDR_SIZE;
+   const size_t key_size = max_key_size + SPLINTERDB_KV_KEY_HDR_SIZE;
+   const size_t msg_size = max_value_size + SPLINTERDB_KV_MSG_HDR_SIZE;
    *out_cfg              = _template_basic_data_config;
    out_cfg->key_size     = key_size;
    out_cfg->message_size = msg_size;
 
    // set max_key
-   char max_app_key[KVSTORE_BASIC_MAX_KEY_SIZE];
+   char max_app_key[SPLINTERDB_KV_MAX_KEY_SIZE];
    memset(max_app_key, 0xFF, sizeof(max_app_key));
    encode_key(out_cfg->max_key, max_app_key, max_key_size);
 
@@ -251,8 +251,8 @@ new_basic_data_config(const size_t max_key_size,   // IN
 // Implementation of public API begins here...
 
 int
-kvstore_basic_create_or_open(const kvstore_basic_cfg *cfg,      // IN
-                             kvstore_basic **         kvsb_out, // OUT
+splinterdb_kv_create_or_open(const splinterdb_kv_cfg *cfg,      // IN
+                             splinterdb_kv **         kvsb_out, // OUT
                              bool                     open_existing)
 {
    data_config data_cfg = {0};
@@ -262,12 +262,12 @@ kvstore_basic_create_or_open(const kvstore_basic_cfg *cfg,      // IN
       return res; // new_basic_data_config already logs on error
    }
 
-   kvstore_basic *kvsb = TYPED_ZALLOC(cfg->heap_id, kvsb);
+   splinterdb_kv *kvsb = TYPED_ZALLOC(cfg->heap_id, kvsb);
    if (kvsb == NULL) {
       platform_error_log("zalloc error\n");
       return ENOMEM;
    }
-   *kvsb = (kvstore_basic){
+   *kvsb = (splinterdb_kv){
       .max_app_key_size = cfg->max_key_size,
       .max_app_val_size = cfg->max_value_size,
       .heap_id          = cfg->heap_id,
@@ -281,8 +281,8 @@ kvstore_basic_create_or_open(const kvstore_basic_cfg *cfg,      // IN
    kvsb->data_config_context = ctxt; // store, so we can free it later
    data_cfg.context          = ctxt; // make it usable from the callbacks
 
-   // this can be stack-allocated since kvstore_create does a shallow-copy
-   kvstore_config kvs_config = {
+   // this can be stack-allocated since splinterdb_create does a shallow-copy
+   splinterdb_config kvs_config = {
       .filename    = cfg->filename,
       .cache_size  = cfg->cache_size,
       .disk_size   = cfg->disk_size,
@@ -292,12 +292,12 @@ kvstore_basic_create_or_open(const kvstore_basic_cfg *cfg,      // IN
    };
 
    if (open_existing) {
-      res = kvstore_open(&kvs_config, &(kvsb->kvs));
+      res = splinterdb_open(&kvs_config, &(kvsb->kvs));
    } else {
-      res = kvstore_create(&kvs_config, &(kvsb->kvs));
+      res = splinterdb_create(&kvs_config, &(kvsb->kvs));
    }
    if (res != 0) {
-      platform_error_log("kvstore_create error\n");
+      platform_error_log("splinterdb_create error\n");
       return res;
    }
    *kvsb_out = kvsb;
@@ -305,25 +305,25 @@ kvstore_basic_create_or_open(const kvstore_basic_cfg *cfg,      // IN
 }
 
 int
-kvstore_basic_create(const kvstore_basic_cfg *cfg,     // IN
-                     kvstore_basic **         kvsb_out // OUT
+splinterdb_kv_create(const splinterdb_kv_cfg *cfg,     // IN
+                     splinterdb_kv **         kvsb_out // OUT
 )
 {
-   return kvstore_basic_create_or_open(cfg, kvsb_out, FALSE);
+   return splinterdb_kv_create_or_open(cfg, kvsb_out, FALSE);
 }
 
 int
-kvstore_basic_open(const kvstore_basic_cfg *cfg,     // IN
-                   kvstore_basic **         kvsb_out // OUT
+splinterdb_kv_open(const splinterdb_kv_cfg *cfg,     // IN
+                   splinterdb_kv **         kvsb_out // OUT
 )
 {
-   return kvstore_basic_create_or_open(cfg, kvsb_out, TRUE);
+   return splinterdb_kv_create_or_open(cfg, kvsb_out, TRUE);
 }
 
 void
-kvstore_basic_close(kvstore_basic *kvsb)
+splinterdb_kv_close(splinterdb_kv *kvsb)
 {
-   kvstore_close(kvsb->kvs);
+   splinterdb_close(kvsb->kvs);
    if (kvsb->data_config_context != NULL) {
       platform_free(kvsb->heap_id, kvsb->data_config_context);
    }
@@ -331,20 +331,20 @@ kvstore_basic_close(kvstore_basic *kvsb)
 }
 
 void
-kvstore_basic_register_thread(const kvstore_basic *kvsb)
+splinterdb_kv_register_thread(const splinterdb_kv *kvsb)
 {
-   kvstore_register_thread(kvsb->kvs);
+   splinterdb_register_thread(kvsb->kvs);
 }
 
 int
-kvstore_basic_insert(const kvstore_basic *kvsb,
+splinterdb_kv_insert(const splinterdb_kv *kvsb,
                      const char *         key,
                      const size_t         key_len,
                      const char *         value,
                      const size_t         val_len)
 {
    if (key_len > kvsb->max_app_key_size) {
-      platform_error_log("kvstore_basic_insert: key_len, %lu, exceeds"
+      platform_error_log("splinterdb_kv_insert: key_len, %lu, exceeds"
                          " max_key_size, %lu bytes; key='%.*s'\n",
                          key_len,
                          kvsb->max_app_key_size,
@@ -354,7 +354,7 @@ kvstore_basic_insert(const kvstore_basic *kvsb,
    }
 
    if (val_len > kvsb->max_app_val_size) {
-      platform_error_log("kvstore_basic_insert: val_len, %lu, exceeds"
+      platform_error_log("splinterdb_kv_insert: val_len, %lu, exceeds"
                          " max_value_size, %lu bytes; value='%.*s ...'\n",
                          val_len,
                          kvsb->max_app_val_size,
@@ -367,16 +367,16 @@ kvstore_basic_insert(const kvstore_basic *kvsb,
    char msg_buffer[MAX_MESSAGE_SIZE] = {0};
    encode_key(key_buffer, key, key_len);
    encode_value(msg_buffer, MESSAGE_TYPE_INSERT, value, val_len);
-   return kvstore_insert(kvsb->kvs, key_buffer, msg_buffer);
+   return splinterdb_insert(kvsb->kvs, key_buffer, msg_buffer);
 }
 
 int
-kvstore_basic_delete(const kvstore_basic *kvsb,
+splinterdb_kv_delete(const splinterdb_kv *kvsb,
                      const char *         key,
                      const size_t         key_len)
 {
    if (key_len > kvsb->max_app_key_size) {
-      platform_error_log("kvstore_basic_delete: key_len, %lu, exceeds"
+      platform_error_log("splinterdb_kv_delete: key_len, %lu, exceeds"
                          " max_key_size, %lu bytes; key='%.*s'\n",
                          key_len,
                          kvsb->max_app_key_size,
@@ -389,12 +389,12 @@ kvstore_basic_delete(const kvstore_basic *kvsb,
    char msg_buffer[MAX_MESSAGE_SIZE] = {0};
    encode_key(key_buffer, key, key_len);
    encode_value(msg_buffer, MESSAGE_TYPE_DELETE, NULL, 0);
-   return kvstore_insert(kvsb->kvs, key_buffer, msg_buffer);
+   return splinterdb_insert(kvsb->kvs, key_buffer, msg_buffer);
 }
 
 
 int
-kvstore_basic_lookup(const kvstore_basic *kvsb,
+splinterdb_kv_lookup(const splinterdb_kv *kvsb,
                      const char *         key,           // IN
                      const size_t         key_len,       // IN
                      char *               val,           // OUT
@@ -405,7 +405,7 @@ kvstore_basic_lookup(const kvstore_basic *kvsb,
 )
 {
    if (key_len > kvsb->max_app_key_size) {
-      platform_error_log("kvstore_basic_lookup: key_len, %lu, exceeds"
+      platform_error_log("splinterdb_kv_lookup: key_len, %lu, exceeds"
                          " max_key_size, %lu bytes; key='%.*s'\n",
                          key_len,
                          kvsb->max_app_key_size,
@@ -420,17 +420,17 @@ kvstore_basic_lookup(const kvstore_basic *kvsb,
 
    basic_message *msg = (basic_message *)msg_buffer;
 
-   // kvstore_basic.h aims to be public API surface, and so this function
+   // splinterdb_kv.h aims to be public API surface, and so this function
    // exposes the _Bool type rather than  typedef int32 bool
    // which is used elsewhere in the codebase
    // So, we pass in int32 found here, and convert to _Bool below
    int32 found;
-   int   result = kvstore_lookup(kvsb->kvs, key_buffer, msg_buffer, &found);
+   int   result = splinterdb_lookup(kvsb->kvs, key_buffer, msg_buffer, &found);
    if (result != 0) {
       return result;
    }
    *found_out     = found ? TRUE : FALSE;
-   size_t n_bytes = KVSTORE_BASIC_MAX_VALUE_SIZE;
+   size_t n_bytes = SPLINTERDB_KV_MAX_VALUE_SIZE;
    if (val_max_len < n_bytes) {
       n_bytes = val_max_len;
    }
@@ -445,20 +445,20 @@ kvstore_basic_lookup(const kvstore_basic *kvsb,
    return result;
 }
 
-struct kvstore_basic_iterator {
-   kvstore_iterator *super;
+struct splinterdb_kv_iterator {
+   splinterdb_iterator *super;
 
    void *heap_id;
 };
 
 int
-kvstore_basic_iter_init(const kvstore_basic *    kvsb,         // IN
-                        kvstore_basic_iterator **iter,         // OUT
+splinterdb_kv_iter_init(const splinterdb_kv *    kvsb,         // IN
+                        splinterdb_kv_iterator **iter,         // OUT
                         const char *             start_key,    // IN
                         const size_t             start_key_len // IN
 )
 {
-   kvstore_basic_iterator *it = TYPED_ZALLOC(kvsb->heap_id, it);
+   splinterdb_kv_iterator *it = TYPED_ZALLOC(kvsb->heap_id, it);
    if (it == NULL) {
       platform_error_log("zalloc error\n");
       return ENOMEM;
@@ -470,7 +470,7 @@ kvstore_basic_iter_init(const kvstore_basic *    kvsb,         // IN
       encode_key(start_key_buffer, start_key, start_key_len);
    }
 
-   int rc = kvstore_iterator_init(
+   int rc = splinterdb_iterator_init(
       kvsb->kvs, &(it->super), start_key ? start_key_buffer : NULL);
    if (rc != 0) {
       platform_error_log("iterator init: %d\n", rc);
@@ -483,34 +483,34 @@ kvstore_basic_iter_init(const kvstore_basic *    kvsb,         // IN
 }
 
 void
-kvstore_basic_iter_deinit(kvstore_basic_iterator **iterpp)
+splinterdb_kv_iter_deinit(splinterdb_kv_iterator **iterpp)
 {
-   kvstore_basic_iterator *iter = *iterpp;
-   kvstore_iterator_deinit(iter->super);
+   splinterdb_kv_iterator *iter = *iterpp;
+   splinterdb_iterator_deinit(iter->super);
    platform_free(iter->heap_id, iter);
    *iterpp = NULL;
 }
 
 _Bool
-kvstore_basic_iter_valid(kvstore_basic_iterator *iter)
+splinterdb_kv_iter_valid(splinterdb_kv_iterator *iter)
 {
-   return kvstore_iterator_valid(iter->super);
+   return splinterdb_iterator_valid(iter->super);
 }
 
 void
-kvstore_basic_iter_next(kvstore_basic_iterator *iter)
+splinterdb_kv_iter_next(splinterdb_kv_iterator *iter)
 {
-   kvstore_iterator_next(iter->super);
+   splinterdb_iterator_next(iter->super);
 }
 
 int
-kvstore_basic_iter_status(const kvstore_basic_iterator *iter)
+splinterdb_kv_iter_status(const splinterdb_kv_iterator *iter)
 {
-   return kvstore_iterator_status(iter->super);
+   return splinterdb_iterator_status(iter->super);
 }
 
 void
-kvstore_basic_iter_get_current(kvstore_basic_iterator *iter,    // IN
+splinterdb_kv_iter_get_current(splinterdb_kv_iterator *iter,    // IN
                                const char **           key,     // OUT
                                size_t *                key_len, // OUT
                                const char **           value,   // OUT
@@ -519,7 +519,7 @@ kvstore_basic_iter_get_current(kvstore_basic_iterator *iter,    // IN
 {
    const char *msg_buffer;
    const char *key_buffer;
-   kvstore_iterator_get_current(iter->super, &key_buffer, &msg_buffer);
+   splinterdb_iterator_get_current(iter->super, &key_buffer, &msg_buffer);
    basic_message *     msg     = (basic_message *)msg_buffer;
    basic_key_encoding *key_enc = (basic_key_encoding *)key_buffer;
    *key_len                    = key_enc->length;

--- a/src/trunk.c
+++ b/src/trunk.c
@@ -2,14 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /*
- * splinter.c --
+ * trunk.c --
  *
  *     This file contains the implementation for splinterDB.
  */
 
 #include "platform.h"
 
-#include "splinter.h"
+#include "trunk.h"
 #include "btree.h"
 #include "memtable.h"
 #include "routing_filter.h"
@@ -41,59 +41,59 @@ static const int64 latency_histo_buckets[LATENCYHISTO_SIZE] = {
    10000000000     // 10  s
 };
 
-#define SPLINTER_NUM_MEMTABLES (4)
-#define SPLINTER_HARD_MAX_NUM_TREES (128)
-#define SPLINTER_MAX_PIVOTS (20)
-#define SPLINTER_MAX_BUNDLES (12)
-#define SPLINTER_MAX_SUBBUNDLES (24)
-#define SPLINTER_MAX_FILTERS (24)
-#define SPLINTER_PREFETCH_MIN (16384)
-#define SPLINTER_MIN_SPACE_RECL (2048)
-#define SPLINTER_SUPER_CSUM_SEED (42)
+#define TRUNK_NUM_MEMTABLES (4)
+#define TRUNK_HARD_MAX_NUM_TREES (128)
+#define TRUNK_MAX_PIVOTS (20)
+#define TRUNK_MAX_BUNDLES (12)
+#define TRUNK_MAX_SUBBUNDLES (24)
+#define TRUNK_MAX_FILTERS (24)
+#define TRUNK_PREFETCH_MIN (16384)
+#define TRUNK_MIN_SPACE_RECL (2048)
+#define TRUNK_SUPER_CSUM_SEED (42)
 
-//#define SPLINTER_LOG
+//#define TRUNK_LOG
 
-#if defined SPLINTER_LOG
-#define splinter_open_log_stream() platform_open_log_stream()
+#if defined TRUNK_LOG
+#define trunk_open_log_stream() platform_open_log_stream()
 #else
-#define splinter_open_log_stream()
+#define trunk_open_log_stream()
 #endif
 
-#if defined SPLINTER_LOG
-#define splinter_close_log_stream() \
+#if defined TRUNK_LOG
+#define trunk_close_log_stream() \
    platform_close_log_stream(PLATFORM_DEFAULT_LOG_HANDLE)
 #else
-#define splinter_close_log_stream()
+#define trunk_close_log_stream()
 #endif
 
 /*
- * splinter_log_stream, splinter_log_node, splinter_log_key should be called
- * between splinter_open_log_stream and splinter_close_log_stream.
+ * trunk_log_stream, trunk_log_node, trunk_log_key should be called
+ * between trunk_open_log_stream and trunk_close_log_stream.
  */
-#if defined SPLINTER_LOG
-#define splinter_log_stream(message, ...)                   \
+#if defined TRUNK_LOG
+#define trunk_log_stream(message, ...)                   \
    platform_log_stream("(%lu) "message, platform_get_tid(), \
                        ##__VA_ARGS__);
-#define splinter_default_log(...)                           \
+#define trunk_default_log(...)                           \
    platform_default_log(__VA_ARGS__);
-#define splinter_log_node(spl, node)                        \
-   splinter_print_locked_node(spl, node, stream);
+#define trunk_log_node(spl, node)                        \
+   trunk_print_locked_node(spl, node, stream);
 #else
-#define splinter_log_stream(message, ...)
-#define splinter_default_log(...)
-#define splinter_log_node(spl, node)
+#define trunk_log_stream(message, ...)
+#define trunk_default_log(...)
+#define trunk_log_node(spl, node)
 #endif
 
-#if defined SPLINTER_LOG
-#define splinter_log_key(spl, key, message, ...)                      \
+#if defined TRUNK_LOG
+#define trunk_log_key(spl, key, message, ...)                      \
    {                                                                  \
       char __key_str[128];                                            \
-      splinter_key_to_string(spl, key, __key_str);                    \
+      trunk_key_to_string(spl, key, __key_str);                    \
       platform_log_stream("(%lu) "message" %s\n", platform_get_tid(), \
                           ##__VA_ARGS__, __key_str);                  \
    }
 #else
-#define splinter_log_key(spl, key, message, ...)
+#define trunk_log_key(spl, key, message, ...)
 #endif
 
 /*
@@ -280,7 +280,7 @@ static const int64 latency_histo_buckets[LATENCYHISTO_SIZE] = {
  *       array of bundles
  *          When a collection of branches are flushed into a node, they are
  *          organized into a bundle. This bundle will be compacted into a
- *          single branch by a call to splinter_compact_bundle. Bundles are
+ *          single branch by a call to trunk_compact_bundle. Bundles are
  *          implemented as a collection of subbundles, each of which covers a
  *          range of branches.
  *       ----------
@@ -303,9 +303,9 @@ static const int64 latency_histo_buckets[LATENCYHISTO_SIZE] = {
  *          start_branch, which is used to determine which branches have tuples
  *          for that pivot (the range start_branch to end_branch).
  *
- *          Each pivot's key is accessible via a call to splinter_get_pivot and
+ *          Each pivot's key is accessible via a call to trunk_get_pivot and
  *          the remaining data is accessible via a call to
- *          splinter_get_pivot_data.
+ *          trunk_get_pivot_data.
  *
  *          The number of pivots has two different limits: a soft limit
  *          (fanout) and a hard limit (max_pivot_keys). When the soft limit is
@@ -355,7 +355,7 @@ static const int64 latency_histo_buckets[LATENCYHISTO_SIZE] = {
  */
 
 // a super block
-typedef struct splinter_super_block {
+typedef struct trunk_super_block {
    uint64      root_addr;
    uint64      meta_tail;
    uint64      log_addr;
@@ -364,7 +364,7 @@ typedef struct splinter_super_block {
    bool        checkpointed;
    bool        dismounted;
    checksum128 checksum;
-} splinter_super_block;
+} trunk_super_block;
 
 /*
  * A subbundle is a collection of branches which originated in the same node.
@@ -373,19 +373,19 @@ typedef struct splinter_super_block {
  * routing filter to filter the branches in the subbundle.
  */
 
-typedef enum splinter_subbundle_state {
+typedef enum trunk_subbundle_state {
    SB_STATE_UNCOMPACTED_INDEX,
    SB_STATE_UNCOMPACTED_LEAF,
    SB_STATE_COMPACTED,         // compacted subbundles are always index
-} splinter_subbundle_state;
+} trunk_subbundle_state;
 
-typedef struct PACKED splinter_subbundle {
-   splinter_subbundle_state state;
+typedef struct PACKED trunk_subbundle {
+   trunk_subbundle_state state;
    uint16                   start_branch;
    uint16                   end_branch;
    uint16                   start_filter;
    uint16                   end_filter;
-} splinter_subbundle;
+} trunk_subbundle;
 
 /*
  * A flush moves branches from the parent to a bundle in the child. The bundle
@@ -400,11 +400,11 @@ typedef struct PACKED splinter_subbundle {
  * maintain the invariant that the outstanding bundles form a contiguous range.
  */
 
-typedef struct PACKED splinter_bundle {
+typedef struct PACKED trunk_bundle {
    uint16 start_subbundle;
    uint16 end_subbundle;
    uint64 num_tuples;
-} splinter_bundle;
+} trunk_bundle;
 
 /*
  * Trunk headers
@@ -421,7 +421,7 @@ typedef struct PACKED splinter_bundle {
  *       all the created leaves.
  */
 
-typedef struct PACKED splinter_trunk_hdr {
+typedef struct PACKED trunk_hdr {
    uint16 num_pivot_keys;    // number of used pivot keys (== num_children + 1)
    uint16 height;            // height of the node
    uint64 next_addr;         // PBN of the node's successor (0 if no successor)
@@ -438,20 +438,20 @@ typedef struct PACKED splinter_trunk_hdr {
    uint16 start_sb_filter;   // first subbundle filter
    uint16 end_sb_filter;     // successor to the last sb filter
 
-   splinter_bundle    bundle[SPLINTER_MAX_BUNDLES];
-   splinter_subbundle subbundle[SPLINTER_MAX_SUBBUNDLES];
-   routing_filter     sb_filter[SPLINTER_MAX_FILTERS];
-} splinter_trunk_hdr;
+   trunk_bundle    bundle[TRUNK_MAX_BUNDLES];
+   trunk_subbundle subbundle[TRUNK_MAX_SUBBUNDLES];
+   routing_filter     sb_filter[TRUNK_MAX_FILTERS];
+} trunk_hdr;
 
 /*
  * a pivot consists of the pivot key (of size cfg.key_size) followed by a
- * splinter_pivot_data
+ * trunk_pivot_data
  *
  * the generation is used by asynchronous processes to determine when a pivot
  * has split
  */
 
-typedef struct splinter_pivot_data {
+typedef struct trunk_pivot_data {
    uint64         addr;         // PBN of the child
    uint64         num_tuples;   // estimate of the # of tuples for this pivot
    uint64         generation;   // receives new higher number when pivot splits
@@ -459,37 +459,37 @@ typedef struct splinter_pivot_data {
    uint16         start_bundle; // first bundle live (not used in leaves)
    routing_filter filter;       // routing filter for keys in this pivot
    int64          srq_idx;      // index in the space rec queue
-} splinter_pivot_data;
+} trunk_pivot_data;
 
 // arguments to a compact_bundle job
-struct splinter_compact_bundle_req {
-   splinter_handle *spl;
+struct trunk_compact_bundle_req {
+   trunk_handle *spl;
    uint64           addr;
    uint16           height;
    uint16           bundle_no;
    uint64           generation;
    uint64           filter_generation;
-   uint64           pivot_generation[SPLINTER_MAX_PIVOTS];
+   uint64           pivot_generation[TRUNK_MAX_PIVOTS];
    uint64           max_pivot_generation;
-   uint64           input_pivot_count[SPLINTER_MAX_PIVOTS];
-   uint64           output_pivot_count[SPLINTER_MAX_PIVOTS];
+   uint64           input_pivot_count[TRUNK_MAX_PIVOTS];
+   uint64           output_pivot_count[TRUNK_MAX_PIVOTS];
    bool             is_space_rec;
    uint64           tuples_reclaimed;
    uint32          *fp_arr;
-   bool             should_build[SPLINTER_MAX_PIVOTS];
-   routing_filter   old_filter[SPLINTER_MAX_PIVOTS];
-   uint16           value[SPLINTER_MAX_PIVOTS];
-   routing_filter   filter[SPLINTER_MAX_PIVOTS];
+   bool             should_build[TRUNK_MAX_PIVOTS];
+   routing_filter   old_filter[TRUNK_MAX_PIVOTS];
+   uint16           value[TRUNK_MAX_PIVOTS];
+   routing_filter   filter[TRUNK_MAX_PIVOTS];
 };
 
 // an iterator which skips masked pivots
-typedef struct splinter_btree_skiperator {
+typedef struct trunk_btree_skiperator {
    iterator        super;
    uint64          curr;
    uint64          end;
-   splinter_branch branch;
-   btree_iterator  itor[SPLINTER_MAX_PIVOTS];
-} splinter_btree_skiperator;
+   trunk_branch branch;
+   btree_iterator  itor[TRUNK_MAX_PIVOTS];
+} trunk_btree_skiperator;
 
 // for find_pivot
 typedef enum lookup_type {
@@ -500,21 +500,21 @@ typedef enum lookup_type {
 } lookup_type;
 
 // for for_each_node
-typedef bool (*node_fn)(splinter_handle *spl,
+typedef bool (*node_fn)(trunk_handle *spl,
                         uint64           addr,
                         void            *arg);
 
-// Used by splinter_compact_bundle()
+// Used by trunk_compact_bundle()
 typedef struct {
-   splinter_btree_skiperator skip_itor[SPLINTER_MAX_TOTAL_DEGREE];
-   iterator*                 itor_arr[SPLINTER_MAX_TOTAL_DEGREE];
-   key_buffer                saved_pivot_keys[SPLINTER_MAX_PIVOTS];
+   trunk_btree_skiperator skip_itor[TRUNK_MAX_TOTAL_DEGREE];
+   iterator*                 itor_arr[TRUNK_MAX_TOTAL_DEGREE];
+   key_buffer                saved_pivot_keys[TRUNK_MAX_PIVOTS];
 } compact_bundle_scratch;
-// Used by splinter_split_leaf()
+// Used by trunk_split_leaf()
 typedef struct {
-   char           pivot[SPLINTER_MAX_PIVOTS][MAX_KEY_SIZE];
-   btree_iterator btree_itor[SPLINTER_MAX_TOTAL_DEGREE];
-   iterator*      rough_itor[SPLINTER_MAX_TOTAL_DEGREE];
+   char           pivot[TRUNK_MAX_PIVOTS][MAX_KEY_SIZE];
+   btree_iterator btree_itor[TRUNK_MAX_TOTAL_DEGREE];
+   iterator*      rough_itor[TRUNK_MAX_TOTAL_DEGREE];
 } split_leaf_scratch;
 
 /*
@@ -525,12 +525,12 @@ typedef struct {
 typedef union {
    compact_bundle_scratch compact_bundle;
    split_leaf_scratch     split_leaf;
-} splinter_task_scratch;
+} trunk_task_scratch;
 
 
 /*
  * Splinter specific state that gets created during initialization in
- * splinter_system_init(). Contains global state for splinter such as the
+ * trunk_system_init(). Contains global state for splinter such as the
  * init thread, init thread's scratch memory, thread_id counter and an array
  * of all the threads, which acts like a map that is accessed by thread id
  * to get the thread pointer.
@@ -540,13 +540,13 @@ typedef union {
  * execution, task queue and clockcache.
  */
 
-typedef struct splinter_system_state {
+typedef struct trunk_system_state {
    // lookup array for threads registered with this system.
    thread_task           *thread_lookup[MAX_THREADS];
    // array of threads for this system.
    thread_task            thread_tasks[MAX_THREADS];
    // scratch memory for each thread.
-   splinter_task_scratch  task_scratch[MAX_THREADS];
+   trunk_task_scratch  task_scratch[MAX_THREADS];
    // IO handle (currently one splinter system has just one)
    platform_io_handle    *ioh;
    /*
@@ -558,7 +558,7 @@ typedef struct splinter_system_state {
    uint64                 tid_bitmask;
    // max thread id so far.
    threadid               max_tid;
-} splinter_system_state;
+} trunk_system_state;
 
 /*
  *-----------------------------------------------------------------------------
@@ -569,89 +569,89 @@ typedef struct splinter_system_state {
  */
 
 // clang-format off
-static inline bool                 splinter_is_leaf                   (splinter_handle *spl, page_handle *node);
-static inline uint64               splinter_next_addr                 (splinter_handle *spl, page_handle *node);
-static inline int                  splinter_key_compare               (splinter_handle *spl, const char *key1, const char *key2);
-static inline page_handle *        splinter_node_get                  (splinter_handle *spl, uint64 addr);
-static inline void                 splinter_node_unget                (splinter_handle *spl, page_handle **node);
-static inline void                 splinter_node_claim                (splinter_handle *spl, page_handle **node);
-static inline void                 splinter_node_unclaim              (splinter_handle *spl, page_handle *node);
-static inline void                 splinter_node_lock                 (splinter_handle *spl, page_handle *node);
-static inline void                 splinter_node_unlock               (splinter_handle *spl, page_handle *node);
-page_handle *                      splinter_alloc                     (splinter_handle *spl, uint64 height);
-static inline char *               splinter_get_pivot                 (splinter_handle *spl, page_handle *node, uint16 pivot_no);
-static inline splinter_pivot_data *splinter_get_pivot_data            (splinter_handle *spl, page_handle *node, uint16 pivot_no);
-static inline uint16               splinter_find_pivot                (splinter_handle *spl, page_handle *node, char *key, lookup_type comp);
-platform_status                    splinter_add_pivot                 (splinter_handle *spl, page_handle *parent, page_handle *child, uint16 pivot_no);
-static inline uint16               splinter_num_children              (splinter_handle *spl, page_handle *node);
-static inline uint16               splinter_num_pivot_keys            (splinter_handle *spl, page_handle *node);
-static inline void                 splinter_inc_num_pivot_keys        (splinter_handle *spl, page_handle *node);
-static inline char *               splinter_max_key                   (splinter_handle *spl, page_handle *node);
-void                               splinter_update_num_tuples         (splinter_handle *spl, page_handle *node, uint16 branch_no);
-void                               splinter_pivot_recount_num_tuples  (splinter_handle *spl, page_handle *node, uint64 pivot_no);
-static inline uint16               splinter_pivot_branch_count        (splinter_handle *spl, page_handle *node, splinter_pivot_data *pdata);
-bool                               splinter_pivot_needs_count_flush   (splinter_handle *spl, page_handle *node, splinter_pivot_data *pdata);
-static inline uint64               splinter_pivot_tuples_in_branch    (splinter_handle *spl, page_handle *node, uint16 pivot_no, uint16 branch_no);
-static inline bool                 splinter_has_vacancy               (splinter_handle *spl, page_handle *node, uint16 num_new_branches);
-static inline uint16               splinter_bundle_no_add             (splinter_handle *spl, uint16 start, uint16 end);
-static inline uint16               splinter_bundle_no_sub             (splinter_handle *spl, uint16 start, uint16 end);
-static inline splinter_bundle     *splinter_get_bundle                (splinter_handle *spl, page_handle *node, uint16 bundle_no);
-static inline uint16               splinter_get_new_bundle            (splinter_handle *spl, page_handle *node);
-static inline uint16               splinter_bundle_start_branch       (splinter_handle *spl, page_handle *node, splinter_bundle *bundle);
-static inline uint16               splinter_start_bundle              (splinter_handle *spl, page_handle *node);
-static inline uint16               splinter_inc_start_bundle          (splinter_handle *spl, page_handle *node);
-static inline uint16               splinter_end_bundle                (splinter_handle *spl, page_handle *node);
-static inline uint16               splinter_bundle_clear_subbundles   (splinter_handle *spl, page_handle *node, splinter_bundle *bundle);
-static inline uint16               splinter_subbundle_no_add          (splinter_handle *spl, uint16 start, uint16 end);
-static inline uint16               splinter_subbundle_no_sub          (splinter_handle *spl, uint16 start, uint16 end);
-static inline uint16               splinter_end_subbundle             (splinter_handle *spl, page_handle *node);
-static inline uint16               splinter_end_sb_filter             (splinter_handle *spl, page_handle *node);
-static inline splinter_branch     *splinter_get_branch                (splinter_handle *spl, page_handle *node, uint32 k);
-static inline splinter_branch     *splinter_get_new_branch            (splinter_handle *spl, page_handle *node);
-static inline uint16               splinter_start_branch              (splinter_handle *spl, page_handle *node);
-static inline uint16               splinter_end_branch                (splinter_handle *spl, page_handle *node);
-static inline uint16               splinter_start_frac_branch         (splinter_handle *spl, page_handle *node);
-static inline void                 splinter_set_start_frac_branch     (splinter_handle *spl, page_handle *node, uint16 branch_no);
-static inline uint16               splinter_branch_count              (splinter_handle *spl, page_handle *node);
-static inline bool                 splinter_branch_valid              (splinter_handle *spl, page_handle *node, uint64 branch_no);
-static inline bool                 splinter_branch_live               (splinter_handle *spl, page_handle *node, uint64 branch_no);
-static inline bool                 splinter_branch_live_for_pivot     (splinter_handle *spl, page_handle *node, uint64 branch_no, uint16 pivot_no);
-static inline bool                 splinter_branch_is_whole           (splinter_handle *spl, page_handle *node, uint64 branch_no);
-splinter_bundle *                  splinter_flush_into_bundle         (splinter_handle *spl, page_handle *parent, page_handle *child, splinter_pivot_data *pdata, splinter_compact_bundle_req *req);
-void                               splinter_replace_bundle_branches   (splinter_handle *spl, page_handle *node, splinter_branch *new_branch, splinter_compact_bundle_req *req);
-static inline uint16               splinter_branch_no_add             (splinter_handle *spl, uint16 branch_no, uint16 offset);
-static inline uint16               splinter_branch_no_sub             (splinter_handle *spl, uint16 branch_no, uint16 offset);
-static inline void                 splinter_dec_ref                   (splinter_handle *spl, splinter_branch *branch, bool is_memtable);
-static inline void                 splinter_zap_branch_range          (splinter_handle *spl, splinter_branch *branch, const char *start_key, const char *end_key, page_type type);
-static inline void                 splinter_inc_intersection          (splinter_handle *spl, splinter_branch *branch, const char *key, bool is_memtable);
-void                               splinter_memtable_flush_virtual    (void *arg, uint64 generation);
-platform_status                    splinter_memtable_insert           (splinter_handle *spl, char *key, char *data);
-void                               splinter_bundle_build_filters  (void *arg, void *scratch);
-static inline void                 splinter_inc_filter                (splinter_handle *spl, routing_filter *filter);
-static inline void                 splinter_dec_filter                (splinter_handle *spl, routing_filter *filter);
-void                               splinter_compact_bundle            (void *arg, void *scratch);
-int                                splinter_flush                     (splinter_handle *spl, page_handle *parent, splinter_pivot_data *pdata, bool is_space_rec);
-int                                splinter_flush_fullest             (splinter_handle *spl, page_handle *node);
-static inline bool                 splinter_needs_split               (splinter_handle *spl, page_handle *node);
-int                                splinter_split_index               (splinter_handle *spl, page_handle *parent, page_handle *child, uint64 pivot_no);
-void                               splinter_split_leaf                (splinter_handle *spl, page_handle *parent, page_handle *leaf, uint16 child_idx);
-int                                splinter_split_root                (splinter_handle *spl, page_handle     *root);
-void                               splinter_print                     (splinter_handle *spl);
-void                               splinter_print_node                (splinter_handle *spl, uint64 addr, platform_stream_handle stream);
-void                               splinter_print_locked_node         (splinter_handle *spl, page_handle *node, platform_stream_handle stream);
-static void                        splinter_btree_skiperator_init     (splinter_handle *spl, splinter_btree_skiperator *skip_itor, page_handle *node, uint16 branch_idx, key_buffer pivots[static SPLINTER_MAX_PIVOTS]);
-void                               splinter_btree_skiperator_get_curr (iterator *itor, char **key, char **data);
-platform_status                    splinter_btree_skiperator_advance  (iterator *itor);
-platform_status                    splinter_btree_skiperator_at_end   (iterator *itor, bool *at_end);
-void                               splinter_btree_skiperator_print    (iterator *itor);
-void                               splinter_btree_skiperator_deinit   (splinter_handle *spl, splinter_btree_skiperator *skip_itor);
-bool                               splinter_verify_node               (splinter_handle *spl, page_handle *node);
-void                               splinter_maybe_reclaim_space       (splinter_handle *spl);
-const static iterator_ops splinter_btree_skiperator_ops = {
-   .get_curr = splinter_btree_skiperator_get_curr,
-   .at_end   = splinter_btree_skiperator_at_end,
-   .advance  = splinter_btree_skiperator_advance,
-   .print    = splinter_btree_skiperator_print,
+static inline bool                 trunk_is_leaf                   (trunk_handle *spl, page_handle *node);
+static inline uint64               trunk_next_addr                 (trunk_handle *spl, page_handle *node);
+static inline int                  trunk_key_compare               (trunk_handle *spl, const char *key1, const char *key2);
+static inline page_handle *        trunk_node_get                  (trunk_handle *spl, uint64 addr);
+static inline void                 trunk_node_unget                (trunk_handle *spl, page_handle **node);
+static inline void                 trunk_node_claim                (trunk_handle *spl, page_handle **node);
+static inline void                 trunk_node_unclaim              (trunk_handle *spl, page_handle *node);
+static inline void                 trunk_node_lock                 (trunk_handle *spl, page_handle *node);
+static inline void                 trunk_node_unlock               (trunk_handle *spl, page_handle *node);
+page_handle *                      trunk_alloc                     (trunk_handle *spl, uint64 height);
+static inline char *               trunk_get_pivot                 (trunk_handle *spl, page_handle *node, uint16 pivot_no);
+static inline trunk_pivot_data *trunk_get_pivot_data            (trunk_handle *spl, page_handle *node, uint16 pivot_no);
+static inline uint16               trunk_find_pivot                (trunk_handle *spl, page_handle *node, char *key, lookup_type comp);
+platform_status                    trunk_add_pivot                 (trunk_handle *spl, page_handle *parent, page_handle *child, uint16 pivot_no);
+static inline uint16               trunk_num_children              (trunk_handle *spl, page_handle *node);
+static inline uint16               trunk_num_pivot_keys            (trunk_handle *spl, page_handle *node);
+static inline void                 trunk_inc_num_pivot_keys        (trunk_handle *spl, page_handle *node);
+static inline char *               trunk_max_key                   (trunk_handle *spl, page_handle *node);
+void                               trunk_update_num_tuples         (trunk_handle *spl, page_handle *node, uint16 branch_no);
+void                               trunk_pivot_recount_num_tuples  (trunk_handle *spl, page_handle *node, uint64 pivot_no);
+static inline uint16               trunk_pivot_branch_count        (trunk_handle *spl, page_handle *node, trunk_pivot_data *pdata);
+bool                               trunk_pivot_needs_count_flush   (trunk_handle *spl, page_handle *node, trunk_pivot_data *pdata);
+static inline uint64               trunk_pivot_tuples_in_branch    (trunk_handle *spl, page_handle *node, uint16 pivot_no, uint16 branch_no);
+static inline bool                 trunk_has_vacancy               (trunk_handle *spl, page_handle *node, uint16 num_new_branches);
+static inline uint16               trunk_bundle_no_add             (trunk_handle *spl, uint16 start, uint16 end);
+static inline uint16               trunk_bundle_no_sub             (trunk_handle *spl, uint16 start, uint16 end);
+static inline trunk_bundle     *trunk_get_bundle                (trunk_handle *spl, page_handle *node, uint16 bundle_no);
+static inline uint16               trunk_get_new_bundle            (trunk_handle *spl, page_handle *node);
+static inline uint16               trunk_bundle_start_branch       (trunk_handle *spl, page_handle *node, trunk_bundle *bundle);
+static inline uint16               trunk_start_bundle              (trunk_handle *spl, page_handle *node);
+static inline uint16               trunk_inc_start_bundle          (trunk_handle *spl, page_handle *node);
+static inline uint16               trunk_end_bundle                (trunk_handle *spl, page_handle *node);
+static inline uint16               trunk_bundle_clear_subbundles   (trunk_handle *spl, page_handle *node, trunk_bundle *bundle);
+static inline uint16               trunk_subbundle_no_add          (trunk_handle *spl, uint16 start, uint16 end);
+static inline uint16               trunk_subbundle_no_sub          (trunk_handle *spl, uint16 start, uint16 end);
+static inline uint16               trunk_end_subbundle             (trunk_handle *spl, page_handle *node);
+static inline uint16               trunk_end_sb_filter             (trunk_handle *spl, page_handle *node);
+static inline trunk_branch     *trunk_get_branch                (trunk_handle *spl, page_handle *node, uint32 k);
+static inline trunk_branch     *trunk_get_new_branch            (trunk_handle *spl, page_handle *node);
+static inline uint16               trunk_start_branch              (trunk_handle *spl, page_handle *node);
+static inline uint16               trunk_end_branch                (trunk_handle *spl, page_handle *node);
+static inline uint16               trunk_start_frac_branch         (trunk_handle *spl, page_handle *node);
+static inline void                 trunk_set_start_frac_branch     (trunk_handle *spl, page_handle *node, uint16 branch_no);
+static inline uint16               trunk_branch_count              (trunk_handle *spl, page_handle *node);
+static inline bool                 trunk_branch_valid              (trunk_handle *spl, page_handle *node, uint64 branch_no);
+static inline bool                 trunk_branch_live               (trunk_handle *spl, page_handle *node, uint64 branch_no);
+static inline bool                 trunk_branch_live_for_pivot     (trunk_handle *spl, page_handle *node, uint64 branch_no, uint16 pivot_no);
+static inline bool                 trunk_branch_is_whole           (trunk_handle *spl, page_handle *node, uint64 branch_no);
+trunk_bundle *                  trunk_flush_into_bundle         (trunk_handle *spl, page_handle *parent, page_handle *child, trunk_pivot_data *pdata, trunk_compact_bundle_req *req);
+void                               trunk_replace_bundle_branches   (trunk_handle *spl, page_handle *node, trunk_branch *new_branch, trunk_compact_bundle_req *req);
+static inline uint16               trunk_branch_no_add             (trunk_handle *spl, uint16 branch_no, uint16 offset);
+static inline uint16               trunk_branch_no_sub             (trunk_handle *spl, uint16 branch_no, uint16 offset);
+static inline void                 trunk_dec_ref                   (trunk_handle *spl, trunk_branch *branch, bool is_memtable);
+static inline void                 trunk_zap_branch_range          (trunk_handle *spl, trunk_branch *branch, const char *start_key, const char *end_key, page_type type);
+static inline void                 trunk_inc_intersection          (trunk_handle *spl, trunk_branch *branch, const char *key, bool is_memtable);
+void                               trunk_memtable_flush_virtual    (void *arg, uint64 generation);
+platform_status                    trunk_memtable_insert           (trunk_handle *spl, char *key, char *data);
+void                               trunk_bundle_build_filters  (void *arg, void *scratch);
+static inline void                 trunk_inc_filter                (trunk_handle *spl, routing_filter *filter);
+static inline void                 trunk_dec_filter                (trunk_handle *spl, routing_filter *filter);
+void                               trunk_compact_bundle            (void *arg, void *scratch);
+int                                trunk_flush                     (trunk_handle *spl, page_handle *parent, trunk_pivot_data *pdata, bool is_space_rec);
+int                                trunk_flush_fullest             (trunk_handle *spl, page_handle *node);
+static inline bool                 trunk_needs_split               (trunk_handle *spl, page_handle *node);
+int                                trunk_split_index               (trunk_handle *spl, page_handle *parent, page_handle *child, uint64 pivot_no);
+void                               trunk_split_leaf                (trunk_handle *spl, page_handle *parent, page_handle *leaf, uint16 child_idx);
+int                                trunk_split_root                (trunk_handle *spl, page_handle     *root);
+void                               trunk_print                     (trunk_handle *spl);
+void                               trunk_print_node                (trunk_handle *spl, uint64 addr, platform_stream_handle stream);
+void                               trunk_print_locked_node         (trunk_handle *spl, page_handle *node, platform_stream_handle stream);
+static void                        trunk_btree_skiperator_init     (trunk_handle *spl, trunk_btree_skiperator *skip_itor, page_handle *node, uint16 branch_idx, key_buffer pivots[static TRUNK_MAX_PIVOTS]);
+void                               trunk_btree_skiperator_get_curr (iterator *itor, char **key, char **data);
+platform_status                    trunk_btree_skiperator_advance  (iterator *itor);
+platform_status                    trunk_btree_skiperator_at_end   (iterator *itor, bool *at_end);
+void                               trunk_btree_skiperator_print    (iterator *itor);
+void                               trunk_btree_skiperator_deinit   (trunk_handle *spl, trunk_btree_skiperator *skip_itor);
+bool                               trunk_verify_node               (trunk_handle *spl, page_handle *node);
+void                               trunk_maybe_reclaim_space       (trunk_handle *spl);
+const static iterator_ops trunk_btree_skiperator_ops = {
+   .get_curr = trunk_btree_skiperator_get_curr,
+   .at_end   = trunk_btree_skiperator_at_end,
+   .advance  = trunk_btree_skiperator_advance,
+   .print    = trunk_btree_skiperator_print,
 };
 
 // clang-format on
@@ -664,14 +664,14 @@ const static iterator_ops splinter_btree_skiperator_ops = {
  *-----------------------------------------------------------------------------
  */
 void
-splinter_set_super_block(splinter_handle *spl,
+trunk_set_super_block(trunk_handle *spl,
                          bool             is_checkpoint,
                          bool             is_dismount,
                          bool             is_create)
 {
    uint64                super_addr;
    page_handle          *super_page;
-   splinter_super_block *super;
+   trunk_super_block *super;
    uint64                wait = 1;
    platform_status rc;
 
@@ -689,7 +689,7 @@ splinter_set_super_block(splinter_handle *spl,
    wait = 1;
    cache_lock(spl->cc, super_page);
 
-   super = (splinter_super_block *)super_page->data;
+   super = (trunk_super_block *)super_page->data;
    super->root_addr     = spl->root_addr;
    super->meta_tail     = mini_allocator_meta_tail(&spl->mini);
    if (spl->cfg.use_log) {
@@ -700,8 +700,8 @@ splinter_set_super_block(splinter_handle *spl,
    super->checkpointed  = is_checkpoint;
    super->dismounted    = is_dismount;
    super->checksum      = platform_checksum128(super,
-         sizeof(splinter_super_block) - sizeof(checksum128),
-         SPLINTER_SUPER_CSUM_SEED);
+         sizeof(trunk_super_block) - sizeof(checksum128),
+         TRUNK_SUPER_CSUM_SEED);
 
    cache_mark_dirty(spl->cc, super_page);
    cache_unlock(spl->cc, super_page);
@@ -710,23 +710,23 @@ splinter_set_super_block(splinter_handle *spl,
    cache_page_sync(spl->cc, super_page, TRUE, PAGE_TYPE_MISC);
 }
 
-splinter_super_block *
-splinter_get_super_block_if_valid(splinter_handle  *spl,
+trunk_super_block *
+trunk_get_super_block_if_valid(trunk_handle  *spl,
                                   page_handle     **super_page)
 {
    uint64                super_addr;
-   splinter_super_block *super;
+   trunk_super_block *super;
 
    platform_status rc =
       allocator_get_super_addr(spl->al, spl->id, &super_addr);
    platform_assert_status_ok(rc);
    *super_page = cache_get(spl->cc, super_addr, TRUE, PAGE_TYPE_MISC);
-   super      = (splinter_super_block *)(*super_page)->data;
+   super      = (trunk_super_block *)(*super_page)->data;
 
    if (!platform_checksum_is_equal(super->checksum,
             platform_checksum128(super,
-               sizeof(splinter_super_block) - sizeof(checksum128),
-               SPLINTER_SUPER_CSUM_SEED))) {
+               sizeof(trunk_super_block) - sizeof(checksum128),
+               TRUNK_SUPER_CSUM_SEED))) {
       cache_unget(spl->cc, *super_page);
       *super_page = NULL;
       return NULL;
@@ -736,7 +736,7 @@ splinter_get_super_block_if_valid(splinter_handle  *spl,
 }
 
 void
-splinter_release_super_block(splinter_handle *spl,
+trunk_release_super_block(trunk_handle *spl,
                              page_handle     *super_page)
 {
    cache_unget(spl->cc, super_page);
@@ -751,33 +751,33 @@ splinter_release_super_block(splinter_handle *spl,
  */
 
 static inline uint16
-splinter_height(splinter_handle *spl,
+trunk_height(trunk_handle *spl,
                 page_handle     *node)
 {
-   splinter_trunk_hdr *hdr = (splinter_trunk_hdr *)node->data;
+   trunk_hdr *hdr = (trunk_hdr *)node->data;
    return hdr->height;
 }
 
 static inline uint16
-splinter_tree_height(splinter_handle *spl)
+trunk_tree_height(trunk_handle *spl)
 {
-   page_handle *root = splinter_node_get(spl, spl->root_addr);
-   uint16 tree_height = splinter_height(spl, root);
-   splinter_node_unget(spl, &root);
+   page_handle *root = trunk_node_get(spl, spl->root_addr);
+   uint16 tree_height = trunk_height(spl, root);
+   trunk_node_unget(spl, &root);
    return tree_height;
 }
 
 static inline bool
-splinter_is_leaf(splinter_handle *spl,
+trunk_is_leaf(trunk_handle *spl,
                  page_handle     *node)
 {
-   return splinter_height(spl, node) == 0;
+   return trunk_height(spl, node) == 0;
 }
 
 uint64
-splinter_trunk_hdr_size()
+trunk_hdr_size()
 {
-   return sizeof(splinter_trunk_hdr);
+   return sizeof(trunk_hdr);
 }
 
 /*
@@ -787,15 +787,15 @@ splinter_trunk_hdr_size()
  */
 
 static inline uint16
-splinter_logical_branch_count(splinter_handle *spl,
+trunk_logical_branch_count(trunk_handle *spl,
                               page_handle     *node)
 {
-   splinter_trunk_hdr *hdr = (splinter_trunk_hdr *)node->data;
+   trunk_hdr *hdr = (trunk_hdr *)node->data;
    // whole branches
-   uint16 num_branches = splinter_branch_no_sub(spl, hdr->start_frac_branch,
+   uint16 num_branches = trunk_branch_no_sub(spl, hdr->start_frac_branch,
          hdr->start_branch);
    // bundles
-   uint16 num_bundles = splinter_bundle_no_sub(spl, hdr->end_bundle,
+   uint16 num_bundles = trunk_bundle_no_sub(spl, hdr->end_bundle,
          hdr->start_bundle);
    return num_branches + num_bundles;
 }
@@ -806,57 +806,57 @@ splinter_logical_branch_count(splinter_handle *spl,
  */
 
 static inline bool
-splinter_node_is_full(splinter_handle *spl,
+trunk_node_is_full(trunk_handle *spl,
                       page_handle     *node)
 {
    uint64 num_tuples = 0;
-   if (splinter_logical_branch_count(spl, node) >
+   if (trunk_logical_branch_count(spl, node) >
          spl->cfg.max_branches_per_node) {
       return TRUE;
    }
-   for (uint16 i = 0; i < splinter_num_children(spl, node); i++) {
-      num_tuples += splinter_get_pivot_data(spl, node, i)->num_tuples;
+   for (uint16 i = 0; i < trunk_num_children(spl, node); i++) {
+      num_tuples += trunk_get_pivot_data(spl, node, i)->num_tuples;
    }
    return num_tuples > spl->cfg.max_tuples_per_node;
 }
 
 static inline uint64
-splinter_next_addr(splinter_handle *spl,
+trunk_next_addr(trunk_handle *spl,
                    page_handle     *node)
 {
-   splinter_trunk_hdr *hdr = (splinter_trunk_hdr *)node->data;
+   trunk_hdr *hdr = (trunk_hdr *)node->data;
    return hdr->next_addr;
 }
 
 static inline void
-splinter_set_next_addr(splinter_handle *spl,
+trunk_set_next_addr(trunk_handle *spl,
                        page_handle     *node,
                        uint64           addr)
 {
-   splinter_trunk_hdr *hdr = (splinter_trunk_hdr *)node->data;
+   trunk_hdr *hdr = (trunk_hdr *)node->data;
    hdr->next_addr = addr;
 }
 
 bool
-splinter_for_each_node(splinter_handle *spl,
+trunk_for_each_node(trunk_handle *spl,
                        node_fn          func,
                        void            *arg)
 {
-   page_handle *root = splinter_node_get(spl, spl->root_addr);
-   uint16 height = splinter_height(spl, root);
-   splinter_node_unget(spl, &root);
+   page_handle *root = trunk_node_get(spl, spl->root_addr);
+   uint16 height = trunk_height(spl, root);
+   trunk_node_unget(spl, &root);
    uint64 next_level_addr = spl->root_addr;
    for (uint64 i = 0; i <= height; i++) {
-      page_handle *node = splinter_node_get(spl, next_level_addr);
+      page_handle *node = trunk_node_get(spl, next_level_addr);
       uint64 addr = next_level_addr;
-      next_level_addr = splinter_get_pivot_data(spl, node, 0)->addr;
-      splinter_node_unget(spl, &node);
+      next_level_addr = trunk_get_pivot_data(spl, node, 0)->addr;
+      trunk_node_unget(spl, &node);
       while (addr != 0) {
          // first get the next_addr, then apply func, in case func
          // deletes the node for example
-         node = splinter_node_get(spl, addr);
-         uint64 next_addr = splinter_next_addr(spl, node);
-         splinter_node_unget(spl, &node);
+         node = trunk_node_get(spl, addr);
+         uint64 next_addr = trunk_next_addr(spl, node);
+         trunk_node_unget(spl, &node);
          bool rc = func(spl, addr, arg);
          if (rc != TRUE) {
             return rc;
@@ -868,7 +868,7 @@ splinter_for_each_node(splinter_handle *spl,
 }
 
 static inline btree_config *
-splinter_btree_config(splinter_handle *spl)
+trunk_btree_config(trunk_handle *spl)
 {
    return &spl->cfg.btree_cfg;
 }
@@ -883,29 +883,29 @@ splinter_btree_config(splinter_handle *spl)
  */
 
 static inline page_handle *
-splinter_node_get(splinter_handle *spl,
+trunk_node_get(trunk_handle *spl,
                   uint64           addr)
 {
    return cache_get(spl->cc, addr, TRUE, PAGE_TYPE_TRUNK);
 }
 
 static inline cache_async_result
-splinter_node_get_async(splinter_handle     *spl,
+trunk_node_get_async(trunk_handle     *spl,
                         uint64               addr,
-                        splinter_async_ctxt *ctxt)
+                        trunk_async_ctxt *ctxt)
 {
    return cache_get_async(spl->cc, addr, PAGE_TYPE_TRUNK, &ctxt->cache_ctxt);
 }
 
 static inline void
-splinter_node_async_done(splinter_handle     *spl,
-                         splinter_async_ctxt *ctxt)
+trunk_node_async_done(trunk_handle     *spl,
+                         trunk_async_ctxt *ctxt)
 {
    cache_async_done(spl->cc, PAGE_TYPE_TRUNK, &ctxt->cache_ctxt);
 }
 
 static inline void
-splinter_node_unget(splinter_handle  *spl,
+trunk_node_unget(trunk_handle  *spl,
                     page_handle     **node)
 {
    cache_unget(spl->cc, *node);
@@ -913,28 +913,28 @@ splinter_node_unget(splinter_handle  *spl,
 }
 
 static inline void
-splinter_node_claim(splinter_handle  *spl,
+trunk_node_claim(trunk_handle  *spl,
                     page_handle     **node)
 {
    uint64 wait = 1;
    while (!cache_claim(spl->cc, *node)) {
       uint64 addr = (*node)->disk_addr;
-      splinter_node_unget(spl, node);
+      trunk_node_unget(spl, node);
       platform_sleep(wait);
       wait = wait > 2048 ? wait : 2 * wait;
-      *node = splinter_node_get(spl, addr);
+      *node = trunk_node_get(spl, addr);
    }
 }
 
 static inline void
-splinter_node_unclaim(splinter_handle *spl,
+trunk_node_unclaim(trunk_handle *spl,
                       page_handle     *node)
 {
    cache_unclaim(spl->cc, node);
 }
 
 static inline void
-splinter_node_lock(splinter_handle *spl,
+trunk_node_lock(trunk_handle *spl,
                    page_handle     *node)
 {
    cache_lock(spl->cc, node);
@@ -942,20 +942,20 @@ splinter_node_lock(splinter_handle *spl,
 }
 
 static inline void
-splinter_node_unlock(splinter_handle *spl,
+trunk_node_unlock(trunk_handle *spl,
                      page_handle     *node)
 {
    cache_unlock(spl->cc, node);
 }
 
 page_handle *
-splinter_alloc(splinter_handle *spl, uint64 height)
+trunk_alloc(trunk_handle *spl, uint64 height)
 {
    uint64 addr = mini_allocator_alloc(&spl->mini, height, NULL, NULL);
    return cache_alloc(spl->cc, addr, PAGE_TYPE_TRUNK);
 }
 
-void splinter_dealloc(splinter_handle *spl,
+void trunk_dealloc(trunk_handle *spl,
                       uint64           addr)
 {
    cache_dealloc(spl->cc, addr, PAGE_TYPE_TRUNK);
@@ -976,7 +976,7 @@ void splinter_dealloc(splinter_handle *spl,
  */
 
 static inline uint16
-splinter_branch_no_add(splinter_handle *spl,
+trunk_branch_no_add(trunk_handle *spl,
                        uint16           branch_no,
                        uint16           offset)
 {
@@ -984,7 +984,7 @@ splinter_branch_no_add(splinter_handle *spl,
 }
 
 static inline uint16
-splinter_branch_no_sub(splinter_handle *spl,
+trunk_branch_no_sub(trunk_handle *spl,
                        uint16           branch_no,
                        uint16           offset)
 {
@@ -993,47 +993,47 @@ splinter_branch_no_sub(splinter_handle *spl,
 }
 
 static inline bool
-splinter_branch_in_range(splinter_handle *spl,
+trunk_branch_in_range(trunk_handle *spl,
                          uint16           branch_no,
                          uint16           start,
                          uint16           end)
 {
-   return splinter_branch_no_sub(spl, branch_no, start)
-      < splinter_branch_no_sub(spl, end, start);
+   return trunk_branch_no_sub(spl, branch_no, start)
+      < trunk_branch_no_sub(spl, end, start);
 }
 
 static inline uint16
-splinter_bundle_no_add(splinter_handle *spl,
+trunk_bundle_no_add(trunk_handle *spl,
                        uint16           start,
                        uint16           end)
 {
-   return (start + end) % SPLINTER_MAX_BUNDLES;
+   return (start + end) % TRUNK_MAX_BUNDLES;
 }
 
 static inline uint16
-splinter_bundle_no_sub(splinter_handle *spl,
+trunk_bundle_no_sub(trunk_handle *spl,
                        uint16           start,
                        uint16           end)
 {
-   return (start + SPLINTER_MAX_BUNDLES - end)
-      % SPLINTER_MAX_BUNDLES;
+   return (start + TRUNK_MAX_BUNDLES - end)
+      % TRUNK_MAX_BUNDLES;
 }
 
 static inline uint16
-splinter_subbundle_no_add(splinter_handle *spl,
+trunk_subbundle_no_add(trunk_handle *spl,
                           uint16           start,
                           uint16           end)
 {
-   return (start + end) % SPLINTER_MAX_SUBBUNDLES;
+   return (start + end) % TRUNK_MAX_SUBBUNDLES;
 }
 
 static inline uint16
-splinter_subbundle_no_sub(splinter_handle *spl,
+trunk_subbundle_no_sub(trunk_handle *spl,
                           uint16           start,
                           uint16           end)
 {
-   return (start + SPLINTER_MAX_SUBBUNDLES - end)
-      % SPLINTER_MAX_SUBBUNDLES;
+   return (start + TRUNK_MAX_SUBBUNDLES - end)
+      % TRUNK_MAX_SUBBUNDLES;
 }
 
 /*
@@ -1045,167 +1045,167 @@ splinter_subbundle_no_sub(splinter_handle *spl,
  */
 
 static inline char *
-splinter_get_pivot(splinter_handle *spl,
+trunk_get_pivot(trunk_handle *spl,
                    page_handle     *node,
                    uint16           pivot_no)
 {
    platform_assert(pivot_no < spl->cfg.max_pivot_keys);
-   splinter_trunk_hdr *hdr = (splinter_trunk_hdr *)node->data;
-   return ((char*)hdr) + sizeof(*hdr) + pivot_no * splinter_pivot_size(spl);
+   trunk_hdr *hdr = (trunk_hdr *)node->data;
+   return ((char*)hdr) + sizeof(*hdr) + pivot_no * trunk_pivot_size(spl);
 }
 
 static inline void
-splinter_set_pivot(splinter_handle *spl,
+trunk_set_pivot(trunk_handle *spl,
                    page_handle     *node,
                    uint16           pivot_no,
                    const char      *pivot_key)
 {
-   debug_assert(pivot_no < splinter_num_pivot_keys(spl, node));
+   debug_assert(pivot_no < trunk_num_pivot_keys(spl, node));
 
-   char *dst_pivot_key = splinter_get_pivot(spl, node, pivot_no);
-   memmove(dst_pivot_key, pivot_key, splinter_key_size(spl));
+   char *dst_pivot_key = trunk_get_pivot(spl, node, pivot_no);
+   memmove(dst_pivot_key, pivot_key, trunk_key_size(spl));
 
    // debug asserts (should be optimized away)
    if (pivot_no != 0) {
       __attribute__ ((unused)) const char *pred_pivot =
-         splinter_get_pivot(spl, node, pivot_no - 1);
-      debug_assert(splinter_key_compare(spl, pred_pivot, pivot_key) < 0);
+         trunk_get_pivot(spl, node, pivot_no - 1);
+      debug_assert(trunk_key_compare(spl, pred_pivot, pivot_key) < 0);
    }
-   if (pivot_no < splinter_num_children(spl, node)) {
+   if (pivot_no < trunk_num_children(spl, node)) {
       __attribute__ ((unused)) const char *succ_pivot =
-         splinter_get_pivot(spl, node, pivot_no + 1);
-      debug_assert(splinter_key_compare(spl, pivot_key, succ_pivot) < 0);
+         trunk_get_pivot(spl, node, pivot_no + 1);
+      debug_assert(trunk_key_compare(spl, pivot_key, succ_pivot) < 0);
    }
 }
 
 static inline void
-splinter_set_initial_pivots(splinter_handle *spl,
+trunk_set_initial_pivots(trunk_handle *spl,
                             page_handle     *node,
                             const char      *min_key,
                             const char      *max_key)
 {
-   debug_assert(splinter_key_compare(spl, min_key, max_key) < 0);
+   debug_assert(trunk_key_compare(spl, min_key, max_key) < 0);
 
-   splinter_trunk_hdr *hdr = (splinter_trunk_hdr *)node->data;
+   trunk_hdr *hdr = (trunk_hdr *)node->data;
    hdr->num_pivot_keys = 2;
 
-   char *dst_pivot_key = splinter_get_pivot(spl, node, 0);
-   memmove(dst_pivot_key, min_key, splinter_key_size(spl));
-   splinter_pivot_data *pdata = splinter_get_pivot_data(spl, node, 0);
+   char *dst_pivot_key = trunk_get_pivot(spl, node, 0);
+   memmove(dst_pivot_key, min_key, trunk_key_size(spl));
+   trunk_pivot_data *pdata = trunk_get_pivot_data(spl, node, 0);
    ZERO_CONTENTS(pdata);
    pdata->srq_idx = -1;
-   dst_pivot_key = splinter_get_pivot(spl, node, 1);
-   memmove(dst_pivot_key, max_key, splinter_key_size(spl));
+   dst_pivot_key = trunk_get_pivot(spl, node, 1);
+   memmove(dst_pivot_key, max_key, trunk_key_size(spl));
 }
 
 UNUSED_FUNCTION()
 static inline char *
-splinter_min_key(splinter_handle *spl,
+trunk_min_key(trunk_handle *spl,
                  page_handle     *node)
 {
-   return splinter_get_pivot(spl, node, 0);
+   return trunk_get_pivot(spl, node, 0);
 }
 
 static inline char *
-splinter_max_key(splinter_handle *spl,
+trunk_max_key(trunk_handle *spl,
                  page_handle     *node)
 {
-   return splinter_get_pivot(spl, node, splinter_num_children(spl, node));
+   return trunk_get_pivot(spl, node, trunk_num_children(spl, node));
 }
 
 static inline uint64
-splinter_pivot_generation(splinter_handle *spl,
+trunk_pivot_generation(trunk_handle *spl,
                           page_handle     *node)
 {
-   splinter_trunk_hdr *hdr = (splinter_trunk_hdr *)node->data;
+   trunk_hdr *hdr = (trunk_hdr *)node->data;
    return hdr->pivot_generation;
 }
 
 static inline uint64
-splinter_inc_pivot_generation(splinter_handle *spl,
+trunk_inc_pivot_generation(trunk_handle *spl,
                               page_handle     *node)
 {
-   splinter_trunk_hdr *hdr = (splinter_trunk_hdr *)node->data;
+   trunk_hdr *hdr = (trunk_hdr *)node->data;
    return hdr->pivot_generation++;
 }
 
 uint64
-splinter_pivot_size(splinter_handle *spl)
+trunk_pivot_size(trunk_handle *spl)
 {
-   return splinter_key_size(spl) + sizeof(splinter_pivot_data);
+   return trunk_key_size(spl) + sizeof(trunk_pivot_data);
 }
 
 uint64
-splinter_pivot_message_size()
+trunk_pivot_message_size()
 {
-   return sizeof(splinter_pivot_data);
+   return sizeof(trunk_pivot_data);
 }
 
-static inline splinter_pivot_data *
-splinter_get_pivot_data(splinter_handle *spl,
+static inline trunk_pivot_data *
+trunk_get_pivot_data(trunk_handle *spl,
                         page_handle     *node,
                         uint16           pivot_no)
 {
-   return (splinter_pivot_data *)(splinter_get_pivot(spl, node, pivot_no)
-         + splinter_key_size(spl));
+   return (trunk_pivot_data *)(trunk_get_pivot(spl, node, pivot_no)
+         + trunk_key_size(spl));
 }
 
 static inline void
-splinter_set_pivot_data_new_root(splinter_handle *spl,
+trunk_set_pivot_data_new_root(trunk_handle *spl,
                                  page_handle     *node,
                                  uint64           child_addr)
 {
-   debug_assert(splinter_height(spl, node) != 0);
-   splinter_pivot_data *pdata = splinter_get_pivot_data(spl, node, 0);
+   debug_assert(trunk_height(spl, node) != 0);
+   trunk_pivot_data *pdata = trunk_get_pivot_data(spl, node, 0);
 
    pdata->addr = child_addr;
    pdata->num_tuples = 0;
-   pdata->start_branch = splinter_start_branch(spl, node);
-   pdata->start_bundle = splinter_end_bundle(spl, node);
+   pdata->start_branch = trunk_start_branch(spl, node);
+   pdata->start_bundle = trunk_end_bundle(spl, node);
    ZERO_STRUCT(pdata->filter);
 }
 
 static inline void
-splinter_copy_pivot_data_from_pred(splinter_handle *spl,
+trunk_copy_pivot_data_from_pred(trunk_handle *spl,
                                    page_handle     *node,
                                    uint16           pivot_no,
                                    uint64           child_addr)
 {
-   debug_assert(splinter_height(spl, node) != 0);
+   debug_assert(trunk_height(spl, node) != 0);
    debug_assert(pivot_no != 0);
-   splinter_pivot_data *pdata = splinter_get_pivot_data(spl, node, pivot_no);
-   splinter_pivot_data *pred_pdata =
-      splinter_get_pivot_data(spl, node, pivot_no - 1);
+   trunk_pivot_data *pdata = trunk_get_pivot_data(spl, node, pivot_no);
+   trunk_pivot_data *pred_pdata =
+      trunk_get_pivot_data(spl, node, pivot_no - 1);
 
    memmove(pdata, pred_pdata, sizeof(*pdata));
    pdata->addr = child_addr;
    pdata->num_tuples = 0;
-   pred_pdata->generation = splinter_inc_pivot_generation(spl, node);
+   pred_pdata->generation = trunk_inc_pivot_generation(spl, node);
    platform_assert(pdata->srq_idx == -1);
 }
 
 static inline uint16
-splinter_pivot_start_branch(splinter_handle *spl,
+trunk_pivot_start_branch(trunk_handle *spl,
                             page_handle     *node,
                             uint16           pivot_no)
 {
-   splinter_pivot_data *pdata = splinter_get_pivot_data(spl, node, pivot_no);
+   trunk_pivot_data *pdata = trunk_get_pivot_data(spl, node, pivot_no);
    return pdata->start_branch;
 }
 
 static inline uint64
-splinter_generation(splinter_handle *spl,
+trunk_generation(trunk_handle *spl,
                     page_handle     *node)
 {
-   splinter_trunk_hdr *hdr = (splinter_trunk_hdr *)node->data;
+   trunk_hdr *hdr = (trunk_hdr *)node->data;
    return hdr->generation;
 }
 
 static inline void
-splinter_inc_generation(splinter_handle *spl,
+trunk_inc_generation(trunk_handle *spl,
                         page_handle     *node)
 {
-   splinter_trunk_hdr *hdr = (splinter_trunk_hdr *)node->data;
+   trunk_hdr *hdr = (trunk_hdr *)node->data;
    hdr->generation++;
 }
 
@@ -1223,7 +1223,7 @@ lowerbound(uint32 size)
  * Used by find_pivot
  */
 static inline void
-splinter_update_lowerbound(uint16 *lo,
+trunk_update_lowerbound(uint16 *lo,
                            uint16 *mid,
                            int cmp,
                            lookup_type comp)
@@ -1248,7 +1248,7 @@ splinter_update_lowerbound(uint16 *lo,
  * which is greater than key. It returns the found pivot's index.
  */
 static inline uint16
-splinter_find_pivot(splinter_handle *spl,
+trunk_find_pivot(trunk_handle *spl,
                     page_handle     *node,
                     char            *key,
                     lookup_type      comp)
@@ -1257,14 +1257,14 @@ splinter_find_pivot(splinter_handle *spl,
    uint16 lo_idx = 0, mid_idx;
    uint32 i;
    int cmp;
-   uint32 size = splinter_num_children(spl, node);
+   uint32 size = trunk_num_children(spl, node);
 
    if (size == 0) {
       return 0;
    }
 
    if (size == 1) {
-      cmp = splinter_key_compare(spl, splinter_get_pivot(spl, node, 0), key);
+      cmp = trunk_key_compare(spl, trunk_get_pivot(spl, node, 0), key);
       switch (comp) {
          case less_than:
             debug_assert(cmp < 0);
@@ -1282,15 +1282,15 @@ splinter_find_pivot(splinter_handle *spl,
    // binary search for the pivot
    mid_idx = size - (1u << (lowerbound(size) - 1));
    size = 1u << (lowerbound(size) - 1);
-   cmp = splinter_key_compare(spl, splinter_get_pivot(spl, node, mid_idx), key);
-   splinter_update_lowerbound(&lo_idx, &mid_idx, cmp, comp);
+   cmp = trunk_key_compare(spl, trunk_get_pivot(spl, node, mid_idx), key);
+   trunk_update_lowerbound(&lo_idx, &mid_idx, cmp, comp);
 
    for (i = lowerbound(size); i != 0; i--) {
       size /= 2;
       mid_idx = lo_idx + size;
-      cmp = splinter_key_compare(spl, splinter_get_pivot(spl, node, mid_idx),
+      cmp = trunk_key_compare(spl, trunk_get_pivot(spl, node, mid_idx),
             key);
-      splinter_update_lowerbound(&lo_idx, &mid_idx, cmp, comp);
+      trunk_update_lowerbound(&lo_idx, &mid_idx, cmp, comp);
    }
 
    switch(comp) {
@@ -1310,15 +1310,15 @@ splinter_find_pivot(splinter_handle *spl,
  * FALSE otherwise.
  */
 static inline bool
-splinter_branch_live_for_pivot(splinter_handle *spl,
+trunk_branch_live_for_pivot(trunk_handle *spl,
                                page_handle     *node,
                                uint64           branch_no,
                                uint16           pivot_no)
 {
-   splinter_trunk_hdr *hdr = (splinter_trunk_hdr *)node->data;
-   splinter_pivot_data *pdata = splinter_get_pivot_data(spl, node, pivot_no);
-   return splinter_branch_no_sub(spl, branch_no, pdata->start_branch)
-      < splinter_branch_no_sub(spl, hdr->end_branch, pdata->start_branch);
+   trunk_hdr *hdr = (trunk_hdr *)node->data;
+   trunk_pivot_data *pdata = trunk_get_pivot_data(spl, node, pivot_no);
+   return trunk_branch_no_sub(spl, branch_no, pdata->start_branch)
+      < trunk_branch_no_sub(spl, hdr->end_branch, pdata->start_branch);
 }
 
 /*
@@ -1326,30 +1326,30 @@ splinter_branch_live_for_pivot(splinter_handle *spl,
  * fractional (part of a bundle) or dead.
  */
 static inline bool
-splinter_branch_is_whole(splinter_handle *spl,
+trunk_branch_is_whole(trunk_handle *spl,
                          page_handle     *node,
                          uint64           branch_no)
 {
-   splinter_trunk_hdr *hdr = (splinter_trunk_hdr *)node->data;
-   return splinter_branch_no_sub(spl, branch_no, hdr->start_branch)
-      < splinter_branch_no_sub(spl, hdr->start_frac_branch, hdr->start_branch);
+   trunk_hdr *hdr = (trunk_hdr *)node->data;
+   return trunk_branch_no_sub(spl, branch_no, hdr->start_branch)
+      < trunk_branch_no_sub(spl, hdr->start_frac_branch, hdr->start_branch);
 }
 
 static inline void
-splinter_shift_pivots(splinter_handle *spl,
+trunk_shift_pivots(trunk_handle *spl,
                       page_handle     *node,
                       uint16           pivot_no,
                       uint16           shift)
 {
-   debug_assert(splinter_height(spl, node) != 0);
-   debug_assert(splinter_num_pivot_keys(spl, node) + shift <
+   debug_assert(trunk_height(spl, node) != 0);
+   debug_assert(trunk_num_pivot_keys(spl, node) + shift <
          spl->cfg.max_pivot_keys);
-   debug_assert(pivot_no < splinter_num_pivot_keys(spl, node));
+   debug_assert(pivot_no < trunk_num_pivot_keys(spl, node));
 
-   char *dst_pivot = splinter_get_pivot(spl, node, pivot_no + shift);
-   char *src_pivot = splinter_get_pivot(spl, node, pivot_no);
-   uint16 pivots_to_shift = splinter_num_pivot_keys(spl, node) - pivot_no;
-   size_t bytes_to_shift = pivots_to_shift * splinter_pivot_size(spl);
+   char *dst_pivot = trunk_get_pivot(spl, node, pivot_no + shift);
+   char *src_pivot = trunk_get_pivot(spl, node, pivot_no);
+   uint16 pivots_to_shift = trunk_num_pivot_keys(spl, node) - pivot_no;
+   size_t bytes_to_shift = pivots_to_shift * trunk_pivot_size(spl);
    memmove(dst_pivot, src_pivot, bytes_to_shift);
 }
 
@@ -1358,47 +1358,47 @@ splinter_shift_pivots(splinter_handle *spl,
  */
 
 platform_status
-splinter_add_pivot(splinter_handle     *spl,
+trunk_add_pivot(trunk_handle     *spl,
                    page_handle         *parent,
                    page_handle         *child,
                    uint16               pivot_no)  // position of new pivot
 {
    // equality is allowed, because we can be adding a pivot at the end
-   platform_assert(pivot_no <= splinter_num_children(spl, parent));
+   platform_assert(pivot_no <= trunk_num_children(spl, parent));
    platform_assert(pivot_no != 0);
 
-   if (splinter_num_pivot_keys(spl, parent) >= spl->cfg.max_pivot_keys) {
+   if (trunk_num_pivot_keys(spl, parent) >= spl->cfg.max_pivot_keys) {
       // No room to add a pivot
-      debug_assert(splinter_num_pivot_keys(spl, parent) ==
+      debug_assert(trunk_num_pivot_keys(spl, parent) ==
                    spl->cfg.max_pivot_keys);
       return STATUS_LIMIT_EXCEEDED;
    }
 
    // move pivots in parent and add new pivot for child
-   splinter_shift_pivots(spl, parent, pivot_no, 1);
-   splinter_inc_num_pivot_keys(spl, parent);
-   const char *pivot_key = splinter_get_pivot(spl, child, 0);
-   splinter_set_pivot(spl, parent, pivot_no, pivot_key);
+   trunk_shift_pivots(spl, parent, pivot_no, 1);
+   trunk_inc_num_pivot_keys(spl, parent);
+   const char *pivot_key = trunk_get_pivot(spl, child, 0);
+   trunk_set_pivot(spl, parent, pivot_no, pivot_key);
 
    uint64 child_addr = child->disk_addr;
-   splinter_copy_pivot_data_from_pred(spl, parent, pivot_no, child_addr);
+   trunk_copy_pivot_data_from_pred(spl, parent, pivot_no, child_addr);
 
    return STATUS_OK;
 }
 
 void
-splinter_add_pivot_new_root(splinter_handle *spl,
+trunk_add_pivot_new_root(trunk_handle *spl,
                             page_handle     *parent,
                             page_handle     *child)
 {
-   const char *pivot_key = splinter_get_pivot(spl, child, 0);
+   const char *pivot_key = trunk_get_pivot(spl, child, 0);
    __attribute__ ((unused)) const char *min_key = spl->cfg.data_cfg->min_key;
-   debug_assert(splinter_key_compare(spl, pivot_key, min_key) == 0);
+   debug_assert(trunk_key_compare(spl, pivot_key, min_key) == 0);
 
    const char *max_key = spl->cfg.data_cfg->max_key;
-   splinter_set_initial_pivots(spl, parent, pivot_key, max_key);
+   trunk_set_initial_pivots(spl, parent, pivot_key, max_key);
    uint64 child_addr = child->disk_addr;
-   splinter_set_pivot_data_new_root(spl, parent, child_addr);
+   trunk_set_pivot_data_new_root(spl, parent, child_addr);
 }
 
 /*
@@ -1408,15 +1408,15 @@ splinter_add_pivot_new_root(splinter_handle *spl,
  * Used when adding new branches to a node as part of a flush.
  */
 void
-splinter_update_num_tuples(splinter_handle *spl,
+trunk_update_num_tuples(trunk_handle *spl,
                            page_handle     *node,
                            uint16           branch_no)
 {
-   uint16 num_children = splinter_num_children(spl, node);
+   uint16 num_children = trunk_num_children(spl, node);
    for (uint16 pivot_no = 0; pivot_no < num_children; pivot_no++) {
-      splinter_pivot_data *pdata = splinter_get_pivot_data(spl, node, pivot_no);
+      trunk_pivot_data *pdata = trunk_get_pivot_data(spl, node, pivot_no);
       pdata->num_tuples +=
-         splinter_pivot_tuples_in_branch(spl, node, pivot_no, branch_no);
+         trunk_pivot_tuples_in_branch(spl, node, pivot_no, branch_no);
    }
 }
 
@@ -1427,43 +1427,43 @@ splinter_update_num_tuples(splinter_handle *spl,
  * Used after index splits.
  */
 void
-splinter_pivot_recount_num_tuples(splinter_handle *spl,
+trunk_pivot_recount_num_tuples(trunk_handle *spl,
                                   page_handle     *node,
                                   uint64           pivot_no)
 {
-   splinter_trunk_hdr *hdr = (splinter_trunk_hdr *)node->data;
-   splinter_pivot_data *pdata = splinter_get_pivot_data(spl, node, pivot_no);
+   trunk_hdr *hdr = (trunk_hdr *)node->data;
+   trunk_pivot_data *pdata = trunk_get_pivot_data(spl, node, pivot_no);
    pdata->num_tuples = 0;
    for (uint64 branch_no = pdata->start_branch;
         branch_no != hdr->end_branch;
-        branch_no = splinter_branch_no_add(spl, branch_no, 1)) {
+        branch_no = trunk_branch_no_add(spl, branch_no, 1)) {
       pdata->num_tuples +=
-         splinter_pivot_tuples_in_branch(spl, node, pivot_no, branch_no);
+         trunk_pivot_tuples_in_branch(spl, node, pivot_no, branch_no);
    }
 }
 
 uint64
-splinter_pivot_num_tuples(splinter_handle *spl,
+trunk_pivot_num_tuples(trunk_handle *spl,
                           page_handle     *node,
                           uint16           pivot_no)
 {
-   splinter_pivot_data *pdata = splinter_get_pivot_data(spl, node, pivot_no);
+   trunk_pivot_data *pdata = trunk_get_pivot_data(spl, node, pivot_no);
    return pdata->num_tuples;
 }
 
 void
-splinter_pivot_set_num_tuples(splinter_handle *spl,
+trunk_pivot_set_num_tuples(trunk_handle *spl,
                               page_handle     *node,
                               uint16           pivot_no,
                               uint64           num_tuples)
 {
-   splinter_pivot_data *pdata = splinter_get_pivot_data(spl, node, pivot_no);
+   trunk_pivot_data *pdata = trunk_get_pivot_data(spl, node, pivot_no);
    pdata->num_tuples = num_tuples;
 }
 
 static inline uint64
-splinter_pivot_tuples_to_reclaim(splinter_handle     *spl,
-                                 splinter_pivot_data *pdata)
+trunk_pivot_tuples_to_reclaim(trunk_handle     *spl,
+                                 trunk_pivot_data *pdata)
 {
    uint64 tuples_in_pivot = pdata->filter.num_fingerprints;
    uint64 est_unique_tuples =
@@ -1475,68 +1475,68 @@ splinter_pivot_tuples_to_reclaim(splinter_handle     *spl,
  * Returns the number of whole branches which are live for the pivot
  */
 static inline uint64
-splinter_pivot_whole_branch_count(splinter_handle     *spl,
+trunk_pivot_whole_branch_count(trunk_handle     *spl,
                                   page_handle         *node,
-                                  splinter_pivot_data *pdata)
+                                  trunk_pivot_data *pdata)
 {
-   splinter_trunk_hdr *hdr = (splinter_trunk_hdr *)node->data;
-   if (!splinter_branch_is_whole(spl, node, pdata->start_branch))
+   trunk_hdr *hdr = (trunk_hdr *)node->data;
+   if (!trunk_branch_is_whole(spl, node, pdata->start_branch))
       return 0;
-   return splinter_branch_no_sub(spl, hdr->start_frac_branch, pdata->start_branch);
+   return trunk_branch_no_sub(spl, hdr->start_frac_branch, pdata->start_branch);
 }
 
 /*
  * Returns the number of bundles which are live for the pivot.
  */
 static inline uint16
-splinter_pivot_bundle_count(splinter_handle     *spl,
+trunk_pivot_bundle_count(trunk_handle     *spl,
                             page_handle         *node,
-                            splinter_pivot_data *pdata)
+                            trunk_pivot_data *pdata)
 {
-   splinter_trunk_hdr *hdr = (splinter_trunk_hdr *)node->data;
-   return splinter_bundle_no_sub(spl, hdr->end_bundle, pdata->start_bundle);
+   trunk_hdr *hdr = (trunk_hdr *)node->data;
+   return trunk_bundle_no_sub(spl, hdr->end_bundle, pdata->start_bundle);
 }
 
 /*
  * Returns the number of subbundles which are live for the pivot.
  */
 static inline uint16
-splinter_pivot_subbundle_count(splinter_handle     *spl,
+trunk_pivot_subbundle_count(trunk_handle     *spl,
                                page_handle         *node,
-                               splinter_pivot_data *pdata)
+                               trunk_pivot_data *pdata)
 {
-   splinter_trunk_hdr *hdr = (splinter_trunk_hdr *)node->data;
+   trunk_hdr *hdr = (trunk_hdr *)node->data;
    uint16 pivot_start_subbundle;
-   splinter_bundle *bundle;
-   if (splinter_pivot_bundle_count(spl, node, pdata) == 0)
+   trunk_bundle *bundle;
+   if (trunk_pivot_bundle_count(spl, node, pdata) == 0)
       return 0;
 
-   bundle = splinter_get_bundle(spl, node, pdata->start_bundle);
+   bundle = trunk_get_bundle(spl, node, pdata->start_bundle);
    pivot_start_subbundle = bundle->start_subbundle;
-   return splinter_subbundle_no_sub(spl, hdr->end_subbundle,
+   return trunk_subbundle_no_sub(spl, hdr->end_subbundle,
                                     pivot_start_subbundle);
 }
 
 static inline uint16
-splinter_pivot_start_subbundle(splinter_handle     *spl,
+trunk_pivot_start_subbundle(trunk_handle     *spl,
                                page_handle         *node,
-                               splinter_pivot_data *pdata)
+                               trunk_pivot_data *pdata)
 {
-   if (pdata->start_bundle == splinter_end_bundle(spl, node)) {
-      return splinter_end_subbundle(spl, node);;
+   if (pdata->start_bundle == trunk_end_bundle(spl, node)) {
+      return trunk_end_subbundle(spl, node);;
    }
-   splinter_bundle *bundle =
-      splinter_get_bundle(spl, node, pdata->start_bundle);
+   trunk_bundle *bundle =
+      trunk_get_bundle(spl, node, pdata->start_bundle);
    return bundle->start_subbundle;
 }
 
 static inline uint16
-splinter_pivot_end_subbundle_for_lookup(splinter_handle     *spl,
+trunk_pivot_end_subbundle_for_lookup(trunk_handle     *spl,
                                         page_handle         *node,
-                                        splinter_pivot_data *pdata)
+                                        trunk_pivot_data *pdata)
 {
-   return splinter_subbundle_no_sub(spl,
-         splinter_pivot_start_subbundle(spl, node, pdata), 1);
+   return trunk_subbundle_no_sub(spl,
+         trunk_pivot_start_subbundle(spl, node, pdata), 1);
 }
 
 /*
@@ -1544,12 +1544,12 @@ splinter_pivot_end_subbundle_for_lookup(splinter_handle     *spl,
  * logical branch is either a whole branch or a bundle.
  */
 static inline uint16
-splinter_pivot_logical_branch_count(splinter_handle     *spl,
+trunk_pivot_logical_branch_count(trunk_handle     *spl,
                                     page_handle         *node,
-                                    splinter_pivot_data *pdata)
+                                    trunk_pivot_data *pdata)
 {
-   return splinter_pivot_whole_branch_count(spl, node, pdata)
-      + splinter_pivot_bundle_count(spl, node, pdata);
+   return trunk_pivot_whole_branch_count(spl, node, pdata)
+      + trunk_pivot_bundle_count(spl, node, pdata);
 }
 
 /*
@@ -1561,11 +1561,11 @@ splinter_pivot_logical_branch_count(splinter_handle     *spl,
  * branch count.
  */
 static inline bool
-splinter_pivot_needs_flush(splinter_handle     *spl,
+trunk_pivot_needs_flush(trunk_handle     *spl,
                            page_handle         *node,
-                           splinter_pivot_data *pdata)
+                           trunk_pivot_data *pdata)
 {
-   return splinter_pivot_logical_branch_count(spl, node, pdata)
+   return trunk_pivot_logical_branch_count(spl, node, pdata)
       > spl->cfg.max_branches_per_node;
 }
 
@@ -1576,23 +1576,23 @@ splinter_pivot_needs_flush(splinter_handle     *spl,
  * pivot_whole_branch_count.
  */
 static inline uint16
-splinter_pivot_branch_count(splinter_handle     *spl,
+trunk_pivot_branch_count(trunk_handle     *spl,
                             page_handle         *node,
-                            splinter_pivot_data *pdata)
+                            trunk_pivot_data *pdata)
 {
-   splinter_trunk_hdr *hdr = (splinter_trunk_hdr *)node->data;
-   return splinter_branch_no_sub(spl, hdr->end_branch, pdata->start_branch);
+   trunk_hdr *hdr = (trunk_hdr *)node->data;
+   return trunk_branch_no_sub(spl, hdr->end_branch, pdata->start_branch);
 }
 
 static inline uint64
-splinter_pivot_tuples_in_btree(splinter_handle *spl,
+trunk_pivot_tuples_in_btree(trunk_handle *spl,
                                page_handle     *node,
                                uint16           pivot_no,
                                uint64           root_addr)
 {
-   char *min_key = splinter_get_pivot(spl, node, pivot_no);
-   char *max_key = splinter_get_pivot(spl, node, pivot_no + 1);
-   return btree_count_in_range(spl->cc, splinter_btree_config(spl), root_addr,
+   char *min_key = trunk_get_pivot(spl, node, pivot_no);
+   char *max_key = trunk_get_pivot(spl, node, pivot_no + 1);
+   return btree_count_in_range(spl->cc, trunk_btree_config(spl), root_addr,
          min_key, max_key);
 }
 
@@ -1601,27 +1601,27 @@ splinter_pivot_tuples_in_btree(splinter_handle *spl,
  * FIXME: [aconway 2020-08-11] Add description
  */
 static inline uint64
-splinter_pivot_tuples_in_branch(splinter_handle *spl,
+trunk_pivot_tuples_in_branch(trunk_handle *spl,
                                 page_handle     *node,
                                 uint16           pivot_no,
                                 uint16           branch_no)
 {
-   splinter_branch *branch = splinter_get_branch(spl, node, branch_no);
-   return splinter_pivot_tuples_in_btree(spl, node, pivot_no,
+   trunk_branch *branch = trunk_get_branch(spl, node, branch_no);
+   return trunk_pivot_tuples_in_btree(spl, node, pivot_no,
                                          branch->root_addr);
 }
 
 __attribute__ ((unused))
 static inline uint64
-splinter_pivot_tuples_in_branch_slow(splinter_handle *spl,
+trunk_pivot_tuples_in_branch_slow(trunk_handle *spl,
                                      page_handle     *node,
                                      uint16           pivot_no,
                                      uint16           branch_no)
 {
-   splinter_branch *branch = splinter_get_branch(spl, node, branch_no);
-   char *min_key = splinter_get_pivot(spl, node, pivot_no);
-   char *max_key = splinter_get_pivot(spl, node, pivot_no + 1);
-   return btree_count_in_range_by_iterator(spl->cc, splinter_btree_config(spl),
+   trunk_branch *branch = trunk_get_branch(spl, node, branch_no);
+   char *min_key = trunk_get_pivot(spl, node, pivot_no);
+   char *max_key = trunk_get_pivot(spl, node, pivot_no + 1);
+   return btree_count_in_range_by_iterator(spl->cc, trunk_btree_config(spl),
          branch->root_addr, min_key, max_key);
 }
 
@@ -1637,18 +1637,18 @@ splinter_pivot_tuples_in_branch_slow(splinter_handle *spl,
  * their tuples.
  */
 void
-splinter_leaf_count_num_tuples(splinter_handle *spl,
+trunk_leaf_count_num_tuples(trunk_handle *spl,
                                page_handle     *node,
                                uint64           first_branch_tuples)
 {
-   splinter_trunk_hdr *hdr = (splinter_trunk_hdr *)node->data;
-   splinter_pivot_data *pdata = splinter_get_pivot_data(spl, node, 0);
+   trunk_hdr *hdr = (trunk_hdr *)node->data;
+   trunk_pivot_data *pdata = trunk_get_pivot_data(spl, node, 0);
    pdata->num_tuples = first_branch_tuples;
-   for (uint16 branch_no = splinter_branch_no_add(spl, hdr->start_branch, 1);
+   for (uint16 branch_no = trunk_branch_no_add(spl, hdr->start_branch, 1);
         branch_no != hdr->end_branch;
-        branch_no = splinter_branch_no_add(spl, branch_no, 1)) {
+        branch_no = trunk_branch_no_add(spl, branch_no, 1)) {
       pdata->num_tuples +=
-         splinter_pivot_tuples_in_branch(spl, node, 0, branch_no);
+         trunk_pivot_tuples_in_branch(spl, node, 0, branch_no);
    }
 }
 
@@ -1661,41 +1661,41 @@ splinter_leaf_count_num_tuples(splinter_handle *spl,
  * sure they are dereferenced and updates the values in the header.
  */
 static inline void
-splinter_reset_start_branch(splinter_handle *spl,
+trunk_reset_start_branch(trunk_handle *spl,
                             page_handle     *node)
 {
-   splinter_trunk_hdr *hdr = (splinter_trunk_hdr *)node->data;
+   trunk_hdr *hdr = (trunk_hdr *)node->data;
    uint16 start_branch = hdr->end_branch;
    uint16 pivot_no, branch_no, bundle_no;
-   splinter_bundle *bundle;
+   trunk_bundle *bundle;
 
    // find the pivot with the smallest branch and bundle
-   for (pivot_no = 0; pivot_no < splinter_num_children(spl, node); pivot_no++) {
-      splinter_pivot_data *pdata = splinter_get_pivot_data(spl, node, pivot_no);
-      if (splinter_branch_no_sub(spl, hdr->end_branch, pdata->start_branch) >
-            splinter_branch_no_sub(spl, hdr->end_branch, start_branch))
+   for (pivot_no = 0; pivot_no < trunk_num_children(spl, node); pivot_no++) {
+      trunk_pivot_data *pdata = trunk_get_pivot_data(spl, node, pivot_no);
+      if (trunk_branch_no_sub(spl, hdr->end_branch, pdata->start_branch) >
+            trunk_branch_no_sub(spl, hdr->end_branch, start_branch))
          start_branch = pdata->start_branch;
    }
 
    // reset the start branch (and maybe the fractional branch)
    hdr->start_branch = start_branch;
-   if (!splinter_branch_valid(spl, node, hdr->start_frac_branch)) {
+   if (!trunk_branch_valid(spl, node, hdr->start_frac_branch)) {
       hdr->start_frac_branch = hdr->start_branch;
    }
 
    // kill any bundles that have no live branches
    for (bundle_no = hdr->start_bundle; bundle_no != hdr->end_bundle;
-         bundle_no = splinter_bundle_no_add(spl, bundle_no, 1)) {
-      bundle = splinter_get_bundle(spl, node, bundle_no);
-      branch_no = splinter_bundle_start_branch(spl, node, bundle);
-      if (!splinter_branch_live(spl, node, branch_no)) {
+         bundle_no = trunk_bundle_no_add(spl, bundle_no, 1)) {
+      bundle = trunk_get_bundle(spl, node, bundle_no);
+      branch_no = trunk_bundle_start_branch(spl, node, bundle);
+      if (!trunk_branch_live(spl, node, branch_no)) {
          /*
           * either all branches in the bundle are live or none are, so in this
           * case none are
           */
-         splinter_bundle_clear_subbundles(spl, node, bundle);
-         splinter_inc_start_bundle(spl, node);
-         splinter_default_log("node %lu evicting bundle %hu\n",
+         trunk_bundle_clear_subbundles(spl, node, bundle);
+         trunk_inc_start_bundle(spl, node);
+         trunk_default_log("node %lu evicting bundle %hu\n",
                               node->disk_addr, bundle_no);
       }
    }
@@ -1708,18 +1708,18 @@ splinter_reset_start_branch(splinter_handle *spl,
  */
 
 static inline void
-splinter_pivot_clear(splinter_handle     *spl,
+trunk_pivot_clear(trunk_handle     *spl,
                      page_handle         *node,
-                     splinter_pivot_data *pdata)
+                     trunk_pivot_data *pdata)
 {
-   splinter_trunk_hdr *hdr = (splinter_trunk_hdr *)node->data;
+   trunk_hdr *hdr = (trunk_hdr *)node->data;
    uint16 start_branch = pdata->start_branch;
    pdata->start_branch = hdr->end_branch;
    pdata->start_bundle = hdr->end_bundle;
    pdata->num_tuples = 0;
    pdata->srq_idx = -1;
    if (start_branch == hdr->start_branch) {
-      splinter_reset_start_branch(spl, node);
+      trunk_reset_start_branch(spl, node);
    }
    pdata->filter.addr = 0;
    pdata->filter.meta_head = 0;
@@ -1730,24 +1730,24 @@ splinter_pivot_clear(splinter_handle     *spl,
  * Returns the index of the pivot with pivot data pdata.
  */
 static inline uint16
-splinter_pdata_to_pivot_index(splinter_handle     *spl,
+trunk_pdata_to_pivot_index(trunk_handle     *spl,
                               page_handle         *node,
-                              splinter_pivot_data *pdata)
+                              trunk_pivot_data *pdata)
 {
    uint64 byte_difference =  (char *)pdata
-      - (char *)splinter_get_pivot_data(spl, node, 0);
-   debug_assert(byte_difference % splinter_pivot_size(spl) == 0);
-   return byte_difference / splinter_pivot_size(spl);
+      - (char *)trunk_get_pivot_data(spl, node, 0);
+   debug_assert(byte_difference % trunk_pivot_size(spl) == 0);
+   return byte_difference / trunk_pivot_size(spl);
 }
 
 /*
  * Returns the number of children of the node
  */
 static inline uint16
-splinter_num_children(splinter_handle *spl,
+trunk_num_children(trunk_handle *spl,
                       page_handle     *node)
 {
-   splinter_trunk_hdr *hdr = (splinter_trunk_hdr *)node->data;
+   trunk_hdr *hdr = (trunk_hdr *)node->data;
    debug_assert(hdr->num_pivot_keys >= 2);
    return hdr->num_pivot_keys - 1;
 }
@@ -1757,19 +1757,19 @@ splinter_num_children(splinter_handle *spl,
  * children + 1 for the upper bound pivot key.
  */
 static inline uint16
-splinter_num_pivot_keys(splinter_handle *spl,
+trunk_num_pivot_keys(trunk_handle *spl,
                         page_handle     *node)
 {
-   splinter_trunk_hdr *hdr = (splinter_trunk_hdr *)node->data;
+   trunk_hdr *hdr = (trunk_hdr *)node->data;
    debug_assert(hdr->num_pivot_keys >= 2);
    return hdr->num_pivot_keys;
 }
 
 static inline void
-splinter_inc_num_pivot_keys(splinter_handle *spl,
+trunk_inc_num_pivot_keys(trunk_handle *spl,
                             page_handle     *node)
 {
-   splinter_trunk_hdr *hdr = (splinter_trunk_hdr *)node->data;
+   trunk_hdr *hdr = (trunk_hdr *)node->data;
    debug_assert(hdr->num_pivot_keys >= 2);
    hdr->num_pivot_keys++;
    debug_assert(hdr->num_pivot_keys <= spl->cfg.max_pivot_keys);
@@ -1784,25 +1784,25 @@ splinter_inc_num_pivot_keys(splinter_handle *spl,
  * root split.
  */
 uint64
-splinter_find_node(splinter_handle *spl,
+trunk_find_node(trunk_handle *spl,
                    char            *key,
                    uint64           height)
 {
-   page_handle *node = splinter_node_get(spl, spl->root_addr);
-   uint16 tree_height = splinter_height(spl, node);
+   page_handle *node = trunk_node_get(spl, spl->root_addr);
+   uint16 tree_height = trunk_height(spl, node);
    for (uint16 h = tree_height; h > height + 1; h--) {
-      uint32 pivot_no = splinter_find_pivot(spl, node, key, less_than_or_equal);
-      debug_assert(pivot_no < splinter_num_children(spl, node));
-      splinter_pivot_data *pdata = splinter_get_pivot_data(spl, node, pivot_no);
-      page_handle *child = splinter_node_get(spl, pdata->addr);
-      splinter_node_unget(spl, &node);
+      uint32 pivot_no = trunk_find_pivot(spl, node, key, less_than_or_equal);
+      debug_assert(pivot_no < trunk_num_children(spl, node));
+      trunk_pivot_data *pdata = trunk_get_pivot_data(spl, node, pivot_no);
+      page_handle *child = trunk_node_get(spl, pdata->addr);
+      trunk_node_unget(spl, &node);
       node = child;
    }
-   uint32 pivot_no = splinter_find_pivot(spl, node, key, less_than_or_equal);
-   debug_assert(pivot_no < splinter_num_children(spl, node));
-   splinter_pivot_data *pdata = splinter_get_pivot_data(spl, node, pivot_no);
+   uint32 pivot_no = trunk_find_pivot(spl, node, key, less_than_or_equal);
+   debug_assert(pivot_no < trunk_num_children(spl, node));
+   trunk_pivot_data *pdata = trunk_get_pivot_data(spl, node, pivot_no);
    uint64 ret_addr = pdata->addr;
-   splinter_node_unget(spl, &node);
+   trunk_node_unget(spl, &node);
    return ret_addr;
 }
 
@@ -1814,12 +1814,12 @@ splinter_find_node(splinter_handle *spl,
  *-----------------------------------------------------------------------------
  */
 
-static inline splinter_bundle *
-splinter_get_bundle(splinter_handle *spl,
+static inline trunk_bundle *
+trunk_get_bundle(trunk_handle *spl,
                     page_handle     *node,
                     uint16           bundle_no)
 {
-   splinter_trunk_hdr *hdr = (splinter_trunk_hdr *)node->data;
+   trunk_hdr *hdr = (trunk_hdr *)node->data;
    return &hdr->bundle[bundle_no];
 }
 
@@ -1831,56 +1831,56 @@ splinter_get_bundle(splinter_handle *spl,
  * buffer
  */
 static inline uint16
-splinter_get_new_bundle(splinter_handle *spl,
+trunk_get_new_bundle(trunk_handle *spl,
                         page_handle     *node)
 {
-   splinter_trunk_hdr *hdr = (splinter_trunk_hdr *)node->data;
+   trunk_hdr *hdr = (trunk_hdr *)node->data;
    uint16 new_bundle_no = hdr->end_bundle;
-   hdr->end_bundle = splinter_bundle_no_add(spl, hdr->end_bundle, 1);
+   hdr->end_bundle = trunk_bundle_no_add(spl, hdr->end_bundle, 1);
    platform_assert(hdr->end_bundle != hdr->start_bundle);
    return new_bundle_no;
 }
 
 static inline uint16
-splinter_start_bundle(splinter_handle *spl,
+trunk_start_bundle(trunk_handle *spl,
                       page_handle     *node)
 {
-   splinter_trunk_hdr *hdr = (splinter_trunk_hdr *)node->data;
+   trunk_hdr *hdr = (trunk_hdr *)node->data;
    return hdr->start_bundle;
 }
 
 static inline uint16
-splinter_end_bundle(splinter_handle *spl,
+trunk_end_bundle(trunk_handle *spl,
                     page_handle     *node)
 {
-   splinter_trunk_hdr *hdr = (splinter_trunk_hdr *)node->data;
+   trunk_hdr *hdr = (trunk_hdr *)node->data;
    return hdr->end_bundle;
 }
 
 static inline uint16
-splinter_inc_start_bundle(splinter_handle *spl,
+trunk_inc_start_bundle(trunk_handle *spl,
                           page_handle     *node)
 {
-   splinter_trunk_hdr *hdr = (splinter_trunk_hdr *)node->data;
-   hdr->start_bundle = splinter_bundle_no_add(spl, hdr->start_bundle, 1);
+   trunk_hdr *hdr = (trunk_hdr *)node->data;
+   hdr->start_bundle = trunk_bundle_no_add(spl, hdr->start_bundle, 1);
    return hdr->start_bundle;
 }
 
-static inline splinter_subbundle *
-splinter_get_subbundle(splinter_handle *spl,
+static inline trunk_subbundle *
+trunk_get_subbundle(trunk_handle *spl,
                        page_handle     *node,
                        uint16           subbundle_no)
 {
-   splinter_trunk_hdr *hdr = (splinter_trunk_hdr *)node->data;
+   trunk_hdr *hdr = (trunk_hdr *)node->data;
    return &hdr->subbundle[subbundle_no];
 }
 
 static inline uint16
-splinter_subbundle_no(splinter_handle    *spl,
+trunk_subbundle_no(trunk_handle    *spl,
                       page_handle        *node,
-                      splinter_subbundle *sb)
+                      trunk_subbundle *sb)
 {
-   return sb - splinter_get_subbundle(spl, node, 0);
+   return sb - trunk_get_subbundle(spl, node, 0);
 }
 
 /*
@@ -1890,41 +1890,41 @@ splinter_subbundle_no(splinter_handle    *spl,
  * FIXME: [aconway 2020-06-21] Currently crashes if there is no room in the
  * buffer
  */
-static inline splinter_subbundle *
-splinter_get_new_subbundle(splinter_handle *spl,
+static inline trunk_subbundle *
+trunk_get_new_subbundle(trunk_handle *spl,
                            page_handle     *node,
                            uint16           num_filters)
 {
-   splinter_trunk_hdr *hdr = (splinter_trunk_hdr *)node->data;
+   trunk_hdr *hdr = (trunk_hdr *)node->data;
    uint16 new_subbundle_no = hdr->end_subbundle;
-   hdr->end_subbundle = splinter_subbundle_no_add(spl, hdr->end_subbundle, 1);
+   hdr->end_subbundle = trunk_subbundle_no_add(spl, hdr->end_subbundle, 1);
    // ALEX: Need a way to handle this better
    platform_assert(hdr->end_subbundle != hdr->start_subbundle);
 
    // get filters
-   splinter_subbundle *sb = splinter_get_subbundle(spl, node, new_subbundle_no);
-   sb->start_filter = splinter_end_sb_filter(spl, node);
+   trunk_subbundle *sb = trunk_get_subbundle(spl, node, new_subbundle_no);
+   sb->start_filter = trunk_end_sb_filter(spl, node);
    hdr->end_sb_filter =
-      splinter_subbundle_no_add(spl, hdr->end_sb_filter, num_filters);
-   sb->end_filter = splinter_end_sb_filter(spl, node);
+      trunk_subbundle_no_add(spl, hdr->end_sb_filter, num_filters);
+   sb->end_filter = trunk_end_sb_filter(spl, node);
    sb->state = SB_STATE_COMPACTED;
    return sb;
 }
 
-static inline splinter_subbundle *
-splinter_leaf_get_new_subbundle_at_head(splinter_handle *spl,
+static inline trunk_subbundle *
+trunk_leaf_get_new_subbundle_at_head(trunk_handle *spl,
                                         page_handle     *node)
 {
-   splinter_trunk_hdr *hdr = (splinter_trunk_hdr *)node->data;
+   trunk_hdr *hdr = (trunk_hdr *)node->data;
    uint16 new_subbundle_no =
-      splinter_subbundle_no_sub(spl, hdr->start_subbundle, 1);
+      trunk_subbundle_no_sub(spl, hdr->start_subbundle, 1);
    platform_assert(new_subbundle_no != hdr->end_subbundle);
    hdr->start_subbundle = new_subbundle_no;
 
    // get filters
-   splinter_subbundle *sb = splinter_get_subbundle(spl, node, new_subbundle_no);
+   trunk_subbundle *sb = trunk_get_subbundle(spl, node, new_subbundle_no);
    sb->end_filter = hdr->start_sb_filter;
-   sb->start_filter = splinter_subbundle_no_sub(spl, hdr->start_sb_filter, 1);
+   sb->start_filter = trunk_subbundle_no_sub(spl, hdr->start_sb_filter, 1);
    platform_assert(sb->start_filter != hdr->end_sb_filter);
    hdr->start_sb_filter = sb->start_filter;
    sb->state = SB_STATE_UNCOMPACTED_LEAF;
@@ -1932,132 +1932,132 @@ splinter_leaf_get_new_subbundle_at_head(splinter_handle *spl,
 }
 
 static inline routing_filter *
-splinter_get_sb_filter(splinter_handle *spl,
+trunk_get_sb_filter(trunk_handle *spl,
                        page_handle     *node,
                        uint16           filter_no)
 {
-   splinter_trunk_hdr *hdr = (splinter_trunk_hdr *)node->data;
+   trunk_hdr *hdr = (trunk_hdr *)node->data;
    return &hdr->sb_filter[filter_no];
 }
 
 static inline uint16
-splinter_start_sb_filter(splinter_handle *spl,
+trunk_start_sb_filter(trunk_handle *spl,
                          page_handle     *node)
 {
-   splinter_trunk_hdr *hdr = (splinter_trunk_hdr *)node->data;
+   trunk_hdr *hdr = (trunk_hdr *)node->data;
    return hdr->start_sb_filter;
 }
 
 static inline uint16
-splinter_end_sb_filter(splinter_handle *spl,
+trunk_end_sb_filter(trunk_handle *spl,
                        page_handle     *node)
 {
-   splinter_trunk_hdr *hdr = (splinter_trunk_hdr *)node->data;
+   trunk_hdr *hdr = (trunk_hdr *)node->data;
    return hdr->end_sb_filter;
 }
 
 static inline uint16
-splinter_subbundle_filter_count(splinter_handle    *spl,
+trunk_subbundle_filter_count(trunk_handle    *spl,
                                 page_handle        *node,
-                                splinter_subbundle *sb)
+                                trunk_subbundle *sb)
 {
-   return splinter_subbundle_no_sub(spl, sb->end_filter, sb->start_filter);
+   return trunk_subbundle_no_sub(spl, sb->end_filter, sb->start_filter);
 }
 
 static inline uint16
-splinter_bundle_filter_count(splinter_handle *spl,
+trunk_bundle_filter_count(trunk_handle *spl,
                              page_handle     *node,
-                             splinter_bundle *bundle)
+                             trunk_bundle *bundle)
 {
    uint16 filter_count = 0;
    for (uint16 sb_no = bundle->start_subbundle;
         sb_no != bundle->end_subbundle;
-        sb_no = splinter_subbundle_no_add(spl, sb_no, 1)) {
-      splinter_subbundle *sb = splinter_get_subbundle(spl, node, sb_no);
-      filter_count += splinter_subbundle_filter_count(spl, node, sb);
+        sb_no = trunk_subbundle_no_add(spl, sb_no, 1)) {
+      trunk_subbundle *sb = trunk_get_subbundle(spl, node, sb_no);
+      filter_count += trunk_subbundle_filter_count(spl, node, sb);
    }
    return filter_count;
 }
 
 static inline uint16
-splinter_bundle_start_filter(splinter_handle *spl,
+trunk_bundle_start_filter(trunk_handle *spl,
                              page_handle     *node,
-                             splinter_bundle *bundle)
+                             trunk_bundle *bundle)
 {
    uint16 sb_no = bundle->start_subbundle;
-   splinter_subbundle *sb = splinter_get_subbundle(spl, node, sb_no);
+   trunk_subbundle *sb = trunk_get_subbundle(spl, node, sb_no);
    return sb->start_filter;
 }
 
 static inline uint16
-splinter_bundle_end_filter(splinter_handle *spl,
+trunk_bundle_end_filter(trunk_handle *spl,
                            page_handle     *node,
-                           splinter_bundle *bundle)
+                           trunk_bundle *bundle)
 {
-   uint16 last_sb_no = splinter_subbundle_no_sub(spl, bundle->end_subbundle, 1);
-   splinter_subbundle *sb = splinter_get_subbundle(spl, node, last_sb_no);
+   uint16 last_sb_no = trunk_subbundle_no_sub(spl, bundle->end_subbundle, 1);
+   trunk_subbundle *sb = trunk_get_subbundle(spl, node, last_sb_no);
    return sb->end_filter;
 }
 
 static inline routing_filter *
-splinter_subbundle_filter(splinter_handle    *spl,
+trunk_subbundle_filter(trunk_handle    *spl,
                           page_handle        *node,
-                          splinter_subbundle *sb,
+                          trunk_subbundle *sb,
                           uint16              filter_off)
 {
    uint16 start_filter = sb->start_filter;
-   uint16 filter_no = splinter_subbundle_no_add(spl, start_filter, filter_off);
-   debug_assert(filter_off < splinter_subbundle_filter_count(spl, node, sb));
-   return splinter_get_sb_filter(spl, node, filter_no);
+   uint16 filter_no = trunk_subbundle_no_add(spl, start_filter, filter_off);
+   debug_assert(filter_off < trunk_subbundle_filter_count(spl, node, sb));
+   return trunk_get_sb_filter(spl, node, filter_no);
 }
 
 __attribute__ ((unused))
 static inline uint16
-splinter_subbundle_branch_count(splinter_handle    *spl,
+trunk_subbundle_branch_count(trunk_handle    *spl,
                                 page_handle        *node,
-                                splinter_subbundle *sb)
+                                trunk_subbundle *sb)
 {
-   return splinter_branch_no_sub(spl, sb->end_branch, sb->start_branch);
+   return trunk_branch_no_sub(spl, sb->end_branch, sb->start_branch);
 }
 
 __attribute__ ((unused))
 static inline uint16
-splinter_start_subbundle(splinter_handle *spl,
+trunk_start_subbundle(trunk_handle *spl,
                          page_handle     *node)
 {
-   splinter_trunk_hdr *hdr = (splinter_trunk_hdr *)node->data;
+   trunk_hdr *hdr = (trunk_hdr *)node->data;
    return hdr->start_subbundle;
 }
 
 static inline uint16
-splinter_end_subbundle(splinter_handle *spl,
+trunk_end_subbundle(trunk_handle *spl,
                        page_handle     *node)
 {
-   splinter_trunk_hdr *hdr = (splinter_trunk_hdr *)node->data;
+   trunk_hdr *hdr = (trunk_hdr *)node->data;
    return hdr->end_subbundle;
 }
 
 static inline uint16
-splinter_start_subbundle_for_lookup(splinter_handle *spl,
+trunk_start_subbundle_for_lookup(trunk_handle *spl,
                                     page_handle     *node)
 {
-   return splinter_subbundle_no_sub(spl, splinter_end_subbundle(spl, node), 1);
+   return trunk_subbundle_no_sub(spl, trunk_end_subbundle(spl, node), 1);
 }
 
 static inline uint16
-splinter_bundle_clear_subbundles(splinter_handle *spl,
+trunk_bundle_clear_subbundles(trunk_handle *spl,
                                  page_handle     *node,
-                                 splinter_bundle *bundle)
+                                 trunk_bundle *bundle)
 {
-   splinter_trunk_hdr *hdr = (splinter_trunk_hdr *)node->data;
-   uint16 start_filter = splinter_bundle_start_filter(spl, node, bundle);
-   uint16 end_filter = splinter_bundle_end_filter(spl, node, bundle);
+   trunk_hdr *hdr = (trunk_hdr *)node->data;
+   uint16 start_filter = trunk_bundle_start_filter(spl, node, bundle);
+   uint16 end_filter = trunk_bundle_end_filter(spl, node, bundle);
    for (uint16 filter_no = start_filter;
         filter_no != end_filter;
-        filter_no = splinter_subbundle_no_add(spl, filter_no, 1)) {
+        filter_no = trunk_subbundle_no_add(spl, filter_no, 1)) {
       routing_filter *filter =
-         splinter_get_sb_filter(spl, node, filter_no);
-      splinter_dec_filter(spl, filter);
+         trunk_get_sb_filter(spl, node, filter_no);
+      trunk_dec_filter(spl, filter);
       //platform_log("dec filter %lu in %lu (%u)\n",
       //      filter->addr, node->disk_addr,
       //      allocator_get_refcount(spl->al, filter->addr));
@@ -2076,17 +2076,17 @@ splinter_bundle_clear_subbundles(splinter_handle *spl,
  * Used in leaf splits to abort compactions in progress.
  */
 static inline void
-splinter_leaf_remove_bundles_except(splinter_handle *spl,
+trunk_leaf_remove_bundles_except(trunk_handle *spl,
                                     page_handle     *node,
                                     uint16           bundle_no)
 {
-   debug_assert(splinter_height(spl, node) == 0);
-   splinter_trunk_hdr *hdr = (splinter_trunk_hdr *)node->data;
-   uint16 last_bundle_no = splinter_end_bundle(spl, node);
-   last_bundle_no = splinter_bundle_no_sub(spl, last_bundle_no, 1);
+   debug_assert(trunk_height(spl, node) == 0);
+   trunk_hdr *hdr = (trunk_hdr *)node->data;
+   uint16 last_bundle_no = trunk_end_bundle(spl, node);
+   last_bundle_no = trunk_bundle_no_sub(spl, last_bundle_no, 1);
    debug_assert(bundle_no == last_bundle_no);
    hdr->start_bundle = bundle_no;
-   splinter_pivot_data *pdata = splinter_get_pivot_data(spl, node, 0);
+   trunk_pivot_data *pdata = trunk_get_pivot_data(spl, node, 0);
    pdata->start_bundle = hdr->start_bundle;
 }
 
@@ -2096,32 +2096,32 @@ splinter_leaf_remove_bundles_except(splinter_handle *spl,
  * Used in leaf splits to abort compactions in progress.
  */
 static inline uint16
-splinter_leaf_rebundle_all_branches(splinter_handle *spl,
+trunk_leaf_rebundle_all_branches(trunk_handle *spl,
                                     page_handle     *node,
                                     uint64           target_num_tuples,
                                     bool             is_space_rec)
 {
-   debug_assert(splinter_height(spl, node) == 0);
-   uint16 bundle_no = splinter_get_new_bundle(spl, node);
-   if (splinter_branch_is_whole(spl, node, splinter_start_branch(spl, node))) {
-      splinter_subbundle *sb =
-         splinter_leaf_get_new_subbundle_at_head(spl, node);
-      sb->start_branch = splinter_start_branch(spl, node);
-      sb->end_branch = splinter_start_frac_branch(spl, node);
-      routing_filter *filter = splinter_subbundle_filter(spl, node, sb, 0);
-      splinter_pivot_data *pdata = splinter_get_pivot_data(spl, node, 0);
+   debug_assert(trunk_height(spl, node) == 0);
+   uint16 bundle_no = trunk_get_new_bundle(spl, node);
+   if (trunk_branch_is_whole(spl, node, trunk_start_branch(spl, node))) {
+      trunk_subbundle *sb =
+         trunk_leaf_get_new_subbundle_at_head(spl, node);
+      sb->start_branch = trunk_start_branch(spl, node);
+      sb->end_branch = trunk_start_frac_branch(spl, node);
+      routing_filter *filter = trunk_subbundle_filter(spl, node, sb, 0);
+      trunk_pivot_data *pdata = trunk_get_pivot_data(spl, node, 0);
       *filter = pdata->filter;
       debug_assert(filter->addr != 0);
       ZERO_STRUCT(pdata->filter);
-      debug_assert(splinter_subbundle_branch_count(spl, node, sb) != 0);
+      debug_assert(trunk_subbundle_branch_count(spl, node, sb) != 0);
    }
-   splinter_bundle *bundle = splinter_get_bundle(spl, node, bundle_no);
+   trunk_bundle *bundle = trunk_get_bundle(spl, node, bundle_no);
    bundle->num_tuples = target_num_tuples;
-   bundle->start_subbundle = splinter_start_subbundle(spl, node);
-   bundle->end_subbundle = splinter_end_subbundle(spl, node);
-   splinter_leaf_remove_bundles_except(spl, node, bundle_no);
-   splinter_set_start_frac_branch(spl, node, splinter_start_branch(spl, node));
-   splinter_pivot_data *pdata = splinter_get_pivot_data(spl, node, 0);
+   bundle->start_subbundle = trunk_start_subbundle(spl, node);
+   bundle->end_subbundle = trunk_end_subbundle(spl, node);
+   trunk_leaf_remove_bundles_except(spl, node, bundle_no);
+   trunk_set_start_frac_branch(spl, node, trunk_start_branch(spl, node));
+   trunk_pivot_data *pdata = trunk_get_pivot_data(spl, node, 0);
    if (!is_space_rec && pdata->srq_idx != -1 &&
          spl->cfg.reclaim_threshold != UINT64_MAX) {
       //platform_log("Deleting %12lu-%lu (index %lu) from SRQ\n",
@@ -2130,7 +2130,7 @@ splinter_leaf_rebundle_all_branches(splinter_handle *spl,
       srq_print(&spl->srq);
       pdata->srq_idx = -1;
    }
-   pdata->generation = splinter_inc_pivot_generation(spl, node);
+   pdata->generation = trunk_inc_pivot_generation(spl, node);
    return bundle_no;
 }
 
@@ -2138,12 +2138,12 @@ splinter_leaf_rebundle_all_branches(splinter_handle *spl,
  * Returns the index of the first branch in the bundle.
  */
 static inline uint16
-splinter_bundle_start_branch(splinter_handle *spl,
+trunk_bundle_start_branch(trunk_handle *spl,
                              page_handle     *node,
-                             splinter_bundle *bundle)
+                             trunk_bundle *bundle)
 {
-   splinter_subbundle *subbundle
-      = splinter_get_subbundle(spl, node, bundle->start_subbundle);
+   trunk_subbundle *subbundle
+      = trunk_get_subbundle(spl, node, bundle->start_subbundle);
    return subbundle->start_branch;
 }
 
@@ -2151,14 +2151,14 @@ splinter_bundle_start_branch(splinter_handle *spl,
  * Returns the index of the successor to the last branch in the bundle.
  */
 static inline uint16
-splinter_bundle_end_branch(splinter_handle *spl,
+trunk_bundle_end_branch(trunk_handle *spl,
                            page_handle     *node,
-                           splinter_bundle *bundle)
+                           trunk_bundle *bundle)
 {
    uint16 last_subbundle_no
-      = splinter_subbundle_no_sub(spl, bundle->end_subbundle, 1);
-   splinter_subbundle *subbundle
-      = splinter_get_subbundle(spl, node, last_subbundle_no);
+      = trunk_subbundle_no_sub(spl, bundle->end_subbundle, 1);
+   trunk_subbundle *subbundle
+      = trunk_get_subbundle(spl, node, last_subbundle_no);
    return subbundle->end_branch;
 }
 
@@ -2166,21 +2166,21 @@ splinter_bundle_end_branch(splinter_handle *spl,
  * Returns the number of (by definition fractional) branches in the bundle.
  */
 static inline uint16
-splinter_bundle_branch_count(splinter_handle *spl,
+trunk_bundle_branch_count(trunk_handle *spl,
                              page_handle     *node,
-                             splinter_bundle *bundle)
+                             trunk_bundle *bundle)
 {
-   return splinter_branch_no_sub(spl,
-         splinter_bundle_end_branch(spl, node, bundle),
-         splinter_bundle_start_branch(spl, node, bundle));
+   return trunk_branch_no_sub(spl,
+         trunk_bundle_end_branch(spl, node, bundle),
+         trunk_bundle_start_branch(spl, node, bundle));
 }
 
 static inline uint16
-splinter_bundle_subbundle_count(splinter_handle *spl,
+trunk_bundle_subbundle_count(trunk_handle *spl,
                                 page_handle     *node,
-                                splinter_bundle *bundle)
+                                trunk_bundle *bundle)
 {
-   return splinter_subbundle_no_sub(spl,
+   return trunk_subbundle_no_sub(spl,
                                     bundle->end_subbundle,
                                     bundle->start_subbundle);
 }
@@ -2189,22 +2189,22 @@ splinter_bundle_subbundle_count(splinter_handle *spl,
  * Returns the number of live bundles in the node.
  */
 static inline uint16
-splinter_bundle_count(splinter_handle *spl,
+trunk_bundle_count(trunk_handle *spl,
                       page_handle     *node)
 {
-   splinter_trunk_hdr *hdr = (splinter_trunk_hdr *)node->data;
-   return splinter_bundle_no_sub(spl, hdr->end_bundle, hdr->start_bundle);
+   trunk_hdr *hdr = (trunk_hdr *)node->data;
+   return trunk_bundle_no_sub(spl, hdr->end_bundle, hdr->start_bundle);
 }
 
 /*
  * Returns the number of live subbundles in the node.
  */
 static inline uint16
-splinter_subbundle_count(splinter_handle *spl,
+trunk_subbundle_count(trunk_handle *spl,
                          page_handle     *node)
 {
-   splinter_trunk_hdr *hdr = (splinter_trunk_hdr *)node->data;
-   return splinter_subbundle_no_sub(spl, hdr->end_subbundle,
+   trunk_hdr *hdr = (trunk_hdr *)node->data;
+   return trunk_subbundle_no_sub(spl, hdr->end_subbundle,
          hdr->start_subbundle);
 }
 
@@ -2212,13 +2212,13 @@ splinter_subbundle_count(splinter_handle *spl,
  * Returns TRUE if the bundle is live in the node and FALSE otherwise.
  */
 static inline bool
-splinter_bundle_live(splinter_handle *spl,
+trunk_bundle_live(trunk_handle *spl,
                      page_handle     *node,
                      uint16           bundle_no)
 {
-   splinter_trunk_hdr *hdr = (splinter_trunk_hdr *)node->data;
-   return splinter_bundle_no_sub(spl, bundle_no, hdr->start_bundle)
-      < splinter_bundle_no_sub(spl, hdr->end_bundle, hdr->start_bundle);
+   trunk_hdr *hdr = (trunk_hdr *)node->data;
+   return trunk_bundle_no_sub(spl, bundle_no, hdr->start_bundle)
+      < trunk_bundle_no_sub(spl, hdr->end_bundle, hdr->start_bundle);
 }
 
 /*
@@ -2226,139 +2226,139 @@ splinter_bundle_live(splinter_handle *spl,
  * FALSE otherwise.
  */
 static inline bool
-splinter_bundle_valid(splinter_handle *spl,
+trunk_bundle_valid(trunk_handle *spl,
                       page_handle     *node,
                       uint16           bundle_no)
 {
-   splinter_trunk_hdr *hdr = (splinter_trunk_hdr *)node->data;
-   return splinter_bundle_no_sub(spl, bundle_no, hdr->start_bundle)
-      <= splinter_bundle_no_sub(spl, hdr->end_bundle, hdr->start_bundle);
+   trunk_hdr *hdr = (trunk_hdr *)node->data;
+   return trunk_bundle_no_sub(spl, bundle_no, hdr->start_bundle)
+      <= trunk_bundle_no_sub(spl, hdr->end_bundle, hdr->start_bundle);
 }
 
 /*
  * Returns TRUE if the bundle is live for the pivot and FALSE otherwise
  */
 static inline bool
-splinter_bundle_live_for_pivot(splinter_handle     *spl,
+trunk_bundle_live_for_pivot(trunk_handle     *spl,
                                page_handle         *node,
                                uint16               bundle_no,
                                uint16               pivot_no)
 {
-   debug_assert(pivot_no < splinter_num_children(spl, node));
-   splinter_bundle *bundle = splinter_get_bundle(spl, node, bundle_no);
-   uint16 branch_no = splinter_bundle_start_branch(spl, node, bundle);
-   return splinter_branch_live_for_pivot(spl, node, branch_no, pivot_no);
+   debug_assert(pivot_no < trunk_num_children(spl, node));
+   trunk_bundle *bundle = trunk_get_bundle(spl, node, bundle_no);
+   uint16 branch_no = trunk_bundle_start_branch(spl, node, bundle);
+   return trunk_branch_live_for_pivot(spl, node, branch_no, pivot_no);
 }
 
 static inline uint16
-splinter_start_frac_branch(splinter_handle *spl,
+trunk_start_frac_branch(trunk_handle *spl,
                            page_handle     *node)
 {
-   splinter_trunk_hdr *hdr = (splinter_trunk_hdr *)node->data;
+   trunk_hdr *hdr = (trunk_hdr *)node->data;
    return hdr->start_frac_branch;
 }
 
 static inline void
-splinter_set_start_frac_branch(splinter_handle *spl,
+trunk_set_start_frac_branch(trunk_handle *spl,
                                page_handle     *node,
                                uint16           branch_no)
 {
-   splinter_trunk_hdr *hdr = (splinter_trunk_hdr *)node->data;
+   trunk_hdr *hdr = (trunk_hdr *)node->data;
    hdr->start_frac_branch = branch_no;
 }
 
 static inline void
-splinter_reset_start_frac_branch(splinter_handle *spl,
+trunk_reset_start_frac_branch(trunk_handle *spl,
                                  page_handle     *node)
 {
-   if (splinter_bundle_count(spl, node) == 0) {
-      splinter_set_start_frac_branch(spl, node, splinter_end_branch(spl, node));
+   if (trunk_bundle_count(spl, node) == 0) {
+      trunk_set_start_frac_branch(spl, node, trunk_end_branch(spl, node));
    } else {
-      uint16 start_bundle = splinter_start_bundle(spl, node);
-      splinter_bundle *bundle = splinter_get_bundle(spl, node, start_bundle);
+      uint16 start_bundle = trunk_start_bundle(spl, node);
+      trunk_bundle *bundle = trunk_get_bundle(spl, node, start_bundle);
       uint16 start_frac_branch =
-         splinter_bundle_start_branch(spl, node, bundle);
-      splinter_set_start_frac_branch(spl, node, start_frac_branch);
+         trunk_bundle_start_branch(spl, node, bundle);
+      trunk_set_start_frac_branch(spl, node, start_frac_branch);
    }
 }
 
 static inline void
-splinter_clear_bundle(splinter_handle *spl,
+trunk_clear_bundle(trunk_handle *spl,
                       page_handle     *node,
                       uint16           bundle_no)
 {
-   platform_assert(bundle_no == splinter_start_bundle(spl, node));
+   platform_assert(bundle_no == trunk_start_bundle(spl, node));
 
-   splinter_bundle *bundle = splinter_get_bundle(spl, node, bundle_no);
+   trunk_bundle *bundle = trunk_get_bundle(spl, node, bundle_no);
 
-   splinter_bundle_clear_subbundles(spl, node, bundle);
-   splinter_inc_start_bundle(spl, node);
+   trunk_bundle_clear_subbundles(spl, node, bundle);
+   trunk_inc_start_bundle(spl, node);
 
    // update the pivot start bundles
-   for (uint16 pivot_no = 0; pivot_no < splinter_num_children(spl, node); pivot_no++) {
-      splinter_pivot_data *pdata =
-         splinter_get_pivot_data(spl, node, pivot_no);
-      if (!splinter_bundle_valid(spl, node, pdata->start_bundle)) {
-         pdata->start_bundle = splinter_start_bundle(spl, node);
+   for (uint16 pivot_no = 0; pivot_no < trunk_num_children(spl, node); pivot_no++) {
+      trunk_pivot_data *pdata =
+         trunk_get_pivot_data(spl, node, pivot_no);
+      if (!trunk_bundle_valid(spl, node, pdata->start_bundle)) {
+         pdata->start_bundle = trunk_start_bundle(spl, node);
       }
    }
 
    // update the fractional start branch
-   splinter_reset_start_frac_branch(spl, node);
+   trunk_reset_start_frac_branch(spl, node);
 }
 
 static inline void
-splinter_tuples_in_bundle(
-      splinter_handle *spl,
+trunk_tuples_in_bundle(
+      trunk_handle *spl,
       page_handle     *node,
-      splinter_bundle *bundle,
-      uint64           pivot_count[static SPLINTER_MAX_PIVOTS])
+      trunk_bundle *bundle,
+      uint64           pivot_count[static TRUNK_MAX_PIVOTS])
 {
    // Can't ZERO_ARRAY because degerates to a uint64 *
-   ZERO_CONTENTS_N(pivot_count, SPLINTER_MAX_PIVOTS);
+   ZERO_CONTENTS_N(pivot_count, TRUNK_MAX_PIVOTS);
 
-   uint16 num_children = splinter_num_children(spl, node);
-   for (uint16 branch_no = splinter_bundle_start_branch(spl, node, bundle);
-        branch_no != splinter_bundle_end_branch(spl, node, bundle);
-        branch_no = splinter_branch_no_add(spl, branch_no, 1)) {
+   uint16 num_children = trunk_num_children(spl, node);
+   for (uint16 branch_no = trunk_bundle_start_branch(spl, node, bundle);
+        branch_no != trunk_bundle_end_branch(spl, node, bundle);
+        branch_no = trunk_branch_no_add(spl, branch_no, 1)) {
       for (uint16 pivot_no = 0; pivot_no < num_children; pivot_no++) {
          pivot_count[pivot_no] +=
-            splinter_pivot_tuples_in_branch(spl, node, pivot_no, branch_no);
+            trunk_pivot_tuples_in_branch(spl, node, pivot_no, branch_no);
       }
    }
 }
 
 static inline void
-splinter_pivot_add_bundle_num_tuples(
-   splinter_handle *spl,
+trunk_pivot_add_bundle_num_tuples(
+   trunk_handle *spl,
    page_handle     *node,
-   splinter_bundle *bundle,
-   uint64           pivot_count[SPLINTER_MAX_PIVOTS])
+   trunk_bundle *bundle,
+   uint64           pivot_count[TRUNK_MAX_PIVOTS])
 {
    bundle->num_tuples = 0;
-   uint16 num_children = splinter_num_children(spl, node);
+   uint16 num_children = trunk_num_children(spl, node);
    for (uint16 pivot_no = 0; pivot_no < num_children; pivot_no++) {
-      splinter_pivot_data *pdata = splinter_get_pivot_data(spl, node, pivot_no);
+      trunk_pivot_data *pdata = trunk_get_pivot_data(spl, node, pivot_no);
       pdata->num_tuples += pivot_count[pivot_no];
       bundle->num_tuples += pivot_count[pivot_no];
    }
 }
 
 static inline void
-splinter_bundle_inc_pivot_rc(splinter_handle *spl,
+trunk_bundle_inc_pivot_rc(trunk_handle *spl,
                              page_handle     *node,
-                             splinter_bundle *bundle)
+                             trunk_bundle *bundle)
 {
-   uint16 num_children = splinter_num_children(spl, node);
+   uint16 num_children = trunk_num_children(spl, node);
    cache *cc = spl->cc;
    btree_config *btree_cfg = &spl->cfg.btree_cfg;
    // Skip the first pivot, because that has been inc'd in the parent
-   for (uint16 branch_no = splinter_bundle_start_branch(spl, node, bundle);
-        branch_no != splinter_bundle_end_branch(spl, node, bundle);
-        branch_no = splinter_branch_no_add(spl, branch_no, 1)) {
-      splinter_branch *branch = splinter_get_branch(spl, node, branch_no);
+   for (uint16 branch_no = trunk_bundle_start_branch(spl, node, bundle);
+        branch_no != trunk_bundle_end_branch(spl, node, bundle);
+        branch_no = trunk_branch_no_add(spl, branch_no, 1)) {
+      trunk_branch *branch = trunk_get_branch(spl, node, branch_no);
       for (uint64 pivot_no = 1; pivot_no < num_children; pivot_no++) {
-         const char *key = splinter_get_pivot(spl, node, pivot_no);
+         const char *key = trunk_get_pivot(spl, node, pivot_no);
          btree_inc_range(cc, btree_cfg, branch->root_addr, key, NULL);
       }
    }
@@ -2381,37 +2381,37 @@ splinter_bundle_inc_pivot_rc(splinter_handle *spl,
  * Returns the number of live branches (including fractional branches).
  */
 static inline uint16
-splinter_branch_count(splinter_handle *spl,
+trunk_branch_count(trunk_handle *spl,
                       page_handle     *node)
 {
-   splinter_trunk_hdr *hdr = (splinter_trunk_hdr *)node->data;
-   return splinter_branch_no_sub(spl, hdr->end_branch, hdr->start_branch);
+   trunk_hdr *hdr = (trunk_hdr *)node->data;
+   return trunk_branch_no_sub(spl, hdr->end_branch, hdr->start_branch);
 }
 
 static inline bool
-splinter_has_vacancy(splinter_handle *spl,
+trunk_has_vacancy(trunk_handle *spl,
                      page_handle     *node,
                      uint16           num_new_branches)
 {
-   uint16 branch_count = splinter_branch_count(spl, node);
+   uint16 branch_count = trunk_branch_count(spl, node);
    uint16 max_branches = spl->cfg.hard_max_branches_per_node;
    return branch_count + num_new_branches + 1 < max_branches;
 }
 
-static inline splinter_branch *
-splinter_get_branch(splinter_handle *spl,
+static inline trunk_branch *
+trunk_get_branch(trunk_handle *spl,
                     page_handle     *node,
                     uint32           k)
 {
-   debug_assert(sizeof(splinter_trunk_hdr) +
-         spl->cfg.max_pivot_keys * splinter_pivot_size(spl) +
-         (k + 1) * sizeof(splinter_branch) < spl->cfg.page_size);
+   debug_assert(sizeof(trunk_hdr) +
+         spl->cfg.max_pivot_keys * trunk_pivot_size(spl) +
+         (k + 1) * sizeof(trunk_branch) < spl->cfg.page_size);
 
    char *cursor = node->data;
-   cursor += sizeof(splinter_trunk_hdr) +
-      spl->cfg.max_pivot_keys * splinter_pivot_size(spl) +
-      k * sizeof(splinter_branch);
-   return (splinter_branch *)cursor;
+   cursor += sizeof(trunk_hdr) +
+      spl->cfg.max_pivot_keys * trunk_pivot_size(spl) +
+      k * sizeof(trunk_branch);
+   return (trunk_branch *)cursor;
 }
 
 /*
@@ -2421,39 +2421,39 @@ splinter_get_branch(splinter_handle *spl,
  * FIXME: [aconway 2020-06-21] Currently crashes if there is no room in the
  * buffer
  */
-static inline splinter_branch *
-splinter_get_new_branch(splinter_handle *spl,
+static inline trunk_branch *
+trunk_get_new_branch(trunk_handle *spl,
                         page_handle     *node)
 {
-   splinter_trunk_hdr *hdr = (splinter_trunk_hdr *)node->data;
-   splinter_branch *new_branch =
-      splinter_get_branch(spl, node, hdr->end_branch);
-   hdr->end_branch = splinter_branch_no_add(spl, hdr->end_branch, 1);
+   trunk_hdr *hdr = (trunk_hdr *)node->data;
+   trunk_branch *new_branch =
+      trunk_get_branch(spl, node, hdr->end_branch);
+   hdr->end_branch = trunk_branch_no_add(spl, hdr->end_branch, 1);
    debug_assert(hdr->end_branch != hdr->start_branch);
    return new_branch;
 }
 
 static inline uint16
-splinter_branch_no(splinter_handle *spl,
+trunk_branch_no(trunk_handle *spl,
                    page_handle     *node,
-                   splinter_branch *branch)
+                   trunk_branch *branch)
 {
-   return branch - splinter_get_branch(spl, node, 0);
+   return branch - trunk_get_branch(spl, node, 0);
 }
 
 static inline uint16
-splinter_start_branch(splinter_handle *spl,
+trunk_start_branch(trunk_handle *spl,
                       page_handle     *node)
 {
-   splinter_trunk_hdr *hdr = (splinter_trunk_hdr *)node->data;
+   trunk_hdr *hdr = (trunk_hdr *)node->data;
    return hdr->start_branch;
 }
 
 static inline uint16
-splinter_end_branch(splinter_handle *spl,
+trunk_end_branch(trunk_handle *spl,
                     page_handle     *node)
 {
-   splinter_trunk_hdr *hdr = (splinter_trunk_hdr *)node->data;
+   trunk_hdr *hdr = (trunk_hdr *)node->data;
    return hdr->end_branch;
 }
 
@@ -2461,12 +2461,12 @@ splinter_end_branch(splinter_handle *spl,
  * branch_live checks if branch_no is live for any pivot in the node.
  */
 static inline bool
-splinter_branch_live(splinter_handle *spl,
+trunk_branch_live(trunk_handle *spl,
                      page_handle     *node,
                      uint64           branch_no)
 {
-   splinter_trunk_hdr *hdr = (splinter_trunk_hdr *)node->data;
-   return splinter_branch_in_range(spl, branch_no, hdr->start_branch,
+   trunk_hdr *hdr = (trunk_hdr *)node->data;
+   return trunk_branch_in_range(spl, branch_no, hdr->start_branch,
          hdr->end_branch);
 }
 
@@ -2476,22 +2476,22 @@ splinter_branch_live(splinter_handle *spl,
  */
 __attribute__ ((unused))
 static inline bool
-splinter_branch_valid(splinter_handle *spl,
+trunk_branch_valid(trunk_handle *spl,
                       page_handle     *node,
                       uint64           branch_no)
 {
-   splinter_trunk_hdr *hdr = (splinter_trunk_hdr *)node->data;
-   return splinter_branch_no_sub(spl, branch_no, hdr->start_branch)
-      <= splinter_branch_no_sub(spl, hdr->end_branch, hdr->start_branch);
+   trunk_hdr *hdr = (trunk_hdr *)node->data;
+   return trunk_branch_no_sub(spl, branch_no, hdr->start_branch)
+      <= trunk_branch_no_sub(spl, hdr->end_branch, hdr->start_branch);
 }
 
 static inline uint64
-splinter_process_generation_to_pos(splinter_handle             *spl,
-                                   splinter_compact_bundle_req *req,
+trunk_process_generation_to_pos(trunk_handle             *spl,
+                                   trunk_compact_bundle_req *req,
                                    uint64                       generation)
 {
    uint64 pos = 0;
-   while (pos != SPLINTER_MAX_PIVOTS &&
+   while (pos != TRUNK_MAX_PIVOTS &&
           req->pivot_generation[pos] != generation) {
       pos++;
    }
@@ -2512,31 +2512,31 @@ splinter_process_generation_to_pos(splinter_handle             *spl,
  *    any remaining bundles to account)
  */
 void
-splinter_replace_bundle_branches(splinter_handle             *spl,
+trunk_replace_bundle_branches(trunk_handle             *spl,
                                  page_handle                 *node,
-                                 splinter_branch             *repl_branch,
-                                 splinter_compact_bundle_req *req)
+                                 trunk_branch             *repl_branch,
+                                 trunk_compact_bundle_req *req)
 {
-   splinter_trunk_hdr *hdr = (splinter_trunk_hdr *)node->data;
-   debug_assert(req->height == splinter_height(spl, node));
+   trunk_hdr *hdr = (trunk_hdr *)node->data;
+   debug_assert(req->height == trunk_height(spl, node));
 
    uint16 bundle_no = req->bundle_no;
-   splinter_bundle *bundle = splinter_get_bundle(spl, node, bundle_no);
-   uint16 bundle_start_branch = splinter_bundle_start_branch(spl, node, bundle);
-   uint16 bundle_end_branch = splinter_bundle_end_branch(spl, node, bundle);
-   uint16 branch_diff = splinter_bundle_branch_count(spl, node, bundle);
+   trunk_bundle *bundle = trunk_get_bundle(spl, node, bundle_no);
+   uint16 bundle_start_branch = trunk_bundle_start_branch(spl, node, bundle);
+   uint16 bundle_end_branch = trunk_bundle_end_branch(spl, node, bundle);
+   uint16 branch_diff = trunk_bundle_branch_count(spl, node, bundle);
 
    // de-ref the dead branches
-   uint16 num_children = splinter_num_children(spl, node);
+   uint16 num_children = trunk_num_children(spl, node);
    for (uint16 branch_no = bundle_start_branch;
         branch_no != bundle_end_branch;
-        branch_no = splinter_branch_no_add(spl, branch_no, 1)) {
-      splinter_branch *branch = splinter_get_branch(spl, node, branch_no);
+        branch_no = trunk_branch_no_add(spl, branch_no, 1)) {
+      trunk_branch *branch = trunk_get_branch(spl, node, branch_no);
       for (uint16 pivot_no = 0; pivot_no < num_children; pivot_no++) {
-         if (splinter_bundle_live_for_pivot(spl, node, bundle_no, pivot_no)) {
-            const char *start_key = splinter_get_pivot(spl, node, pivot_no);
-            const char *end_key = splinter_get_pivot(spl, node, pivot_no + 1);
-            splinter_zap_branch_range(spl, branch, start_key, end_key,
+         if (trunk_bundle_live_for_pivot(spl, node, bundle_no, pivot_no)) {
+            const char *start_key = trunk_get_pivot(spl, node, pivot_no);
+            const char *end_key = trunk_get_pivot(spl, node, pivot_no + 1);
+            trunk_zap_branch_range(spl, branch, start_key, end_key,
                   PAGE_TYPE_BRANCH);
          }
       }
@@ -2545,25 +2545,25 @@ splinter_replace_bundle_branches(splinter_handle             *spl,
    // add new branch
    uint16 new_branch_no = UINT16_MAX;
    if (repl_branch != NULL) {
-      splinter_branch *new_branch =
-         splinter_get_branch(spl, node, bundle_start_branch);
+      trunk_branch *new_branch =
+         trunk_get_branch(spl, node, bundle_start_branch);
       *new_branch = *repl_branch;
       branch_diff--;
-      new_branch_no = splinter_branch_no(spl, node, new_branch);
+      new_branch_no = trunk_branch_no(spl, node, new_branch);
 
       // increment the fringes of the new branch along the pivots
-      uint16 num_pivot_keys = splinter_num_pivot_keys(spl, node);
+      uint16 num_pivot_keys = trunk_num_pivot_keys(spl, node);
       for (uint16 pivot_no = 1; pivot_no < num_pivot_keys; pivot_no++) {
-         const char *start_key = splinter_get_pivot(spl, node, pivot_no);
-         splinter_inc_intersection(spl, new_branch, start_key, FALSE);
+         const char *start_key = trunk_get_pivot(spl, node, pivot_no);
+         trunk_inc_intersection(spl, new_branch, start_key, FALSE);
       }
 
       // slice out the pivots ranges for which this branch is already dead
       for (uint16 pivot_no = 0; pivot_no < num_children; pivot_no++) {
-         if (!splinter_bundle_live_for_pivot(spl, node, bundle_no, pivot_no)) {
-            const char *start_key = splinter_get_pivot(spl, node, pivot_no);
-            const char *end_key = splinter_get_pivot(spl, node, pivot_no + 1);
-            splinter_zap_branch_range(spl, new_branch, start_key, end_key, PAGE_TYPE_BRANCH);
+         if (!trunk_bundle_live_for_pivot(spl, node, bundle_no, pivot_no)) {
+            const char *start_key = trunk_get_pivot(spl, node, pivot_no);
+            const char *end_key = trunk_get_pivot(spl, node, pivot_no + 1);
+            trunk_zap_branch_range(spl, new_branch, start_key, end_key, PAGE_TYPE_BRANCH);
          }
       }
    }
@@ -2571,11 +2571,11 @@ splinter_replace_bundle_branches(splinter_handle             *spl,
    // move any remaining branches to maintain a contiguous array
    for (uint16 branch_no = bundle_end_branch;
         branch_no != hdr->end_branch;
-        branch_no = splinter_branch_no_add(spl, branch_no, 1)) {
+        branch_no = trunk_branch_no_add(spl, branch_no, 1)) {
       uint16 dst_branch_no =
-         splinter_branch_no_sub(spl, branch_no, branch_diff);
-      *splinter_get_branch(spl, node, dst_branch_no) =
-         *splinter_get_branch(spl, node, branch_no);
+         trunk_branch_no_sub(spl, branch_no, branch_diff);
+      *trunk_get_branch(spl, node, dst_branch_no) =
+         *trunk_get_branch(spl, node, branch_no);
    }
 
    /*
@@ -2583,26 +2583,26 @@ splinter_replace_bundle_branches(splinter_handle             *spl,
     */
    if (repl_branch == NULL) {
       // decrement the ref counts of the old filters
-      for (uint16 filter_no = splinter_bundle_start_filter(spl, node, bundle);
-           filter_no != splinter_bundle_end_filter(spl, node, bundle);
-           filter_no = splinter_subbundle_no_add(spl, filter_no, 1)) {
+      for (uint16 filter_no = trunk_bundle_start_filter(spl, node, bundle);
+           filter_no != trunk_bundle_end_filter(spl, node, bundle);
+           filter_no = trunk_subbundle_no_add(spl, filter_no, 1)) {
          routing_filter *old_filter =
-            splinter_get_sb_filter(spl, node, filter_no);
-         splinter_dec_filter(spl, old_filter);
+            trunk_get_sb_filter(spl, node, filter_no);
+         trunk_dec_filter(spl, old_filter);
          //platform_log("dec filter %lu in %lu (%u)\n",
          //      old_filter->addr, node->disk_addr,
          //      allocator_get_refcount(spl->al, old_filter->addr));
       }
 
       // move any later filters
-      uint16 filter_diff = splinter_bundle_filter_count(spl, node, bundle);
-      for (uint16 filter_no = splinter_bundle_end_filter(spl, node, bundle);
-           filter_no != splinter_end_sb_filter(spl, node);
-           filter_no = splinter_subbundle_no_add(spl, filter_no, 1)) {
+      uint16 filter_diff = trunk_bundle_filter_count(spl, node, bundle);
+      for (uint16 filter_no = trunk_bundle_end_filter(spl, node, bundle);
+           filter_no != trunk_end_sb_filter(spl, node);
+           filter_no = trunk_subbundle_no_add(spl, filter_no, 1)) {
          uint16 dst_filter_no =
-            splinter_subbundle_no_sub(spl, filter_no, filter_diff);
-         *splinter_get_sb_filter(spl, node, dst_filter_no) =
-            *splinter_get_sb_filter(spl, node, filter_no);
+            trunk_subbundle_no_sub(spl, filter_no, filter_diff);
+         *trunk_get_sb_filter(spl, node, dst_filter_no) =
+            *trunk_get_sb_filter(spl, node, filter_no);
       }
    }
 
@@ -2610,79 +2610,79 @@ splinter_replace_bundle_branches(splinter_handle             *spl,
     * the compacted bundle will have a single branch in a single subbundle
     * containing all the filters.
     */
-   uint16 sb_diff = splinter_bundle_subbundle_count(spl, node, bundle);
+   uint16 sb_diff = trunk_bundle_subbundle_count(spl, node, bundle);
    uint16 first_later_sb = bundle->end_subbundle;
    if (repl_branch != NULL) {
       uint16 sb_no = bundle->start_subbundle;
-      splinter_subbundle *sb = splinter_get_subbundle(spl, node, sb_no);
-      sb->end_branch = splinter_branch_no_add(spl, bundle_start_branch, 1);
-      sb->end_filter = splinter_bundle_end_filter(spl, node, bundle);
+      trunk_subbundle *sb = trunk_get_subbundle(spl, node, sb_no);
+      sb->end_branch = trunk_branch_no_add(spl, bundle_start_branch, 1);
+      sb->end_filter = trunk_bundle_end_filter(spl, node, bundle);
       sb->state = SB_STATE_COMPACTED;
       sb_diff--;
-      bundle->end_subbundle = splinter_subbundle_no_add(spl, sb_no, 1);
+      bundle->end_subbundle = trunk_subbundle_no_add(spl, sb_no, 1);
    }
 
    for (uint16 sb_no = first_later_sb;
         sb_no != hdr->end_subbundle;
-        sb_no = splinter_subbundle_no_add(spl, sb_no, 1)) {
-      splinter_subbundle *sb = splinter_get_subbundle(spl, node, sb_no);
+        sb_no = trunk_subbundle_no_add(spl, sb_no, 1)) {
+      trunk_subbundle *sb = trunk_get_subbundle(spl, node, sb_no);
       sb->start_branch =
-         splinter_branch_no_sub(spl, sb->start_branch, branch_diff);
-      sb->end_branch = splinter_branch_no_sub(spl, sb->end_branch, branch_diff);
-      uint16 dst_sb_no = splinter_subbundle_no_sub(spl, sb_no, sb_diff);
-      *splinter_get_subbundle(spl, node, dst_sb_no) = *sb;
+         trunk_branch_no_sub(spl, sb->start_branch, branch_diff);
+      sb->end_branch = trunk_branch_no_sub(spl, sb->end_branch, branch_diff);
+      uint16 dst_sb_no = trunk_subbundle_no_sub(spl, sb_no, sb_diff);
+      *trunk_get_subbundle(spl, node, dst_sb_no) = *sb;
    }
    hdr->end_subbundle =
-      splinter_subbundle_no_sub(spl, hdr->end_subbundle, sb_diff);
-   for (uint16 later_bundle_no = splinter_bundle_no_add(spl, bundle_no, 1);
+      trunk_subbundle_no_sub(spl, hdr->end_subbundle, sb_diff);
+   for (uint16 later_bundle_no = trunk_bundle_no_add(spl, bundle_no, 1);
         later_bundle_no != hdr->end_bundle;
-        later_bundle_no = splinter_bundle_no_add(spl, later_bundle_no, 1)) {
-      splinter_bundle *bundle = splinter_get_bundle(spl, node, later_bundle_no);
+        later_bundle_no = trunk_bundle_no_add(spl, later_bundle_no, 1)) {
+      trunk_bundle *bundle = trunk_get_bundle(spl, node, later_bundle_no);
       bundle->start_subbundle =
-         splinter_subbundle_no_sub(spl, bundle->start_subbundle, sb_diff);
+         trunk_subbundle_no_sub(spl, bundle->start_subbundle, sb_diff);
       bundle->end_subbundle =
-         splinter_subbundle_no_sub(spl, bundle->end_subbundle, sb_diff);
+         trunk_subbundle_no_sub(spl, bundle->end_subbundle, sb_diff);
    }
-   debug_assert(splinter_bundle_start_branch(spl, node, bundle) ==
+   debug_assert(trunk_bundle_start_branch(spl, node, bundle) ==
                 bundle_start_branch);
 
    if (repl_branch == NULL) {
       for (uint16 later_bundle_no = bundle_no;
-           later_bundle_no != splinter_bundle_no_sub(spl, hdr->end_bundle, 1);
-           later_bundle_no = splinter_bundle_no_add(spl, later_bundle_no, 1)) {
+           later_bundle_no != trunk_bundle_no_sub(spl, hdr->end_bundle, 1);
+           later_bundle_no = trunk_bundle_no_add(spl, later_bundle_no, 1)) {
          uint16 src_later_bundle_no =
-            splinter_bundle_no_add(spl, later_bundle_no, 1);
-         *splinter_get_bundle(spl, node, later_bundle_no) =
-            *splinter_get_bundle(spl, node, src_later_bundle_no);
+            trunk_bundle_no_add(spl, later_bundle_no, 1);
+         *trunk_get_bundle(spl, node, later_bundle_no) =
+            *trunk_get_bundle(spl, node, src_later_bundle_no);
       }
-      hdr->end_bundle = splinter_bundle_no_sub(spl, hdr->end_bundle, 1);
+      hdr->end_bundle = trunk_bundle_no_sub(spl, hdr->end_bundle, 1);
    }
 
    // fix the pivot start branches
    for (uint16 pivot_no = 0; pivot_no < num_children; pivot_no++) {
-      splinter_pivot_data *pdata = splinter_get_pivot_data(spl, node, pivot_no);
-      if (!splinter_branch_live_for_pivot(spl, node, bundle_start_branch,
+      trunk_pivot_data *pdata = trunk_get_pivot_data(spl, node, pivot_no);
+      if (!trunk_branch_live_for_pivot(spl, node, bundle_start_branch,
                pivot_no)) {
          pdata->start_branch =
-            splinter_branch_no_sub(spl, pdata->start_branch, branch_diff);
-         debug_assert(splinter_branch_valid(spl, node, pdata->start_branch));
+            trunk_branch_no_sub(spl, pdata->start_branch, branch_diff);
+         debug_assert(trunk_branch_valid(spl, node, pdata->start_branch));
       }
    }
 
    // fix the pivot tuples
    for (uint16 pivot_no = 0; pivot_no < num_children; pivot_no++) {
-      if (splinter_bundle_live_for_pivot(spl, node, bundle_no, pivot_no)) {
-         splinter_pivot_data *pdata =
-            splinter_get_pivot_data(spl, node, pivot_no);
+      if (trunk_bundle_live_for_pivot(spl, node, bundle_no, pivot_no)) {
+         trunk_pivot_data *pdata =
+            trunk_get_pivot_data(spl, node, pivot_no);
          uint64 pos =
-            splinter_process_generation_to_pos(spl, req, pdata->generation);
-         platform_assert(pos != SPLINTER_MAX_PIVOTS);
+            trunk_process_generation_to_pos(spl, req, pdata->generation);
+         platform_assert(pos != TRUNK_MAX_PIVOTS);
          uint64 bundle_num_tuples = req->input_pivot_count[pos];
          debug_assert(pdata->num_tuples >= bundle_num_tuples);
          pdata->num_tuples -= bundle_num_tuples;
          if (repl_branch != NULL) {
             req->output_pivot_count[pos] =
-               splinter_pivot_tuples_in_branch(spl, node, pivot_no,
+               trunk_pivot_tuples_in_branch(spl, node, pivot_no,
                new_branch_no);
             pdata->num_tuples += req->output_pivot_count[pos];
          }
@@ -2692,12 +2692,12 @@ splinter_replace_bundle_branches(splinter_handle             *spl,
    }
 
    // update the end_branch
-   hdr->end_branch = splinter_branch_no_sub(spl, hdr->end_branch, branch_diff);
+   hdr->end_branch = trunk_branch_no_sub(spl, hdr->end_branch, branch_diff);
 }
 
 static inline void
-splinter_inc_branch_range(splinter_handle *spl,
-                          splinter_branch *branch,
+trunk_inc_branch_range(trunk_handle *spl,
+                          trunk_branch *branch,
                           const char      *start_key,
                           const char      *end_key)
 {
@@ -2708,8 +2708,8 @@ splinter_inc_branch_range(splinter_handle *spl,
 }
 
 static inline void
-splinter_zap_branch_range(splinter_handle *spl,
-                          splinter_branch *branch,
+trunk_zap_branch_range(trunk_handle *spl,
+                          trunk_branch *branch,
                           const char      *start_key,
                           const char      *end_key,
                           page_type        type)
@@ -2731,29 +2731,29 @@ splinter_zap_branch_range(splinter_handle *spl,
  * reaches 0.
  */
 static inline void
-splinter_dec_ref(splinter_handle *spl,
-                 splinter_branch *branch,
+trunk_dec_ref(trunk_handle *spl,
+                 trunk_branch *branch,
                  bool             is_memtable)
 {
    page_type type = is_memtable ? PAGE_TYPE_MEMTABLE : PAGE_TYPE_BRANCH;
-   splinter_zap_branch_range(spl, branch, NULL, NULL, type);
+   trunk_zap_branch_range(spl, branch, NULL, NULL, type);
 }
 
 /*
  * Increment the ref count for all extents whose key range intersects with key
  */
 static inline void
-splinter_inc_intersection(splinter_handle *spl,
-                          splinter_branch *branch,
+trunk_inc_intersection(trunk_handle *spl,
+                          trunk_branch *branch,
                           const char      *key,
                           bool             is_memtable)
 {
    platform_assert(IMPLIES(is_memtable, key == NULL));
-   splinter_inc_branch_range(spl, branch, key, NULL);
+   trunk_inc_branch_range(spl, branch, key, NULL);
 }
 
 /*
- * splinter_btree_lookup performs a lookup for key in branch.
+ * trunk_btree_lookup performs a lookup for key in branch.
  *
  * Pre-conditions:
  *    If *found
@@ -2765,8 +2765,8 @@ splinter_inc_intersection(splinter_handle *spl,
  */
 
 static inline bool
-splinter_btree_lookup(splinter_handle *spl,
-                      splinter_branch *branch,
+trunk_btree_lookup(trunk_handle *spl,
+                      trunk_branch *branch,
                       const char      *key,
                       char            *data,
                       bool            *found)
@@ -2786,7 +2786,7 @@ splinter_btree_lookup(splinter_handle *spl,
       if (needs_merge) {
          data_merge_tuples(data_cfg, key, data_temp, data);
       } else {
-         memmove(data, data_temp, splinter_message_size(spl));
+         memmove(data, data_temp, trunk_message_size(spl));
       }
       btree_node_unget(cc, cfg, &node);
    }
@@ -2796,7 +2796,7 @@ splinter_btree_lookup(splinter_handle *spl,
 
 /*
  *-----------------------------------------------------------------------------
- * splinter_btree_lookup_async
+ * trunk_btree_lookup_async
  *
  * Pre-conditions:
  *    The ctxt should've been initialized using btree_ctxt_init().
@@ -2820,8 +2820,8 @@ splinter_btree_lookup(splinter_handle *spl,
  */
 
 static cache_async_result
-splinter_btree_lookup_async(splinter_handle     *spl,      // IN
-                            splinter_branch     *branch,   // IN
+trunk_btree_lookup_async(trunk_handle     *spl,      // IN
+                            trunk_branch     *branch,   // IN
                             char                *key,      // IN
                             char                *data,     // OUT
                             bool                *found,    // IN/OUT
@@ -2843,7 +2843,7 @@ splinter_btree_lookup_async(splinter_handle     *spl,      // IN
       if (needs_merge) {
          data_merge_tuples(data_cfg, key, data_temp, data);
       } else {
-         memmove(data, data_temp, splinter_message_size(spl));
+         memmove(data, data_temp, trunk_message_size(spl));
       }
       btree_node_unget(cc, cfg, &node);
    }
@@ -2863,11 +2863,11 @@ splinter_btree_lookup_async(splinter_handle     *spl,      // IN
 // FIXME: [aconway 2020-09-02] Both these functions (get_memtable and
 // try_get_memtable) belong in memtable.[ch]
 memtable *
-splinter_try_get_memtable(splinter_handle *spl,
+trunk_try_get_memtable(trunk_handle *spl,
                           uint64           generation)
 {
    // FIXME: [aconway 2020-09-01] change to cfg
-   uint64 memtable_idx = generation % SPLINTER_NUM_MEMTABLES;
+   uint64 memtable_idx = generation % TRUNK_NUM_MEMTABLES;
    memtable *mt = &spl->mt_ctxt->mt[memtable_idx];
    if (mt->generation != generation) {
       mt = NULL;
@@ -2880,43 +2880,43 @@ splinter_try_get_memtable(splinter_handle *spl,
  * that there exists a memtable with the appropriate generation.
  */
 memtable *
-splinter_get_memtable(splinter_handle *spl,
+trunk_get_memtable(trunk_handle *spl,
                       uint64           generation)
 {
    // FIXME: [aconway 2020-09-01] change to cfg
-   uint64 memtable_idx = generation % SPLINTER_NUM_MEMTABLES;
+   uint64 memtable_idx = generation % TRUNK_NUM_MEMTABLES;
    memtable *mt = &spl->mt_ctxt->mt[memtable_idx];
    platform_assert(mt->generation == generation);
    return mt;
 }
 
-splinter_compacted_memtable *
-splinter_get_compacted_memtable(splinter_handle *spl,
+trunk_compacted_memtable *
+trunk_get_compacted_memtable(trunk_handle *spl,
                                 uint64           generation)
 {
-   uint64 memtable_idx = generation % SPLINTER_NUM_MEMTABLES;
+   uint64 memtable_idx = generation % TRUNK_NUM_MEMTABLES;
 
    // this call asserts the generation is correct
-   memtable *mt = splinter_get_memtable(spl, generation);
+   memtable *mt = trunk_get_memtable(spl, generation);
    platform_assert(mt->state != MEMTABLE_STATE_READY);
 
    return &spl->compacted_memtable[memtable_idx];
 }
 
 static inline void
-splinter_memtable_inc_ref(splinter_handle *spl,
+trunk_memtable_inc_ref(trunk_handle *spl,
                           uint64           mt_gen)
 {
-   memtable *mt = splinter_get_memtable(spl, mt_gen);
+   memtable *mt = trunk_get_memtable(spl, mt_gen);
    allocator_inc_refcount(spl->al, mt->root_addr);
 }
 
 
 void
-splinter_memtable_dec_ref(splinter_handle *spl,
+trunk_memtable_dec_ref(trunk_handle *spl,
                           uint64           generation)
 {
-   memtable *mt = splinter_get_memtable(spl, generation);
+   memtable *mt = trunk_get_memtable(spl, generation);
    memtable_dec_ref_maybe_recycle(spl->mt_ctxt, mt);
 
    // the branch in the compacted memtable is now in the tree, so don't zap it,
@@ -2929,7 +2929,7 @@ splinter_memtable_dec_ref(splinter_handle *spl,
  * the memtable ref count and cleans up if ref count == 0
  */
 static void
-splinter_memtable_iterator_init(splinter_handle *spl,
+trunk_memtable_iterator_init(trunk_handle *spl,
                                 btree_iterator  *itor,
                                 uint64           root_addr,
                                 const char      *min_key,
@@ -2953,14 +2953,14 @@ splinter_memtable_iterator_init(splinter_handle *spl,
 }
 
 static void
-splinter_memtable_iterator_deinit(splinter_handle *spl,
+trunk_memtable_iterator_deinit(trunk_handle *spl,
                                   btree_iterator  *itor,
                                   uint64           mt_gen,
                                   bool             dec_refcount)
 {
    btree_iterator_deinit(itor);
    if (dec_refcount) {
-      splinter_memtable_dec_ref(spl, mt_gen);
+      trunk_memtable_dec_ref(spl, mt_gen);
    }
 }
 
@@ -2974,7 +2974,7 @@ splinter_memtable_iterator_deinit(splinter_handle *spl,
  *       responsible for flushing it.
  */
 platform_status
-splinter_memtable_insert(splinter_handle *spl,
+trunk_memtable_insert(trunk_handle *spl,
                          char            *key,
                          char            *data)
 {
@@ -2987,7 +2987,7 @@ splinter_memtable_insert(splinter_handle *spl,
    }
 
    // this call is safe because we hold the insert lock
-   memtable *mt = splinter_get_memtable(spl, generation);
+   memtable *mt = trunk_get_memtable(spl, generation);
    uint64 leaf_generation; // used for ordering the log
    rc = memtable_insert(spl->mt_ctxt, mt, key, data, &leaf_generation);
    if (!SUCCESS(rc)) {
@@ -3012,20 +3012,20 @@ out:
  * Returns a pointer to the memtable.
  */
 static memtable *
-splinter_memtable_compact_and_build_filter(splinter_handle *spl,
+trunk_memtable_compact_and_build_filter(trunk_handle *spl,
                                            uint64           generation,
                                            const threadid   tid)
 {
    timestamp comp_start = platform_get_timestamp();
 
-   memtable *mt = splinter_get_memtable(spl, generation);
+   memtable *mt = trunk_get_memtable(spl, generation);
 
    memtable_transition(mt, MEMTABLE_STATE_FINALIZED, MEMTABLE_STATE_COMPACTING);
    mini_allocator_release(&mt->mini, NULL);
 
-   splinter_compacted_memtable *cmt =
-      splinter_get_compacted_memtable(spl, generation);
-   splinter_branch *new_branch = &cmt->branch;
+   trunk_compacted_memtable *cmt =
+      trunk_get_compacted_memtable(spl, generation);
+   trunk_branch *new_branch = &cmt->branch;
    ZERO_CONTENTS(new_branch);
 
    uint64          memtable_root_addr = mt->root_addr;
@@ -3033,7 +3033,7 @@ splinter_memtable_compact_and_build_filter(splinter_handle *spl,
    iterator       *itor = &btree_itor.super;
    const char     *min_key = spl->cfg.data_cfg->min_key;
 
-   splinter_memtable_iterator_init(spl, &btree_itor, memtable_root_addr,
+   trunk_memtable_iterator_init(spl, &btree_itor, memtable_root_addr,
          min_key, NULL, FALSE, FALSE);
    btree_pack_req  req;
    btree_pack_req_init(&req, spl->cc, &spl->cfg.btree_cfg, itor,
@@ -3055,7 +3055,7 @@ splinter_memtable_compact_and_build_filter(splinter_handle *spl,
          spl->stats[tid].root_compaction_max_tuples = req.num_tuples;
       }
    }
-   splinter_memtable_iterator_deinit(spl, &btree_itor, FALSE, FALSE);
+   trunk_memtable_iterator_deinit(spl, &btree_itor, FALSE, FALSE);
 
    new_branch->root_addr = req.root_addr;
 
@@ -3108,13 +3108,13 @@ splinter_memtable_compact_and_build_filter(splinter_handle *spl,
  *       should_wait will be set to generation, so try_start will incorp
  */
 static inline bool
-splinter_try_start_incorporate(splinter_handle *spl,
+trunk_try_start_incorporate(trunk_handle *spl,
                                uint64           generation)
 {
    bool should_start = FALSE;
 
    memtable_lock_incorporation_lock(spl->mt_ctxt);
-   memtable *mt = splinter_try_get_memtable(spl, generation);
+   memtable *mt = trunk_try_get_memtable(spl, generation);
    if ((mt == NULL) ||
        (generation != memtable_generation_to_incorporate(spl->mt_ctxt)))
    {
@@ -3132,13 +3132,13 @@ unlock_incorp_lock:
 }
 
 static inline bool
-splinter_try_continue_incorporate(splinter_handle *spl,
+trunk_try_continue_incorporate(trunk_handle *spl,
                                   uint64           next_generation)
 {
    bool should_continue = FALSE;
 
    memtable_lock_incorporation_lock(spl->mt_ctxt);
-   memtable *mt = splinter_try_get_memtable(spl, next_generation);
+   memtable *mt = trunk_try_get_memtable(spl, next_generation);
    if (mt == NULL) {
       should_continue = FALSE;
       goto unlock_incorp_lock;
@@ -3171,7 +3171,7 @@ unlock_incorp_lock:
  */
 
 static void
-splinter_memtable_incorporate(splinter_handle *spl,
+trunk_memtable_incorporate(trunk_handle *spl,
                               uint64           generation,
                               const threadid   tid)
 {
@@ -3185,13 +3185,13 @@ splinter_memtable_incorporate(splinter_handle *spl,
    //    * If the memtable is empty, we do not want to incorporate it,
    //    * just release the claim , read lock and zap.
    //    */
-   //   splinter_branch memtable_branch;
+   //   trunk_branch memtable_branch;
    //   ZERO_STRUCT(memtable_branch);
    //   memtable_branch.root_addr = spl->memtable[curr_memtable]->root_addr;
-   //   splinter_clear_memtable(spl, spl->memtable[curr_memtable]);
-   //   splinter_node_unclaim(spl, root);
-   //   splinter_node_unget(spl, &root);
-   //   splinter_dec_ref(spl, &memtable_branch, TRUE);
+   //   trunk_clear_memtable(spl, spl->memtable[curr_memtable]);
+   //   trunk_node_unclaim(spl, root);
+   //   trunk_node_unget(spl, &root);
+   //   trunk_dec_ref(spl, &memtable_branch, TRUE);
    //   return;
    //}
 
@@ -3204,17 +3204,17 @@ splinter_memtable_incorporate(splinter_handle *spl,
    memtable_increment_to_generation_retired(spl->mt_ctxt, generation);
 
    // X. Get, claim and lock the root
-   page_handle *root = splinter_node_get(spl, spl->root_addr);
-   splinter_node_claim(spl, &root);
+   page_handle *root = trunk_node_get(spl, spl->root_addr);
+   trunk_node_claim(spl, &root);
    // FIXME: [aconway 2020-08-31] Change this to account for possibly
    //        incorporating more than 1 memtable
-   platform_assert(splinter_has_vacancy(spl, root, 1));
-   splinter_node_lock(spl, root);
+   platform_assert(trunk_has_vacancy(spl, root, 1));
+   trunk_node_lock(spl, root);
 
-   splinter_open_log_stream();
-   splinter_log_stream("incorporate memtable gen %lu into root %lu\n", generation, spl->root_addr);
-   splinter_log_node(spl, root);
-   splinter_log_stream("----------------------------------------\n");
+   trunk_open_log_stream();
+   trunk_log_stream("incorporate memtable gen %lu into root %lu\n", generation, spl->root_addr);
+   trunk_log_node(spl, root);
+   trunk_log_stream("----------------------------------------\n");
 
    // X. Release lookup lock
    memtable_unlock_unclaim_unget_lookup_lock(spl->mt_ctxt, mt_lookup_lock_page);
@@ -3222,47 +3222,47 @@ splinter_memtable_incorporate(splinter_handle *spl,
    /*
     * X. Get a new branch in a bundle for the memtable
     */
-   splinter_compacted_memtable *cmt =
-      splinter_get_compacted_memtable(spl, generation);
-   splinter_compact_bundle_req *req = cmt->req;
-   req->bundle_no = splinter_get_new_bundle(spl, root);
-   splinter_bundle *bundle = splinter_get_bundle(spl, root, req->bundle_no);
-   splinter_subbundle *sb = splinter_get_new_subbundle(spl, root, 1);
-   splinter_branch *branch = splinter_get_new_branch(spl, root);
+   trunk_compacted_memtable *cmt =
+      trunk_get_compacted_memtable(spl, generation);
+   trunk_compact_bundle_req *req = cmt->req;
+   req->bundle_no = trunk_get_new_bundle(spl, root);
+   trunk_bundle *bundle = trunk_get_bundle(spl, root, req->bundle_no);
+   trunk_subbundle *sb = trunk_get_new_subbundle(spl, root, 1);
+   trunk_branch *branch = trunk_get_new_branch(spl, root);
    *branch = cmt->branch;
-   bundle->start_subbundle = splinter_subbundle_no(spl, root, sb);
-   bundle->end_subbundle = splinter_end_subbundle(spl, root);
-   sb->start_branch = splinter_branch_no(spl, root, branch);
-   sb->end_branch = splinter_end_branch(spl, root);
+   bundle->start_subbundle = trunk_subbundle_no(spl, root, sb);
+   bundle->end_subbundle = trunk_end_subbundle(spl, root);
+   sb->start_branch = trunk_branch_no(spl, root, branch);
+   sb->end_branch = trunk_end_branch(spl, root);
    sb->state = SB_STATE_COMPACTED;
-   routing_filter *filter = splinter_subbundle_filter(spl, root, sb, 0);
+   routing_filter *filter = trunk_subbundle_filter(spl, root, sb, 0);
    *filter = cmt->filter;
    req->spl = spl;
    req->addr = spl->root_addr;
-   req->height = splinter_height(spl, root);
-   req->generation = splinter_generation(spl, root);
-   req->max_pivot_generation = splinter_pivot_generation(spl, root);
+   req->height = trunk_height(spl, root);
+   req->generation = trunk_generation(spl, root);
+   req->max_pivot_generation = trunk_pivot_generation(spl, root);
    // FIXME: [aconway 2020-09-01] This should happen during claim before
    // lock, for root maybe even just read (SPLINTER-87)
-   splinter_tuples_in_bundle(spl, root, bundle, req->output_pivot_count);
-   splinter_pivot_add_bundle_num_tuples(spl, root, bundle, req->output_pivot_count);
-   uint16 num_children = splinter_num_children(spl, root);
+   trunk_tuples_in_bundle(spl, root, bundle, req->output_pivot_count);
+   trunk_pivot_add_bundle_num_tuples(spl, root, bundle, req->output_pivot_count);
+   uint16 num_children = trunk_num_children(spl, root);
    for (uint16 pivot_no = 0; pivot_no < num_children; pivot_no++) {
       if (pivot_no != 0) {
-         const char *key = splinter_get_pivot(spl, root, pivot_no);
-         splinter_inc_intersection(spl, branch, key, FALSE);
+         const char *key = trunk_get_pivot(spl, root, pivot_no);
+         trunk_inc_intersection(spl, branch, key, FALSE);
       }
-      splinter_pivot_data *pdata = splinter_get_pivot_data(spl, root, pivot_no);
+      trunk_pivot_data *pdata = trunk_get_pivot_data(spl, root, pivot_no);
       req->pivot_generation[pivot_no] = pdata->generation;
    }
-   debug_assert(splinter_subbundle_branch_count(spl, root, sb) != 0);
-   splinter_log_stream("enqueuing build filter %lu-%u\n",
+   debug_assert(trunk_subbundle_branch_count(spl, root, sb) != 0);
+   trunk_log_stream("enqueuing build filter %lu-%u\n",
          req->addr, req->bundle_no);
-   task_enqueue(spl->ts, TASK_TYPE_NORMAL, splinter_bundle_build_filters, req,
+   task_enqueue(spl->ts, TASK_TYPE_NORMAL, trunk_bundle_build_filters, req,
                 TRUE);
 
    // X. Incorporate new memtable into the bundle
-   memtable *mt = splinter_get_memtable(spl, generation);
+   memtable *mt = trunk_get_memtable(spl, generation);
    // Normally need to hold incorp_mutex, but debug code and also guaranteed no
    // one is changing gen_to_incorp (we are the only thread that would try)
    debug_assert(generation == memtable_generation_to_incorporate(spl->mt_ctxt));
@@ -3278,10 +3278,10 @@ splinter_memtable_incorporate(splinter_handle *spl,
 
    memtable_transition(
          mt, MEMTABLE_STATE_INCORPORATING, MEMTABLE_STATE_INCORPORATED);
-   splinter_log_node(spl, root);
-   splinter_log_stream("----------------------------------------\n");
-   splinter_log_stream("\n");
-   splinter_close_log_stream();
+   trunk_log_node(spl, root);
+   trunk_log_stream("----------------------------------------\n");
+   trunk_log_stream("\n");
+   trunk_close_log_stream();
 
    // X. If root is full, flush until it is no longer full
    uint64 flush_start;
@@ -3290,25 +3290,25 @@ splinter_memtable_incorporate(splinter_handle *spl,
    }
    bool did_flush = FALSE;
    uint64 wait = 1;
-   while (!did_flush && splinter_node_is_full(spl, root)) {
-      did_flush = splinter_flush_fullest(spl, root);
+   while (!did_flush && trunk_node_is_full(spl, root)) {
+      did_flush = trunk_flush_fullest(spl, root);
       if (!did_flush) {
-         splinter_node_unlock(spl, root);
+         trunk_node_unlock(spl, root);
          platform_sleep(wait);
          wait = wait > 2048 ? 2048 : 2 * wait;
-         splinter_node_lock(spl, root);
+         trunk_node_lock(spl, root);
       }
    }
 
    // X. If necessary, split the root
-   if (splinter_needs_split(spl, root)) {
-      splinter_split_root(spl, root);
+   if (trunk_needs_split(spl, root)) {
+      trunk_split_root(spl, root);
    }
 
    // X. Unlock the root
-   splinter_node_unlock(spl, root);
-   splinter_node_unclaim(spl, root);
-   splinter_node_unget(spl, &root);
+   trunk_node_unlock(spl, root);
+   trunk_node_unclaim(spl, root);
+   trunk_node_unget(spl, &root);
 
    // X. Dec-ref the now-incorporated memtable
    memtable_dec_ref_maybe_recycle(spl->mt_ctxt, mt);
@@ -3335,30 +3335,30 @@ splinter_memtable_incorporate(splinter_handle *spl,
  */
 
 static void
-splinter_memtable_flush_internal(splinter_handle *spl,
+trunk_memtable_flush_internal(trunk_handle *spl,
                                  uint64           generation)
 {
    const threadid tid = platform_get_tid();
    // pack and build filter.
-   splinter_memtable_compact_and_build_filter(spl, generation, tid);
+   trunk_memtable_compact_and_build_filter(spl, generation, tid);
 
    // If we are assigned to do so, incorporate the memtable onto the root node.
-   if (!splinter_try_start_incorporate(spl, generation)) {
+   if (!trunk_try_start_incorporate(spl, generation)) {
       goto out;
    }
    do {
-      splinter_memtable_incorporate(spl, generation, tid);
+      trunk_memtable_incorporate(spl, generation, tid);
       generation++;
-   } while (splinter_try_continue_incorporate(spl, generation));
+   } while (trunk_try_continue_incorporate(spl, generation));
 out:
    return;
 }
 
 static void
-splinter_memtable_flush_internal_virtual(void *arg, void *scratch)
+trunk_memtable_flush_internal_virtual(void *arg, void *scratch)
 {
-   splinter_memtable_args *mt_args = arg;
-   splinter_memtable_flush_internal(mt_args->spl, mt_args->generation);
+   trunk_memtable_args *mt_args = arg;
+   trunk_memtable_flush_internal(mt_args->spl, mt_args->generation);
 }
 
 /*
@@ -3372,40 +3372,40 @@ splinter_memtable_flush_internal_virtual(void *arg, void *scratch)
  */
 
 void
-splinter_memtable_flush(splinter_handle *spl,
+trunk_memtable_flush(trunk_handle *spl,
                         uint64           generation)
 {
-   splinter_compacted_memtable *cmt =
-      splinter_get_compacted_memtable(spl, generation);
+   trunk_compacted_memtable *cmt =
+      trunk_get_compacted_memtable(spl, generation);
    cmt->mt_args.spl = spl;
    cmt->mt_args.generation = generation;
    task_enqueue(spl->ts, TASK_TYPE_MEMTABLE,
-         splinter_memtable_flush_internal_virtual, &cmt->mt_args, FALSE);
+         trunk_memtable_flush_internal_virtual, &cmt->mt_args, FALSE);
 }
 
 void
-splinter_memtable_flush_virtual(void   *arg,
+trunk_memtable_flush_virtual(void   *arg,
                                 uint64  generation)
 {
-   splinter_handle *spl = arg;
-   splinter_memtable_flush(spl, generation);
+   trunk_handle *spl = arg;
+   trunk_memtable_flush(spl, generation);
 }
 
 static inline uint64
-splinter_memtable_root_addr_for_lookup(splinter_handle *spl,
+trunk_memtable_root_addr_for_lookup(trunk_handle *spl,
                                        uint64           generation,
                                        bool            *is_compacted)
 {
    // FIXME: [aconway 2020-09-02] This needs to be try or the caller needs to
    // try (and then pass the mt into here)
-   memtable *mt = splinter_get_memtable(spl, generation);
+   memtable *mt = trunk_get_memtable(spl, generation);
    platform_assert(memtable_ok_to_lookup(mt));
 
    if (memtable_ok_to_lookup_compacted(mt)) {
       // lookup in packed tree
       *is_compacted = TRUE;
-      splinter_compacted_memtable *cmt =
-         splinter_get_compacted_memtable(spl, generation);
+      trunk_compacted_memtable *cmt =
+         trunk_get_compacted_memtable(spl, generation);
       return cmt->branch.root_addr;
    } else {
       *is_compacted = FALSE;
@@ -3414,7 +3414,7 @@ splinter_memtable_root_addr_for_lookup(splinter_handle *spl,
 }
 
 /*
- * splinter_memtable_lookup
+ * trunk_memtable_lookup
  *
  * Pre-conditions:
  *    If *found
@@ -3425,7 +3425,7 @@ splinter_memtable_root_addr_for_lookup(splinter_handle *spl,
  *    if *found, the data can be found in `data`.
  */
 static bool
-splinter_memtable_lookup(splinter_handle *spl,
+trunk_memtable_lookup(trunk_handle *spl,
                          uint64           generation,
                          char            *key,
                          char            *data,
@@ -3443,7 +3443,7 @@ splinter_memtable_lookup(splinter_handle *spl,
 
    // FIXME: [aconway 2020-09-01] Maybe use this in stats
    bool memtable_is_compacted;
-   uint64 root_addr = splinter_memtable_root_addr_for_lookup(spl, generation,
+   uint64 root_addr = trunk_memtable_root_addr_for_lookup(spl, generation,
          &memtable_is_compacted);
    btree_lookup_with_ref(cc, cfg, root_addr, &node, PAGE_TYPE_MEMTABLE, key,
          &data_temp, &local_found);
@@ -3453,7 +3453,7 @@ splinter_memtable_lookup(splinter_handle *spl,
       if (needs_merge) {
          data_merge_tuples(data_cfg, key, data_temp, data);
       } else {
-         memmove(data, data_temp, splinter_message_size(spl));
+         memmove(data, data_temp, trunk_message_size(spl));
       }
       btree_node_unget(cc, cfg, &node);
       message_type type = data_message_class(data_cfg, data);
@@ -3473,7 +3473,7 @@ splinter_memtable_lookup(splinter_handle *spl,
  */
 
 static inline routing_config *
-splinter_routing_cfg(splinter_handle *spl,
+trunk_routing_cfg(trunk_handle *spl,
                      bool             is_leaf)
 {
    //if (is_leaf) {
@@ -3484,7 +3484,7 @@ splinter_routing_cfg(splinter_handle *spl,
 }
 
 static inline void
-splinter_inc_filter(splinter_handle *spl,
+trunk_inc_filter(trunk_handle *spl,
                     routing_filter  *filter)
 {
    debug_assert(filter->addr != 0);
@@ -3493,7 +3493,7 @@ splinter_inc_filter(splinter_handle *spl,
 }
 
 static inline void
-splinter_dec_filter(splinter_handle *spl,
+trunk_dec_filter(trunk_handle *spl,
                     routing_filter  *filter)
 {
    if (filter->addr == 0) {
@@ -3535,38 +3535,38 @@ splinter_dec_filter(splinter_handle *spl,
 }
 
 static inline page_handle *
-splinter_node_get_maybe_descend(splinter_handle             *spl,
-                                splinter_compact_bundle_req *req)
+trunk_node_get_maybe_descend(trunk_handle             *spl,
+                                trunk_compact_bundle_req *req)
 {
-   page_handle *node = splinter_node_get(spl, req->addr);
-   while (splinter_height(spl, node) != req->height) {
-      debug_assert(splinter_height(spl, node) > req->height);
+   page_handle *node = trunk_node_get(spl, req->addr);
+   while (trunk_height(spl, node) != req->height) {
+      debug_assert(trunk_height(spl, node) > req->height);
       debug_assert(req->height != 0);
-      splinter_pivot_data *pdata = splinter_get_pivot_data(spl, node, 0);
+      trunk_pivot_data *pdata = trunk_get_pivot_data(spl, node, 0);
       req->addr = pdata->addr;
-      splinter_open_log_stream();
-      splinter_log_stream("build_filter descending from root\n");
-      splinter_log_stream("enqueuing build filter %lu-%u\n",
+      trunk_open_log_stream();
+      trunk_log_stream("build_filter descending from root\n");
+      trunk_log_stream("enqueuing build filter %lu-%u\n",
             req->addr, req->bundle_no);
-      splinter_log_node(spl, node);
-      splinter_node_unget(spl, &node);
-      node = splinter_node_get(spl, req->addr);
+      trunk_log_node(spl, node);
+      trunk_node_unget(spl, &node);
+      node = trunk_node_get(spl, req->addr);
    }
    return node;
 }
 
 static inline page_handle *
-splinter_node_get_claim_maybe_descend(splinter_handle             *spl,
-                                      splinter_compact_bundle_req *req)
+trunk_node_get_claim_maybe_descend(trunk_handle             *spl,
+                                      trunk_compact_bundle_req *req)
 {
    page_handle *node;
    uint64 wait = 1;
    while (1) {
-      node = splinter_node_get_maybe_descend(spl, req);
+      node = trunk_node_get_maybe_descend(spl, req);
       if (cache_claim(spl->cc, node)) {
          break;
       }
-      splinter_node_unget(spl, &node);
+      trunk_node_unget(spl, &node);
       platform_sleep(wait);
       wait = wait > 2048 ? wait : 2 * wait;
    }
@@ -3574,102 +3574,102 @@ splinter_node_get_claim_maybe_descend(splinter_handle             *spl,
 }
 
 static inline bool
-splinter_build_filter_should_abort(splinter_compact_bundle_req *req,
+trunk_build_filter_should_abort(trunk_compact_bundle_req *req,
                                    page_handle                 *node)
 {
-   splinter_handle *spl = req->spl;
-   uint16 height = splinter_height(spl, node);
-   if (height == 0 && req->generation < splinter_generation(spl, node)) {
-      splinter_open_log_stream();
-      splinter_log_stream("build_filter leaf abort %lu-%u\n",
+   trunk_handle *spl = req->spl;
+   uint16 height = trunk_height(spl, node);
+   if (height == 0 && req->generation < trunk_generation(spl, node)) {
+      trunk_open_log_stream();
+      trunk_log_stream("build_filter leaf abort %lu-%u\n",
             req->addr, req->bundle_no);
-      splinter_log_node(spl, node);
-      splinter_close_log_stream();
+      trunk_log_node(spl, node);
+      trunk_close_log_stream();
       return TRUE;
    }
    return FALSE;
 }
 
 static inline bool
-splinter_build_filter_should_skip(splinter_compact_bundle_req *req,
+trunk_build_filter_should_skip(trunk_compact_bundle_req *req,
                                   page_handle                 *node)
 {
-   splinter_handle *spl = req->spl;
-   if (!splinter_bundle_live(spl, node, req->bundle_no)) {
-      splinter_open_log_stream();
-      splinter_log_stream("build_filter flush abort %lu-%u (%u)\n",
+   trunk_handle *spl = req->spl;
+   if (!trunk_bundle_live(spl, node, req->bundle_no)) {
+      trunk_open_log_stream();
+      trunk_log_stream("build_filter flush abort %lu-%u (%u)\n",
             req->addr, req->bundle_no, req->height);
-      splinter_log_node(spl, node);
-      splinter_close_log_stream();
+      trunk_log_node(spl, node);
+      trunk_close_log_stream();
       return TRUE;
    }
    return FALSE;
 }
 
 static inline bool
-splinter_build_filter_should_reenqueue(splinter_compact_bundle_req *req,
+trunk_build_filter_should_reenqueue(trunk_compact_bundle_req *req,
                                        page_handle                 *node)
 {
-   splinter_handle *spl = req->spl;
-   if (req->bundle_no != splinter_start_bundle(spl, node)) {
-      splinter_open_log_stream();
-      splinter_log_stream("build filter for %lu bundle %u\n",
+   trunk_handle *spl = req->spl;
+   if (req->bundle_no != trunk_start_bundle(spl, node)) {
+      trunk_open_log_stream();
+      trunk_log_stream("build filter for %lu bundle %u\n",
             req->addr, req->bundle_no);
-      splinter_log_node(spl, node);
-      splinter_log_stream("reenqueuing build filter %lu-%u\n",
+      trunk_log_node(spl, node);
+      trunk_log_stream("reenqueuing build filter %lu-%u\n",
             req->addr, req->bundle_no);
-      splinter_close_log_stream();
+      trunk_close_log_stream();
       return TRUE;
    }
    return FALSE;
 }
 
 static inline void
-splinter_prepare_build_filter(splinter_handle             *spl,
-                              splinter_compact_bundle_req *req,
+trunk_prepare_build_filter(trunk_handle             *spl,
+                              trunk_compact_bundle_req *req,
                               page_handle                 *node)
 {
-   uint16 height = splinter_height(spl, node);
+   uint16 height = trunk_height(spl, node);
    platform_assert(req->height == height);
-   platform_assert(req->bundle_no == splinter_start_bundle(spl, node));
+   platform_assert(req->bundle_no == trunk_start_bundle(spl, node));
 
-   uint16 num_children = splinter_num_children(spl, node);
+   uint16 num_children = trunk_num_children(spl, node);
    for (uint16 pivot_no = 0; pivot_no < num_children; pivot_no++) {
-      splinter_pivot_data *pdata = splinter_get_pivot_data(spl, node, pivot_no);
-      if (splinter_bundle_live_for_pivot(spl, node, req->bundle_no, pivot_no)) {
+      trunk_pivot_data *pdata = trunk_get_pivot_data(spl, node, pivot_no);
+      if (trunk_bundle_live_for_pivot(spl, node, req->bundle_no, pivot_no)) {
          uint64 pos =
-            splinter_process_generation_to_pos(spl, req, pdata->generation);
-         platform_assert(pos != SPLINTER_MAX_PIVOTS);
+            trunk_process_generation_to_pos(spl, req, pdata->generation);
+         platform_assert(pos != TRUNK_MAX_PIVOTS);
          req->old_filter[pos] = pdata->filter;
-         req->value[pos] = splinter_pivot_whole_branch_count(spl, node, pdata);
+         req->value[pos] = trunk_pivot_whole_branch_count(spl, node, pdata);
          req->should_build[pos] = TRUE;
       }
    }
 }
 
 static inline void
-splinter_process_generation_to_fp_bounds(splinter_handle             *spl,
-                                         splinter_compact_bundle_req *req,
+trunk_process_generation_to_fp_bounds(trunk_handle             *spl,
+                                         trunk_compact_bundle_req *req,
                                          uint64                       generation,
                                          uint32                      *fp_start,
                                          uint32                      *fp_end)
 {
    uint64 pos = 0;
    uint64 fp_start_int = 0;
-   while (pos != SPLINTER_MAX_PIVOTS &&
+   while (pos != TRUNK_MAX_PIVOTS &&
           req->pivot_generation[pos] != generation) {
       fp_start_int += req->output_pivot_count[pos];
       pos++;
    }
-   platform_assert(pos + 1 != SPLINTER_MAX_PIVOTS);
+   platform_assert(pos + 1 != TRUNK_MAX_PIVOTS);
    uint64 fp_end_int = fp_start_int + req->output_pivot_count[pos];
    *fp_start = fp_start_int;
    *fp_end = fp_end_int;
 }
 
 static inline void
-splinter_build_filters(splinter_handle             *spl,
-                       splinter_compact_bundle_req *req)
+trunk_build_filters(trunk_handle             *spl,
+                       trunk_compact_bundle_req *req)
 {
    threadid tid;
    uint64 filter_build_start;
@@ -3680,20 +3680,20 @@ splinter_build_filters(splinter_handle             *spl,
       filter_build_start = platform_get_timestamp();
    }
 
-   for (uint64 pos = 0; pos < SPLINTER_MAX_PIVOTS; pos++) {
+   for (uint64 pos = 0; pos < TRUNK_MAX_PIVOTS; pos++) {
       if (!req->should_build[pos]) {
          continue;
       }
       routing_filter old_filter = req->old_filter[pos];
       uint32 fp_start, fp_end;
       uint64 generation = req->pivot_generation[pos];
-      splinter_process_generation_to_fp_bounds(spl, req, generation, &fp_start,
+      trunk_process_generation_to_fp_bounds(spl, req, generation, &fp_start,
                                                &fp_end);
       uint32 *fp_arr = req->fp_arr + fp_start;
       uint32 num_fingerprints = fp_end - fp_start;
       if (num_fingerprints == 0) {
          if (old_filter.addr != 0) {
-            splinter_inc_filter(spl, &old_filter);
+            trunk_inc_filter(spl, &old_filter);
          }
          req->filter[pos] = old_filter;
          continue;
@@ -3726,20 +3726,20 @@ splinter_build_filters(splinter_handle             *spl,
 }
 
 static inline void
-splinter_replace_routing_filter(splinter_handle             *spl,
-                                splinter_compact_bundle_req *req,
+trunk_replace_routing_filter(trunk_handle             *spl,
+                                trunk_compact_bundle_req *req,
                                 page_handle                 *node)
 {
-   uint16 num_children = splinter_num_children(spl, node);
+   uint16 num_children = trunk_num_children(spl, node);
    for (uint16 pivot_no = 0; pivot_no < num_children; pivot_no++) {
-      splinter_pivot_data *pdata = splinter_get_pivot_data(spl, node, pivot_no);
+      trunk_pivot_data *pdata = trunk_get_pivot_data(spl, node, pivot_no);
       uint64 pos =
-         splinter_process_generation_to_pos(spl, req, pdata->generation);
-      if (!splinter_bundle_live_for_pivot(spl, node, req->bundle_no, pivot_no)) {
+         trunk_process_generation_to_pos(spl, req, pdata->generation);
+      if (!trunk_bundle_live_for_pivot(spl, node, req->bundle_no, pivot_no)) {
          //platform_log("not live: %lu %lu %lu %lu\n",
          //      node->disk_addr, pdata->generation, pos, req->filter[pos].addr);
-         if (pos != SPLINTER_MAX_PIVOTS && req->filter[pos].addr != 0) {
-            splinter_dec_filter(spl, &req->filter[pos]);
+         if (pos != TRUNK_MAX_PIVOTS && req->filter[pos].addr != 0) {
+            trunk_dec_filter(spl, &req->filter[pos]);
             ZERO_CONTENTS(&req->filter[pos]);
             //platform_log("dec filter %lu in %lu (%u)\n",
             //      req->filter[pos].addr, node->disk_addr,
@@ -3747,16 +3747,16 @@ splinter_replace_routing_filter(splinter_handle             *spl,
          }
          continue;
       }
-      platform_assert(pos != SPLINTER_MAX_PIVOTS);
+      platform_assert(pos != TRUNK_MAX_PIVOTS);
       debug_assert(pdata->generation < req->max_pivot_generation);
-      splinter_dec_filter(spl, &pdata->filter);
+      trunk_dec_filter(spl, &pdata->filter);
       //platform_log("dec filter %lu in %lu (%u)\n",
       //      pdata->filter.addr, node->disk_addr,
       //      allocator_get_refcount(spl->al, pdata->filter.addr));
       pdata->filter = req->filter[pos];
       ZERO_CONTENTS(&req->filter[pos]);
       uint64 num_tuples_to_reclaim =
-         splinter_pivot_tuples_to_reclaim(spl, pdata);
+         trunk_pivot_tuples_to_reclaim(spl, pdata);
       //platform_log("New routing filter with %u fp %u unique (%lu to reclaim)\n",
       //      pdata->filter.num_fingerprints, pdata->filter.num_unique,
       //      num_tuples_to_reclaim);
@@ -3765,7 +3765,7 @@ splinter_replace_routing_filter(splinter_handle             *spl,
          //   node->disk_addr, pdata->generation, num_tuples_to_reclaim);
          srq_update(&spl->srq, pdata->srq_idx, num_tuples_to_reclaim);
          srq_print(&spl->srq);
-      } else if (num_tuples_to_reclaim > SPLINTER_MIN_SPACE_RECL && spl->cfg.reclaim_threshold != UINT64_MAX) {
+      } else if (num_tuples_to_reclaim > TRUNK_MIN_SPACE_RECL && spl->cfg.reclaim_threshold != UINT64_MAX) {
          srq_data data = { .addr             = node->disk_addr,
                            .pivot_generation = pdata->generation,
                            .priority         = num_tuples_to_reclaim };
@@ -3783,106 +3783,106 @@ splinter_replace_routing_filter(splinter_handle             *spl,
  * bundle
  */
 void
-splinter_bundle_build_filters(void *arg,
+trunk_bundle_build_filters(void *arg,
                               void *scratch)
 {
-   splinter_compact_bundle_req *req = (splinter_compact_bundle_req *)arg;
-   splinter_handle *spl = req->spl;
+   trunk_compact_bundle_req *req = (trunk_compact_bundle_req *)arg;
+   trunk_handle *spl = req->spl;
 
    uint64 generation;
    do {
-      page_handle *node = splinter_node_get_maybe_descend(spl, req);
+      page_handle *node = trunk_node_get_maybe_descend(spl, req);
       platform_assert(node != NULL);
 
-      splinter_open_log_stream();
-      splinter_log_stream("build filter for %lu bundle %u pivot_gen %lu\n",
+      trunk_open_log_stream();
+      trunk_log_stream("build filter for %lu bundle %u pivot_gen %lu\n",
             req->addr, req->bundle_no, req->max_pivot_generation);
-      splinter_log_node(spl, node);
-      if (splinter_build_filter_should_abort(req, node)) {
-         splinter_log_stream("leaf split, aborting\n");
-         splinter_node_unget(spl, &node);
+      trunk_log_node(spl, node);
+      if (trunk_build_filter_should_abort(req, node)) {
+         trunk_log_stream("leaf split, aborting\n");
+         trunk_node_unget(spl, &node);
          goto out;
       }
-      if (splinter_build_filter_should_skip(req, node)) {
-         splinter_log_stream("bundle flushed, skipping\n");
+      if (trunk_build_filter_should_skip(req, node)) {
+         trunk_log_stream("bundle flushed, skipping\n");
          goto next_node;
       }
 
-      if (splinter_build_filter_should_reenqueue(req, node)) {
+      if (trunk_build_filter_should_reenqueue(req, node)) {
          task_enqueue(spl->ts, TASK_TYPE_NORMAL,
-                      splinter_bundle_build_filters, req, FALSE);
-         splinter_log_stream("out of order, reequeuing\n");
-         splinter_close_log_stream();
-         splinter_node_unget(spl, &node);
+                      trunk_bundle_build_filters, req, FALSE);
+         trunk_log_stream("out of order, reequeuing\n");
+         trunk_close_log_stream();
+         trunk_node_unget(spl, &node);
          return;
       }
 
-      for (uint64 i = 0; i < SPLINTER_MAX_PIVOTS; i++) {
+      for (uint64 i = 0; i < TRUNK_MAX_PIVOTS; i++) {
          platform_assert(!req->should_build[i]);
       }
-      splinter_prepare_build_filter(spl, req, node);
-      req->filter_generation = splinter_generation(spl, node);
-      splinter_node_unget(spl, &node);
+      trunk_prepare_build_filter(spl, req, node);
+      req->filter_generation = trunk_generation(spl, node);
+      trunk_node_unget(spl, &node);
 
-      splinter_build_filters(spl, req);
+      trunk_build_filters(spl, req);
 
-      splinter_log_stream("----------------------------------------\n");
+      trunk_log_stream("----------------------------------------\n");
 
       do {
-         node = splinter_node_get_claim_maybe_descend(spl, req);
-         if (splinter_build_filter_should_abort(req, node)) {
-            splinter_log_stream("replace_filter abort leaf split (%lu)\n", req->addr);
-            splinter_node_unclaim(spl, node);
-            splinter_node_unget(spl, &node);
+         node = trunk_node_get_claim_maybe_descend(spl, req);
+         if (trunk_build_filter_should_abort(req, node)) {
+            trunk_log_stream("replace_filter abort leaf split (%lu)\n", req->addr);
+            trunk_node_unclaim(spl, node);
+            trunk_node_unget(spl, &node);
             goto out;
          }
-         splinter_node_lock(spl, node);
-         splinter_replace_routing_filter(spl, req, node);
-         if (splinter_bundle_live(spl, node, req->bundle_no)) {
-            splinter_clear_bundle(spl, node, req->bundle_no);
+         trunk_node_lock(spl, node);
+         trunk_replace_routing_filter(spl, req, node);
+         if (trunk_bundle_live(spl, node, req->bundle_no)) {
+            trunk_clear_bundle(spl, node, req->bundle_no);
          }
-         splinter_node_unlock(spl, node);
-         splinter_node_unclaim(spl, node);
-         req->addr = splinter_next_addr(spl, node);
-         generation = splinter_generation(spl, node);
-         debug_assert(splinter_verify_node(spl, node));
+         trunk_node_unlock(spl, node);
+         trunk_node_unclaim(spl, node);
+         req->addr = trunk_next_addr(spl, node);
+         generation = trunk_generation(spl, node);
+         debug_assert(trunk_verify_node(spl, node));
          if (generation != req->filter_generation) {
-            splinter_log_stream("replace_filter split to %lu\n", req->addr);
+            trunk_log_stream("replace_filter split to %lu\n", req->addr);
             debug_assert(req->height != 0);
             debug_assert(req->addr != 0);
-            splinter_node_unget(spl, &node);
+            trunk_node_unget(spl, &node);
          }
       } while (generation != req->filter_generation);
 
-      splinter_log_node(spl, node);
-      splinter_log_stream("----------------------------------------\n");
-      splinter_log_stream("\n");
+      trunk_log_node(spl, node);
+      trunk_log_stream("----------------------------------------\n");
+      trunk_log_stream("\n");
 
 next_node:
-      req->addr = splinter_next_addr(spl, node);
-      generation = splinter_generation(spl, node);
-      debug_assert(splinter_verify_node(spl, node));
-      splinter_node_unget(spl, &node);
+      req->addr = trunk_next_addr(spl, node);
+      generation = trunk_generation(spl, node);
+      debug_assert(trunk_verify_node(spl, node));
+      trunk_node_unget(spl, &node);
       if (req->generation != generation) {
-         splinter_log_stream("build_filter split to %lu\n", req->addr);
+         trunk_log_stream("build_filter split to %lu\n", req->addr);
          debug_assert(req->height != 0);
          debug_assert(req->addr != 0);
       }
-      splinter_close_log_stream();
+      trunk_close_log_stream();
    } while (req->generation != generation);
 
 out:
-   for (uint64 pos = 0; pos < SPLINTER_MAX_PIVOTS; pos++) {
-      splinter_dec_filter(spl, &req->filter[pos]);
+   for (uint64 pos = 0; pos < TRUNK_MAX_PIVOTS; pos++) {
+      trunk_dec_filter(spl, &req->filter[pos]);
    }
    platform_free(spl->heap_id, req->fp_arr);
    platform_free(spl->heap_id, req);
-   splinter_maybe_reclaim_space(spl);
+   trunk_maybe_reclaim_space(spl);
    return;
 }
 
 static cache_async_result
-splinter_filter_lookup_async(splinter_handle    *spl,
+trunk_filter_lookup_async(trunk_handle    *spl,
                              routing_config     *cfg,
                              routing_filter     *filter,
                              char               *key,
@@ -3908,121 +3908,121 @@ splinter_filter_lookup_async(splinter_handle    *spl,
  *
  * NOTE: parent and child must be write locked.
  */
-splinter_bundle *
-splinter_flush_into_bundle(splinter_handle             *spl,    // IN
+trunk_bundle *
+trunk_flush_into_bundle(trunk_handle             *spl,    // IN
                            page_handle                 *parent, // IN (modified)
                            page_handle                 *child,  // IN (modified)
-                           splinter_pivot_data         *pdata,  // IN
-                           splinter_compact_bundle_req *req)    // IN/OUT
+                           trunk_pivot_data         *pdata,  // IN
+                           trunk_compact_bundle_req *req)    // IN/OUT
 {
-   splinter_open_log_stream();
-   splinter_log_stream("flush from %lu to %lu\n", parent->disk_addr,
+   trunk_open_log_stream();
+   trunk_log_stream("flush from %lu to %lu\n", parent->disk_addr,
                        child->disk_addr);
-   splinter_log_node(spl, parent);
-   splinter_log_node(spl, child);
-   splinter_log_stream("----------------------------------------\n");
+   trunk_log_node(spl, parent);
+   trunk_log_node(spl, child);
+   trunk_log_stream("----------------------------------------\n");
 
    req->spl = spl;
    req->addr = child->disk_addr;
-   req->height = splinter_height(spl, child);
+   req->height = trunk_height(spl, child);
    debug_assert(req->addr != 0);
-   req->bundle_no = splinter_get_new_bundle(spl, child);
-   req->generation = splinter_generation(spl, child);
-   req->max_pivot_generation = splinter_pivot_generation(spl, child);
+   req->bundle_no = trunk_get_new_bundle(spl, child);
+   req->generation = trunk_generation(spl, child);
+   req->max_pivot_generation = trunk_pivot_generation(spl, child);
 
-   uint16 num_children = splinter_num_children(spl, child);
+   uint16 num_children = trunk_num_children(spl, child);
    for (uint16 pivot_no = 0; pivot_no < num_children; pivot_no++) {
-      splinter_pivot_data *pdata = splinter_get_pivot_data(spl, child, pivot_no);
+      trunk_pivot_data *pdata = trunk_get_pivot_data(spl, child, pivot_no);
       req->pivot_generation[pivot_no] = pdata->generation;
    }
 
-   splinter_bundle *bundle = splinter_get_bundle(spl, child, req->bundle_no);
+   trunk_bundle *bundle = trunk_get_bundle(spl, child, req->bundle_no);
 
    // if there are whole branches, flush them into a subbundle
-   if (splinter_branch_is_whole(spl, parent, pdata->start_branch)) {
-      splinter_subbundle *child_sb =
-         splinter_get_new_subbundle(spl, child, 1);
+   if (trunk_branch_is_whole(spl, parent, pdata->start_branch)) {
+      trunk_subbundle *child_sb =
+         trunk_get_new_subbundle(spl, child, 1);
       bundle->start_subbundle =
-         splinter_subbundle_no(spl, child, child_sb);
+         trunk_subbundle_no(spl, child, child_sb);
       child_sb->state = SB_STATE_UNCOMPACTED_INDEX;
 
       // create a subbundle from the whole branches of the parent
-      child_sb->start_branch = splinter_end_branch(spl, child);
-      splinter_log_stream("subbundle %hu\n", bundle->start_subbundle);
+      child_sb->start_branch = trunk_end_branch(spl, child);
+      trunk_log_stream("subbundle %hu\n", bundle->start_subbundle);
       for (uint16 branch_no = pdata->start_branch;
-           splinter_branch_is_whole(spl, parent, branch_no);
-           branch_no = splinter_branch_no_add(spl, branch_no, 1)) {
-         splinter_branch *parent_branch =
-            splinter_get_branch(spl, parent, branch_no);
-         splinter_log_stream("%lu\n", parent_branch->root_addr);
-         splinter_branch *new_branch = splinter_get_new_branch(spl, child);
+           trunk_branch_is_whole(spl, parent, branch_no);
+           branch_no = trunk_branch_no_add(spl, branch_no, 1)) {
+         trunk_branch *parent_branch =
+            trunk_get_branch(spl, parent, branch_no);
+         trunk_log_stream("%lu\n", parent_branch->root_addr);
+         trunk_branch *new_branch = trunk_get_new_branch(spl, child);
          *new_branch = *parent_branch;
       }
-      child_sb->end_branch = splinter_end_branch(spl, child);
+      child_sb->end_branch = trunk_end_branch(spl, child);
       routing_filter *child_filter =
-         splinter_subbundle_filter(spl, child, child_sb, 0);
+         trunk_subbundle_filter(spl, child, child_sb, 0);
       *child_filter = pdata->filter;
       ZERO_STRUCT(pdata->filter);
-      debug_assert(splinter_subbundle_branch_count(spl, child, child_sb) != 0);
+      debug_assert(trunk_subbundle_branch_count(spl, child, child_sb) != 0);
    } else {
-      bundle->start_subbundle = splinter_end_subbundle(spl, child);
+      bundle->start_subbundle = trunk_end_subbundle(spl, child);
    }
 
    // for each subbundle in the parent, create a subbundle in the child
-   if (splinter_pivot_bundle_count(spl, parent, pdata) != 0) {
+   if (trunk_pivot_bundle_count(spl, parent, pdata) != 0) {
       uint16 pivot_start_sb_no =
-         splinter_pivot_start_subbundle(spl, parent, pdata);
+         trunk_pivot_start_subbundle(spl, parent, pdata);
       for (uint16 parent_sb_no = pivot_start_sb_no;
-           parent_sb_no != splinter_end_subbundle(spl, parent);
-           parent_sb_no = splinter_subbundle_no_add(spl, parent_sb_no, 1)) {
-         splinter_subbundle *parent_sb =
-            splinter_get_subbundle(spl, parent, parent_sb_no);
+           parent_sb_no != trunk_end_subbundle(spl, parent);
+           parent_sb_no = trunk_subbundle_no_add(spl, parent_sb_no, 1)) {
+         trunk_subbundle *parent_sb =
+            trunk_get_subbundle(spl, parent, parent_sb_no);
          uint16 filter_count =
-            splinter_subbundle_filter_count(spl, parent, parent_sb);
-         splinter_subbundle *child_sb =
-            splinter_get_new_subbundle(spl, child, filter_count);
+            trunk_subbundle_filter_count(spl, parent, parent_sb);
+         trunk_subbundle *child_sb =
+            trunk_get_new_subbundle(spl, child, filter_count);
          child_sb->state = parent_sb->state;
-         child_sb->start_branch = splinter_end_branch(spl, child);
-         splinter_log_stream("subbundle %hu from subbundle %hu\n",
-                             splinter_subbundle_no(spl, child, child_sb),
+         child_sb->start_branch = trunk_end_branch(spl, child);
+         trunk_log_stream("subbundle %hu from subbundle %hu\n",
+                             trunk_subbundle_no(spl, child, child_sb),
                              parent_sb_no);
          for (uint16 branch_no = parent_sb->start_branch;
               branch_no != parent_sb->end_branch;
-              branch_no = splinter_branch_no_add(spl, branch_no, 1)) {
-            splinter_branch *parent_branch =
-               splinter_get_branch(spl, parent, branch_no);
-            splinter_log_stream("%lu\n", parent_branch->root_addr);
-            splinter_branch *new_branch =
-               splinter_get_new_branch(spl, child);
+              branch_no = trunk_branch_no_add(spl, branch_no, 1)) {
+            trunk_branch *parent_branch =
+               trunk_get_branch(spl, parent, branch_no);
+            trunk_log_stream("%lu\n", parent_branch->root_addr);
+            trunk_branch *new_branch =
+               trunk_get_new_branch(spl, child);
             *new_branch = *parent_branch;
          }
-         child_sb->end_branch = splinter_end_branch(spl, child);
+         child_sb->end_branch = trunk_end_branch(spl, child);
          for (uint16 i = 0; i < filter_count; i++) {
             routing_filter *child_filter =
-               splinter_subbundle_filter(spl, child, child_sb, i);
+               trunk_subbundle_filter(spl, child, child_sb, i);
             routing_filter *parent_filter =
-               splinter_subbundle_filter(spl, parent, parent_sb, i);
+               trunk_subbundle_filter(spl, parent, parent_sb, i);
             *child_filter = *parent_filter;
-            splinter_inc_filter(spl, child_filter);
-            //splinter_log_stream("inc filter %lu in %lu (%u)\n",
+            trunk_inc_filter(spl, child_filter);
+            //trunk_log_stream("inc filter %lu in %lu (%u)\n",
             //      child_filter->addr, child->disk_addr,
             //      allocator_get_refcount(spl->al, child_filter->addr));
          }
-         debug_assert(splinter_subbundle_branch_count(spl,
+         debug_assert(trunk_subbundle_branch_count(spl,
                                                       child, child_sb) != 0);
       }
    }
-   bundle->end_subbundle = splinter_end_subbundle(spl, child);
+   bundle->end_subbundle = trunk_end_subbundle(spl, child);
 
    // clear the branches in the parent's pivot
-   splinter_pivot_clear(spl, parent, pdata);
+   trunk_pivot_clear(spl, parent, pdata);
 
-   splinter_log_stream("----------------------------------------\n");
-   splinter_log_node(spl, parent);
-   splinter_log_node(spl, child);
-   splinter_log_stream("flush done\n");
-   splinter_log_stream("\n");
-   splinter_close_log_stream();
+   trunk_log_stream("----------------------------------------\n");
+   trunk_log_node(spl, parent);
+   trunk_log_node(spl, child);
+   trunk_log_stream("flush done\n");
+   trunk_log_stream("\n");
+   trunk_close_log_stream();
 
    return bundle;
 }
@@ -4034,20 +4034,20 @@ splinter_flush_into_bundle(splinter_handle             *spl,    // IN
  * NOTE: parent and child must have at least read locks
  */
 static inline bool
-splinter_room_to_flush(splinter_handle     *spl,
+trunk_room_to_flush(trunk_handle     *spl,
                        page_handle         *parent,
                        page_handle         *child,
-                       splinter_pivot_data *pdata)
+                       trunk_pivot_data *pdata)
 {
-   uint16 child_branches = splinter_branch_count(spl, child);
-   uint16 flush_branches = splinter_pivot_branch_count(spl, parent, pdata);
-   uint16 child_bundles = splinter_bundle_count(spl, child);
-   uint16 child_subbundles = splinter_subbundle_count(spl, child);
+   uint16 child_branches = trunk_branch_count(spl, child);
+   uint16 flush_branches = trunk_pivot_branch_count(spl, parent, pdata);
+   uint16 child_bundles = trunk_bundle_count(spl, child);
+   uint16 child_subbundles = trunk_subbundle_count(spl, child);
    uint16 flush_subbundles =
-      splinter_pivot_subbundle_count(spl, parent, pdata) + 1;
+      trunk_pivot_subbundle_count(spl, parent, pdata) + 1;
    return child_branches + flush_branches < spl->cfg.hard_max_branches_per_node
-      && child_bundles + 2 <= SPLINTER_MAX_BUNDLES
-      && child_subbundles + flush_subbundles + 1 < SPLINTER_MAX_SUBBUNDLES;
+      && child_bundles + 2 <= TRUNK_MAX_BUNDLES
+      && child_subbundles + flush_subbundles + 1 < TRUNK_MAX_SUBBUNDLES;
 }
 
 /*
@@ -4058,34 +4058,34 @@ splinter_room_to_flush(splinter_handle     *spl,
  * NOTE: parent must be write locked
  */
 bool
-splinter_flush(splinter_handle     *spl,
+trunk_flush(trunk_handle     *spl,
                page_handle         *parent,
-               splinter_pivot_data *pdata,
+               trunk_pivot_data *pdata,
                bool                 is_space_rec)
 {
    uint64 wait_start, flush_start;
    if (spl->cfg.use_stats)
       wait_start = platform_get_timestamp();
-   page_handle *child = splinter_node_get(spl, pdata->addr);
+   page_handle *child = trunk_node_get(spl, pdata->addr);
    threadid tid;
    platform_status rc;
 
    if (spl->cfg.use_stats) {
       tid = platform_get_tid();
    }
-   splinter_node_claim(spl, &child);
+   trunk_node_claim(spl, &child);
 
-   if (!splinter_room_to_flush(spl, parent, child, pdata)) {
+   if (!trunk_room_to_flush(spl, parent, child, pdata)) {
       platform_error_log("Flush failed: %lu %lu\n",
                          parent->disk_addr, child->disk_addr);
       if (spl->cfg.use_stats) {
          if (parent->disk_addr == spl->root_addr)
             spl->stats[tid].root_failed_flushes++;
          else
-            spl->stats[tid].failed_flushes[splinter_height(spl, parent)]++;
+            spl->stats[tid].failed_flushes[trunk_height(spl, parent)]++;
       }
-      splinter_node_unclaim(spl, child);
-      splinter_node_unget(spl, &child);
+      trunk_node_unclaim(spl, child);
+      trunk_node_unget(spl, &child);
       return FALSE;
    }
 
@@ -4096,52 +4096,52 @@ splinter_flush(splinter_handle     *spl,
       srq_print(&spl->srq);
       pdata->srq_idx = -1;
    }
-   splinter_node_lock(spl, child);
+   trunk_node_lock(spl, child);
 
    if (spl->cfg.use_stats) {
       if (parent->disk_addr == spl->root_addr) {
          spl->stats[tid].root_flush_wait_time_ns
             += platform_timestamp_elapsed(wait_start);
       } else {
-         spl->stats[tid].flush_wait_time_ns[splinter_height(spl, parent)]
+         spl->stats[tid].flush_wait_time_ns[trunk_height(spl, parent)]
             += platform_timestamp_elapsed(wait_start);
       }
       flush_start = platform_get_timestamp();
    }
 
    // flush the branch references into a new bundle in the child
-   splinter_compact_bundle_req *req = TYPED_ZALLOC(spl->heap_id, req);
-   splinter_bundle *bundle = splinter_flush_into_bundle(spl, parent, child,
+   trunk_compact_bundle_req *req = TYPED_ZALLOC(spl->heap_id, req);
+   trunk_bundle *bundle = trunk_flush_into_bundle(spl, parent, child,
                                                         pdata, req);
-   splinter_tuples_in_bundle(spl, child, bundle, req->input_pivot_count);
-   splinter_pivot_add_bundle_num_tuples(spl, child, bundle,
+   trunk_tuples_in_bundle(spl, child, bundle, req->input_pivot_count);
+   trunk_pivot_add_bundle_num_tuples(spl, child, bundle,
          req->input_pivot_count);
-   splinter_bundle_inc_pivot_rc(spl, child, bundle);
+   trunk_bundle_inc_pivot_rc(spl, child, bundle);
    debug_assert(cache_page_valid(spl->cc, req->addr));
    req->is_space_rec = is_space_rec;
 
    // split child if necessary
-   if (splinter_needs_split(spl, child)) {
-      if (splinter_is_leaf(spl, child)) {
+   if (trunk_needs_split(spl, child)) {
+      if (trunk_is_leaf(spl, child)) {
          platform_free(spl->heap_id, req);
-         uint16 child_idx = splinter_pdata_to_pivot_index(spl, parent, pdata);
-         splinter_split_leaf(spl, parent, child, child_idx);
-         debug_assert(splinter_verify_node(spl, child));
+         uint16 child_idx = trunk_pdata_to_pivot_index(spl, parent, pdata);
+         trunk_split_leaf(spl, parent, child, child_idx);
+         debug_assert(trunk_verify_node(spl, child));
          return TRUE;
       } else {
-         uint64 child_idx = splinter_pdata_to_pivot_index(spl, parent, pdata);
-         splinter_split_index(spl, parent, child, child_idx);
+         uint64 child_idx = trunk_pdata_to_pivot_index(spl, parent, pdata);
+         trunk_split_index(spl, parent, child, child_idx);
       }
    }
 
-   debug_assert(splinter_verify_node(spl, child));
-   splinter_node_unlock(spl, child);
-   splinter_node_unclaim(spl, child);
-   splinter_node_unget(spl, &child);
+   debug_assert(trunk_verify_node(spl, child));
+   trunk_node_unlock(spl, child);
+   trunk_node_unclaim(spl, child);
+   trunk_node_unget(spl, &child);
 
-   splinter_default_log("enqueuing compact_bundle %lu-%u\n",
+   trunk_default_log("enqueuing compact_bundle %lu-%u\n",
                         req->addr, req->bundle_no);
-   rc = task_enqueue(spl->ts, TASK_TYPE_NORMAL, splinter_compact_bundle, req,
+   rc = task_enqueue(spl->ts, TASK_TYPE_NORMAL, trunk_compact_bundle, req,
                      FALSE);
    platform_assert_status_ok(rc);
    if (spl->cfg.use_stats) {
@@ -4152,7 +4152,7 @@ splinter_flush(splinter_handle     *spl,
             spl->stats[tid].root_flush_time_max_ns = flush_start;
          }
       } else {
-         const uint32 h = splinter_height(spl, parent);
+         const uint32 h = trunk_height(spl, parent);
          spl->stats[tid].flush_time_ns[h] += flush_start;
          if (flush_start > spl->stats[tid].flush_time_max_ns[h]) {
             spl->stats[tid].flush_time_max_ns[h] = flush_start;
@@ -4170,59 +4170,59 @@ splinter_flush(splinter_handle     *spl,
  * does.
  */
 bool
-splinter_flush_fullest(splinter_handle *spl,
+trunk_flush_fullest(trunk_handle *spl,
                        page_handle     *node)
 {
-   splinter_pivot_data *fullest_pivot_data = splinter_get_pivot_data(spl, node, 0);
+   trunk_pivot_data *fullest_pivot_data = trunk_get_pivot_data(spl, node, 0);
    uint16 pivot_no;
    threadid tid;
 
    if (spl->cfg.use_stats) {
       tid = platform_get_tid();
    }
-   if (splinter_pivot_needs_flush(spl, node, fullest_pivot_data)) {
-      splinter_flush(spl, node, fullest_pivot_data, FALSE);
+   if (trunk_pivot_needs_flush(spl, node, fullest_pivot_data)) {
+      trunk_flush(spl, node, fullest_pivot_data, FALSE);
       if (spl->cfg.use_stats) {
          if (node->disk_addr == spl->root_addr)
             spl->stats[tid].root_count_flushes++;
          else
-            spl->stats[tid].count_flushes[splinter_height(spl, node)]++;
+            spl->stats[tid].count_flushes[trunk_height(spl, node)]++;
       }
    }
-   for (pivot_no = 1; pivot_no < splinter_num_children(spl, node); pivot_no++) {
-      splinter_pivot_data *pdata = splinter_get_pivot_data(spl, node, pivot_no);
+   for (pivot_no = 1; pivot_no < trunk_num_children(spl, node); pivot_no++) {
+      trunk_pivot_data *pdata = trunk_get_pivot_data(spl, node, pivot_no);
       // if a pivot has too many branches, just flush it here
-      if (splinter_pivot_needs_flush(spl, node, pdata)) {
-         splinter_flush(spl, node, pdata, FALSE);
+      if (trunk_pivot_needs_flush(spl, node, pdata)) {
+         trunk_flush(spl, node, pdata, FALSE);
          if (spl->cfg.use_stats) {
             if (node->disk_addr == spl->root_addr)
                spl->stats[tid].root_count_flushes++;
             else
-               spl->stats[tid].count_flushes[splinter_height(spl, node)]++;
+               spl->stats[tid].count_flushes[trunk_height(spl, node)]++;
          }
       }
       if (pdata->num_tuples > fullest_pivot_data->num_tuples) {
          fullest_pivot_data = pdata;
       }
    }
-   if (splinter_node_is_full(spl, node)) {
+   if (trunk_node_is_full(spl, node)) {
       if (spl->cfg.use_stats) {
          if (node->disk_addr == spl->root_addr)
             spl->stats[tid].root_full_flushes++;
          else
-            spl->stats[tid].full_flushes[splinter_height(spl, node)]++;
+            spl->stats[tid].full_flushes[trunk_height(spl, node)]++;
       }
-      return splinter_flush(spl, node, fullest_pivot_data, FALSE);
+      return trunk_flush(spl, node, fullest_pivot_data, FALSE);
    }
    return FALSE;
 }
 
 void
-save_pivots_to_compact_bundle_scratch(splinter_handle        *spl,     // IN
+save_pivots_to_compact_bundle_scratch(trunk_handle        *spl,     // IN
                                       page_handle            *node,    // IN
                                       compact_bundle_scratch *scratch) // IN/OUT
 {
-   uint32 num_pivot_keys = splinter_num_pivot_keys(spl, node);
+   uint32 num_pivot_keys = trunk_num_pivot_keys(spl, node);
 
    btree_config *cfg = &spl->cfg.btree_cfg;
 
@@ -4231,7 +4231,7 @@ save_pivots_to_compact_bundle_scratch(splinter_handle        *spl,     // IN
    // Save all num_pivots regular pivots and the upper bound pivot
    for (uint32 i = 0; i < num_pivot_keys; i++) {
       memmove(&scratch->saved_pivot_keys[i].k,
-              splinter_get_pivot(spl, node, i),
+              trunk_get_pivot(spl, node, i),
               cfg->data_cfg->key_size);
    }
 }
@@ -4241,9 +4241,9 @@ save_pivots_to_compact_bundle_scratch(splinter_handle        *spl,     // IN
  */
 
 void
-splinter_branch_iterator_init(splinter_handle *spl,
+trunk_branch_iterator_init(trunk_handle *spl,
                               btree_iterator  *itor,
-                              splinter_branch *branch,
+                              trunk_branch *branch,
                               const char      *min_key,
                               const char      *max_key,
                               bool             do_prefetch,
@@ -4268,7 +4268,7 @@ splinter_branch_iterator_init(splinter_handle *spl,
 }
 
 void
-splinter_branch_iterator_deinit(splinter_handle *spl,
+trunk_branch_iterator_deinit(trunk_handle *spl,
                                 btree_iterator  *itor,
                                 bool             should_dec_ref)
 {
@@ -4296,29 +4296,29 @@ splinter_branch_iterator_deinit(splinter_handle *spl,
  */
 
 static void
-splinter_btree_skiperator_init(
-      splinter_handle           *spl,
-      splinter_btree_skiperator *skip_itor,
+trunk_btree_skiperator_init(
+      trunk_handle           *spl,
+      trunk_btree_skiperator *skip_itor,
       page_handle               *node,
       uint16                     branch_idx,
-      key_buffer                 pivots[static SPLINTER_MAX_PIVOTS])
+      key_buffer                 pivots[static TRUNK_MAX_PIVOTS])
 {
    ZERO_CONTENTS(skip_itor);
-   skip_itor->super.ops = &splinter_btree_skiperator_ops;
+   skip_itor->super.ops = &trunk_btree_skiperator_ops;
    uint16 min_pivot_no = 0;
-   uint16 max_pivot_no = splinter_num_children(spl, node);
-   debug_assert(max_pivot_no < SPLINTER_MAX_PIVOTS);
+   uint16 max_pivot_no = trunk_num_children(spl, node);
+   debug_assert(max_pivot_no < TRUNK_MAX_PIVOTS);
 
    char *min_key = pivots[min_pivot_no].k;
    char *max_key = pivots[max_pivot_no].k;
-   skip_itor->branch = *splinter_get_branch(spl, node, branch_idx);
+   skip_itor->branch = *trunk_get_branch(spl, node, branch_idx);
 
    uint16 first_pivot = 0;
    bool iterator_started = FALSE;
 
    for (uint16 i = min_pivot_no; i < max_pivot_no + 1; i++) {
       bool branch_valid = i == max_pivot_no ?
-         FALSE : splinter_branch_live_for_pivot(spl, node, branch_idx, i);
+         FALSE : trunk_branch_live_for_pivot(spl, node, branch_idx, i);
       if (branch_valid && !iterator_started) {
          first_pivot = i;
          iterator_started = TRUE;
@@ -4329,7 +4329,7 @@ splinter_btree_skiperator_init(
             min_key : pivots[first_pivot].k;
          char *pivot_max_key = i == max_pivot_no ? max_key : pivots[i].k;
          btree_iterator *btree_itor = &skip_itor->itor[skip_itor->end++];
-         splinter_branch_iterator_init(spl,
+         trunk_branch_iterator_init(spl,
                                        btree_itor,
                                        &skip_itor->branch,
                                        pivot_min_key,
@@ -4355,18 +4355,18 @@ splinter_btree_skiperator_init(
 }
 
 void
-splinter_btree_skiperator_get_curr(iterator *itor, char **key, char **data)
+trunk_btree_skiperator_get_curr(iterator *itor, char **key, char **data)
 {
    debug_assert(itor != NULL);
-   splinter_btree_skiperator *skip_itor = (splinter_btree_skiperator *)itor;
+   trunk_btree_skiperator *skip_itor = (trunk_btree_skiperator *)itor;
    iterator_get_curr(&skip_itor->itor[skip_itor->curr].super, key, data);
 }
 
 platform_status
-splinter_btree_skiperator_advance(iterator *itor)
+trunk_btree_skiperator_advance(iterator *itor)
 {
    debug_assert(itor != NULL);
-   splinter_btree_skiperator *skip_itor = (splinter_btree_skiperator *)itor;
+   trunk_btree_skiperator *skip_itor = (trunk_btree_skiperator *)itor;
    platform_status rc =
       iterator_advance(&skip_itor->itor[skip_itor->curr].super);
    if (!SUCCESS(rc)) {
@@ -4386,10 +4386,10 @@ splinter_btree_skiperator_advance(iterator *itor)
 }
 
 platform_status
-splinter_btree_skiperator_at_end(iterator *itor,
+trunk_btree_skiperator_at_end(iterator *itor,
                                  bool     *at_end)
 {
-   splinter_btree_skiperator *skip_itor = (splinter_btree_skiperator *)itor;
+   trunk_btree_skiperator *skip_itor = (trunk_btree_skiperator *)itor;
    if (skip_itor->curr == skip_itor->end) {
       *at_end = TRUE;
       return STATUS_OK;
@@ -4400,9 +4400,9 @@ splinter_btree_skiperator_at_end(iterator *itor,
 }
 
 void
-splinter_btree_skiperator_print(iterator *itor)
+trunk_btree_skiperator_print(iterator *itor)
 {
-   splinter_btree_skiperator *skip_itor = (splinter_btree_skiperator *)itor;
+   trunk_btree_skiperator *skip_itor = (trunk_btree_skiperator *)itor;
    platform_log("$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$\n");
    platform_log("$$ skiperator: %p\n", skip_itor);
    platform_log("$$ curr: %lu\n", skip_itor->curr);
@@ -4410,11 +4410,11 @@ splinter_btree_skiperator_print(iterator *itor)
 }
 
 void
-splinter_btree_skiperator_deinit(splinter_handle           *spl,
-                                 splinter_btree_skiperator *skip_itor)
+trunk_btree_skiperator_deinit(trunk_handle           *spl,
+                                 trunk_btree_skiperator *skip_itor)
 {
    for (uint64 i = 0; i < skip_itor->end; i++) {
-      splinter_branch_iterator_deinit(spl, &skip_itor->itor[i], TRUE);
+      trunk_branch_iterator_deinit(spl, &skip_itor->itor[i], TRUE);
    }
 }
 
@@ -4428,7 +4428,7 @@ splinter_btree_skiperator_deinit(splinter_handle           *spl,
 
 
 static inline void
-splinter_btree_pack_req_init(splinter_handle *spl,
+trunk_btree_pack_req_init(trunk_handle *spl,
                              iterator *       itor,
                              btree_pack_req * req)
 {
@@ -4487,33 +4487,33 @@ splinter_btree_pack_req_init(splinter_handle *spl,
 
 
 void
-splinter_compact_bundle(void *arg,
+trunk_compact_bundle(void *arg,
                         void *scratch_buf)
 {
    platform_status rc;
-   splinter_compact_bundle_req *req = arg;
-   splinter_task_scratch *task_scratch = scratch_buf;
+   trunk_compact_bundle_req *req = arg;
+   trunk_task_scratch *task_scratch = scratch_buf;
    compact_bundle_scratch *scratch = &task_scratch->compact_bundle;
-   splinter_handle *spl = req->spl;
+   trunk_handle *spl = req->spl;
    __attribute__ ((unused)) threadid tid;
 
    /*
     * 1. Acquire node read lock
     */
-   page_handle *node = splinter_node_get(spl, req->addr);
+   page_handle *node = trunk_node_get(spl, req->addr);
 
    /*
     * 2. Flush if node is full (acquires write lock)
     */
-   uint16 height = splinter_height(spl, node);
-   if (height != 0 && splinter_node_is_full(spl, node)) {
-      splinter_node_claim(spl, &node);
-      splinter_node_lock(spl, node);
+   uint16 height = trunk_height(spl, node);
+   if (height != 0 && trunk_node_is_full(spl, node)) {
+      trunk_node_claim(spl, &node);
+      trunk_node_lock(spl, node);
       bool flush_successful = TRUE;
-      while (flush_successful && splinter_node_is_full(spl, node))
-         flush_successful = splinter_flush_fullest(spl, node);
-      splinter_node_unlock(spl, node);
-      splinter_node_unclaim(spl, node);
+      while (flush_successful && trunk_node_is_full(spl, node))
+         flush_successful = trunk_flush_fullest(spl, node);
+      trunk_node_unlock(spl, node);
+      trunk_node_unclaim(spl, node);
    }
 
    // timers for stats if enabled
@@ -4530,28 +4530,28 @@ splinter_compact_bundle(void *arg,
     *    bundle was copied to the new sibling[s], so issue compact_bundles for
     *    those nodes
     */
-   if (req->generation < splinter_generation(spl, node)) {
+   if (req->generation < trunk_generation(spl, node)) {
       if (height != 0) {
-         debug_assert(splinter_next_addr(spl, node) != 0);
-         splinter_compact_bundle_req *next_req =
+         debug_assert(trunk_next_addr(spl, node) != 0);
+         trunk_compact_bundle_req *next_req =
             TYPED_MALLOC(spl->heap_id, next_req);
-         memmove(next_req, req, sizeof(splinter_compact_bundle_req));
-         next_req->addr = splinter_next_addr(spl, node);
+         memmove(next_req, req, sizeof(trunk_compact_bundle_req));
+         next_req->addr = trunk_next_addr(spl, node);
          debug_assert(next_req->addr != 0);
 
-         req->generation = splinter_generation(spl, node);
+         req->generation = trunk_generation(spl, node);
 
-         splinter_default_log("compact_bundle split from %lu to %lu\n",
+         trunk_default_log("compact_bundle split from %lu to %lu\n",
                               req->addr, next_req->addr);
-         rc = task_enqueue(spl->ts, TASK_TYPE_NORMAL, splinter_compact_bundle,
+         rc = task_enqueue(spl->ts, TASK_TYPE_NORMAL, trunk_compact_bundle,
                            next_req, FALSE);
          platform_assert_status_ok(rc);
       } else {
          /*
           * 4. Abort if node is a splitting leaf (interaction 6)
           */
-         splinter_node_unget(spl, &node);
-         splinter_default_log("compact_bundle abort leaf split %lu\n",
+         trunk_node_unget(spl, &node);
+         trunk_default_log("compact_bundle abort leaf split %lu\n",
                req->addr);
          platform_free(spl->heap_id, req);
          if (spl->cfg.use_stats) {
@@ -4564,7 +4564,7 @@ splinter_compact_bundle(void *arg,
    }
 
    // store the generation of the node so we can detect splits after compaction
-   uint64 start_generation = splinter_generation(spl, node);
+   uint64 start_generation = trunk_generation(spl, node);
 
    /*
     * 5. The bundle may have been completely flushed by 2., if so abort
@@ -4572,10 +4572,10 @@ splinter_compact_bundle(void *arg,
     *          generation number would change and it would be caught by step 4
     *          above).
     */
-   if (!splinter_bundle_live(spl, node, req->bundle_no)) {
+   if (!trunk_bundle_live(spl, node, req->bundle_no)) {
       debug_assert(height != 0);
-      splinter_node_unget(spl, &node);
-      splinter_default_log("compact_bundle abort flushed %lu\n", req->addr);
+      trunk_node_unget(spl, &node);
+      trunk_default_log("compact_bundle abort flushed %lu\n", req->addr);
       platform_free(spl->heap_id, req);
       if (spl->cfg.use_stats) {
          spl->stats[tid].compactions_aborted_flushed[height]++;
@@ -4585,10 +4585,10 @@ splinter_compact_bundle(void *arg,
       return;
    }
 
-   splinter_bundle *bundle    = splinter_get_bundle(spl, node, req->bundle_no);
-   uint16 bundle_start_branch = splinter_bundle_start_branch(spl, node, bundle);
-   uint16 bundle_end_branch   = splinter_bundle_end_branch(spl, node, bundle);
-   uint16 num_branches        = splinter_bundle_branch_count(spl, node, bundle);
+   trunk_bundle *bundle    = trunk_get_bundle(spl, node, req->bundle_no);
+   uint16 bundle_start_branch = trunk_bundle_start_branch(spl, node, bundle);
+   uint16 bundle_end_branch   = trunk_bundle_end_branch(spl, node, bundle);
+   uint16 num_branches        = trunk_bundle_branch_count(spl, node, bundle);
 
    /*
     * Update and delete messages need to be kept around until/unless they have
@@ -4598,28 +4598,28 @@ splinter_compact_bundle(void *arg,
     * branch).
     */
    bool resolve_updates_and_discard_deletes =
-      height == 0 && bundle_start_branch == splinter_start_branch(spl, node);
+      height == 0 && bundle_start_branch == trunk_start_branch(spl, node);
 
-   splinter_open_log_stream();
-   splinter_log_stream("compact_bundle addr %lu bundle %hu\n", req->addr,
+   trunk_open_log_stream();
+   trunk_log_stream("compact_bundle addr %lu bundle %hu\n", req->addr,
                        req->bundle_no);
 
    /*
     * 6. Build iterators
     */
    platform_assert(num_branches <= ARRAY_SIZE(scratch->skip_itor));
-   splinter_btree_skiperator *skip_itor_arr = scratch->skip_itor;
+   trunk_btree_skiperator *skip_itor_arr = scratch->skip_itor;
    iterator **itor_arr = scratch->itor_arr;
 
    save_pivots_to_compact_bundle_scratch(spl, node, scratch);
 
    uint16 tree_offset = 0;
    for (uint16 branch_no = bundle_start_branch; branch_no != bundle_end_branch;
-         branch_no = splinter_branch_no_add(spl, branch_no, 1)) {
+         branch_no = trunk_branch_no_add(spl, branch_no, 1)) {
       /*
        * We are iterating from oldest to newest branch
        */
-      splinter_btree_skiperator_init(spl,
+      trunk_btree_skiperator_init(spl,
                                      &skip_itor_arr[tree_offset],
                                      node,
                                      branch_no,
@@ -4627,12 +4627,12 @@ splinter_compact_bundle(void *arg,
       itor_arr[tree_offset] = &skip_itor_arr[tree_offset].super;
       tree_offset++;
    }
-   splinter_log_node(spl, node);
+   trunk_log_node(spl, node);
 
    /*
     * 7. Release read lock
     */
-   splinter_node_unget(spl, &node);
+   trunk_node_unget(spl, &node);
 
    /*
     * 8. Perform compaction
@@ -4648,7 +4648,7 @@ splinter_compact_bundle(void *arg,
                               &merge_itor);
    platform_assert_status_ok(rc);
    btree_pack_req pack_req;
-   splinter_btree_pack_req_init(spl, &merge_itor->super, &pack_req);
+   trunk_btree_pack_req_init(spl, &merge_itor->super, &pack_req);
    req->fp_arr = pack_req.fingerprint_arr;
    if (spl->cfg.use_stats) {
       pack_start = platform_get_timestamp();
@@ -4659,12 +4659,12 @@ splinter_compact_bundle(void *arg,
          += platform_timestamp_elapsed(pack_start);
    }
 
-   splinter_branch new_branch;
+   trunk_branch new_branch;
    new_branch.root_addr = pack_req.root_addr;
 
    req->fp_arr = pack_req.fingerprint_arr;
 
-   splinter_log_stream("output: %lu\n", req->root_addr);
+   trunk_log_stream("output: %lu\n", req->root_addr);
    if (spl->cfg.use_stats) {
       if (pack_req.num_tuples == 0) {
          spl->stats[tid].compactions_empty[height]++;
@@ -4675,7 +4675,7 @@ splinter_compact_bundle(void *arg,
       }
    }
 
-   splinter_log_stream("output point: %lu\n", pack_req.root_addr);
+   trunk_log_stream("output point: %lu\n", pack_req.root_addr);
 
    /*
     * 10. Clean up
@@ -4683,13 +4683,13 @@ splinter_compact_bundle(void *arg,
    rc = merge_iterator_destroy(spl->heap_id, &merge_itor);
    platform_assert_status_ok(rc);
    for (uint64 i = 0; i < num_branches; i++) {
-      splinter_btree_skiperator_deinit(spl, &skip_itor_arr[i]);
+      trunk_btree_skiperator_deinit(spl, &skip_itor_arr[i]);
    }
 
    /*
     * 11. Reacquire read lock
     */
-   node = splinter_node_get(spl, req->addr);
+   node = trunk_node_get(spl, req->addr);
    platform_assert(node != NULL);
 
    /*
@@ -4700,10 +4700,10 @@ splinter_compact_bundle(void *arg,
    uint64 generation;
    do {
       platform_assert(node != NULL);
-      splinter_node_claim(spl, &node);
-      splinter_node_lock(spl, node);
+      trunk_node_claim(spl, &node);
+      trunk_node_lock(spl, node);
 
-      splinter_log_node(spl, node);
+      trunk_log_node(spl, node);
 
       /*
        * 12a. ...unless node is a leaf which has split, in which case discard
@@ -4713,64 +4713,64 @@ splinter_compact_bundle(void *arg,
        *      need to look for the bundle in the split siblings, so simply
        *      exit.
        */
-      if (height == 0 && req->generation < splinter_generation(spl, node)) {
-         splinter_log_stream("compact_bundle discard split %lu\n", req->addr);
+      if (height == 0 && req->generation < trunk_generation(spl, node)) {
+         trunk_log_stream("compact_bundle discard split %lu\n", req->addr);
          if (spl->cfg.use_stats) {
             spl->stats[tid].compactions_discarded_leaf_split[height]++;
             spl->stats[tid].compaction_time_wasted_ns[height]
                += platform_timestamp_elapsed(compaction_start);
          }
-         splinter_node_unlock(spl, node);
-         splinter_node_unclaim(spl, node);
-         splinter_node_unget(spl, &node);
+         trunk_node_unlock(spl, node);
+         trunk_node_unclaim(spl, node);
+         trunk_node_unget(spl, &node);
 
-         splinter_dec_ref(spl, &new_branch, FALSE);
+         trunk_dec_ref(spl, &new_branch, FALSE);
          platform_free(spl->heap_id, req->fp_arr);
          platform_free(spl->heap_id, req);
          goto out;
       }
 
-      if (splinter_bundle_live(spl, node, req->bundle_no)) {
+      if (trunk_bundle_live(spl, node, req->bundle_no)) {
          if (pack_req.num_tuples != 0) {
-            splinter_replace_bundle_branches(spl, node, &new_branch, req);
+            trunk_replace_bundle_branches(spl, node, &new_branch, req);
             num_replacements++;
-            splinter_log_stream("inserted %lu into %lu\n",
+            trunk_log_stream("inserted %lu into %lu\n",
                                 new_branch.root_addr, addr);
          } else {
             // FIXME: [yfogel 2020-07-02] come back
             // This may create an empty branch, set the empty one to null before getting in loop?
             // 1. Don't create it until the first element per tree: Perf cost
             // 2. Delete it after pack: Maybe wierd interaction with ref_count
-            splinter_replace_bundle_branches(spl, node, NULL, req);
-            splinter_log_stream("compact_bundle empty %lu\n", addr);
+            trunk_replace_bundle_branches(spl, node, NULL, req);
+            trunk_log_stream("compact_bundle empty %lu\n", addr);
          }
       } else {
          /*
           * 12b. ...unless node is internal and bundle has been flushed
           */
          platform_assert(height != 0);
-         splinter_log_stream("compact_bundle discarded flushed %lu\n", addr);
+         trunk_log_stream("compact_bundle discarded flushed %lu\n", addr);
       }
 
-      addr = splinter_next_addr(spl, node);
-      generation = splinter_generation(spl, node);
-      splinter_log_node(spl, node);
-      debug_assert(splinter_verify_node(spl, node));
+      addr = trunk_next_addr(spl, node);
+      generation = trunk_generation(spl, node);
+      trunk_log_node(spl, node);
+      debug_assert(trunk_verify_node(spl, node));
 
       if (num_replacements != 0 && pack_req.num_tuples != 0 &&
           start_generation == generation) {
-         const char *max_key = splinter_max_key(spl, node);
-         splinter_zap_branch_range(spl, &new_branch, max_key, NULL,
+         const char *max_key = trunk_max_key(spl, node);
+         trunk_zap_branch_range(spl, &new_branch, max_key, NULL,
                PAGE_TYPE_BRANCH);
       }
 
-      splinter_node_unlock(spl, node);
-      splinter_node_unclaim(spl, node);
-      splinter_node_unget(spl, &node);
+      trunk_node_unlock(spl, node);
+      trunk_node_unclaim(spl, node);
+      trunk_node_unget(spl, &node);
       if (start_generation != generation) {
          debug_assert(height != 0);
          debug_assert(addr != 0);
-         node = splinter_node_get(spl, addr);
+         node = trunk_node_get(spl, addr);
       }
    } while (start_generation != generation);
 
@@ -4782,7 +4782,7 @@ splinter_compact_bundle(void *arg,
       spl->stats[tid].tuples_reclaimed[height] += req->tuples_reclaimed;
    }
    if (num_replacements == 0) {
-      splinter_dec_ref(spl, &new_branch, FALSE);
+      trunk_dec_ref(spl, &new_branch, FALSE);
       if (spl->cfg.use_stats) {
          spl->stats[tid].compactions_discarded_flushed[height]++;
          spl->stats[tid].compaction_time_wasted_ns[height]
@@ -4797,60 +4797,60 @@ splinter_compact_bundle(void *arg,
             spl->stats[tid].compaction_time_max_ns[height] = compaction_start;
          }
       }
-      splinter_log_stream("enqueuing build filter %lu-%u\n",
+      trunk_log_stream("enqueuing build filter %lu-%u\n",
             req->addr, req->bundle_no);
-      task_enqueue(spl->ts, TASK_TYPE_NORMAL, splinter_bundle_build_filters, req, TRUE);
+      task_enqueue(spl->ts, TASK_TYPE_NORMAL, trunk_bundle_build_filters, req, TRUE);
    }
 out:
-   splinter_log_stream("\n");
-   splinter_close_log_stream();
+   trunk_log_stream("\n");
+   trunk_close_log_stream();
 }
 
 
 bool
-splinter_flush_node(splinter_handle *spl, uint64 addr, void *arg)
+trunk_flush_node(trunk_handle *spl, uint64 addr, void *arg)
 {
-   page_handle *node = splinter_node_get(spl, addr);
-   splinter_node_claim(spl, &node);
-   splinter_node_lock(spl, node);
+   page_handle *node = trunk_node_get(spl, addr);
+   trunk_node_claim(spl, &node);
+   trunk_node_lock(spl, node);
 
-   if (splinter_height(spl, node) != 0) {
+   if (trunk_height(spl, node) != 0) {
       for (uint16 pivot_no = 0;
-           pivot_no < splinter_num_children(spl, node);
+           pivot_no < trunk_num_children(spl, node);
            pivot_no++) {
-         splinter_pivot_data *pdata =
-            splinter_get_pivot_data(spl, node, pivot_no);
-         if (splinter_pivot_branch_count(spl, node, pdata) != 0)
-            splinter_flush(spl, node, pdata, FALSE);
+         trunk_pivot_data *pdata =
+            trunk_get_pivot_data(spl, node, pivot_no);
+         if (trunk_pivot_branch_count(spl, node, pdata) != 0)
+            trunk_flush(spl, node, pdata, FALSE);
       }
    }
 
-   splinter_node_unlock(spl, node);
-   splinter_node_unclaim(spl, node);
-   splinter_node_unget(spl, &node);
+   trunk_node_unlock(spl, node);
+   trunk_node_unclaim(spl, node);
+   trunk_node_unget(spl, &node);
 
    task_perform_all(spl->ts);
 
-   node = splinter_node_get(spl, addr);
-   splinter_node_claim(spl, &node);
-   splinter_node_lock(spl, node);
+   node = trunk_node_get(spl, addr);
+   trunk_node_claim(spl, &node);
+   trunk_node_lock(spl, node);
 
-   if (splinter_height(spl, node) == 1) {
+   if (trunk_height(spl, node) == 1) {
       for (uint16 pivot_no = 0;
-           pivot_no < splinter_num_children(spl, node);
+           pivot_no < trunk_num_children(spl, node);
            pivot_no++) {
-         splinter_pivot_data *pdata =
-            splinter_get_pivot_data(spl, node, pivot_no);
-         page_handle *leaf = splinter_node_get(spl, pdata->addr);
-         splinter_node_claim(spl, &leaf);
-         splinter_node_lock(spl, leaf);
-         splinter_split_leaf(spl, node, leaf, pivot_no);
+         trunk_pivot_data *pdata =
+            trunk_get_pivot_data(spl, node, pivot_no);
+         page_handle *leaf = trunk_node_get(spl, pdata->addr);
+         trunk_node_claim(spl, &leaf);
+         trunk_node_lock(spl, leaf);
+         trunk_split_leaf(spl, node, leaf, pivot_no);
       }
    }
 
-   splinter_node_unlock(spl, node);
-   splinter_node_unclaim(spl, node);
-   splinter_node_unget(spl, &node);
+   trunk_node_unlock(spl, node);
+   trunk_node_unclaim(spl, node);
+   trunk_node_unget(spl, &node);
 
    task_perform_all(spl->ts);
 
@@ -4859,7 +4859,7 @@ splinter_flush_node(splinter_handle *spl, uint64 addr, void *arg)
 
 
 void
-splinter_force_flush(splinter_handle *spl)
+trunk_force_flush(trunk_handle *spl)
 {
    // FIXME [yfogel/aconway 2020-07-29] There is a race condition where both
    //       this thread and (already existing thread) are both trying to flush
@@ -4874,7 +4874,7 @@ splinter_force_flush(splinter_handle *spl)
    task_perform_all(spl->ts);
    memtable_unget_insert_lock(spl->mt_ctxt, lock_page);
    task_perform_all(spl->ts);
-   splinter_for_each_node(spl, splinter_flush_node, NULL);
+   trunk_for_each_node(spl, trunk_flush_node, NULL);
 }
 
 
@@ -4887,66 +4887,66 @@ splinter_force_flush(splinter_handle *spl)
  */
 
 static inline bool
-splinter_needs_split(splinter_handle *spl,
+trunk_needs_split(trunk_handle *spl,
                      page_handle     *node)
 {
-   uint16 height = splinter_height(spl, node);
+   uint16 height = trunk_height(spl, node);
    if (height == 0) {
-      uint64 num_tuples = splinter_get_pivot_data(spl, node, 0)->num_tuples;
+      uint64 num_tuples = trunk_get_pivot_data(spl, node, 0)->num_tuples;
       return num_tuples > spl->cfg.max_tuples_per_node
-         || splinter_logical_branch_count(spl, node) > spl->cfg.max_branches_per_node;
+         || trunk_logical_branch_count(spl, node) > spl->cfg.max_branches_per_node;
    }
-   return splinter_num_children(spl, node) > spl->cfg.fanout;
+   return trunk_num_children(spl, node) > spl->cfg.fanout;
 }
 
 int
-splinter_split_index(splinter_handle *spl,
+trunk_split_index(trunk_handle *spl,
                      page_handle     *parent,
                      page_handle     *child,
                      uint64           pivot_no)
 {
-   splinter_open_log_stream();
-   splinter_log_stream("split index %lu with parent %lu\n",
+   trunk_open_log_stream();
+   trunk_log_stream("split index %lu with parent %lu\n",
          child->disk_addr, parent->disk_addr);
-   splinter_log_node(spl, parent);
-   splinter_log_node(spl, child);
+   trunk_log_node(spl, parent);
+   trunk_log_node(spl, child);
    page_handle *left_node = child;
-   uint16 target_num_children = splinter_num_children(spl, left_node) / 2;
-   uint16 height = splinter_height(spl, left_node);
+   uint16 target_num_children = trunk_num_children(spl, left_node) / 2;
+   uint16 height = trunk_height(spl, left_node);
 
    if (spl->cfg.use_stats)
       spl->stats[platform_get_tid()].index_splits++;
 
    // allocate right node and write lock it
-   page_handle *right_node = splinter_alloc(spl, height);
+   page_handle *right_node = trunk_alloc(spl, height);
    uint64       right_addr = right_node->disk_addr;
 
    // ALEX: Maybe worth figuring out the real page size
    memmove(right_node->data, left_node->data, spl->cfg.page_size);
-   char *right_start_pivot = splinter_get_pivot(spl, right_node, 0);
+   char *right_start_pivot = trunk_get_pivot(spl, right_node, 0);
    char *left_split_pivot =
-      splinter_get_pivot(spl, left_node, target_num_children);
+      trunk_get_pivot(spl, left_node, target_num_children);
    uint16 pivots_to_copy =
-      splinter_num_pivot_keys(spl, left_node) - target_num_children;
-   size_t bytes_to_copy = pivots_to_copy * splinter_pivot_size(spl);
+      trunk_num_pivot_keys(spl, left_node) - target_num_children;
+   size_t bytes_to_copy = pivots_to_copy * trunk_pivot_size(spl);
    memmove(right_start_pivot, left_split_pivot, bytes_to_copy);
 
-   uint16 start_filter = splinter_start_sb_filter(spl, left_node);
-   uint16 end_filter = splinter_end_sb_filter(spl, left_node);
+   uint16 start_filter = trunk_start_sb_filter(spl, left_node);
+   uint16 end_filter = trunk_end_sb_filter(spl, left_node);
    for (uint16 filter_no = start_filter;
         filter_no != end_filter;
-        filter_no = splinter_subbundle_no_add(spl, filter_no, 1)) {
+        filter_no = trunk_subbundle_no_add(spl, filter_no, 1)) {
       routing_filter *filter =
-         splinter_get_sb_filter(spl, left_node, filter_no);
-      splinter_inc_filter(spl, filter);
+         trunk_get_sb_filter(spl, left_node, filter_no);
+      trunk_inc_filter(spl, filter);
       //platform_log("inc filter %lu in %lu (%u)\n",
       //      filter->addr, right_node->disk_addr,
       //      allocator_get_refcount(spl->al, filter->addr));
    }
 
    // set the headers appropriately
-   splinter_trunk_hdr *left_hdr  = (splinter_trunk_hdr *)left_node->data;
-   splinter_trunk_hdr *right_hdr = (splinter_trunk_hdr *)right_node->data;
+   trunk_hdr *left_hdr  = (trunk_hdr *)left_node->data;
+   trunk_hdr *right_hdr = (trunk_hdr *)right_node->data;
 
    right_hdr->num_pivot_keys = left_hdr->num_pivot_keys - target_num_children;
    left_hdr->num_pivot_keys  = target_num_children + 1;
@@ -4955,14 +4955,14 @@ splinter_split_index(splinter_handle *spl,
    left_hdr->next_addr  = right_addr;
 
    left_hdr->generation++;
-   splinter_reset_start_branch(spl, right_node);
-   splinter_reset_start_branch(spl, left_node);
+   trunk_reset_start_branch(spl, right_node);
+   trunk_reset_start_branch(spl, left_node);
 
    // fix the entries in the reclamation queue
-   uint16 right_num_children = splinter_num_children(spl, right_node);
+   uint16 right_num_children = trunk_num_children(spl, right_node);
    for (uint16 pivot_no = 0; pivot_no < right_num_children; pivot_no++) {
-      splinter_pivot_data *pdata =
-         splinter_get_pivot_data(spl, right_node, pivot_no);
+      trunk_pivot_data *pdata =
+         trunk_get_pivot_data(spl, right_node, pivot_no);
       if (pdata->srq_idx != -1 && spl->cfg.reclaim_threshold != UINT64_MAX) {
          //platform_log("Deleting %12lu-%lu (index %lu) from SRQ\n",
          //      left_node->disk_addr, pdata->generation, pdata->srq_idx);
@@ -4976,20 +4976,20 @@ splinter_split_index(splinter_handle *spl,
 
    // add right child to parent
    platform_status rc =
-      splinter_add_pivot(spl, parent, right_node, pivot_no + 1);
+      trunk_add_pivot(spl, parent, right_node, pivot_no + 1);
    platform_assert(SUCCESS(rc));
-   splinter_pivot_recount_num_tuples(spl, parent, pivot_no);
-   splinter_pivot_recount_num_tuples(spl, parent, pivot_no + 1);
+   trunk_pivot_recount_num_tuples(spl, parent, pivot_no);
+   trunk_pivot_recount_num_tuples(spl, parent, pivot_no + 1);
 
-   splinter_log_stream("----------------------------------------\n");
-   splinter_log_node(spl, parent);
-   splinter_log_node(spl, left_node);
-   splinter_log_node(spl, right_node);
-   splinter_close_log_stream();
+   trunk_log_stream("----------------------------------------\n");
+   trunk_log_node(spl, parent);
+   trunk_log_node(spl, left_node);
+   trunk_log_node(spl, right_node);
+   trunk_close_log_stream();
 
-   splinter_node_unlock(spl, right_node);
-   splinter_node_unclaim(spl, right_node);
-   splinter_node_unget(spl, &right_node);
+   trunk_node_unlock(spl, right_node);
+   trunk_node_unclaim(spl, right_node);
+   trunk_node_unget(spl, &right_node);
 
    return 0;
 }
@@ -5000,9 +5000,9 @@ splinter_split_index(splinter_handle *spl,
 
 __attribute__ ((unused))
 static inline uint64
-splinter_pivot_estimate_unique_keys(splinter_handle     *spl,
+trunk_pivot_estimate_unique_keys(trunk_handle     *spl,
                                     page_handle         *node,
-                                    splinter_pivot_data *pdata)
+                                    trunk_pivot_data *pdata)
 {
    routing_filter filter[MAX_FILTERS];
    uint64 filter_no = 0;
@@ -5010,12 +5010,12 @@ splinter_pivot_estimate_unique_keys(splinter_handle     *spl,
 
    uint64 num_sb_fp = 0;
    uint64 num_sb_unique = 0;
-   for (uint16 sb_filter_no = splinter_start_sb_filter(spl, node);
-        sb_filter_no != splinter_end_sb_filter(spl, node);
-        sb_filter_no = splinter_subbundle_no_add(spl, sb_filter_no, 1))
+   for (uint16 sb_filter_no = trunk_start_sb_filter(spl, node);
+        sb_filter_no != trunk_end_sb_filter(spl, node);
+        sb_filter_no = trunk_subbundle_no_add(spl, sb_filter_no, 1))
    {
       routing_filter *sb_filter =
-         splinter_get_sb_filter(spl, node, sb_filter_no);
+         trunk_get_sb_filter(spl, node, sb_filter_no);
       num_sb_fp += sb_filter->num_fingerprints;
       num_sb_unique += sb_filter->num_unique;
       filter[filter_no++] = *sb_filter;
@@ -5030,10 +5030,10 @@ splinter_pivot_estimate_unique_keys(splinter_handle     *spl,
 
    uint64 num_leaf_sb_fp = 0;
    for (uint16 bundle_no = pdata->start_bundle;
-        bundle_no != splinter_end_bundle(spl, node);
-        bundle_no = splinter_bundle_no_add(spl, bundle_no, 1))
+        bundle_no != trunk_end_bundle(spl, node);
+        bundle_no = trunk_bundle_no_add(spl, bundle_no, 1))
    {
-      splinter_bundle *bundle = splinter_get_bundle(spl, node, bundle_no);
+      trunk_bundle *bundle = trunk_get_bundle(spl, node, bundle_no);
       num_leaf_sb_fp += bundle->num_tuples;
    }
    uint64 est_num_leaf_sb_unique = num_sb_unique * num_leaf_sb_fp / num_sb_fp;
@@ -5075,24 +5075,24 @@ splinter_pivot_estimate_unique_keys(splinter_handle     *spl,
  */
 
 void
-splinter_split_leaf(splinter_handle *spl,
+trunk_split_leaf(trunk_handle *spl,
                     page_handle     *parent,
                     page_handle     *leaf,
                     uint16           child_idx)
 {
    const threadid tid = platform_get_tid();
    // FIXME: [aconway 2020-06-19] This scratch lookup feels a bit dirty
-   splinter_task_scratch *task_scratch =
+   trunk_task_scratch *task_scratch =
       task_system_get_thread_scratch(spl->ts, tid);
    split_leaf_scratch *scratch = &task_scratch->split_leaf;
-   uint64 num_branches = splinter_branch_count(spl, leaf);
-   uint64 start_branch = splinter_start_branch(spl, leaf);
+   uint64 num_branches = trunk_branch_count(spl, leaf);
+   uint64 start_branch = trunk_start_branch(spl, leaf);
 
-   splinter_node_unlock(spl, parent);
-   splinter_node_unlock(spl, leaf);
+   trunk_node_unlock(spl, parent);
+   trunk_node_unlock(spl, leaf);
 
-   splinter_open_log_stream();
-   splinter_log_stream("split_leaf addr %lu\n", leaf->disk_addr);
+   trunk_open_log_stream();
+   trunk_log_stream("split_leaf addr %lu\n", leaf->disk_addr);
 
    uint64 split_start;
    if (spl->cfg.use_stats) {
@@ -5100,10 +5100,10 @@ splinter_split_leaf(splinter_handle *spl,
       split_start = platform_get_timestamp();
    }
 
-   splinter_pivot_data *pdata = splinter_get_pivot_data(spl, leaf, 0);
+   trunk_pivot_data *pdata = trunk_get_pivot_data(spl, leaf, 0);
    uint64 estimated_unique_keys =
-      splinter_pivot_estimate_unique_keys(spl, leaf, pdata);
-   uint64 num_tuples = splinter_pivot_num_tuples(spl, leaf, 0);
+      trunk_pivot_estimate_unique_keys(spl, leaf, pdata);
+   uint64 num_tuples = trunk_pivot_num_tuples(spl, leaf, 0);
    if (estimated_unique_keys > num_tuples * 19 / 20) {
       estimated_unique_keys = num_tuples;
    }
@@ -5120,8 +5120,8 @@ splinter_split_leaf(splinter_handle *spl,
 
    // copy pivot (in parent) of leaf
    memmove(scratch->pivot[0],
-           splinter_min_key(spl, leaf),
-           splinter_key_size(spl));
+           trunk_min_key(spl, leaf),
+           trunk_key_size(spl));
 
    if (target_num_leaves != 1) {
       /*
@@ -5146,16 +5146,16 @@ splinter_split_leaf(splinter_handle *spl,
       char            min_key[MAX_KEY_SIZE];
       char            max_key[MAX_KEY_SIZE];
       memmove(
-         min_key, splinter_get_pivot(spl, leaf, 0), splinter_key_size(spl));
+         min_key, trunk_get_pivot(spl, leaf, 0), trunk_key_size(spl));
       memmove(
-         max_key, splinter_get_pivot(spl, leaf, 1), splinter_key_size(spl));
+         max_key, trunk_get_pivot(spl, leaf, 1), trunk_key_size(spl));
 
       for (uint64 branch_offset = 0; branch_offset < num_branches;
            branch_offset++) {
          uint64 branch_no =
-            splinter_branch_no_add(spl, start_branch, branch_offset);
-         debug_assert(branch_no != splinter_end_branch(spl, leaf));
-         splinter_branch *branch = splinter_get_branch(spl, leaf, branch_no);
+            trunk_branch_no_add(spl, start_branch, branch_offset);
+         debug_assert(branch_no != trunk_end_branch(spl, leaf));
+         trunk_branch *branch = trunk_get_branch(spl, leaf, branch_no);
          btree_iterator_init(spl->cc,
                              &spl->cfg.btree_cfg,
                              &rough_btree_itor[branch_offset],
@@ -5204,7 +5204,7 @@ splinter_split_leaf(splinter_handle *spl,
             // copy new pivot (in parent) of new leaf
             memmove(scratch->pivot[num_leaves + 1],
                     curr_key,
-                    splinter_key_size(spl));
+                    trunk_key_size(spl));
          }
       }
 
@@ -5220,29 +5220,29 @@ splinter_split_leaf(splinter_handle *spl,
 
    // copy max key of last new leaf (max key of leaf)
    memmove(scratch->pivot[num_leaves],
-           splinter_max_key(spl, leaf),
-           splinter_key_size(spl));
+           trunk_max_key(spl, leaf),
+           trunk_key_size(spl));
 
    /*
     * FIXME: [aconway 2020-07-16] This case can only happen with default params
     * with a height 8+ tree and worst case flush. We do not currently handle
     * this case.
     */
-   platform_assert(num_leaves + splinter_num_pivot_keys(spl, parent)
+   platform_assert(num_leaves + trunk_num_pivot_keys(spl, parent)
          <= spl->cfg.max_pivot_keys);
 
    /*
     * 3. Clear old bundles from leaf and put all branches in a new bundle
     */
-   splinter_node_lock(spl, parent);
-   splinter_log_node(spl, parent);
-   splinter_node_lock(spl, leaf);
-   splinter_log_node(spl, leaf);
+   trunk_node_lock(spl, parent);
+   trunk_log_node(spl, parent);
+   trunk_node_lock(spl, leaf);
+   trunk_log_node(spl, leaf);
 
    uint16 bundle_no =
-      splinter_leaf_rebundle_all_branches(spl, leaf, target_leaf_tuples, FALSE);
-   splinter_inc_generation(spl, leaf);
-   uint64 last_next_addr = splinter_next_addr(spl, leaf);
+      trunk_leaf_rebundle_all_branches(spl, leaf, target_leaf_tuples, FALSE);
+   trunk_inc_generation(spl, leaf);
+   uint64 last_next_addr = trunk_next_addr(spl, leaf);
 
    for (uint16 leaf_no = 0; leaf_no < num_leaves; leaf_no++) {
       /*
@@ -5262,7 +5262,7 @@ splinter_split_leaf(splinter_handle *spl,
       page_handle *new_leaf;
       if (leaf_no != 0) {
          // allocate a new leaf
-         new_leaf = splinter_alloc(spl, 0);
+         new_leaf = trunk_alloc(spl, 0);
 
          // copy leaf to new leaf
          memmove(new_leaf->data, leaf->data, spl->cfg.page_size);
@@ -5272,48 +5272,48 @@ splinter_split_leaf(splinter_handle *spl,
       }
 
       // adjust min key
-      memmove(splinter_get_pivot(spl, new_leaf, 0),
+      memmove(trunk_get_pivot(spl, new_leaf, 0),
               scratch->pivot[leaf_no],
-              splinter_key_size(spl));
+              trunk_key_size(spl));
       // adjust max key
-      memmove(splinter_get_pivot(spl, new_leaf, 1),
+      memmove(trunk_get_pivot(spl, new_leaf, 1),
               scratch->pivot[leaf_no + 1],
-              splinter_key_size(spl));
+              trunk_key_size(spl));
 
       // set new_leaf tuple_count
-      splinter_bundle *bundle = splinter_get_bundle(spl, new_leaf, bundle_no);
-      uint64 new_leaf_num_tuples[SPLINTER_MAX_PIVOTS];
-      splinter_tuples_in_bundle(spl, new_leaf, bundle, new_leaf_num_tuples);
-      splinter_pivot_set_num_tuples(spl, new_leaf, 0, new_leaf_num_tuples[0]);
+      trunk_bundle *bundle = trunk_get_bundle(spl, new_leaf, bundle_no);
+      uint64 new_leaf_num_tuples[TRUNK_MAX_PIVOTS];
+      trunk_tuples_in_bundle(spl, new_leaf, bundle, new_leaf_num_tuples);
+      trunk_pivot_set_num_tuples(spl, new_leaf, 0, new_leaf_num_tuples[0]);
 
       if (leaf_no != 0) {
          // set next_addr of leaf
-         splinter_set_next_addr(spl, leaf, new_leaf->disk_addr);
+         trunk_set_next_addr(spl, leaf, new_leaf->disk_addr);
 
          // inc the refs of all the branches
-         for (uint16 branch_no = splinter_start_branch(spl, new_leaf);
-              branch_no != splinter_end_branch(spl, new_leaf);
-              branch_no = splinter_branch_no_add(spl, branch_no, 1)) {
-            splinter_branch *branch =
-               splinter_get_branch(spl, new_leaf, branch_no);
-            const char *min_key = splinter_min_key(spl, new_leaf);
-            splinter_inc_intersection(spl, branch, min_key, FALSE);
+         for (uint16 branch_no = trunk_start_branch(spl, new_leaf);
+              branch_no != trunk_end_branch(spl, new_leaf);
+              branch_no = trunk_branch_no_add(spl, branch_no, 1)) {
+            trunk_branch *branch =
+               trunk_get_branch(spl, new_leaf, branch_no);
+            const char *min_key = trunk_min_key(spl, new_leaf);
+            trunk_inc_intersection(spl, branch, min_key, FALSE);
          }
 
          // inc the refs of all the filters
-         splinter_bundle *bundle =
-            splinter_get_bundle(spl, new_leaf, bundle_no);
+         trunk_bundle *bundle =
+            trunk_get_bundle(spl, new_leaf, bundle_no);
          uint16 start_filter =
-            splinter_bundle_start_filter(spl, new_leaf, bundle);
+            trunk_bundle_start_filter(spl, new_leaf, bundle);
          uint16 end_filter =
-            splinter_bundle_end_filter(spl, new_leaf, bundle);
+            trunk_bundle_end_filter(spl, new_leaf, bundle);
          for (uint16 filter_no = start_filter;
               filter_no != end_filter;
-              filter_no = splinter_subbundle_no_add(spl, filter_no, 1)) {
+              filter_no = trunk_subbundle_no_add(spl, filter_no, 1)) {
             routing_filter *filter =
-               splinter_get_sb_filter(spl, new_leaf, filter_no);
-            splinter_inc_filter(spl, filter);
-            //splinter_log_stream("inc filter %lu in %lu (%u)\n",
+               trunk_get_sb_filter(spl, new_leaf, filter_no);
+            trunk_inc_filter(spl, filter);
+            //trunk_log_stream("inc filter %lu in %lu (%u)\n",
             //      filter->addr, new_leaf->disk_addr,
             //      allocator_get_refcount(spl->al, filter->addr));
          }
@@ -5322,70 +5322,70 @@ splinter_split_leaf(splinter_handle *spl,
           * 5. Add new leaf to parent
           */
          platform_status rc =
-            splinter_add_pivot(spl, parent, new_leaf, child_idx + leaf_no);
+            trunk_add_pivot(spl, parent, new_leaf, child_idx + leaf_no);
          platform_assert(SUCCESS(rc));
 
          /*
           * 6. Issue compact_bundle for leaf and release
           */
-         splinter_compact_bundle_req *req = TYPED_ZALLOC(spl->heap_id, req);
+         trunk_compact_bundle_req *req = TYPED_ZALLOC(spl->heap_id, req);
          req->spl = spl;
          req->addr = leaf->disk_addr;
          // req->height already 0
          req->bundle_no = bundle_no;
-         req->generation = splinter_generation(spl, leaf);
-         req->max_pivot_generation = splinter_pivot_generation(spl, leaf);
-         req->pivot_generation[0] = splinter_pivot_generation(spl, leaf) - 1;
-         req->input_pivot_count[0] = splinter_pivot_num_tuples(spl, leaf, 0);
+         req->generation = trunk_generation(spl, leaf);
+         req->max_pivot_generation = trunk_pivot_generation(spl, leaf);
+         req->pivot_generation[0] = trunk_pivot_generation(spl, leaf) - 1;
+         req->input_pivot_count[0] = trunk_pivot_num_tuples(spl, leaf, 0);
 
-         splinter_default_log("enqueuing compact_bundle %lu-%u\n",
+         trunk_default_log("enqueuing compact_bundle %lu-%u\n",
                req->addr, req->bundle_no);
-         rc = task_enqueue(spl->ts, TASK_TYPE_NORMAL, splinter_compact_bundle,
+         rc = task_enqueue(spl->ts, TASK_TYPE_NORMAL, trunk_compact_bundle,
                            req, FALSE);
          platform_assert(SUCCESS(rc));
 
-         splinter_log_node(spl, leaf);
+         trunk_log_node(spl, leaf);
 
-         debug_assert(splinter_verify_node(spl, leaf));
-         splinter_node_unlock(spl, leaf);
-         splinter_node_unclaim(spl, leaf);
-         splinter_node_unget(spl, &leaf);
+         debug_assert(trunk_verify_node(spl, leaf));
+         trunk_node_unlock(spl, leaf);
+         trunk_node_unclaim(spl, leaf);
+         trunk_node_unget(spl, &leaf);
       }
 
       leaf = new_leaf;
    }
 
    // set next_addr of leaf (from last iteration)
-   splinter_set_next_addr(spl, leaf, last_next_addr);
-   splinter_compact_bundle_req *req = TYPED_ZALLOC(spl->heap_id, req);
+   trunk_set_next_addr(spl, leaf, last_next_addr);
+   trunk_compact_bundle_req *req = TYPED_ZALLOC(spl->heap_id, req);
    req->spl = spl;
    req->addr = leaf->disk_addr;
    // req->height already 0
    req->bundle_no = bundle_no;
-   req->generation = splinter_generation(spl, leaf);
-   req->max_pivot_generation = splinter_pivot_generation(spl, leaf);
-   req->pivot_generation[0] = splinter_pivot_generation(spl, leaf) - 1;
-   req->input_pivot_count[0] = splinter_pivot_num_tuples(spl, leaf, 0);
+   req->generation = trunk_generation(spl, leaf);
+   req->max_pivot_generation = trunk_pivot_generation(spl, leaf);
+   req->pivot_generation[0] = trunk_pivot_generation(spl, leaf) - 1;
+   req->input_pivot_count[0] = trunk_pivot_num_tuples(spl, leaf, 0);
 
    // issue compact_bundle for leaf and release
-   splinter_default_log("enqueuing compact_bundle %lu-%u\n",
+   trunk_default_log("enqueuing compact_bundle %lu-%u\n",
                         req->addr, req->bundle_no);
    platform_status rc =
-      task_enqueue(spl->ts, TASK_TYPE_NORMAL, splinter_compact_bundle, req,
+      task_enqueue(spl->ts, TASK_TYPE_NORMAL, trunk_compact_bundle, req,
                    FALSE);
    platform_assert(SUCCESS(rc));
 
-   splinter_log_node(spl, leaf);
+   trunk_log_node(spl, leaf);
 
-   debug_assert(splinter_verify_node(spl, leaf));
-   splinter_node_unlock(spl, leaf);
-   splinter_node_unclaim(spl, leaf);
-   splinter_node_unget(spl, &leaf);
+   debug_assert(trunk_verify_node(spl, leaf));
+   trunk_node_unlock(spl, leaf);
+   trunk_node_unclaim(spl, leaf);
+   trunk_node_unget(spl, &leaf);
 
    /*
     * 8. Clean up
     */
-   splinter_close_log_stream();
+   trunk_close_log_stream();
 
    if (spl->cfg.use_stats) {
       // Doesn't include the original leaf
@@ -5401,14 +5401,14 @@ splinter_split_leaf(splinter_handle *spl,
 
 
 int
-splinter_split_root(splinter_handle *spl,
+trunk_split_root(trunk_handle *spl,
                     page_handle     *root)
 {
-   splinter_trunk_hdr *root_hdr = (splinter_trunk_hdr *)root->data;
+   trunk_hdr *root_hdr = (trunk_hdr *)root->data;
 
    // allocate a new child node
-   page_handle *       child     = splinter_alloc(spl, root_hdr->height);
-   splinter_trunk_hdr *child_hdr = (splinter_trunk_hdr *)child->data;
+   page_handle *       child     = trunk_alloc(spl, root_hdr->height);
+   trunk_hdr *child_hdr = (trunk_hdr *)child->data;
 
    // copy root to child, fix up root, then split
    memmove(child_hdr, root_hdr, spl->cfg.page_size);
@@ -5426,13 +5426,13 @@ splinter_split_root(splinter_handle *spl,
    root_hdr->start_sb_filter   = 0;
    root_hdr->end_sb_filter     = 0;
 
-   splinter_add_pivot_new_root(spl, root, child);
+   trunk_add_pivot_new_root(spl, root, child);
 
-   splinter_split_index(spl, root, child, 0);
+   trunk_split_index(spl, root, child, 0);
 
-   splinter_node_unlock(spl, child);
-   splinter_node_unclaim(spl, child);
-   splinter_node_unget(spl, &child);
+   trunk_node_unlock(spl, child);
+   trunk_node_unclaim(spl, child);
+   trunk_node_unget(spl, &child);
 
    return 0;
 }
@@ -5443,54 +5443,54 @@ splinter_split_root(splinter_handle *spl,
  *
  * range functions and iterators
  *
- *      splinter_node_iterator
- *      splinter_iterator
+ *      trunk_node_iterator
+ *      trunk_iterator
  *
  *-----------------------------------------------------------------------------
  */
 
 void
-                 splinter_range_iterator_get_curr(iterator *itor, char **key, char **data);
-platform_status  splinter_range_iterator_at_end   (iterator *itor, bool *at_end);
-platform_status  splinter_range_iterator_advance  (iterator *itor);
-void             splinter_range_iterator_deinit   (splinter_range_iterator *range_itor);
+                 trunk_range_iterator_get_curr(iterator *itor, char **key, char **data);
+platform_status  trunk_range_iterator_at_end   (iterator *itor, bool *at_end);
+platform_status  trunk_range_iterator_advance  (iterator *itor);
+void             trunk_range_iterator_deinit   (trunk_range_iterator *range_itor);
 
-const static iterator_ops splinter_range_iterator_ops = {
-   .get_curr = splinter_range_iterator_get_curr,
-   .at_end   = splinter_range_iterator_at_end,
-   .advance  = splinter_range_iterator_advance,
+const static iterator_ops trunk_range_iterator_ops = {
+   .get_curr = trunk_range_iterator_get_curr,
+   .at_end   = trunk_range_iterator_at_end,
+   .advance  = trunk_range_iterator_advance,
 };
 
 platform_status
-splinter_range_iterator_init(splinter_handle         *spl,
-                             splinter_range_iterator *range_itor,
+trunk_range_iterator_init(trunk_handle         *spl,
+                             trunk_range_iterator *range_itor,
                              char                    *min_key,
                              char                    *max_key,
                              uint64                   num_tuples)
 {
    range_itor->spl = spl;
-   range_itor->super.ops = &splinter_range_iterator_ops;
+   range_itor->super.ops = &trunk_range_iterator_ops;
    range_itor->num_branches = 0;
    range_itor->num_tuples = num_tuples;
    if (min_key == NULL) {
      min_key = spl->cfg.data_cfg->min_key;
    }
-   memmove(range_itor->min_key, min_key, splinter_key_size(spl));
+   memmove(range_itor->min_key, min_key, trunk_key_size(spl));
    if (max_key) {
       range_itor->has_max_key = TRUE;
-      memmove(range_itor->max_key, max_key, splinter_key_size(spl));
+      memmove(range_itor->max_key, max_key, trunk_key_size(spl));
    } else {
       range_itor->has_max_key = FALSE;
-      memset(range_itor->max_key, 0, splinter_key_size(spl));
+      memset(range_itor->max_key, 0, trunk_key_size(spl));
    }
 
    const char *hard_max_key = max_key ? max_key : spl->cfg.data_cfg->max_key;
-   if (splinter_key_compare(spl, min_key, hard_max_key) == 0) {
+   if (trunk_key_compare(spl, min_key, hard_max_key) == 0) {
       range_itor->at_end = TRUE;
       return STATUS_OK;
    }
 
-   if (max_key && splinter_key_compare(spl, max_key, min_key) <= 0) {
+   if (max_key && trunk_key_compare(spl, max_key, min_key) <= 0) {
       range_itor->at_end = TRUE;
       return STATUS_OK;
    }
@@ -5513,19 +5513,19 @@ splinter_range_iterator_init(splinter_handle         *spl,
    for (uint64 mt_gen = range_itor->memtable_start_gen;
         mt_gen != range_itor->memtable_end_gen;
         mt_gen--) {
-      platform_assert(range_itor->num_branches < SPLINTER_MAX_TOTAL_DEGREE);
+      platform_assert(range_itor->num_branches < TRUNK_MAX_TOTAL_DEGREE);
       debug_assert(range_itor->num_branches < ARRAY_SIZE(range_itor->branch));
 
       bool compacted;
       uint64 root_addr =
-         splinter_memtable_root_addr_for_lookup(spl, mt_gen, &compacted);
+         trunk_memtable_root_addr_for_lookup(spl, mt_gen, &compacted);
       range_itor->compacted[range_itor->num_branches] = compacted;
       page_type type = compacted ?  PAGE_TYPE_BRANCH : PAGE_TYPE_MEMTABLE;
       if (compacted) {
          range_itor->meta_page[range_itor->num_branches] =
             btree_blind_inc(spl->cc, &spl->cfg.btree_cfg, root_addr, type);
       } else {
-         splinter_memtable_inc_ref(spl, mt_gen);
+         trunk_memtable_inc_ref(spl, mt_gen);
       }
 
       range_itor->branch[range_itor->num_branches].root_addr = root_addr;
@@ -5533,26 +5533,26 @@ splinter_range_iterator_init(splinter_handle         *spl,
       range_itor->num_branches++;
    }
 
-   page_handle *node = splinter_node_get(spl, spl->root_addr);
+   page_handle *node = trunk_node_get(spl, spl->root_addr);
    memtable_unget_lookup_lock(spl->mt_ctxt, mt_lookup_lock_page);
 
    // index btrees
-   uint16 height = splinter_height(spl, node);
+   uint16 height = trunk_height(spl, node);
    for (uint16 h = height; h > 0; h--) {
-      uint16 pivot_no = splinter_find_pivot(spl, node, range_itor->min_key,
+      uint16 pivot_no = trunk_find_pivot(spl, node, range_itor->min_key,
             less_than_or_equal);
-      debug_assert(pivot_no < splinter_num_children(spl, node));
-      splinter_pivot_data *pdata = splinter_get_pivot_data(spl, node, pivot_no);
+      debug_assert(pivot_no < trunk_num_children(spl, node));
+      trunk_pivot_data *pdata = trunk_get_pivot_data(spl, node, pivot_no);
 
       for (uint16 branch_offset = 0; branch_offset !=
-           splinter_pivot_branch_count(spl, node, pdata);
+           trunk_pivot_branch_count(spl, node, pdata);
            branch_offset++) {
-         platform_assert(range_itor->num_branches < SPLINTER_MAX_TOTAL_DEGREE);
+         platform_assert(range_itor->num_branches < TRUNK_MAX_TOTAL_DEGREE);
          debug_assert(range_itor->num_branches < ARRAY_SIZE(range_itor->branch));
-         uint16 branch_no = splinter_branch_no_sub(spl,
-               splinter_end_branch(spl, node), branch_offset + 1);
+         uint16 branch_no = trunk_branch_no_sub(spl,
+               trunk_end_branch(spl, node), branch_offset + 1);
          range_itor->branch[range_itor->num_branches] =
-            *splinter_get_branch(spl, node, branch_no);
+            *trunk_get_branch(spl, node, branch_no);
          range_itor->compacted[range_itor->num_branches] = TRUE;
          uint64 root_addr = range_itor->branch[range_itor->num_branches].root_addr;
 
@@ -5561,19 +5561,19 @@ splinter_range_iterator_init(splinter_handle         *spl,
          range_itor->num_branches++;
       }
 
-      page_handle *child = splinter_node_get(spl, pdata->addr);
-      splinter_node_unget(spl, &node);
+      page_handle *child = trunk_node_get(spl, pdata->addr);
+      trunk_node_unget(spl, &node);
       node = child;
    }
 
    // leaf btrees
    for (uint16 branch_offset = 0;
-        branch_offset != splinter_branch_count(spl, node);
+        branch_offset != trunk_branch_count(spl, node);
         branch_offset++) {
-      uint16 branch_no = splinter_branch_no_sub(spl,
-            splinter_end_branch(spl, node), branch_offset + 1);
+      uint16 branch_no = trunk_branch_no_sub(spl,
+            trunk_end_branch(spl, node), branch_offset + 1);
       range_itor->branch[range_itor->num_branches] =
-         *splinter_get_branch(spl, node, branch_no);
+         *trunk_get_branch(spl, node, branch_no);
       uint64 root_addr = range_itor->branch[range_itor->num_branches].root_addr;
       range_itor->meta_page[range_itor->num_branches] =
          btree_blind_inc(spl->cc, &spl->cfg.btree_cfg, root_addr, PAGE_TYPE_BRANCH);
@@ -5584,26 +5584,26 @@ splinter_range_iterator_init(splinter_handle         *spl,
    // have a leaf, use to get rebuild key
    char *rebuild_key =
      !range_itor->has_max_key
-     || splinter_key_compare(spl, splinter_max_key(spl, node), max_key) < 0
-     ? splinter_max_key(spl, node)
+     || trunk_key_compare(spl, trunk_max_key(spl, node), max_key) < 0
+     ? trunk_max_key(spl, node)
      : max_key;
-   memmove(range_itor->rebuild_key, rebuild_key, splinter_key_size(spl));
-   if (max_key && splinter_key_compare(spl, max_key, rebuild_key) < 0) {
-     memcpy(range_itor->local_max_key, max_key, splinter_key_size(spl));
+   memmove(range_itor->rebuild_key, rebuild_key, trunk_key_size(spl));
+   if (max_key && trunk_key_compare(spl, max_key, rebuild_key) < 0) {
+     memcpy(range_itor->local_max_key, max_key, trunk_key_size(spl));
    } else {
-     memcpy(range_itor->local_max_key, rebuild_key, splinter_key_size(spl));
+     memcpy(range_itor->local_max_key, rebuild_key, trunk_key_size(spl));
    }
 
-   splinter_node_unget(spl, &node);
+   trunk_node_unget(spl, &node);
 
    for (uint64 i = 0; i < range_itor->num_branches; i++) {
       uint64 branch_no = range_itor->num_branches - i - 1;
       btree_iterator *btree_itor = &range_itor->btree_itor[branch_no];
-      splinter_branch *branch = &range_itor->branch[branch_no];
+      trunk_branch *branch = &range_itor->branch[branch_no];
       if (range_itor->compacted[branch_no]) {
          bool do_prefetch = range_itor->compacted[branch_no] &&
-            num_tuples > SPLINTER_PREFETCH_MIN ? TRUE : FALSE;
-         splinter_branch_iterator_init(spl,
+            num_tuples > TRUNK_PREFETCH_MIN ? TRUE : FALSE;
+         trunk_branch_iterator_init(spl,
                                        btree_itor,
                                        branch,
                                        range_itor->min_key,
@@ -5613,7 +5613,7 @@ splinter_range_iterator_init(splinter_handle         *spl,
       } else {
          uint64 mt_root_addr = branch->root_addr;
          bool is_live = branch_no == 0;
-         splinter_memtable_iterator_init(spl, btree_itor, mt_root_addr,
+         trunk_memtable_iterator_init(spl, btree_itor, mt_root_addr,
                range_itor->min_key, range_itor->local_max_key, is_live, FALSE);
       }
       range_itor->itor[i] = &btree_itor->super;
@@ -5639,13 +5639,13 @@ splinter_range_iterator_init(splinter_handle         *spl,
     * db/range, move to next leaf
     */
    if (at_end) {
-      splinter_range_iterator_deinit(range_itor);
-      if (1 && splinter_key_compare(spl, range_itor->local_max_key,
+      trunk_range_iterator_deinit(range_itor);
+      if (1 && trunk_key_compare(spl, range_itor->local_max_key,
                spl->cfg.data_cfg->max_key) != 0
             && (0 || !range_itor->has_max_key
-                  || splinter_key_compare(spl, range_itor->local_max_key,
+                  || trunk_key_compare(spl, range_itor->local_max_key,
                      range_itor->max_key) < 0)) {
-         rc = splinter_range_iterator_init(spl, range_itor,
+         rc = trunk_range_iterator_init(spl, range_itor,
                range_itor->rebuild_key, max_key, range_itor->num_tuples);
          if (!SUCCESS(rc)) {
             return rc;
@@ -5660,18 +5660,18 @@ splinter_range_iterator_init(splinter_handle         *spl,
 }
 
 void
-splinter_range_iterator_get_curr(iterator *itor, char **key, char **data)
+trunk_range_iterator_get_curr(iterator *itor, char **key, char **data)
 {
    debug_assert(itor != NULL);
-   splinter_range_iterator *range_itor = (splinter_range_iterator *)itor;
+   trunk_range_iterator *range_itor = (trunk_range_iterator *)itor;
    iterator_get_curr(&range_itor->merge_itor->super, key, data);
 }
 
 platform_status
-splinter_range_iterator_advance(iterator *itor)
+trunk_range_iterator_advance(iterator *itor)
 {
    debug_assert(itor != NULL);
-   splinter_range_iterator *range_itor = (splinter_range_iterator *)itor;
+   trunk_range_iterator *range_itor = (trunk_range_iterator *)itor;
    iterator_advance(&range_itor->merge_itor->super);
    range_itor->num_tuples++;
    bool at_end;
@@ -5679,12 +5679,12 @@ splinter_range_iterator_advance(iterator *itor)
    platform_status rc;
    // robj: shouldn't this be a while loop, like in the init function?
    if (at_end) {
-      splinter_range_iterator_deinit(range_itor);
+      trunk_range_iterator_deinit(range_itor);
       if (range_itor->has_max_key) {
-         rc = splinter_range_iterator_init(range_itor->spl, range_itor,
+         rc = trunk_range_iterator_init(range_itor->spl, range_itor,
                range_itor->rebuild_key, range_itor->max_key, range_itor->num_tuples);
       } else {
-         rc = splinter_range_iterator_init(range_itor->spl, range_itor,
+         rc = trunk_range_iterator_init(range_itor->spl, range_itor,
                range_itor->rebuild_key, NULL, range_itor->num_tuples);
       }
       if (!SUCCESS(rc)) {
@@ -5700,35 +5700,35 @@ splinter_range_iterator_advance(iterator *itor)
 }
 
 platform_status
-splinter_range_iterator_at_end(iterator *itor,
+trunk_range_iterator_at_end(iterator *itor,
                                bool     *at_end)
 {
    debug_assert(itor != NULL);
-   splinter_range_iterator *range_itor = (splinter_range_iterator *)itor;
+   trunk_range_iterator *range_itor = (trunk_range_iterator *)itor;
 
    *at_end = range_itor->at_end;
    return STATUS_OK;
 }
 
 void
-splinter_range_iterator_deinit(splinter_range_iterator *range_itor)
+trunk_range_iterator_deinit(trunk_range_iterator *range_itor)
 {
    // If the iterator is at end, then it has already been deinitialized
    if (range_itor->at_end) {
       return;
    }
-   splinter_handle *spl = range_itor->spl;
+   trunk_handle *spl = range_itor->spl;
    merge_iterator_destroy(range_itor->spl->heap_id, &range_itor->merge_itor);
    for (uint64 i = 0; i < range_itor->num_branches; i++) {
       btree_iterator *btree_itor = &range_itor->btree_itor[i];
       if (range_itor->compacted[i]) {
-         splinter_branch_iterator_deinit(spl, btree_itor, FALSE);
+         trunk_branch_iterator_deinit(spl, btree_itor, FALSE);
          page_handle *meta_page = range_itor->meta_page[i];
          btree_blind_zap(spl->cc, &spl->cfg.btree_cfg, meta_page, PAGE_TYPE_BRANCH);
       } else {
          uint64 mt_gen = range_itor->memtable_start_gen - i;
-         splinter_memtable_iterator_deinit(spl, btree_itor, mt_gen, FALSE);
-         splinter_memtable_dec_ref(spl, mt_gen);
+         trunk_memtable_iterator_deinit(spl, btree_itor, mt_gen, FALSE);
+         trunk_memtable_dec_ref(spl, mt_gen);
       }
    }
 }
@@ -5739,15 +5739,15 @@ splinter_range_iterator_deinit(splinter_range_iterator *range_itor)
  *
  * Returns node with a write loc
  */
-splinter_pivot_data *
-splinter_find_pivot_from_generation(splinter_handle *spl,
+trunk_pivot_data *
+trunk_find_pivot_from_generation(trunk_handle *spl,
                                     page_handle     *leaf,
                                     uint64           pivot_generation)
 {
-   uint16 num_children = splinter_num_children(spl, leaf);
+   uint16 num_children = trunk_num_children(spl, leaf);
    for (uint16 pivot_no = 0; pivot_no < num_children; pivot_no++) {
-      splinter_pivot_data *pdata =
-         splinter_get_pivot_data(spl, leaf, pivot_no);
+      trunk_pivot_data *pdata =
+         trunk_get_pivot_data(spl, leaf, pivot_no);
       if (pivot_generation == pdata->generation) {
          return pdata;
       }
@@ -5756,15 +5756,15 @@ splinter_find_pivot_from_generation(splinter_handle *spl,
 }
 
 platform_status
-splinter_compact_leaf(splinter_handle *spl,
+trunk_compact_leaf(trunk_handle *spl,
                       page_handle     *leaf)
 {
    const threadid tid = platform_get_tid();
    // FIXME: [aconway 2020-06-19] This scratch lookup feels a bit dirty
 
-   splinter_open_log_stream();
-   splinter_log_stream("compact_leaf addr %lu\n", leaf->disk_addr);
-   splinter_log_node(spl, leaf);
+   trunk_open_log_stream();
+   trunk_log_stream("compact_leaf addr %lu\n", leaf->disk_addr);
+   trunk_log_node(spl, leaf);
 
    uint64 sr_start;
    if (spl->cfg.use_stats) {
@@ -5773,37 +5773,37 @@ splinter_compact_leaf(splinter_handle *spl,
    }
 
    // Clear old bundles from leaf and put all branches in a new bundle
-   uint64 num_tuples = splinter_pivot_num_tuples(spl, leaf, 0);
+   uint64 num_tuples = trunk_pivot_num_tuples(spl, leaf, 0);
    uint16 bundle_no =
-      splinter_leaf_rebundle_all_branches(spl, leaf, num_tuples, TRUE);
-   splinter_inc_generation(spl, leaf);
+      trunk_leaf_rebundle_all_branches(spl, leaf, num_tuples, TRUE);
+   trunk_inc_generation(spl, leaf);
 
    // Issue compact_bundle for leaf and release
-   splinter_compact_bundle_req *req = TYPED_ZALLOC(spl->heap_id, req);
+   trunk_compact_bundle_req *req = TYPED_ZALLOC(spl->heap_id, req);
    req->spl = spl;
    req->addr = leaf->disk_addr;
    // req->height already 0
    req->bundle_no = bundle_no;
-   req->generation = splinter_generation(spl, leaf);
-   req->max_pivot_generation = splinter_pivot_generation(spl, leaf);
-   req->pivot_generation[0] = splinter_pivot_generation(spl, leaf) - 1;
-   req->input_pivot_count[0] = splinter_pivot_num_tuples(spl, leaf, 0);
+   req->generation = trunk_generation(spl, leaf);
+   req->max_pivot_generation = trunk_pivot_generation(spl, leaf);
+   req->pivot_generation[0] = trunk_pivot_generation(spl, leaf) - 1;
+   req->input_pivot_count[0] = trunk_pivot_num_tuples(spl, leaf, 0);
    req->is_space_rec = TRUE;
 
-   splinter_default_log("enqueuing compact_bundle %lu-%u\n",
+   trunk_default_log("enqueuing compact_bundle %lu-%u\n",
          req->addr, req->bundle_no);
    platform_status rc = task_enqueue(spl->ts, TASK_TYPE_NORMAL,
-         splinter_compact_bundle, req, FALSE);
+         trunk_compact_bundle, req, FALSE);
    platform_assert(SUCCESS(rc));
 
-   splinter_log_node(spl, leaf);
+   trunk_log_node(spl, leaf);
 
-   debug_assert(splinter_verify_node(spl, leaf));
+   debug_assert(trunk_verify_node(spl, leaf));
 
    /*
     * 8. Clean up
     */
-   splinter_close_log_stream();
+   trunk_close_log_stream();
 
    if (spl->cfg.use_stats) {
       // Doesn't include the original leaf
@@ -5823,7 +5823,7 @@ splinter_compact_leaf(splinter_handle *spl,
  */
 
 bool
-splinter_should_reclaim_space(splinter_handle *spl)
+trunk_should_reclaim_space(trunk_handle *spl)
 {
    if (spl->cfg.reclaim_threshold == UINT64_MAX) {
       return FALSE;
@@ -5837,7 +5837,7 @@ splinter_should_reclaim_space(splinter_handle *spl)
 }
 
 platform_status
-splinter_reclaim_space(splinter_handle *spl)
+trunk_reclaim_space(trunk_handle *spl)
 {
    platform_assert(spl->cfg.reclaim_threshold != UINT64_MAX);
    while (TRUE) {
@@ -5846,55 +5846,55 @@ splinter_reclaim_space(splinter_handle *spl)
       if (!srq_data_found(&space_rec)) {
          return STATUS_NOT_FOUND;
       }
-      page_handle *node = splinter_node_get(spl, space_rec.addr);
-      splinter_node_claim(spl, &node);
-      splinter_pivot_data *pdata = splinter_find_pivot_from_generation(spl,
+      page_handle *node = trunk_node_get(spl, space_rec.addr);
+      trunk_node_claim(spl, &node);
+      trunk_pivot_data *pdata = trunk_find_pivot_from_generation(spl,
             node, space_rec.pivot_generation);
       if (pdata == NULL) {
-         splinter_node_unclaim(spl, node);
-         splinter_node_unget(spl, &node);
+         trunk_node_unclaim(spl, node);
+         trunk_node_unget(spl, &node);
          continue;
       }
       pdata->srq_idx = -1;
 
       //platform_log("Space rec: %lu-%u\n",
-      //      node->disk_addr, splinter_pdata_to_pivot_index(spl, node, pdata));
+      //      node->disk_addr, trunk_pdata_to_pivot_index(spl, node, pdata));
 
-      splinter_node_lock(spl, node);
-      if (splinter_is_leaf(spl, node)) {
-         splinter_compact_leaf(spl, node);
+      trunk_node_lock(spl, node);
+      if (trunk_is_leaf(spl, node)) {
+         trunk_compact_leaf(spl, node);
       } else {
          uint64 sr_start;
          if (spl->cfg.use_stats) {
             sr_start = platform_get_timestamp();
          }
-         bool flush_succeeded = splinter_flush(spl, node, pdata, TRUE);
+         bool flush_succeeded = trunk_flush(spl, node, pdata, TRUE);
          if (spl->cfg.use_stats) {
             const threadid tid = platform_get_tid();
-            uint16 height = splinter_height(spl, node);
+            uint16 height = trunk_height(spl, node);
             spl->stats[tid].space_recs[height]++;
             spl->stats[tid].space_rec_time_ns[height] +=
                platform_timestamp_elapsed(sr_start);
          }
          if (!flush_succeeded) {
-            splinter_node_unlock(spl, node);
-            splinter_node_unclaim(spl, node);
-            splinter_node_unget(spl, &node);
+            trunk_node_unlock(spl, node);
+            trunk_node_unclaim(spl, node);
+            trunk_node_unget(spl, &node);
             continue;
          }
       }
-      splinter_node_unlock(spl, node);
-      splinter_node_unclaim(spl, node);
-      splinter_node_unget(spl, &node);
+      trunk_node_unlock(spl, node);
+      trunk_node_unclaim(spl, node);
+      trunk_node_unget(spl, &node);
       return STATUS_OK;
    }
 }
 
 void
-splinter_maybe_reclaim_space(splinter_handle *spl)
+trunk_maybe_reclaim_space(trunk_handle *spl)
 {
-   while (splinter_should_reclaim_space(spl)) {
-      platform_status rc = splinter_reclaim_space(spl);
+   while (trunk_should_reclaim_space(spl)) {
+      platform_status rc = trunk_reclaim_space(spl);
       if (STATUS_IS_EQ(rc, STATUS_NOT_FOUND)) {
          break;
       }
@@ -5914,7 +5914,7 @@ splinter_maybe_reclaim_space(splinter_handle *spl)
  */
 
 platform_status
-splinter_insert(splinter_handle *spl,
+trunk_insert(trunk_handle *spl,
                 char            *key,
                 char            *data)
 {
@@ -5926,7 +5926,7 @@ splinter_insert(splinter_handle *spl,
       data_cfg = spl->cfg.data_cfg;
    }
 
-   platform_status rc = splinter_memtable_insert(spl, key, data);
+   platform_status rc = trunk_memtable_insert(spl, key, data);
    if (!SUCCESS(rc)) {
       goto out;
    }
@@ -5962,7 +5962,7 @@ out:
 }
 
 bool
-splinter_filter_lookup(splinter_handle *spl,
+trunk_filter_lookup(trunk_handle *spl,
                        page_handle     *node,
                        routing_filter  *filter,
                        routing_config  *cfg,
@@ -5975,7 +5975,7 @@ splinter_filter_lookup(splinter_handle *spl,
    threadid tid;
    if (spl->cfg.use_stats) {
       tid = platform_get_tid();
-      height = splinter_height(spl, node);
+      height = trunk_height(spl, node);
    }
 
    uint64 found_values;
@@ -5989,9 +5989,9 @@ splinter_filter_lookup(splinter_handle *spl,
       routing_filter_get_next_value(found_values, ROUTING_NOT_FOUND);
    while (next_value != ROUTING_NOT_FOUND) {
       uint16 branch_no =
-         splinter_branch_no_add(spl, start_branch, next_value);
-      splinter_branch *branch = splinter_get_branch(spl, node, branch_no);
-      bool local_found = splinter_btree_lookup(spl, branch, key, data, found);
+         trunk_branch_no_add(spl, start_branch, next_value);
+      trunk_branch *branch = trunk_get_branch(spl, node, branch_no);
+      bool local_found = trunk_btree_lookup(spl, branch, key, data, found);
       if (spl->cfg.use_stats) {
          spl->stats[tid].branch_lookups[height]++;
       }
@@ -6008,30 +6008,30 @@ splinter_filter_lookup(splinter_handle *spl,
 }
 
 bool
-splinter_compacted_subbundle_lookup(splinter_handle    *spl,
+trunk_compacted_subbundle_lookup(trunk_handle    *spl,
                                     page_handle        *node,
-                                    splinter_subbundle *sb,
+                                    trunk_subbundle *sb,
                                     const char         *key,
                                     char               *data,
                                     bool               *found)
 {
    debug_assert(sb->state == SB_STATE_COMPACTED);
-   debug_assert(splinter_subbundle_branch_count(spl, node, sb) == 1);
+   debug_assert(trunk_subbundle_branch_count(spl, node, sb) == 1);
    uint16 height;
    threadid tid;
    if (spl->cfg.use_stats) {
       tid = platform_get_tid();
-      height = splinter_height(spl, node);
+      height = trunk_height(spl, node);
    }
 
-   uint16 filter_count = splinter_subbundle_filter_count(spl, node, sb);
+   uint16 filter_count = trunk_subbundle_filter_count(spl, node, sb);
    for (uint16 filter_no = 0; filter_no != filter_count; filter_no++) {
       if (spl->cfg.use_stats) {
          spl->stats[tid].filter_lookups[height]++;
       }
       uint64 found_values;
       routing_filter *filter =
-         splinter_subbundle_filter(spl, node, sb, filter_no);
+         trunk_subbundle_filter(spl, node, sb, filter_no);
       debug_assert(filter->addr != 0);
       // FIXME: [aconway 2020-09-14] was index
       platform_status rc = routing_filter_lookup(spl->cc,
@@ -6039,9 +6039,9 @@ splinter_compacted_subbundle_lookup(splinter_handle    *spl,
       platform_assert_status_ok(rc);
       if (found_values) {
          uint16 branch_no = sb->start_branch;
-         splinter_branch *branch = splinter_get_branch(spl, node, branch_no);
+         trunk_branch *branch = trunk_get_branch(spl, node, branch_no);
          bool local_found =
-            splinter_btree_lookup(spl, branch, key, data, found);
+            trunk_btree_lookup(spl, branch, key, data, found);
          if (spl->cfg.use_stats) {
             spl->stats[tid].branch_lookups[height]++;
          }
@@ -6059,29 +6059,29 @@ splinter_compacted_subbundle_lookup(splinter_handle    *spl,
 }
 
 bool
-splinter_bundle_lookup(splinter_handle *spl,
+trunk_bundle_lookup(trunk_handle *spl,
                        page_handle     *node,
-                       splinter_bundle *bundle,
+                       trunk_bundle *bundle,
                        char            *key,
                        char            *data,
                        bool            *found)
 {
-   uint16 sb_count = splinter_bundle_subbundle_count(spl, node, bundle);
+   uint16 sb_count = trunk_bundle_subbundle_count(spl, node, bundle);
    for (uint16 sb_off = 0; sb_off != sb_count; sb_off++) {
       uint16 sb_no =
-         splinter_subbundle_no_sub(spl, bundle->end_subbundle, sb_off + 1);
-      splinter_subbundle *sb = splinter_get_subbundle(spl, node, sb_no);
+         trunk_subbundle_no_sub(spl, bundle->end_subbundle, sb_off + 1);
+      trunk_subbundle *sb = trunk_get_subbundle(spl, node, sb_no);
       bool should_continue;
       if (sb->state == SB_STATE_COMPACTED) {
-         should_continue = splinter_compacted_subbundle_lookup(spl, node, sb,
+         should_continue = trunk_compacted_subbundle_lookup(spl, node, sb,
                key, data, found);
       } else {
-         routing_filter *filter = splinter_subbundle_filter(spl, node, sb, 0);
+         routing_filter *filter = trunk_subbundle_filter(spl, node, sb, 0);
          routing_config *cfg = &spl->cfg.leaf_filter_cfg;
          //routing_config *cfg = sb->state == SB_STATE_UNCOMPACTED_LEAF ?
          //   &spl->cfg.leaf_filter_cfg : &spl->cfg.index_filter_cfg;
          debug_assert(filter->addr != 0);
-         should_continue = splinter_filter_lookup(spl, node, filter, cfg,
+         should_continue = trunk_filter_lookup(spl, node, filter, cfg,
                sb->start_branch, key, data, found);
       }
       if (!should_continue) {
@@ -6092,37 +6092,37 @@ splinter_bundle_lookup(splinter_handle *spl,
 }
 
 bool
-splinter_pivot_lookup(splinter_handle     *spl,
+trunk_pivot_lookup(trunk_handle     *spl,
                       page_handle         *node,
-                      splinter_pivot_data *pdata,
+                      trunk_pivot_data *pdata,
                       char                *key,
                       char                *data,
                       bool                *found)
 {
    // first check in bundles
-   uint16 num_bundles = splinter_pivot_bundle_count(spl, node, pdata);
+   uint16 num_bundles = trunk_pivot_bundle_count(spl, node, pdata);
    for (uint16 bundle_off = 0; bundle_off != num_bundles; bundle_off++) {
-      uint16 bundle_no = splinter_bundle_no_sub(spl,
-            splinter_end_bundle(spl, node), bundle_off + 1);
-      debug_assert(splinter_bundle_live(spl, node, bundle_no));
-      splinter_bundle *bundle = splinter_get_bundle(spl, node, bundle_no);
+      uint16 bundle_no = trunk_bundle_no_sub(spl,
+            trunk_end_bundle(spl, node), bundle_off + 1);
+      debug_assert(trunk_bundle_live(spl, node, bundle_no));
+      trunk_bundle *bundle = trunk_get_bundle(spl, node, bundle_no);
       bool should_continue =
-         splinter_bundle_lookup(spl, node, bundle, key, data, found);
+         trunk_bundle_lookup(spl, node, bundle, key, data, found);
       if (!should_continue) {
          return should_continue;
       }
    }
 
    routing_config *cfg = &spl->cfg.leaf_filter_cfg;
-   //routing_config *cfg = splinter_height(spl, node) == 0 ?
+   //routing_config *cfg = trunk_height(spl, node) == 0 ?
    //                      &spl->cfg.leaf_filter_cfg : &spl->cfg.index_filter_cfg;
-   return splinter_filter_lookup(spl, node, &pdata->filter, cfg,
+   return trunk_filter_lookup(spl, node, &pdata->filter, cfg,
          pdata->start_branch, key, data, found);
 }
 
-// If any change is made in here, please make similar change in splinter_lookup_async
+// If any change is made in here, please make similar change in trunk_lookup_async
 platform_status
-splinter_lookup(splinter_handle *spl,
+trunk_lookup(trunk_handle *spl,
                 char            *key,
                 char            *data,
                 bool            *found)
@@ -6145,7 +6145,7 @@ splinter_lookup(splinter_handle *spl,
    uint64 mt_gen_end = memtable_generation_retired(spl->mt_ctxt);
    for (uint64 mt_gen = mt_gen_start; mt_gen != mt_gen_end; mt_gen--) {
       // FIXME: [aconway 2020-08-26] wrap with a branch lookup
-      splinter_memtable_lookup(spl, mt_gen, key, data, found);
+      trunk_memtable_lookup(spl, mt_gen, key, data, found);
       if (*found) {
          type = data_message_class(data_cfg, data);
          if (type != MESSAGE_TYPE_UPDATE) {
@@ -6156,30 +6156,30 @@ splinter_lookup(splinter_handle *spl,
    }
 
    // hold root read lock to prevent memtable flush
-   page_handle *node = splinter_node_get(spl, spl->root_addr);
+   page_handle *node = trunk_node_get(spl, spl->root_addr);
 
    // release memtable lookup lock
    memtable_unget_lookup_lock(spl->mt_ctxt, mt_lookup_lock_page);
 
    // look in index nodes
-   uint16 height = splinter_height(spl, node);
+   uint16 height = trunk_height(spl, node);
    for (uint16 h = height; h > 0; h--) {
-      uint16 pivot_no = splinter_find_pivot(spl, node, key, less_than_or_equal);
-      debug_assert(pivot_no < splinter_num_children(spl, node));
-      splinter_pivot_data *pdata = splinter_get_pivot_data(spl, node, pivot_no);
+      uint16 pivot_no = trunk_find_pivot(spl, node, key, less_than_or_equal);
+      debug_assert(pivot_no < trunk_num_children(spl, node));
+      trunk_pivot_data *pdata = trunk_get_pivot_data(spl, node, pivot_no);
       bool should_continue =
-         splinter_pivot_lookup(spl, node, pdata, key, data, found);
+         trunk_pivot_lookup(spl, node, pdata, key, data, found);
       if (!should_continue) {
          goto found_final_answer_early;
       }
-      page_handle *child = splinter_node_get(spl, pdata->addr);
-      splinter_node_unget(spl, &node);
+      page_handle *child = trunk_node_get(spl, pdata->addr);
+      trunk_node_unget(spl, &node);
       node = child;
    }
 
    // look in leaf
-   splinter_pivot_data *pdata = splinter_get_pivot_data(spl, node, 0);
-   bool should_continue = splinter_pivot_lookup(spl, node, pdata, key, data, found);
+   trunk_pivot_data *pdata = trunk_get_pivot_data(spl, node, 0);
+   bool should_continue = trunk_pivot_lookup(spl, node, pdata, key, data, found);
    if (!should_continue) {
       goto found_final_answer_early;
    }
@@ -6196,7 +6196,7 @@ found_final_answer_early:
       // release memtable lookup lock
       memtable_unget_lookup_lock(spl->mt_ctxt, mt_lookup_lock_page);
    } else {
-      splinter_node_unget(spl, &node);
+      trunk_node_unget(spl, &node);
    }
    if (spl->cfg.use_stats) {
       threadid tid = platform_get_tid();
@@ -6211,13 +6211,13 @@ found_final_answer_early:
 }
 
 /*
- * splinter_async_set_state sets the state of the async splinter
+ * trunk_async_set_state sets the state of the async splinter
  * lookup state machine.
  */
 
 static inline void
-splinter_async_set_state(splinter_async_ctxt *ctxt,
-                         splinter_async_state new_state)
+trunk_async_set_state(trunk_async_ctxt *ctxt,
+                         trunk_async_state new_state)
 {
    ctxt->prev_state = ctxt->state;
    ctxt->state = new_state;
@@ -6225,7 +6225,7 @@ splinter_async_set_state(splinter_async_ctxt *ctxt,
 
 
 /*
- * splinter_trunk_async_callback
+ * trunk_async_callback
  *
  *      Callback that's called when the async cache get for a trunk
  *      node loads a page for the child into the cache. This function
@@ -6235,9 +6235,9 @@ splinter_async_set_state(splinter_async_ctxt *ctxt,
  */
 
 static void
-splinter_trunk_async_callback(cache_async_ctxt *cache_ctxt)
+trunk_async_callback(cache_async_ctxt *cache_ctxt)
 {
-   splinter_async_ctxt *ctxt = container_of(cache_ctxt, splinter_async_ctxt,
+   trunk_async_ctxt *ctxt = container_of(cache_ctxt, trunk_async_ctxt,
                                             cache_ctxt);
    platform_assert(SUCCESS(cache_ctxt->status));
    platform_assert(cache_ctxt->page);
@@ -6247,17 +6247,17 @@ splinter_trunk_async_callback(cache_async_ctxt *cache_ctxt)
    ctxt->was_async = TRUE;
    // Move state machine ahead and requeue for dispatch
    if (UNLIKELY(ctxt->state == async_state_get_root_reentrant)) {
-      splinter_async_set_state(ctxt, async_state_trunk_node_lookup);
+      trunk_async_set_state(ctxt, async_state_trunk_node_lookup);
    } else {
       debug_assert(ctxt->state == async_state_get_child_trunk_node_reentrant);
-      splinter_async_set_state(ctxt, async_state_unget_parent_trunk_node);
+      trunk_async_set_state(ctxt, async_state_unget_parent_trunk_node);
    }
    ctxt->cb(ctxt);
 }
 
 
 /*
- * splinter_filter_async_callback
+ * trunk_filter_async_callback
  *
  *      Callback that's called when the async filter get api has loaded
  *      a page into cache. This just requeues the splinter lookup for
@@ -6266,9 +6266,9 @@ splinter_trunk_async_callback(cache_async_ctxt *cache_ctxt)
  */
 
 static void
-splinter_filter_async_callback(routing_async_ctxt *filter_ctxt)
+trunk_filter_async_callback(routing_async_ctxt *filter_ctxt)
 {
-   splinter_async_ctxt *ctxt = container_of(filter_ctxt, splinter_async_ctxt,
+   trunk_async_ctxt *ctxt = container_of(filter_ctxt, trunk_async_ctxt,
                                             filter_ctxt);
 //   platform_log("%s:%d tid %2lu: ctxt %p is callback\n",
 //                __FILE__, __LINE__, platform_get_tid(), ctxt);
@@ -6278,7 +6278,7 @@ splinter_filter_async_callback(routing_async_ctxt *filter_ctxt)
 
 
 /*
- * splinter_btree_async_callback
+ * trunk_btree_async_callback
  *
  *      Callback that's called when the async btree lookup api has loaded
  *      a page into cache. This just requeues the splinter lookup for
@@ -6287,9 +6287,9 @@ splinter_filter_async_callback(routing_async_ctxt *filter_ctxt)
  */
 
 static void
-splinter_btree_async_callback(btree_async_ctxt *btree_ctxt)
+trunk_btree_async_callback(btree_async_ctxt *btree_ctxt)
 {
-   splinter_async_ctxt *ctxt = container_of(btree_ctxt, splinter_async_ctxt,
+   trunk_async_ctxt *ctxt = container_of(btree_ctxt, trunk_async_ctxt,
                                             btree_ctxt);
 //   platform_log("%s:%d tid %2lu: ctxt %p is callback\n",
 //                __FILE__, __LINE__, platform_get_tid(), ctxt);
@@ -6299,15 +6299,15 @@ splinter_btree_async_callback(btree_async_ctxt *btree_ctxt)
 
 
 /*
- * Async splinter lookup. Caller must have called splinter_async_ctxt_init()
+ * Async splinter lookup. Caller must have called trunk_async_ctxt_init()
  * on the context before the first invocation.
  *
  * This uses hand over hand locking to descend the trunk tree and
  * every time a child node needs to be looked up from the cache, it
  * uses the async get api. A reference to the parent node is held in
- * splinter_async_ctxt->trunk_node while a reference to the child page
+ * trunk_async_ctxt->trunk_node while a reference to the child page
  * is obtained by the cache_get_async() into
- * splinter_async_ctxt->cache_ctxt->page
+ * trunk_async_ctxt->cache_ctxt->page
  *
  * Returns:
  *    async_success: results are available in *found and *data
@@ -6327,11 +6327,11 @@ splinter_btree_async_callback(btree_async_ctxt *btree_ctxt)
  */
 
 cache_async_result
-splinter_lookup_async(splinter_handle     *spl,    // IN
+trunk_lookup_async(trunk_handle     *spl,    // IN
                       char                *key,    // IN
                       char                *data,   // OUT
                       bool                *found,  // OUT
-                      splinter_async_ctxt *ctxt)   // IN/OUT
+                      trunk_async_ctxt *ctxt)   // IN/OUT
 {
    // FIXME: [yfogel 2020-08-26] giant switch statements are impossible to read
    //       this needs to be refactored.
@@ -6344,7 +6344,7 @@ splinter_lookup_async(splinter_handle     *spl,    // IN
    threadid tid;
    data_config *data_cfg = spl->cfg.data_cfg;
 
-#if SPLINTER_DEBUG
+#if TRUNK_DEBUG
    cache_enable_sync_get(spl->cc, FALSE);
 #endif
    if (spl->cfg.use_stats) {
@@ -6358,7 +6358,7 @@ splinter_lookup_async(splinter_handle     *spl,    // IN
       case async_state_start:
       {
          ctxt->found = FALSE;
-         splinter_async_set_state(ctxt, async_state_lookup_memtable);
+         trunk_async_set_state(ctxt, async_state_lookup_memtable);
          // fallthrough
       }
       case async_state_lookup_memtable:
@@ -6368,11 +6368,11 @@ splinter_lookup_async(splinter_handle     *spl,    // IN
          uint64 mt_gen_end = memtable_generation_retired(spl->mt_ctxt);
          for (uint64 mt_gen = mt_gen_start; mt_gen != mt_gen_end; mt_gen--) {
             // FIXME: [aconway 2020-08-26] wrap with a branch lookup
-            splinter_memtable_lookup(spl, mt_gen, key, data, &ctxt->found);
+            trunk_memtable_lookup(spl, mt_gen, key, data, &ctxt->found);
             if (ctxt->found) {
                ctxt->type = data_message_class(data_cfg, data);
                if (ctxt->type != MESSAGE_TYPE_UPDATE) {
-                  splinter_async_set_state(ctxt,
+                  trunk_async_set_state(ctxt,
                         async_state_found_final_answer_early);
                   break;
                }
@@ -6382,9 +6382,9 @@ splinter_lookup_async(splinter_handle     *spl,    // IN
       }
       case async_state_get_root_reentrant:
       {
-         cache_ctxt_init(spl->cc, splinter_trunk_async_callback, NULL,
+         cache_ctxt_init(spl->cc, trunk_async_callback, NULL,
                          &ctxt->cache_ctxt);
-         res = splinter_node_get_async(spl, spl->root_addr, ctxt);
+         res = trunk_node_get_async(spl, spl->root_addr, ctxt);
          switch (res) {
          case async_locked:
          case async_no_reqs:
@@ -6404,7 +6404,7 @@ splinter_lookup_async(splinter_handle     *spl,    // IN
             break;
          case async_success:
             ctxt->was_async = FALSE;
-            splinter_async_set_state(ctxt, async_state_trunk_node_lookup);
+            trunk_async_set_state(ctxt, async_state_trunk_node_lookup);
             platform_assert(node == NULL);
             ctxt->trunk_node = node = ctxt->cache_ctxt.page;
             memtable_unget_lookup_lock(spl->mt_ctxt, ctxt->mt_lock_page);
@@ -6417,18 +6417,18 @@ splinter_lookup_async(splinter_handle     *spl,    // IN
       }
       case async_state_trunk_node_lookup:
       {
-         ctxt->height = splinter_height(spl, node);
-         uint16 pivot_no = splinter_find_pivot(spl, node, key,
+         ctxt->height = trunk_height(spl, node);
+         uint16 pivot_no = trunk_find_pivot(spl, node, key,
                less_than_or_equal);
-         debug_assert(pivot_no < splinter_num_children(spl, node));
-         ctxt->pdata = splinter_get_pivot_data(spl, node, pivot_no);
-         ctxt->sb_no = splinter_start_subbundle_for_lookup(spl, node);
+         debug_assert(pivot_no < trunk_num_children(spl, node));
+         ctxt->pdata = trunk_get_pivot_data(spl, node, pivot_no);
+         ctxt->sb_no = trunk_start_subbundle_for_lookup(spl, node);
          ctxt->end_sb_no =
-            splinter_pivot_end_subbundle_for_lookup(spl, node, ctxt->pdata);
+            trunk_pivot_end_subbundle_for_lookup(spl, node, ctxt->pdata);
          ctxt->filter_no = 0;
          char key_str[128];
-         splinter_key_to_string(spl, key, key_str);
-         splinter_async_set_state(ctxt, async_state_subbundle_lookup);
+         trunk_key_to_string(spl, key, key_str);
+         trunk_async_set_state(ctxt, async_state_subbundle_lookup);
          // fallthrough
       }
       case async_state_subbundle_lookup:
@@ -6436,27 +6436,27 @@ splinter_lookup_async(splinter_handle     *spl,    // IN
          if (ctxt->sb_no == ctxt->end_sb_no) {
             debug_assert(ctxt->filter_no == 0);
             ctxt->lookup_state = async_lookup_state_pivot;
-            splinter_async_set_state(ctxt, async_state_pivot_lookup);
+            trunk_async_set_state(ctxt, async_state_pivot_lookup);
             break;
          }
-         ctxt->sb = splinter_get_subbundle(spl, node, ctxt->sb_no);
+         ctxt->sb = trunk_get_subbundle(spl, node, ctxt->sb_no);
          if (ctxt->sb->state == SB_STATE_COMPACTED) {
             ctxt->lookup_state = async_lookup_state_compacted_subbundle;
          } else {
             ctxt->lookup_state = async_lookup_state_subbundle;
          }
          debug_assert(ctxt->filter_no <
-               splinter_subbundle_filter_count(spl, node, ctxt->sb));
+               trunk_subbundle_filter_count(spl, node, ctxt->sb));
          ctxt->filter =
-            splinter_subbundle_filter(spl, node, ctxt->sb, ctxt->filter_no);
-         splinter_async_set_state(ctxt, async_state_filter_lookup_start);
+            trunk_subbundle_filter(spl, node, ctxt->sb, ctxt->filter_no);
+         trunk_async_set_state(ctxt, async_state_filter_lookup_start);
          break;
       }
       case async_state_pivot_lookup:
       {
          ctxt->sb = NULL;
          ctxt->filter = &ctxt->pdata->filter;
-         splinter_async_set_state(ctxt, async_state_filter_lookup_start);
+         trunk_async_set_state(ctxt, async_state_filter_lookup_start);
          // fall through
       }
       case async_state_filter_lookup_start:
@@ -6464,15 +6464,15 @@ splinter_lookup_async(splinter_handle     *spl,    // IN
          ctxt->value = ROUTING_NOT_FOUND;
          if (ctxt->filter->addr == 0) {
             platform_assert(ctxt->lookup_state == async_lookup_state_pivot);
-            splinter_async_set_state(ctxt, async_state_next_in_node);
+            trunk_async_set_state(ctxt, async_state_next_in_node);
             break;
          }
          if (spl->cfg.use_stats) {
             spl->stats[tid].filter_lookups[ctxt->height]++;
          }
          routing_filter_ctxt_init(&ctxt->filter_ctxt, &ctxt->cache_ctxt,
-               splinter_filter_async_callback);
-         splinter_async_set_state(ctxt, async_state_filter_lookup_reentrant);
+               trunk_filter_async_callback);
+         trunk_async_set_state(ctxt, async_state_filter_lookup_reentrant);
          break;
       }
       case async_state_filter_lookup_reentrant:
@@ -6491,8 +6491,8 @@ splinter_lookup_async(splinter_handle     *spl,    // IN
          //      break;
          //}
 
-         routing_config *filter_cfg = splinter_routing_cfg(spl, TRUE);
-         res = splinter_filter_lookup_async(spl, filter_cfg, ctxt->filter, key,
+         routing_config *filter_cfg = trunk_routing_cfg(spl, TRUE);
+         res = trunk_filter_lookup_async(spl, filter_cfg, ctxt->filter, key,
                &ctxt->found_values, &ctxt->filter_ctxt);
          switch (res) {
          case async_locked:
@@ -6513,7 +6513,7 @@ splinter_lookup_async(splinter_handle     *spl,    // IN
             break;
          case async_success:
             // I don't own the cache context, filter does
-            splinter_async_set_state(ctxt, async_state_btree_lookup_start);
+            trunk_async_set_state(ctxt, async_state_btree_lookup_start);
             break;
          default:
             platform_assert(0);
@@ -6529,10 +6529,10 @@ splinter_lookup_async(splinter_handle     *spl,    // IN
                ctxt->value =
                   routing_filter_get_next_value(ctxt->found_values, ctxt->value);
                if (ctxt->value == ROUTING_NOT_FOUND) {
-                  splinter_async_set_state(ctxt, async_state_next_in_node);
+                  trunk_async_set_state(ctxt, async_state_next_in_node);
                   continue;
                }
-               branch_no = splinter_branch_no_add(spl,
+               branch_no = trunk_branch_no_add(spl,
                      ctxt->pdata->start_branch, ctxt->value);
                break;
             case async_lookup_state_subbundle:
@@ -6540,10 +6540,10 @@ splinter_lookup_async(splinter_handle     *spl,    // IN
                ctxt->value =
                   routing_filter_get_next_value(ctxt->found_values, ctxt->value);
                if (ctxt->value == ROUTING_NOT_FOUND) {
-                  splinter_async_set_state(ctxt, async_state_next_in_node);
+                  trunk_async_set_state(ctxt, async_state_next_in_node);
                   continue;
                }
-               branch_no = splinter_branch_no_add(spl,
+               branch_no = trunk_branch_no_add(spl,
                      ctxt->sb->start_branch, ctxt->value);
                branch_no = ctxt->sb->start_branch + ctxt->value;
                break;
@@ -6551,21 +6551,21 @@ splinter_lookup_async(splinter_handle     *spl,    // IN
                debug_assert(ctxt->sb != NULL);
                if (ctxt->found_values == 0) {
                   ctxt->value = ROUTING_NOT_FOUND;
-                  splinter_async_set_state(ctxt, async_state_next_in_node);
+                  trunk_async_set_state(ctxt, async_state_next_in_node);
                   continue;
                }
                branch_no = ctxt->sb->start_branch;
                break;
          }
-         ctxt->branch = splinter_get_branch(spl, node, branch_no);
+         ctxt->branch = trunk_get_branch(spl, node, branch_no);
          btree_ctxt_init(&ctxt->btree_ctxt, &ctxt->cache_ctxt,
-                         splinter_btree_async_callback);
-         splinter_async_set_state(ctxt, async_state_btree_lookup_reentrant);
+                         trunk_btree_async_callback);
+         trunk_async_set_state(ctxt, async_state_btree_lookup_reentrant);
          break;
       }
       case async_state_btree_lookup_reentrant:
       {
-         res = splinter_btree_lookup_async(spl, ctxt->branch, key, data,
+         res = trunk_btree_lookup_async(spl, ctxt->branch, key, data,
                                            &ctxt->found, &ctxt->btree_ctxt);
          switch (res) {
          case async_locked:
@@ -6589,15 +6589,15 @@ splinter_lookup_async(splinter_handle     *spl,    // IN
             if (ctxt->found) {
                ctxt->type = data_message_class(data_cfg, data);
                if (ctxt->type != MESSAGE_TYPE_UPDATE) {
-                  splinter_async_set_state(ctxt,
+                  trunk_async_set_state(ctxt,
                              async_state_found_final_answer_early);
                   break;
                }
             } else if (spl->cfg.use_stats) {
-               const uint16 height = splinter_height(spl, node);
+               const uint16 height = trunk_height(spl, node);
                spl->stats[tid].filter_false_positives[height]++;
             }
-            splinter_async_set_state(ctxt, async_state_next_in_node);
+            trunk_async_set_state(ctxt, async_state_next_in_node);
             break;
          default:
             platform_assert(0);
@@ -6610,39 +6610,39 @@ splinter_lookup_async(splinter_handle     *spl,    // IN
             case async_lookup_state_pivot:
                debug_assert(ctxt->filter_no == 0);
                if (ctxt->value == ROUTING_NOT_FOUND) {
-                  splinter_async_set_state(ctxt, async_state_trunk_node_done);
+                  trunk_async_set_state(ctxt, async_state_trunk_node_done);
                } else {
-                  splinter_async_set_state(ctxt,
+                  trunk_async_set_state(ctxt,
                                            async_state_btree_lookup_start);
                }
                continue;
             case async_lookup_state_subbundle:
                debug_assert(ctxt->filter_no == 0);
                if (ctxt->value == ROUTING_NOT_FOUND) {
-                  ctxt->sb_no = splinter_subbundle_no_sub(spl, ctxt->sb_no, 1);
-                  splinter_async_set_state(ctxt, async_state_subbundle_lookup);
+                  ctxt->sb_no = trunk_subbundle_no_sub(spl, ctxt->sb_no, 1);
+                  trunk_async_set_state(ctxt, async_state_subbundle_lookup);
                   break;
                } else {
-                  splinter_async_set_state(ctxt,
+                  trunk_async_set_state(ctxt,
                                            async_state_btree_lookup_start);
                }
                continue;
             case async_lookup_state_compacted_subbundle:
                if (ctxt->found_values != 0) {
-                  ctxt->sb_no = splinter_subbundle_no_sub(spl, ctxt->sb_no, 1);
+                  ctxt->sb_no = trunk_subbundle_no_sub(spl, ctxt->sb_no, 1);
                   ctxt->filter_no = 0;
                } else {
                   ctxt->filter_no++;
                   uint16 sb_filter_count =
-                     splinter_subbundle_filter_count(spl, node, ctxt->sb);
+                     trunk_subbundle_filter_count(spl, node, ctxt->sb);
                   if (ctxt->filter_no >= sb_filter_count) {
                      debug_assert(ctxt->filter_no == sb_filter_count);
                      ctxt->sb_no =
-                        splinter_subbundle_no_sub(spl, ctxt->sb_no, 1);
+                        trunk_subbundle_no_sub(spl, ctxt->sb_no, 1);
                      ctxt->filter_no = 0;
                   }
                }
-               splinter_async_set_state(ctxt, async_state_subbundle_lookup);
+               trunk_async_set_state(ctxt, async_state_subbundle_lookup);
                continue;
          }
          break;
@@ -6655,20 +6655,20 @@ splinter_lookup_async(splinter_handle     *spl,    // IN
                ctxt->type = data_message_class(data_cfg, data);
                ctxt->found = ctxt->type != MESSAGE_TYPE_DELETE;
             }
-            splinter_async_set_state(ctxt, async_state_end);
+            trunk_async_set_state(ctxt, async_state_end);
             break;
          } else {
-            splinter_async_set_state(ctxt,
+            trunk_async_set_state(ctxt,
                   async_state_get_child_trunk_node_reentrant);
             break;
          }
       }
       case async_state_get_child_trunk_node_reentrant:
       {
-         cache_ctxt_init(spl->cc, splinter_trunk_async_callback, NULL,
+         cache_ctxt_init(spl->cc, trunk_async_callback, NULL,
                          &ctxt->cache_ctxt);
          debug_assert(ctxt->pdata != NULL);
-         res = splinter_node_get_async(spl, ctxt->pdata->addr, ctxt);
+         res = trunk_node_get_async(spl, ctxt->pdata->addr, ctxt);
          switch (res) {
          case async_locked:
          case async_no_reqs:
@@ -6688,7 +6688,7 @@ splinter_lookup_async(splinter_handle     *spl,    // IN
             break;
          case async_success:
             ctxt->was_async = FALSE;
-            splinter_async_set_state(ctxt, async_state_unget_parent_trunk_node);
+            trunk_async_set_state(ctxt, async_state_unget_parent_trunk_node);
             break;
          default:
             platform_assert(0);
@@ -6698,18 +6698,18 @@ splinter_lookup_async(splinter_handle     *spl,    // IN
       case async_state_unget_parent_trunk_node:
       {
          if (ctxt->was_async) {
-            splinter_node_async_done(spl, ctxt);
+            trunk_node_async_done(spl, ctxt);
          }
-         splinter_node_unget(spl, &node);
+         trunk_node_unget(spl, &node);
          ctxt->pdata = NULL;
          ctxt->trunk_node = node = ctxt->cache_ctxt.page;
-         splinter_async_set_state(ctxt, async_state_trunk_node_lookup);
+         trunk_async_set_state(ctxt, async_state_trunk_node_lookup);
          break;
       }
       case async_state_found_final_answer_early:
       {
          ctxt->found = ctxt->type != MESSAGE_TYPE_DELETE;
-         splinter_async_set_state(ctxt, async_state_end);
+         trunk_async_set_state(ctxt, async_state_end);
          break;
       }
       case async_state_end:
@@ -6719,7 +6719,7 @@ splinter_lookup_async(splinter_handle     *spl,    // IN
             ctxt->mt_lock_page = NULL;
             debug_assert(node == NULL);
          } else {
-            splinter_node_unget(spl, &node);
+            trunk_node_unget(spl, &node);
          }
          ctxt->trunk_node = NULL;
          if (spl->cfg.use_stats) {
@@ -6738,7 +6738,7 @@ splinter_lookup_async(splinter_handle     *spl,    // IN
          platform_assert(0);
       }
    } while (!done);
-#if SPLINTER_DEBUG
+#if TRUNK_DEBUG
    cache_enable_sync_get(spl->cc, TRUE);
 #endif
 
@@ -6747,14 +6747,14 @@ splinter_lookup_async(splinter_handle     *spl,    // IN
 
 
 platform_status
-splinter_range(splinter_handle *spl,
+trunk_range(trunk_handle *spl,
                char            *start_key,
                uint64           num_tuples,
                uint64          *tuples_returned,
                char            *out)
 {
-   splinter_range_iterator *range_itor = TYPED_MALLOC(spl->heap_id, range_itor);
-   platform_status rc = splinter_range_iterator_init(spl, range_itor,
+   trunk_range_iterator *range_itor = TYPED_MALLOC(spl->heap_id, range_itor);
+   platform_status rc = trunk_range_iterator_init(spl, range_itor,
                                                      start_key, NULL,
                                                      num_tuples);
    if (!SUCCESS(rc)) {
@@ -6767,16 +6767,16 @@ splinter_range(splinter_handle *spl,
    for (*tuples_returned = 0; *tuples_returned < num_tuples && !at_end; (*tuples_returned)++) {
       char *key, *data;
       iterator_get_curr(&range_itor->super, &key, &data);
-      char *next_key = out + *tuples_returned * (splinter_key_size(spl) + splinter_message_size(spl));
-      char *next_data = next_key + splinter_key_size(spl);
-      memmove(next_key, key, splinter_key_size(spl));
-      memmove(next_data, data, splinter_message_size(spl));
+      char *next_key = out + *tuples_returned * (trunk_key_size(spl) + trunk_message_size(spl));
+      char *next_data = next_key + trunk_key_size(spl);
+      memmove(next_key, key, trunk_key_size(spl));
+      memmove(next_data, data, trunk_message_size(spl));
       iterator_advance(&range_itor->super);
       iterator_at_end(&range_itor->super, &at_end);
    }
 
 destroy_range_itor:
-   splinter_range_iterator_deinit(range_itor);
+   trunk_range_iterator_deinit(range_itor);
    platform_free(spl->heap_id, range_itor);
    return rc;
 }
@@ -6791,8 +6791,8 @@ destroy_range_itor:
  *-----------------------------------------------------------------------------
  */
 
-splinter_handle *
-splinter_create(splinter_config  *cfg,
+trunk_handle *
+trunk_create(trunk_config  *cfg,
                 allocator        *al,
                 cache            *cc,
                 task_system      *ts,
@@ -6800,8 +6800,8 @@ splinter_create(splinter_config  *cfg,
                 platform_heap_id  hid)
 {
    // FIXME: [yfogel 2020-03-30] handle all failures and properly cleanup
-   splinter_handle *spl = TYPED_FLEXIBLE_STRUCT_ZALLOC(hid, spl,
-         compacted_memtable, SPLINTER_NUM_MEMTABLES);
+   trunk_handle *spl = TYPED_FLEXIBLE_STRUCT_ZALLOC(hid, spl,
+         compacted_memtable, TRUNK_NUM_MEMTABLES);
    memmove(&spl->cfg, cfg, sizeof(*cfg));
    spl->al = al;
    spl->cc = cc;
@@ -6818,7 +6818,7 @@ splinter_create(splinter_config  *cfg,
    platform_status rc = allocator_alloc_extent(spl->al, &spl->root_addr);
    platform_assert_status_ok(rc);
    page_handle *root = cache_alloc(spl->cc, spl->root_addr, PAGE_TYPE_TRUNK);
-   splinter_trunk_hdr *root_hdr = (splinter_trunk_hdr *)root->data;
+   trunk_hdr *root_hdr = (trunk_hdr *)root->data;
    ZERO_CONTENTS(root_hdr);
 
    // set up the mini allocator
@@ -6829,13 +6829,13 @@ splinter_create(splinter_config  *cfg,
                        spl->cfg.data_cfg,
                        meta_addr,
                        0,
-                       SPLINTER_MAX_HEIGHT,
+                       TRUNK_MAX_HEIGHT,
                        PAGE_TYPE_TRUNK);
 
    // set up the memtable context
    memtable_config *mt_cfg = &spl->cfg.mt_cfg;
    spl->mt_ctxt = memtable_context_create(spl->heap_id, cc, mt_cfg,
-         splinter_memtable_flush_virtual, spl);
+         trunk_memtable_flush_virtual, spl);
 
    // set up the log
    if (spl->cfg.use_log) {
@@ -6843,29 +6843,29 @@ splinter_create(splinter_config  *cfg,
    }
 
    // ALEX: For now we assume an init means destroying any present super blocks
-   splinter_set_super_block(spl, FALSE, FALSE, TRUE);
+   trunk_set_super_block(spl, FALSE, FALSE, TRUE);
 
    // set up the initial leaf
-   page_handle *       leaf     = splinter_alloc(spl, 0);
-   splinter_trunk_hdr *leaf_hdr = (splinter_trunk_hdr *)leaf->data;
+   page_handle *       leaf     = trunk_alloc(spl, 0);
+   trunk_hdr *leaf_hdr = (trunk_hdr *)leaf->data;
    memset(leaf_hdr, 0, spl->cfg.page_size);
    const char *min_key = spl->cfg.data_cfg->min_key;
    const char *max_key = spl->cfg.data_cfg->max_key;
-   splinter_set_initial_pivots(spl, leaf, min_key, max_key);
-   splinter_inc_pivot_generation(spl, leaf);
+   trunk_set_initial_pivots(spl, leaf, min_key, max_key);
+   trunk_inc_pivot_generation(spl, leaf);
 
    // add leaf to root and fix up root
    root_hdr->height = 1;
-   splinter_add_pivot_new_root(spl, root, leaf);
-   splinter_inc_pivot_generation(spl, root);
+   trunk_add_pivot_new_root(spl, root, leaf);
+   trunk_inc_pivot_generation(spl, root);
 
-   splinter_node_unlock(spl, leaf);
-   splinter_node_unclaim(spl, leaf);
-   splinter_node_unget(spl, &leaf);
+   trunk_node_unlock(spl, leaf);
+   trunk_node_unclaim(spl, leaf);
+   trunk_node_unget(spl, &leaf);
 
-   splinter_node_unlock(spl, root);
-   splinter_node_unclaim(spl, root);
-   splinter_node_unget(spl, &root);
+   trunk_node_unlock(spl, root);
+   trunk_node_unclaim(spl, root);
+   trunk_node_unget(spl, &root);
 
    if (spl->cfg.use_stats) {
       spl->stats = TYPED_ARRAY_ZALLOC(spl->heap_id, spl->stats, MAX_THREADS);
@@ -6890,7 +6890,7 @@ splinter_create(splinter_config  *cfg,
       }
    }
 
-   splinter_list_insert(&spl->links);
+   trunk_list_insert(&spl->links);
 
    // FIXME: [yfogel 2020-03-30] cleanup has to properly handle all the things
    //        that were allocated (possibly calling destroy/deinit something)
@@ -6898,16 +6898,16 @@ splinter_create(splinter_config  *cfg,
 }
 
 // open (mount) an existing splinter database
-splinter_handle *
-splinter_mount(splinter_config  *cfg,
+trunk_handle *
+trunk_mount(trunk_config  *cfg,
                allocator        *al,
                cache            *cc,
                task_system      *ts,
                allocator_root_id       id,
                platform_heap_id  hid)
  {
-   splinter_handle *spl = TYPED_FLEXIBLE_STRUCT_ZALLOC(hid, spl,
-         compacted_memtable, SPLINTER_NUM_MEMTABLES);
+   trunk_handle *spl = TYPED_FLEXIBLE_STRUCT_ZALLOC(hid, spl,
+         compacted_memtable, TRUNK_NUM_MEMTABLES);
    memmove(&spl->cfg, cfg, sizeof(*cfg));
    spl->al = al;
    spl->cc = cc;
@@ -6923,15 +6923,15 @@ splinter_mount(splinter_config  *cfg,
    uint64 meta_tail = 0;
    uint64 latest_timestamp = 0;
    page_handle          *super_page;
-   splinter_super_block *super =
-      splinter_get_super_block_if_valid(spl, &super_page);
+   trunk_super_block *super =
+      trunk_get_super_block_if_valid(spl, &super_page);
    if (super != NULL) {
       if (super->dismounted && super->timestamp > latest_timestamp) {
          spl->root_addr = super->root_addr;
          meta_tail = super->meta_tail;
          latest_timestamp = super->timestamp;
       }
-      splinter_release_super_block(spl, super_page);
+      trunk_release_super_block(spl, super_page);
    }
    if (spl->root_addr == 0) {
       // FIXME: [yfogel 2020-03-30] we forgot to clean up (e.g.
@@ -6946,15 +6946,15 @@ splinter_mount(splinter_config  *cfg,
 
    memtable_config *mt_cfg = &spl->cfg.mt_cfg;
    spl->mt_ctxt = memtable_context_create(spl->heap_id, cc, mt_cfg,
-         splinter_memtable_flush_virtual, spl);
+         trunk_memtable_flush_virtual, spl);
 
    mini_allocator_init(&spl->mini, cc, spl->cfg.data_cfg, meta_head, meta_tail,
-         SPLINTER_MAX_HEIGHT, PAGE_TYPE_TRUNK);
+         TRUNK_MAX_HEIGHT, PAGE_TYPE_TRUNK);
    if (spl->cfg.use_log) {
       spl->log = log_create(cc, spl->cfg.log_cfg, spl->heap_id);
    }
 
-   splinter_set_super_block(spl, FALSE, FALSE, FALSE);
+   trunk_set_super_block(spl, FALSE, FALSE, FALSE);
 
    if (spl->cfg.use_stats) {
       spl->stats = TYPED_ARRAY_ZALLOC(spl->heap_id, spl->stats, MAX_THREADS);
@@ -6978,13 +6978,13 @@ splinter_mount(splinter_config  *cfg,
          platform_assert_status_ok(rc);
       }
    }
-   splinter_list_insert(&spl->links);
+   trunk_list_insert(&spl->links);
    // FIXME: [yfogel 2020-03-30] proper error handling for this entire function
    return spl;
 }
 
 void
-splinter_deinit(splinter_handle *spl)
+trunk_deinit(trunk_handle *spl)
 {
    // write current memtable to disk
    // (any others must already be flushing/flushed)
@@ -6995,7 +6995,7 @@ splinter_deinit(splinter_handle *spl)
    //        insert lock or rotate while flushing the memtable.
    if (!memtable_is_empty(spl->mt_ctxt)) {
       uint64 generation = memtable_force_finalize(spl->mt_ctxt);
-      splinter_memtable_flush(spl, generation);
+      trunk_memtable_flush(spl, generation);
    }
 
    // finish any outstanding tasks and destroy task system for this table.
@@ -7014,58 +7014,58 @@ splinter_deinit(splinter_handle *spl)
 }
 
 bool
-splinter_node_destroy(splinter_handle *spl,
+trunk_node_destroy(trunk_handle *spl,
                       uint64           addr,
                       void            *arg)
 {
-   page_handle *node = splinter_node_get(spl, addr);
-   splinter_node_claim(spl, &node);
-   splinter_node_lock(spl, node);
-   uint16 num_children = splinter_num_children(spl, node);
+   page_handle *node = trunk_node_get(spl, addr);
+   trunk_node_claim(spl, &node);
+   trunk_node_lock(spl, node);
+   uint16 num_children = trunk_num_children(spl, node);
    for (uint16 pivot_no = 0; pivot_no < num_children; pivot_no++) {
-      splinter_pivot_data *pdata = splinter_get_pivot_data(spl, node, pivot_no);
+      trunk_pivot_data *pdata = trunk_get_pivot_data(spl, node, pivot_no);
       if (pdata->filter.addr != 0) {
-         splinter_dec_filter(spl, &pdata->filter);
+         trunk_dec_filter(spl, &pdata->filter);
          //platform_log("dec filter %lu in %lu (%u)\n",
          //      pdata->filter.addr, node->disk_addr,
          //      allocator_get_refcount(spl->al, pdata->filter.addr));
       }
       for (uint16 branch_no = pdata->start_branch;
-           branch_no != splinter_end_branch(spl, node);
-           branch_no = splinter_branch_no_add(spl, branch_no, 1)) {
-         splinter_branch *branch = splinter_get_branch(spl, node, branch_no);
-         const char *start_key = splinter_get_pivot(spl, node, pivot_no);
-         const char *end_key = splinter_get_pivot(spl, node, pivot_no + 1);
-         splinter_zap_branch_range(spl, branch, start_key, end_key,
+           branch_no != trunk_end_branch(spl, node);
+           branch_no = trunk_branch_no_add(spl, branch_no, 1)) {
+         trunk_branch *branch = trunk_get_branch(spl, node, branch_no);
+         const char *start_key = trunk_get_pivot(spl, node, pivot_no);
+         const char *end_key = trunk_get_pivot(spl, node, pivot_no + 1);
+         trunk_zap_branch_range(spl, branch, start_key, end_key,
                PAGE_TYPE_BRANCH);
       }
    }
-   uint16 start_filter = splinter_start_sb_filter(spl, node);
-   uint16 end_filter = splinter_end_sb_filter(spl, node);
+   uint16 start_filter = trunk_start_sb_filter(spl, node);
+   uint16 end_filter = trunk_end_sb_filter(spl, node);
    for (uint16 filter_no = start_filter; filter_no != end_filter; filter_no++) {
-      routing_filter *filter = splinter_get_sb_filter(spl, node, filter_no);
-      splinter_dec_filter(spl, filter);
+      routing_filter *filter = trunk_get_sb_filter(spl, node, filter_no);
+      trunk_dec_filter(spl, filter);
       //platform_log("dec filter %lu in %lu (%u)\n",
       //      filter->addr, node->disk_addr,
       //      allocator_get_refcount(spl->al, filter->addr));
    }
 
-   splinter_node_unlock(spl, node);
-   splinter_node_unclaim(spl, node);
-   splinter_node_unget(spl, &node);
+   trunk_node_unlock(spl, node);
+   trunk_node_unclaim(spl, node);
+   trunk_node_unget(spl, &node);
    return TRUE;
 }
 
 // destroy a database such that it cannot be re-opened later
 void
-splinter_destroy(splinter_handle *spl)
+trunk_destroy(trunk_handle *spl)
 {
    srq_deinit(&spl->srq);
-   splinter_list_remove(&spl->links);
+   trunk_list_remove(&spl->links);
 
-   splinter_deinit(spl);
+   trunk_deinit(spl);
 
-   splinter_for_each_node(spl, splinter_node_destroy, NULL);
+   trunk_for_each_node(spl, trunk_node_destroy, NULL);
 
    mini_allocator_zap(spl->cc, NULL, spl->mini.meta_head, NULL, NULL,
          PAGE_TYPE_TRUNK);
@@ -7088,14 +7088,14 @@ splinter_destroy(splinter_handle *spl)
 }
 
 // close (dismount) a database without destroying it
-// it can be re-opened later with splinter_mount
+// it can be re-opened later with trunk_mount
 void
-splinter_dismount(splinter_handle *spl)
+trunk_dismount(trunk_handle *spl)
 {
    srq_deinit(&spl->srq);
-   splinter_list_remove(&spl->links);
-   splinter_set_super_block(spl, FALSE, TRUE, FALSE);
-   splinter_deinit(spl);
+   trunk_list_remove(&spl->links);
+   trunk_set_super_block(spl, FALSE, TRUE, FALSE);
+   trunk_deinit(spl);
    if (spl->cfg.use_stats) {
       for (uint64 i = 0; i < MAX_THREADS; i++) {
          platform_histo_destroy(spl->heap_id,
@@ -7113,7 +7113,7 @@ splinter_dismount(splinter_handle *spl)
 /*
  *-----------------------------------------------------------------------------
  *
- * splinter_perform_task
+ * trunk_perform_task
  *
  *      do a batch of tasks
  *
@@ -7121,7 +7121,7 @@ splinter_dismount(splinter_handle *spl)
  */
 
 void
-splinter_perform_tasks(splinter_handle *spl)
+trunk_perform_tasks(trunk_handle *spl)
 {
    task_perform_all(spl->ts);
    cache_cleanup(spl->cc);
@@ -7147,26 +7147,26 @@ splinter_perform_tasks(splinter_handle *spl)
  */
 
 bool
-splinter_verify_node(splinter_handle *spl,
+trunk_verify_node(trunk_handle *spl,
                      page_handle     *node)
 {
    bool is_valid = FALSE;
    uint64 addr = node->disk_addr;
 
    // check values in trunk hdr (currently just num_pivot_keys)
-   if (splinter_num_pivot_keys(spl, node) > spl->cfg.max_pivot_keys) {
-      platform_error_log("splinter_verify: too many pivots\n");
+   if (trunk_num_pivot_keys(spl, node) > spl->cfg.max_pivot_keys) {
+      platform_error_log("trunk_verify: too many pivots\n");
       platform_error_log("addr: %lu\n", addr);
       goto out;
    }
 
    // check that pivots are coherent
-   uint16 num_children = splinter_num_children(spl, node);
+   uint16 num_children = trunk_num_children(spl, node);
    for (uint16 pivot_no = 0; pivot_no < num_children; pivot_no++) {
-      const char *pivot = splinter_get_pivot(spl, node, pivot_no);
-      const char *next_pivot = splinter_get_pivot(spl, node, pivot_no + 1);
-      if (splinter_key_compare(spl, pivot, next_pivot) >= 0) {
-         platform_error_log("splinter_verify: pivots out of order\n");
+      const char *pivot = trunk_get_pivot(spl, node, pivot_no);
+      const char *next_pivot = trunk_get_pivot(spl, node, pivot_no + 1);
+      if (trunk_key_compare(spl, pivot, next_pivot) >= 0) {
+         platform_error_log("trunk_verify: pivots out of order\n");
          platform_error_log("addr: %lu\n", addr);
          goto out;
       }
@@ -7174,9 +7174,9 @@ splinter_verify_node(splinter_handle *spl,
 
    // check that pivot generations are < hdr->pivot_generation
    for (uint16 pivot_no = 0; pivot_no < num_children; pivot_no++) {
-      splinter_pivot_data *pdata = splinter_get_pivot_data(spl, node, pivot_no);
-      if (pdata->generation >= splinter_pivot_generation(spl, node)) {
-         platform_error_log("splinter_verify: pivot generation out of bound\n");
+      trunk_pivot_data *pdata = trunk_get_pivot_data(spl, node, pivot_no);
+      if (pdata->generation >= trunk_pivot_generation(spl, node)) {
+         platform_error_log("trunk_verify: pivot generation out of bound\n");
          platform_error_log("addr: %lu\n", addr);
          goto out;
       }
@@ -7187,22 +7187,22 @@ splinter_verify_node(splinter_handle *spl,
       uint64 count = 0;
       //uint64 slow_count = 0;
       uint16 pivot_start_branch =
-         splinter_pivot_start_branch(spl, node, pivot_no);
+         trunk_pivot_start_branch(spl, node, pivot_no);
       for (uint16 branch_no = pivot_start_branch;
-           branch_no != splinter_end_branch(spl, node);
-           branch_no = splinter_branch_no_add(spl, branch_no, 1)) {
-         //slow_count += splinter_pivot_tuples_in_branch_slow(spl, node,
+           branch_no != trunk_end_branch(spl, node);
+           branch_no = trunk_branch_no_add(spl, branch_no, 1)) {
+         //slow_count += trunk_pivot_tuples_in_branch_slow(spl, node,
          //      pivot_no, branch_no);
-         count += splinter_pivot_tuples_in_branch(spl, node, pivot_no,
+         count += trunk_pivot_tuples_in_branch(spl, node, pivot_no,
                                                   branch_no);
       }
       //if (count != slow_count) {
-      //   platform_error_log("splinter_verify: count != slow_count\n");
+      //   platform_error_log("trunk_verify: count != slow_count\n");
       //   platform_error_log("addr: %lu\n", addr);
       //   goto out;
       //}
-      if (splinter_pivot_num_tuples(spl, node, pivot_no) != count) {
-         platform_error_log("splinter_verify: pivot num tuples incorrect\n");
+      if (trunk_pivot_num_tuples(spl, node, pivot_no) != count) {
+         platform_error_log("trunk_verify: pivot num tuples incorrect\n");
          platform_error_log("addr: %lu\n", addr);
          goto out;
       }
@@ -7210,42 +7210,42 @@ splinter_verify_node(splinter_handle *spl,
 
    // check that pivot branches and bundles are valid
    for (uint16 pivot_no = 0; pivot_no < num_children; pivot_no++) {
-      splinter_pivot_data *pdata = splinter_get_pivot_data(spl, node, pivot_no);
-      if (!splinter_branch_valid(spl, node, pdata->start_branch)) {
-         platform_error_log("splinter_verify: invalid pivot start branch\n");
+      trunk_pivot_data *pdata = trunk_get_pivot_data(spl, node, pivot_no);
+      if (!trunk_branch_valid(spl, node, pdata->start_branch)) {
+         platform_error_log("trunk_verify: invalid pivot start branch\n");
          platform_error_log("addr: %lu\n", addr);
          goto out;
       }
-      if (!splinter_bundle_valid(spl, node, pdata->start_bundle)) {
-         platform_error_log("splinter_verify: invalid pivot start bundle\n");
+      if (!trunk_bundle_valid(spl, node, pdata->start_bundle)) {
+         platform_error_log("trunk_verify: invalid pivot start bundle\n");
          platform_error_log("addr: %lu\n", addr);
          goto out;
       }
    }
 
    // check bundles are coherent
-   splinter_bundle *last_bundle = NULL;
-   for (uint16 bundle_no = splinter_start_bundle(spl, node);
-        bundle_no != splinter_end_bundle(spl, node);
-        bundle_no = splinter_bundle_no_add(spl, bundle_no, 1)) {
-      splinter_bundle *bundle = splinter_get_bundle(spl, node, bundle_no);
-      if (bundle_no == splinter_start_bundle(spl, node)) {
-         if (splinter_start_subbundle(spl, node) != bundle->start_subbundle) {
-            platform_error_log("splinter_verify: start_subbundle mismatch\n");
+   trunk_bundle *last_bundle = NULL;
+   for (uint16 bundle_no = trunk_start_bundle(spl, node);
+        bundle_no != trunk_end_bundle(spl, node);
+        bundle_no = trunk_bundle_no_add(spl, bundle_no, 1)) {
+      trunk_bundle *bundle = trunk_get_bundle(spl, node, bundle_no);
+      if (bundle_no == trunk_start_bundle(spl, node)) {
+         if (trunk_start_subbundle(spl, node) != bundle->start_subbundle) {
+            platform_error_log("trunk_verify: start_subbundle mismatch\n");
             platform_error_log("addr: %lu\n", addr);
             goto out;
          }
       } else {
          if (last_bundle->end_subbundle != bundle->start_subbundle) {
-            platform_error_log("splinter_verify: "
+            platform_error_log("trunk_verify: "
                   "bundles have mismatched subbundles\n");
             platform_error_log("addr: %lu\n", addr);
             goto out;
          }
       }
-      if (bundle_no + 1 == splinter_end_bundle(spl, node)) {
-         if (bundle->end_subbundle != splinter_end_subbundle(spl, node)) {
-            platform_error_log("splinter_verify: end_subbundle mismatch\n");
+      if (bundle_no + 1 == trunk_end_bundle(spl, node)) {
+         if (bundle->end_subbundle != trunk_end_subbundle(spl, node)) {
+            platform_error_log("trunk_verify: end_subbundle mismatch\n");
             platform_error_log("addr: %lu\n", addr);
             goto out;
          }
@@ -7254,28 +7254,28 @@ splinter_verify_node(splinter_handle *spl,
    }
 
    // check subbundles are coherent
-   splinter_subbundle *last_sb = NULL;
-   for (uint16 sb_no = splinter_start_subbundle(spl, node);
-        sb_no != splinter_end_subbundle(spl, node);
-        sb_no = splinter_subbundle_no_add(spl, sb_no, 1)) {
-      splinter_subbundle *sb = splinter_get_subbundle(spl, node, sb_no);
-      if (sb_no == splinter_start_subbundle(spl, node)) {
-         if (sb->start_branch != splinter_start_frac_branch(spl, node)) {
-            platform_error_log("splinter_verify: start_branch mismatch\n");
+   trunk_subbundle *last_sb = NULL;
+   for (uint16 sb_no = trunk_start_subbundle(spl, node);
+        sb_no != trunk_end_subbundle(spl, node);
+        sb_no = trunk_subbundle_no_add(spl, sb_no, 1)) {
+      trunk_subbundle *sb = trunk_get_subbundle(spl, node, sb_no);
+      if (sb_no == trunk_start_subbundle(spl, node)) {
+         if (sb->start_branch != trunk_start_frac_branch(spl, node)) {
+            platform_error_log("trunk_verify: start_branch mismatch\n");
             platform_error_log("addr: %lu\n", addr);
             goto out;
          }
       } else {
          if (sb->start_branch != last_sb->end_branch) {
-            platform_error_log("splinter_verify: "
+            platform_error_log("trunk_verify: "
                   "subbundles have mismatched branches\n");
             platform_error_log("addr: %lu\n", addr);
             goto out;
          }
       }
-      if (sb_no + 1 == splinter_end_subbundle(spl, node)) {
-         if (sb->end_branch != splinter_end_branch(spl, node)) {
-            platform_error_log("splinter_verify: end_branch mismatch\n");
+      if (sb_no + 1 == trunk_end_subbundle(spl, node)) {
+         if (sb->end_branch != trunk_end_branch(spl, node)) {
+            platform_error_log("trunk_verify: end_branch mismatch\n");
             platform_error_log("addr: %lu\n", addr);
             goto out;
          }
@@ -7285,28 +7285,28 @@ splinter_verify_node(splinter_handle *spl,
 
    // check that pivot start branches and start bundles are coherent
    for (uint16 pivot_no = 0; pivot_no < num_children; pivot_no++) {
-      splinter_pivot_data *pdata = splinter_get_pivot_data(spl, node, pivot_no);
-      if (!splinter_bundle_live(spl, node, pdata->start_bundle)) {
-         if (1 && pdata->start_branch != splinter_end_branch(spl, node)
-               && splinter_bundle_count(spl, node) != 0) {
-            platform_error_log("splinter_verify: pivot start bundle doesn't match start branch\n");
+      trunk_pivot_data *pdata = trunk_get_pivot_data(spl, node, pivot_no);
+      if (!trunk_bundle_live(spl, node, pdata->start_bundle)) {
+         if (1 && pdata->start_branch != trunk_end_branch(spl, node)
+               && trunk_bundle_count(spl, node) != 0) {
+            platform_error_log("trunk_verify: pivot start bundle doesn't match start branch\n");
             platform_error_log("addr: %lu\n", addr);
             goto out;
          }
       } else {
-         splinter_bundle *bundle =
-            splinter_get_bundle(spl, node, pdata->start_bundle);
-         splinter_subbundle *sb =
-            splinter_get_subbundle(spl, node, bundle->start_subbundle);
+         trunk_bundle *bundle =
+            trunk_get_bundle(spl, node, pdata->start_bundle);
+         trunk_subbundle *sb =
+            trunk_get_subbundle(spl, node, bundle->start_subbundle);
          if (pdata->start_branch != sb->start_branch) {
-            if (!splinter_branch_in_range(spl, pdata->start_branch,
-                     splinter_start_branch(spl, node), sb->start_branch)) {
-               platform_error_log("splinter_verify: pivot start branch out of order with bundle start branch\n");
+            if (!trunk_branch_in_range(spl, pdata->start_branch,
+                     trunk_start_branch(spl, node), sb->start_branch)) {
+               platform_error_log("trunk_verify: pivot start branch out of order with bundle start branch\n");
                platform_error_log("addr: %lu\n", addr);
                goto out;
             }
-            if (pdata->start_bundle != splinter_start_bundle(spl, node)) {
-               platform_error_log("splinter_verify: pivot start bundle incoherent with start branch\n");
+            if (pdata->start_bundle != trunk_start_bundle(spl, node)) {
+               platform_error_log("trunk_verify: pivot start bundle incoherent with start branch\n");
                platform_error_log("addr: %lu\n", addr);
                goto out;
             }
@@ -7314,9 +7314,9 @@ splinter_verify_node(splinter_handle *spl,
       }
    }
 
-   if (splinter_height(spl, node) == 0) {
-      if (splinter_num_children(spl, node) != 1) {
-         platform_error_log("splinter_verify: leaf with multiple children\n");
+   if (trunk_height(spl, node) == 0) {
+      if (trunk_num_children(spl, node) != 1) {
+         platform_error_log("trunk_verify: leaf with multiple children\n");
          platform_error_log("addr: %lu\n", addr);
          goto out;
       }
@@ -7325,7 +7325,7 @@ splinter_verify_node(splinter_handle *spl,
    is_valid = TRUE;
 out:
    if (!is_valid) {
-      splinter_print_locked_node(spl, node, PLATFORM_ERR_LOG_HANDLE);
+      trunk_print_locked_node(spl, node, PLATFORM_ERR_LOG_HANDLE);
    }
    return is_valid;
 }
@@ -7337,94 +7337,94 @@ out:
  */
 
 bool
-splinter_verify_node_with_neighbors(splinter_handle *spl,
+trunk_verify_node_with_neighbors(trunk_handle *spl,
                                     page_handle     *node)
 {
    bool is_valid = FALSE;
    uint64 addr = node->disk_addr;
 
    // check node and successor have coherent pivots
-   uint64 succ_addr = splinter_next_addr(spl, node);
+   uint64 succ_addr = trunk_next_addr(spl, node);
    if (succ_addr != 0) {
-      page_handle *succ = splinter_node_get(spl, succ_addr);
-      const char *ube = splinter_max_key(spl, node);
-      const char *succ_lbi = splinter_min_key(spl, succ);
-      if (splinter_key_compare(spl, ube, succ_lbi) != 0) {
-         platform_log("splinter_verify_node_with_neighbors: "
+      page_handle *succ = trunk_node_get(spl, succ_addr);
+      const char *ube = trunk_max_key(spl, node);
+      const char *succ_lbi = trunk_min_key(spl, succ);
+      if (trunk_key_compare(spl, ube, succ_lbi) != 0) {
+         platform_log("trunk_verify_node_with_neighbors: "
                "mismatched pivots with successor\n");
          platform_log("addr: %lu\n", addr);
-         splinter_node_unget(spl, &succ);
+         trunk_node_unget(spl, &succ);
          goto out;
       }
-      splinter_node_unget(spl, &succ);
+      trunk_node_unget(spl, &succ);
    }
 
-   if (splinter_height(spl, node) == 0) {
+   if (trunk_height(spl, node) == 0) {
       is_valid = TRUE;
       goto out;
    }
 
    // check node and each child have coherent pivots
-   uint16 num_children = splinter_num_children(spl, node);
+   uint16 num_children = trunk_num_children(spl, node);
    for (uint16 pivot_no = 0; pivot_no != num_children; pivot_no++) {
-      splinter_pivot_data *pdata = splinter_get_pivot_data(spl, node, pivot_no);
+      trunk_pivot_data *pdata = trunk_get_pivot_data(spl, node, pivot_no);
       uint64 child_addr = pdata->addr;
-      page_handle *child = splinter_node_get(spl, child_addr);
+      page_handle *child = trunk_node_get(spl, child_addr);
 
       // check pivot == child min key
-      const char *pivot = splinter_get_pivot(spl, node, pivot_no);
-      const char *child_min_key = splinter_min_key(spl, child);
-      if (splinter_key_compare(spl, pivot, child_min_key) != 0) {
-         platform_log("splinter_verify_node_with_neighbors: "
+      const char *pivot = trunk_get_pivot(spl, node, pivot_no);
+      const char *child_min_key = trunk_min_key(spl, child);
+      if (trunk_key_compare(spl, pivot, child_min_key) != 0) {
+         platform_log("trunk_verify_node_with_neighbors: "
                "mismatched pivot with child min key\n");
          platform_log("0x%016lx%016lx%016lx\n", *((uint64 *)pivot), *(((uint64 *)pivot) + 1), *(((uint64 *)pivot) + 2));
          platform_log("0x%016lx%016lx%016lx\n", *((uint64 *)child_min_key), *(((uint64 *)child_min_key) + 1), *(((uint64 *)child_min_key) + 2));
 
          platform_log("addr: %lu\n", addr);
          platform_log("child addr: %lu\n", child_addr);
-         splinter_node_unget(spl, &child);
+         trunk_node_unget(spl, &child);
          goto out;
       }
-      const char *next_pivot = splinter_get_pivot(spl, node, pivot_no + 1);
-      const char *child_max_key = splinter_max_key(spl, child);
-      if (splinter_key_compare(spl, next_pivot, child_max_key) != 0) {
-         platform_log("splinter_verify_node_with_neighbors: "
+      const char *next_pivot = trunk_get_pivot(spl, node, pivot_no + 1);
+      const char *child_max_key = trunk_max_key(spl, child);
+      if (trunk_key_compare(spl, next_pivot, child_max_key) != 0) {
+         platform_log("trunk_verify_node_with_neighbors: "
                "mismatched pivot with child max key\n");
          platform_log("addr: %lu\n", addr);
          platform_log("child addr: %lu\n", child_addr);
-         splinter_node_unget(spl, &child);
+         trunk_node_unget(spl, &child);
          goto out;
       }
 
-      splinter_node_unget(spl, &child);
+      trunk_node_unget(spl, &child);
    }
 
    is_valid = TRUE;
 out:
    if (!is_valid) {
-      splinter_print_locked_node(spl, node, PLATFORM_DEFAULT_LOG_HANDLE);
+      trunk_print_locked_node(spl, node, PLATFORM_DEFAULT_LOG_HANDLE);
    }
    return is_valid;
 }
 
 /*
- * wrapper for splinter_for_each_node
+ * wrapper for trunk_for_each_node
  */
 
 bool
-splinter_verify_node_and_neighbors(splinter_handle *spl,
+trunk_verify_node_and_neighbors(trunk_handle *spl,
                                    uint64           addr,
                                    void            *arg)
 {
-   page_handle *node = splinter_node_get(spl, addr);
-   bool is_valid = splinter_verify_node(spl, node);
+   page_handle *node = trunk_node_get(spl, addr);
+   bool is_valid = trunk_verify_node(spl, node);
    if (!is_valid) {
       goto out;
    }
-   is_valid = splinter_verify_node_with_neighbors(spl, node);
+   is_valid = trunk_verify_node_with_neighbors(spl, node);
 
 out:
-   splinter_node_unget(spl, &node);
+   trunk_node_unget(spl, &node);
    return is_valid;
 }
 
@@ -7433,9 +7433,9 @@ out:
  */
 
 bool
-splinter_verify_tree(splinter_handle *spl)
+trunk_verify_tree(trunk_handle *spl)
 {
-   return splinter_for_each_node(spl, splinter_verify_node_and_neighbors, NULL);
+   return trunk_for_each_node(spl, trunk_verify_node_and_neighbors, NULL);
 }
 
 /*
@@ -7443,32 +7443,32 @@ splinter_verify_tree(splinter_handle *spl)
  */
 
 bool
-splinter_node_space_use(splinter_handle *spl,
+trunk_node_space_use(trunk_handle *spl,
                         uint64           addr,
                         void            *arg)
 {
    uint64 *bytes_used_on_level = (uint64 *)arg;
    uint64 bytes_used_in_node = 0;
-   page_handle *node = splinter_node_get(spl, addr);
-   uint16 num_pivot_keys = splinter_num_pivot_keys(spl, node);
-   uint16 num_children = splinter_num_children(spl, node);
-   for (uint16 branch_no = splinter_start_branch(spl, node);
-        branch_no != splinter_end_branch(spl, node);
-        branch_no = splinter_branch_no_add(spl, branch_no, 1))
+   page_handle *node = trunk_node_get(spl, addr);
+   uint16 num_pivot_keys = trunk_num_pivot_keys(spl, node);
+   uint16 num_children = trunk_num_children(spl, node);
+   for (uint16 branch_no = trunk_start_branch(spl, node);
+        branch_no != trunk_end_branch(spl, node);
+        branch_no = trunk_branch_no_add(spl, branch_no, 1))
    {
-      splinter_branch *branch = splinter_get_branch(spl, node, branch_no);
+      trunk_branch *branch = trunk_get_branch(spl, node, branch_no);
       char *start_key = NULL;
       char *end_key = NULL;
       for (uint16 pivot_no = 0; pivot_no < num_pivot_keys; pivot_no++) {
          if (1 && pivot_no != num_children
-               && splinter_branch_live_for_pivot(spl, node, branch_no, pivot_no))
+               && trunk_branch_live_for_pivot(spl, node, branch_no, pivot_no))
          {
             if (start_key == NULL) {
-               start_key = splinter_get_pivot(spl, node, pivot_no);
+               start_key = trunk_get_pivot(spl, node, pivot_no);
             }
          } else {
             if (start_key != NULL) {
-               end_key = splinter_get_pivot(spl, node, pivot_no);
+               end_key = trunk_get_pivot(spl, node, pivot_no);
                uint64 bytes_used_in_branch_range =
                   btree_space_use_in_range(spl->cc, &spl->cfg.btree_cfg,
                         branch->root_addr, PAGE_TYPE_BRANCH, start_key,
@@ -7481,49 +7481,49 @@ splinter_node_space_use(splinter_handle *spl,
       }
    }
 
-   uint16 height = splinter_height(spl, node);
+   uint16 height = trunk_height(spl, node);
    bytes_used_on_level[height] += bytes_used_in_node;
-   splinter_node_unget(spl, &node);
+   trunk_node_unget(spl, &node);
    return TRUE;
 }
 
 void
-splinter_print_space_use(splinter_handle *spl)
+trunk_print_space_use(trunk_handle *spl)
 {
-   uint64 bytes_used_by_level[SPLINTER_MAX_HEIGHT] = { 0 };
-   splinter_for_each_node(spl, splinter_node_space_use, bytes_used_by_level);
+   uint64 bytes_used_by_level[TRUNK_MAX_HEIGHT] = { 0 };
+   trunk_for_each_node(spl, trunk_node_space_use, bytes_used_by_level);
 
    platform_log("Space used by level:\n");
-   for (uint16 i = 0; i <= splinter_tree_height(spl); i++) {
+   for (uint16 i = 0; i <= trunk_tree_height(spl); i++) {
       platform_log("%u: %8luMiB\n", i, B_TO_MiB(bytes_used_by_level[i]));
    }
    platform_log("\n");
 }
 
 void
-splinter_print_locked_node(splinter_handle        *spl,
+trunk_print_locked_node(trunk_handle        *spl,
                            page_handle            *node,
                            platform_stream_handle stream)
 {
-   uint16 height = splinter_height(spl, node);
+   uint16 height = trunk_height(spl, node);
    platform_log_stream("---------------------------------------------------------------------------------------\n");
    platform_log_stream("|          |     addr      |   next addr  | height |   gen   | pvt gen |              |\n");
    platform_log_stream("|  HEADER  |---------------|--------------|--------|---------|---------|--------------|\n");
    platform_log_stream("|          | %12lu^ | %12lu | %6u | %7lu | %7lu |              |\n",
-         node->disk_addr, splinter_next_addr(spl, node), height, splinter_generation(spl, node), splinter_pivot_generation(spl, node));
+         node->disk_addr, trunk_next_addr(spl, node), height, trunk_generation(spl, node), trunk_pivot_generation(spl, node));
    platform_log_stream("|-------------------------------------------------------------------------------------|\n");
    platform_log_stream("|                                       PIVOTS                                        |\n");
    platform_log_stream("|-------------------------------------------------------------------------------------|\n");
    platform_log_stream("|         pivot key        |  child addr  |  filter addr | tuple count |  srq |  gen  |\n");
    platform_log_stream("|--------------------------|--------------|--------------|-------------|------|-------|\n");
    for (uint16 pivot_no = 0;
-        pivot_no < splinter_num_pivot_keys(spl, node);
+        pivot_no < trunk_num_pivot_keys(spl, node);
         pivot_no++)
    {
       char key_string[128];
-      splinter_key_to_string(spl, splinter_get_pivot(spl, node, pivot_no), key_string);
-      splinter_pivot_data *pdata = splinter_get_pivot_data(spl, node, pivot_no);
-      if (pivot_no == splinter_num_pivot_keys(spl, node) - 1) {
+      trunk_key_to_string(spl, trunk_get_pivot(spl, node, pivot_no), key_string);
+      trunk_pivot_data *pdata = trunk_get_pivot_data(spl, node, pivot_no);
+      if (pivot_no == trunk_num_pivot_keys(spl, node) - 1) {
          platform_log_stream("| %24s | %12s | %12s | %11s | %4s | %5s |\n",
                key_string, "", "", "", "", "");
       } else {
@@ -7540,21 +7540,21 @@ splinter_print_locked_node(splinter_handle        *spl,
    platform_log_stream("|     |    pivot/bundle/subbundle   |  num tuples  |              |              |    |\n");
    platform_log_stream("|-----|--------------|--------------|--------------|--------------|--------------|----|\n");
    // clang-format on
-   uint16 start_branch = splinter_start_branch(spl, node);
-   uint16 end_branch = splinter_end_branch(spl, node);
-   uint16 start_bundle = splinter_start_bundle(spl, node);
-   uint16 end_bundle = splinter_end_bundle(spl, node);
-   uint16 start_sb = splinter_start_subbundle(spl, node);
-   uint16 end_sb = splinter_end_subbundle(spl, node);
+   uint16 start_branch = trunk_start_branch(spl, node);
+   uint16 end_branch = trunk_end_branch(spl, node);
+   uint16 start_bundle = trunk_start_bundle(spl, node);
+   uint16 end_bundle = trunk_end_bundle(spl, node);
+   uint16 start_sb = trunk_start_subbundle(spl, node);
+   uint16 end_sb = trunk_end_subbundle(spl, node);
    for (uint16 branch_no = start_branch;
         branch_no != end_branch;
-        branch_no = splinter_branch_no_add(spl, branch_no, 1))
+        branch_no = trunk_branch_no_add(spl, branch_no, 1))
    {
       for (uint16 pivot_no = 0;
-           pivot_no < splinter_num_children(spl, node);
+           pivot_no < trunk_num_children(spl, node);
            pivot_no++)
       {
-         if (branch_no == splinter_pivot_start_branch(spl, node, pivot_no)) {
+         if (branch_no == trunk_pivot_start_branch(spl, node, pivot_no)) {
             // clang-format off
             platform_log_stream("|     |        -- pivot %2u --       |              |              |              |    |\n",
                                 pivot_no);
@@ -7563,31 +7563,31 @@ splinter_print_locked_node(splinter_handle        *spl,
       }
       for (uint16 bundle_no = start_bundle;
            bundle_no != end_bundle;
-           bundle_no = splinter_bundle_no_add(spl, bundle_no, 1))
+           bundle_no = trunk_bundle_no_add(spl, bundle_no, 1))
       {
-         splinter_bundle *bundle = splinter_get_bundle(spl, node, bundle_no);
-         if (branch_no == splinter_bundle_start_branch(spl, node, bundle)) {
+         trunk_bundle *bundle = trunk_get_bundle(spl, node, bundle_no);
+         if (branch_no == trunk_bundle_start_branch(spl, node, bundle)) {
             platform_log_stream("|     |       -- bundle %2u --       | %12lu |              |              |    |\n", bundle_no, bundle->num_tuples);
          }
       }
       for (uint16 sb_no = start_sb;
            sb_no != end_sb;
-           sb_no = splinter_subbundle_no_add(spl, sb_no, 1))
+           sb_no = trunk_subbundle_no_add(spl, sb_no, 1))
       {
-         splinter_subbundle *sb = splinter_get_subbundle(spl, node, sb_no);
+         trunk_subbundle *sb = trunk_get_subbundle(spl, node, sb_no);
          if (branch_no == sb->start_branch) {
-            uint16 filter_count = splinter_subbundle_filter_count(spl, node, sb);
+            uint16 filter_count = trunk_subbundle_filter_count(spl, node, sb);
             platform_log_stream("|     |  -- %scomp subbundle %2u --  | %12lu | %12lu | %12lu | %s |\n",
                                 sb->state == SB_STATE_COMPACTED ? "" : "un",
                                 sb_no,
-                                0 < filter_count ? splinter_subbundle_filter(spl, node, sb, 0)->addr : 0,
-                                1 < filter_count ? splinter_subbundle_filter(spl, node, sb, 1)->addr : 0,
-                                2 < filter_count ? splinter_subbundle_filter(spl, node, sb, 2)->addr : 0,
+                                0 < filter_count ? trunk_subbundle_filter(spl, node, sb, 0)->addr : 0,
+                                1 < filter_count ? trunk_subbundle_filter(spl, node, sb, 1)->addr : 0,
+                                2 < filter_count ? trunk_subbundle_filter(spl, node, sb, 2)->addr : 0,
                                 3 < filter_count ? " *" : "  ");
          }
       }
 
-      splinter_branch *branch = splinter_get_branch(spl, node, branch_no);
+      trunk_branch *branch = trunk_get_branch(spl, node, branch_no);
       // clang-format off
       platform_log_stream("| %3u |         %12lu       |              |              |              |    |\n",
                           branch_no,
@@ -7599,7 +7599,7 @@ splinter_print_locked_node(splinter_handle        *spl,
 }
 
 void
-splinter_print_node(splinter_handle       *spl,
+trunk_print_node(trunk_handle       *spl,
                     uint64                 addr,
                     platform_stream_handle stream)
 {
@@ -7611,35 +7611,35 @@ splinter_print_node(splinter_handle       *spl,
       return;
    }
 
-   page_handle *node = splinter_node_get(spl, addr);
-   splinter_print_locked_node(spl, node, stream);
+   page_handle *node = trunk_node_get(spl, addr);
+   trunk_print_locked_node(spl, node, stream);
    cache_unget(spl->cc, node);
 }
 
 void
-splinter_print_subtree(splinter_handle        *spl,
+trunk_print_subtree(trunk_handle        *spl,
                        uint64                  addr,
                        platform_stream_handle  stream)
 {
-   splinter_print_node(spl, addr, stream);
-   page_handle *node = splinter_node_get(spl, addr);
-   splinter_trunk_hdr *hdr = (splinter_trunk_hdr *)node->data;
+   trunk_print_node(spl, addr, stream);
+   page_handle *node = trunk_node_get(spl, addr);
+   trunk_hdr *hdr = (trunk_hdr *)node->data;
 
    if (hdr->height != 0) {
-      for (uint32 i = 0; i < splinter_num_children(spl, node); i++) {
-         splinter_pivot_data *data = splinter_get_pivot_data(spl, node, i);
-         splinter_print_subtree(spl, data->addr, stream);
+      for (uint32 i = 0; i < trunk_num_children(spl, node); i++) {
+         trunk_pivot_data *data = trunk_get_pivot_data(spl, node, i);
+         trunk_print_subtree(spl, data->addr, stream);
       }
    }
    cache_unget(spl->cc, node);
 }
 
 void
-splinter_print_memtable(splinter_handle        *spl,
+trunk_print_memtable(trunk_handle        *spl,
                         platform_stream_handle  stream)
 {
    uint64 curr_memtable =
-      memtable_generation(spl->mt_ctxt) % SPLINTER_NUM_MEMTABLES;
+      memtable_generation(spl->mt_ctxt) % TRUNK_NUM_MEMTABLES;
    platform_log_stream("&&&&&&&&&&&&&&&&&&&\n");
    platform_log_stream("&&  MEMTABLES \n");
    platform_log_stream("&&  curr: %lu\n", curr_memtable);
@@ -7648,7 +7648,7 @@ splinter_print_memtable(splinter_handle        *spl,
    uint64 mt_gen_start = memtable_generation(spl->mt_ctxt);
    uint64 mt_gen_end = memtable_generation_retired(spl->mt_ctxt);
    for (uint64 mt_gen = mt_gen_start; mt_gen != mt_gen_end; mt_gen--) {
-      memtable *mt = splinter_get_memtable(spl, mt_gen);
+      memtable *mt = trunk_get_memtable(spl, mt_gen);
       platform_log_stream("%lu: gen %lu ref_count %u state %d\n",
             mt_gen, mt->root_addr,
             allocator_get_refcount(spl->al, mt->root_addr), mt->state);
@@ -7657,16 +7657,16 @@ splinter_print_memtable(splinter_handle        *spl,
 }
 
 void
-splinter_print(splinter_handle *spl)
+trunk_print(trunk_handle *spl)
 {
    platform_open_log_stream();
-   splinter_print_memtable(spl, stream);
-   splinter_print_subtree(spl, spl->root_addr, stream);
+   trunk_print_memtable(spl, stream);
+   trunk_print_subtree(spl, spl->root_addr, stream);
    platform_close_log_stream(PLATFORM_DEFAULT_LOG_HANDLE);
 }
 
 void
-splinter_print_insertion_stats(splinter_handle *spl)
+trunk_print_insertion_stats(trunk_handle *spl)
 {
    if (!spl->cfg.use_stats) {
       platform_log("Statistics are not enabled\n");
@@ -7678,11 +7678,11 @@ splinter_print_insertion_stats(splinter_handle *spl)
    uint64 avg_filter_tuples, avg_filter_time, filter_time_per_tuple;
    uint32 h, rev_h;
    threadid thr_i;
-   page_handle *node = splinter_node_get(spl, spl->root_addr);
-   uint32 height = splinter_height(spl, node);
-   splinter_node_unget(spl, &node);
+   page_handle *node = trunk_node_get(spl, spl->root_addr);
+   uint32 height = trunk_height(spl, node);
+   trunk_node_unget(spl, &node);
 
-   splinter_stats *global;
+   trunk_stats *global;
 
    global = TYPED_ZALLOC(spl->heap_id, global);
    if (global == NULL) {
@@ -7970,7 +7970,7 @@ splinter_print_insertion_stats(splinter_handle *spl)
 
 
 void
-splinter_print_lookup_stats(splinter_handle *spl)
+trunk_print_lookup_stats(trunk_handle *spl)
 {
    if (!spl->cfg.use_stats) {
       platform_log("Statistics are not enabled\n");
@@ -7981,11 +7981,11 @@ splinter_print_lookup_stats(splinter_handle *spl)
    uint32 h, rev_h;
    uint64 lookups;
    fraction avg_filter_lookups, avg_filter_false_positives, avg_branch_lookups;
-   page_handle *node = splinter_node_get(spl, spl->root_addr);
-   uint32 height = splinter_height(spl, node);
-   splinter_node_unget(spl, &node);
+   page_handle *node = trunk_node_get(spl, spl->root_addr);
+   uint32 height = trunk_height(spl, node);
+   trunk_node_unget(spl, &node);
 
-   splinter_stats *global;
+   trunk_stats *global;
 
    global = TYPED_ZALLOC(spl->heap_id, global);
    if (global == NULL) {
@@ -8057,7 +8057,7 @@ splinter_print_lookup_stats(splinter_handle *spl)
 
 
 void
-splinter_print_lookup(splinter_handle *spl,
+trunk_print_lookup(trunk_handle *spl,
                       char            *key)
 {
    bool found = FALSE;
@@ -8070,15 +8070,15 @@ splinter_print_lookup(splinter_handle *spl,
    uint64 mt_gen_end = memtable_generation_retired(spl->mt_ctxt);
    for (uint64 mt_gen = mt_gen_start; mt_gen != mt_gen_end; mt_gen--) {
       bool memtable_is_compacted;
-      uint64 root_addr = splinter_memtable_root_addr_for_lookup(spl, mt_gen,
+      uint64 root_addr = trunk_memtable_root_addr_for_lookup(spl, mt_gen,
             &memtable_is_compacted);
 
       btree_lookup(spl->cc, &spl->cfg.btree_cfg, root_addr, key, data, &found);
       if (found) {
          char key_str[128];
          char message_str[128];
-         splinter_key_to_string(spl, key, key_str);
-         splinter_message_to_string(spl, data, message_str);
+         trunk_key_to_string(spl, key, key_str);
+         trunk_message_to_string(spl, data, message_str);
          platform_log("Key %s found in memtable %lu (gen %lu comp %d) with data %s\n",
                       key_str,
                       root_addr,
@@ -8091,33 +8091,33 @@ splinter_print_lookup(splinter_handle *spl,
       found = FALSE;
    }
 
-   page_handle *node = splinter_node_get(spl, spl->root_addr);
-   uint16 height = splinter_height(spl, node);
+   page_handle *node = trunk_node_get(spl, spl->root_addr);
+   uint16 height = trunk_height(spl, node);
    for (uint16 h = height; h > 0; h--) {
-      splinter_print_locked_node(spl, node, PLATFORM_DEFAULT_LOG_HANDLE);
-      uint16 pivot_no = splinter_find_pivot(spl, node, key, less_than_or_equal);
-      debug_assert(pivot_no < splinter_num_children(spl, node));
-      splinter_pivot_data *pdata = splinter_get_pivot_data(spl, node, pivot_no);
-      splinter_pivot_lookup(spl, node, pdata, key, data, &found);
+      trunk_print_locked_node(spl, node, PLATFORM_DEFAULT_LOG_HANDLE);
+      uint16 pivot_no = trunk_find_pivot(spl, node, key, less_than_or_equal);
+      debug_assert(pivot_no < trunk_num_children(spl, node));
+      trunk_pivot_data *pdata = trunk_get_pivot_data(spl, node, pivot_no);
+      trunk_pivot_lookup(spl, node, pdata, key, data, &found);
       if (found) {
          char key_str[128];
          char message_str[128];
-         splinter_key_to_string(spl, key, key_str);
-         splinter_message_to_string(spl, data, message_str);
+         trunk_key_to_string(spl, key, key_str);
+         trunk_message_to_string(spl, data, message_str);
          platform_log("Key %s found in node %lu pivot %u with data %s\n",
                       key_str, node->disk_addr, pivot_no, message_str);
          found = FALSE;
       } else {
          for (uint16 branch_no = pdata->start_branch;
-              branch_no != splinter_end_branch(spl, node);
-              branch_no = splinter_branch_no_add(spl, branch_no, 1)) {
-            splinter_branch *branch = splinter_get_branch(spl, node, branch_no);
-            splinter_btree_lookup(spl, branch, key, data, &found);
+              branch_no != trunk_end_branch(spl, node);
+              branch_no = trunk_branch_no_add(spl, branch_no, 1)) {
+            trunk_branch *branch = trunk_get_branch(spl, node, branch_no);
+            trunk_btree_lookup(spl, branch, key, data, &found);
             if (found) {
                char key_str[128];
                char message_str[128];
-               splinter_key_to_string(spl, key, key_str);
-               splinter_message_to_string(spl, data, message_str);
+               trunk_key_to_string(spl, key, key_str);
+               trunk_message_to_string(spl, data, message_str);
                platform_log("!! Key %s found in branch %u of node %lu pivot %u "
                             "with data %s\n",
                             key_str, branch_no, node->disk_addr, pivot_no,
@@ -8126,106 +8126,106 @@ splinter_print_lookup(splinter_handle *spl,
             found = FALSE;
          }
       }
-      page_handle *child = splinter_node_get(spl, pdata->addr);
-      splinter_node_unget(spl, &node);
+      page_handle *child = trunk_node_get(spl, pdata->addr);
+      trunk_node_unget(spl, &node);
       node = child;
    }
 
    // look in leaf
-   splinter_print_locked_node(spl, node, PLATFORM_DEFAULT_LOG_HANDLE);
-   splinter_pivot_data *pdata = splinter_get_pivot_data(spl, node, 0);
-   splinter_pivot_lookup(spl, node, pdata, key, data, &found);
+   trunk_print_locked_node(spl, node, PLATFORM_DEFAULT_LOG_HANDLE);
+   trunk_pivot_data *pdata = trunk_get_pivot_data(spl, node, 0);
+   trunk_pivot_lookup(spl, node, pdata, key, data, &found);
    if (found) {
       char key_str[128];
       char message_str[128];
-      splinter_key_to_string(spl, key, key_str);
-      splinter_message_to_string(spl, data, message_str);
+      trunk_key_to_string(spl, key, key_str);
+      trunk_message_to_string(spl, data, message_str);
       platform_log("Key %s found in node %lu pivot %u with data %s\n",
                    key_str, node->disk_addr, 0, message_str);
       found = FALSE;
    } else {
       for (uint16 branch_no = pdata->start_branch;
-           branch_no != splinter_end_branch(spl, node);
-           branch_no = splinter_branch_no_add(spl, branch_no, 1)) {
-         splinter_branch *branch = splinter_get_branch(spl, node, branch_no);
-         splinter_btree_lookup(spl, branch, key, data, &found);
+           branch_no != trunk_end_branch(spl, node);
+           branch_no = trunk_branch_no_add(spl, branch_no, 1)) {
+         trunk_branch *branch = trunk_get_branch(spl, node, branch_no);
+         trunk_btree_lookup(spl, branch, key, data, &found);
          if (found) {
             char key_str[128];
             char message_str[128];
-            splinter_key_to_string(spl, key, key_str);
-            splinter_message_to_string(spl, data, message_str);
+            trunk_key_to_string(spl, key, key_str);
+            trunk_message_to_string(spl, data, message_str);
             platform_log("!! Key %s found in branch %u of node %lu pivot %u "
                   "with data %s\n",
                   key_str, branch_no, node->disk_addr, 0, message_str);
          }
       }
    }
-   splinter_node_unget(spl, &node);
+   trunk_node_unget(spl, &node);
 }
 
 void
-splinter_reset_stats(splinter_handle *spl)
+trunk_reset_stats(trunk_handle *spl)
 {
    if (spl->cfg.use_stats) {
-      memset(spl->stats, 0, MAX_THREADS * sizeof(splinter_stats));
+      memset(spl->stats, 0, MAX_THREADS * sizeof(trunk_stats));
    }
 }
 
 uint64
-splinter_branch_count_num_tuples(splinter_handle *spl,
+trunk_branch_count_num_tuples(trunk_handle *spl,
                                  page_handle     *node,
                                  uint16           branch_no)
 {
-   uint16 num_children = splinter_num_children(spl, node);
+   uint16 num_children = trunk_num_children(spl, node);
    uint64 num_tuples = 0;
    for (uint16 pivot_no = 0; pivot_no < num_children; pivot_no++) {
-      if (splinter_branch_live_for_pivot(spl, node, branch_no, pivot_no)) {
+      if (trunk_branch_live_for_pivot(spl, node, branch_no, pivot_no)) {
          num_tuples +=
-            splinter_pivot_tuples_in_branch(spl, node, pivot_no, branch_no);
+            trunk_pivot_tuples_in_branch(spl, node, pivot_no, branch_no);
       }
    }
    return num_tuples;
 }
 
 uint64
-splinter_branch_extent_count(splinter_handle *spl,
+trunk_branch_extent_count(trunk_handle *spl,
                              page_handle     *node,
                              uint16           branch_no)
 {
-   splinter_branch *branch = splinter_get_branch(spl, node, branch_no);
+   trunk_branch *branch = trunk_get_branch(spl, node, branch_no);
    return btree_extent_count(spl->cc, &spl->cfg.btree_cfg, branch->root_addr);
 }
 
 bool
-splinter_node_print_branches(splinter_handle *spl,
+trunk_node_print_branches(trunk_handle *spl,
                              uint64           addr,
                              void            *arg)
 {
-   page_handle *node = splinter_node_get(spl, addr);
+   page_handle *node = trunk_node_get(spl, addr);
 
    platform_log("------------------------------------------------------------------\n");
-   platform_log("| node %12lu height %u\n", addr, splinter_height(spl, node));
+   platform_log("| node %12lu height %u\n", addr, trunk_height(spl, node));
    platform_log("------------------------------------------------------------------\n");
-   uint16 num_pivot_keys = splinter_num_pivot_keys(spl, node);
+   uint16 num_pivot_keys = trunk_num_pivot_keys(spl, node);
    platform_log("| pivots:\n");
    for (uint16 pivot_no = 0; pivot_no < num_pivot_keys; pivot_no++) {
       char key_str[128];
-      splinter_key_to_string(spl, splinter_get_pivot(spl, node, pivot_no), key_str);
+      trunk_key_to_string(spl, trunk_get_pivot(spl, node, pivot_no), key_str);
       platform_log("| %u: %s\n", pivot_no, key_str);
    }
 
    platform_log("--------------------------------------------------------------------\n");
    platform_log("| branch |     addr     |  num tuples  |    space    |  space amp  |\n");
    platform_log("--------------------------------------------------------------------\n");
-   uint16 start_branch = splinter_start_branch(spl, node);
-   uint16 end_branch = splinter_end_branch(spl, node);
+   uint16 start_branch = trunk_start_branch(spl, node);
+   uint16 end_branch = trunk_end_branch(spl, node);
    for (uint16 branch_no = start_branch;
         branch_no != end_branch;
-        branch_no = splinter_branch_no_add(spl, branch_no, 1))
+        branch_no = trunk_branch_no_add(spl, branch_no, 1))
    {
-      uint64 addr = splinter_get_branch(spl, node, branch_no)->root_addr;
-      uint64 num_tuples_in_branch = splinter_branch_count_num_tuples(spl, node, branch_no);
-      uint64 kib_in_branch = splinter_branch_extent_count(spl, node, branch_no);
+      uint64 addr = trunk_get_branch(spl, node, branch_no)->root_addr;
+      uint64 num_tuples_in_branch = trunk_branch_count_num_tuples(spl, node, branch_no);
+      uint64 kib_in_branch = trunk_branch_extent_count(spl, node, branch_no);
       kib_in_branch *= spl->cfg.extent_size / 1024;
       fraction space_amp = init_fraction(kib_in_branch * 1024,
             num_tuples_in_branch * (spl->cfg.data_cfg->key_size +
@@ -8236,48 +8236,48 @@ splinter_node_print_branches(splinter_handle *spl,
    }
    platform_log("------------------------------------------------------------------\n");
    platform_log("\n");
-   splinter_node_unget(spl, &node);
+   trunk_node_unget(spl, &node);
    return TRUE;
 }
 
 void
-splinter_print_branches(splinter_handle *spl)
+trunk_print_branches(trunk_handle *spl)
 {
-   splinter_for_each_node(spl, splinter_node_print_branches, NULL);
+   trunk_for_each_node(spl, trunk_node_print_branches, NULL);
 }
 
 bool
-splinter_node_print_extent_count(splinter_handle *spl,
+trunk_node_print_extent_count(trunk_handle *spl,
                                  uint64           addr,
                                  void            *arg)
 {
-   page_handle *node = splinter_node_get(spl, addr);
+   page_handle *node = trunk_node_get(spl, addr);
 
-   uint16 start_branch = splinter_start_branch(spl, node);
-   uint16 end_branch = splinter_end_branch(spl, node);
+   uint16 start_branch = trunk_start_branch(spl, node);
+   uint16 end_branch = trunk_end_branch(spl, node);
    uint64 num_extents = 0;
    for (uint16 branch_no = start_branch;
         branch_no != end_branch;
-        branch_no = splinter_branch_no_add(spl, branch_no, 1))
+        branch_no = trunk_branch_no_add(spl, branch_no, 1))
    {
-      num_extents += splinter_branch_extent_count(spl, node, branch_no);
+      num_extents += trunk_branch_extent_count(spl, node, branch_no);
    }
    platform_log("%8lu\n", num_extents);
-   splinter_node_unget(spl, &node);
+   trunk_node_unget(spl, &node);
    return TRUE;
 }
 
 void
-splinter_print_extent_counts(splinter_handle *spl)
+trunk_print_extent_counts(trunk_handle *spl)
 {
    platform_log("extent counts:\n");
-   splinter_for_each_node(spl, splinter_node_print_extent_count, NULL);
+   trunk_for_each_node(spl, trunk_node_print_extent_count, NULL);
 }
 
 /*
  *-----------------------------------------------------------------------------
  *
- * splinter_config_init --
+ * trunk_config_init --
  *
  *       Initialize splinter config
  *       This function calls btree_config_init
@@ -8286,7 +8286,7 @@ splinter_print_extent_counts(splinter_handle *spl)
  */
 
 void
-splinter_config_init(splinter_config *splinter_cfg,
+trunk_config_init(trunk_config *trunk_cfg,
                      data_config     *data_cfg,
                      log_config      *log_cfg,
                      uint64           memtable_capacity,
@@ -8301,49 +8301,49 @@ splinter_config_init(splinter_config *splinter_cfg,
                      uint64           use_log,
                      uint64           use_stats)
 {
-   uint64 splinter_pivot_size;
+   uint64 trunk_pivot_size;
    uint64 bytes_for_branches;
-   routing_config *index_filter_cfg = &splinter_cfg->index_filter_cfg;
-   routing_config *leaf_filter_cfg = &splinter_cfg->leaf_filter_cfg;
+   routing_config *index_filter_cfg = &trunk_cfg->index_filter_cfg;
+   routing_config *leaf_filter_cfg = &trunk_cfg->leaf_filter_cfg;
 
-   ZERO_CONTENTS(splinter_cfg);
-   splinter_cfg->data_cfg = data_cfg;
+   ZERO_CONTENTS(trunk_cfg);
+   trunk_cfg->data_cfg = data_cfg;
 
-   splinter_cfg->log_cfg = log_cfg;
+   trunk_cfg->log_cfg = log_cfg;
 
-   splinter_cfg->page_size             = page_size;
-   splinter_cfg->extent_size           = extent_size;
-   splinter_cfg->fanout                = fanout;
-   splinter_cfg->max_branches_per_node = max_branches_per_node;
-   splinter_cfg->reclaim_threshold     = reclaim_threshold;
-   splinter_cfg->use_log               = use_log;
-   splinter_cfg->use_stats             = use_stats;
+   trunk_cfg->page_size             = page_size;
+   trunk_cfg->extent_size           = extent_size;
+   trunk_cfg->fanout                = fanout;
+   trunk_cfg->max_branches_per_node = max_branches_per_node;
+   trunk_cfg->reclaim_threshold     = reclaim_threshold;
+   trunk_cfg->use_log               = use_log;
+   trunk_cfg->use_stats             = use_stats;
 
-   splinter_pivot_size = data_cfg->key_size + splinter_pivot_message_size();
+   trunk_pivot_size = data_cfg->key_size + trunk_pivot_message_size();
    // Setting hard limit and over overprovisioning
-   splinter_cfg->max_pivot_keys = splinter_cfg->fanout + 6;
-   bytes_for_branches = splinter_cfg->page_size - splinter_trunk_hdr_size()
-      - splinter_cfg->max_pivot_keys * splinter_pivot_size;
-   splinter_cfg->hard_max_branches_per_node
-      = bytes_for_branches / sizeof(splinter_branch) - 1;
+   trunk_cfg->max_pivot_keys = trunk_cfg->fanout + 6;
+   bytes_for_branches = trunk_cfg->page_size - trunk_hdr_size()
+      - trunk_cfg->max_pivot_keys * trunk_pivot_size;
+   trunk_cfg->hard_max_branches_per_node
+      = bytes_for_branches / sizeof(trunk_branch) - 1;
 
    // Initialize point message btree
-   btree_config_init(&splinter_cfg->btree_cfg,
-                     splinter_cfg->data_cfg,
+   btree_config_init(&trunk_cfg->btree_cfg,
+                     trunk_cfg->data_cfg,
                      btree_rough_count_height,
-                     splinter_cfg->page_size, splinter_cfg->extent_size);
+                     trunk_cfg->page_size, trunk_cfg->extent_size);
 
    // FIXME: [yfogel 2020-08-27] MUST not be hardcoded for
-   //    SPLINTER_NUM_MEMTABLES
+   //    TRUNK_NUM_MEMTABLES
    //    tests need to specify and that must happen HERE
    //    so must be plumbed
-   memtable_config_init(&splinter_cfg->mt_cfg, &splinter_cfg->btree_cfg,
-         SPLINTER_NUM_MEMTABLES, memtable_capacity);
+   memtable_config_init(&trunk_cfg->mt_cfg, &trunk_cfg->btree_cfg,
+         TRUNK_NUM_MEMTABLES, memtable_capacity);
 
    // Has to be set after btree_config_init is called
-   splinter_cfg->max_tuples_per_node
-      = splinter_cfg->fanout * splinter_cfg->mt_cfg.max_tuples_per_memtable;
-   splinter_cfg->target_leaf_tuples = splinter_cfg->max_tuples_per_node / 2;
+   trunk_cfg->max_tuples_per_node
+      = trunk_cfg->fanout * trunk_cfg->mt_cfg.max_tuples_per_memtable;
+   trunk_cfg->target_leaf_tuples = trunk_cfg->max_tuples_per_node / 2;
 
    // filter config settings
    index_filter_cfg->page_size = page_size;
@@ -8353,18 +8353,18 @@ splinter_config_init(splinter_config *splinter_cfg,
 
    index_filter_cfg->index_size = filter_index_size;
    index_filter_cfg->seed       = 42;
-   index_filter_cfg->hash       = splinter_cfg->data_cfg->key_hash;
-   index_filter_cfg->data_cfg   = splinter_cfg->data_cfg;
+   index_filter_cfg->hash       = trunk_cfg->data_cfg->key_hash;
+   index_filter_cfg->data_cfg   = trunk_cfg->data_cfg;
    index_filter_cfg->log_index_size =
       31 - __builtin_clz(index_filter_cfg->index_size);
    memmove(leaf_filter_cfg, index_filter_cfg, sizeof(*leaf_filter_cfg));
 
-   uint64 filter_max_fingerprints = splinter_cfg->max_tuples_per_node;
+   uint64 filter_max_fingerprints = trunk_cfg->max_tuples_per_node;
    uint64 filter_quotient_size = 64 - __builtin_clzll(filter_max_fingerprints);
    uint64 filter_fingerprint_size = filter_remainder_size + filter_quotient_size;
    index_filter_cfg->fingerprint_size = filter_fingerprint_size;
    leaf_filter_cfg->fingerprint_size = filter_fingerprint_size;
-   uint64 max_value = splinter_cfg->max_branches_per_node;
+   uint64 max_value = trunk_cfg->max_branches_per_node;
    size_t max_value_size = 64 - __builtin_clzll(max_value);
    if (filter_fingerprint_size > 32 - max_value_size) {
       platform_error_log("Fingerprint size %lu too large, max value size is %lu, "
@@ -8386,7 +8386,7 @@ splinter_config_init(splinter_config *splinter_cfg,
     *   - cfg is of type quick_filter_config
     *   - index is less than num_indices, which equals to params.num_buckets /
     *     cfg->index_size. params.num_buckets should be less than
-    *     splinter_cfg.max_tuples_per_node
+    *     trunk_cfg.max_tuples_per_node
     *   - addrs_per_page = cfg->page_size / sizeof(uint64)
     *   - pages_per_extent = cfg->extent_size / cfg->page_size
     *
@@ -8400,10 +8400,10 @@ splinter_config_init(splinter_config *splinter_cfg,
     *   filter_cfg.index_size > (max_tuples_per_node / (addrs_per_page *
     *   pages_per_extent))
     */
-   uint64 addrs_per_page = splinter_cfg->page_size / sizeof(uint64);
-   uint64 pages_per_extent = splinter_cfg->extent_size /
-      splinter_cfg->page_size;
-   while (leaf_filter_cfg->index_size <= splinter_cfg->max_tuples_per_node /
+   uint64 addrs_per_page = trunk_cfg->page_size / sizeof(uint64);
+   uint64 pages_per_extent = trunk_cfg->extent_size /
+      trunk_cfg->page_size;
+   while (leaf_filter_cfg->index_size <= trunk_cfg->max_tuples_per_node /
        (addrs_per_page * pages_per_extent)) {
       platform_error_log("filter-index-size: %u is too small, "
                          "setting to %u\n",
@@ -8414,8 +8414,8 @@ splinter_config_init(splinter_config *splinter_cfg,
 }
 
 size_t
-splinter_get_scratch_size()
+trunk_get_scratch_size()
 {
-   return sizeof(splinter_task_scratch);
+   return sizeof(trunk_task_scratch);
 }
 

--- a/src/trunk.h
+++ b/src/trunk.h
@@ -2,13 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /*
- * splinter.h --
+ * trunk.h --
  *
  *     This file contains the interface for SplinterDB.
  */
 
-#ifndef __SPLINTER_H
-#define __SPLINTER_H
+#ifndef __TRUNK_H
+#define __TRUNK_H
 
 #include "splinterdb/data.h"
 #include "btree.h"
@@ -21,10 +21,10 @@
 #include "log.h"
 #include "srq.h"
 
-#define SPLINTER_MAX_HEIGHT 8
+#define TRUNK_MAX_HEIGHT 8
 // FIXME: [yfogel 2020-07-02] 72 * 2 > 128
 // examin cost of increasing
-#define SPLINTER_MAX_TOTAL_DEGREE 256
+#define TRUNK_MAX_TOTAL_DEGREE 256
 
 /*
  *----------------------------------------------------------------------
@@ -36,7 +36,7 @@
  *----------------------------------------------------------------------
  */
 
-typedef struct splinter_config {
+typedef struct trunk_config {
    // robj: if these are redundant, maybe delete them?
    uint64               page_size;               // must match the cache/fs page_size
    uint64               extent_size;             // same
@@ -62,9 +62,9 @@ typedef struct splinter_config {
 
    bool                 use_log;
    log_config          *log_cfg;
-} splinter_config;
+} trunk_config;
 
-typedef struct splinter_stats {
+typedef struct trunk_stats {
    uint64 insertions;
    uint64 updates;
    uint64 deletions;
@@ -73,11 +73,11 @@ typedef struct splinter_stats {
    platform_histo_handle update_latency_histo;
    platform_histo_handle delete_latency_histo;
 
-   uint64 flush_wait_time_ns[SPLINTER_MAX_HEIGHT];
-   uint64 flush_time_ns[SPLINTER_MAX_HEIGHT];
-   uint64 flush_time_max_ns[SPLINTER_MAX_HEIGHT];
-   uint64 full_flushes[SPLINTER_MAX_HEIGHT];
-   uint64 count_flushes[SPLINTER_MAX_HEIGHT];
+   uint64 flush_wait_time_ns[TRUNK_MAX_HEIGHT];
+   uint64 flush_time_ns[TRUNK_MAX_HEIGHT];
+   uint64 flush_time_max_ns[TRUNK_MAX_HEIGHT];
+   uint64 full_flushes[TRUNK_MAX_HEIGHT];
+   uint64 count_flushes[TRUNK_MAX_HEIGHT];
    uint64 memtable_flushes;
    uint64 memtable_flush_time_ns;
    uint64 memtable_flush_time_max_ns;
@@ -88,22 +88,22 @@ typedef struct splinter_stats {
    uint64 root_flush_time_ns;
    uint64 root_flush_time_max_ns;
    uint64 root_flush_wait_time_ns;
-   uint64 failed_flushes[SPLINTER_MAX_HEIGHT];
+   uint64 failed_flushes[TRUNK_MAX_HEIGHT];
    uint64 root_failed_flushes;
    uint64 memtable_failed_flushes;
 
-   uint64 compactions[SPLINTER_MAX_HEIGHT];
-   uint64 compactions_aborted_flushed[SPLINTER_MAX_HEIGHT];
-   uint64 compactions_aborted_leaf_split[SPLINTER_MAX_HEIGHT];
-   uint64 compactions_discarded_flushed[SPLINTER_MAX_HEIGHT];
-   uint64 compactions_discarded_leaf_split[SPLINTER_MAX_HEIGHT];
-   uint64 compactions_empty[SPLINTER_MAX_HEIGHT];
-   uint64 compaction_tuples[SPLINTER_MAX_HEIGHT];
-   uint64 compaction_max_tuples[SPLINTER_MAX_HEIGHT];
-   uint64 compaction_time_ns[SPLINTER_MAX_HEIGHT];
-   uint64 compaction_time_max_ns[SPLINTER_MAX_HEIGHT];
-   uint64 compaction_time_wasted_ns[SPLINTER_MAX_HEIGHT];
-   uint64 compaction_pack_time_ns[SPLINTER_MAX_HEIGHT];
+   uint64 compactions[TRUNK_MAX_HEIGHT];
+   uint64 compactions_aborted_flushed[TRUNK_MAX_HEIGHT];
+   uint64 compactions_aborted_leaf_split[TRUNK_MAX_HEIGHT];
+   uint64 compactions_discarded_flushed[TRUNK_MAX_HEIGHT];
+   uint64 compactions_discarded_leaf_split[TRUNK_MAX_HEIGHT];
+   uint64 compactions_empty[TRUNK_MAX_HEIGHT];
+   uint64 compaction_tuples[TRUNK_MAX_HEIGHT];
+   uint64 compaction_max_tuples[TRUNK_MAX_HEIGHT];
+   uint64 compaction_time_ns[TRUNK_MAX_HEIGHT];
+   uint64 compaction_time_max_ns[TRUNK_MAX_HEIGHT];
+   uint64 compaction_time_wasted_ns[TRUNK_MAX_HEIGHT];
+   uint64 compaction_pack_time_ns[TRUNK_MAX_HEIGHT];
 
    uint64 root_compactions;
    uint64 root_compaction_pack_time_ns;
@@ -122,48 +122,48 @@ typedef struct splinter_stats {
    uint64 root_filters_built;
    uint64 root_filter_tuples;
    uint64 root_filter_time_ns;
-   uint64 filters_built[SPLINTER_MAX_HEIGHT];
-   uint64 filter_tuples[SPLINTER_MAX_HEIGHT];
-   uint64 filter_time_ns[SPLINTER_MAX_HEIGHT];
+   uint64 filters_built[TRUNK_MAX_HEIGHT];
+   uint64 filter_tuples[TRUNK_MAX_HEIGHT];
+   uint64 filter_time_ns[TRUNK_MAX_HEIGHT];
 
    uint64 lookups_found;
    uint64 lookups_not_found;
-   uint64 filter_lookups[SPLINTER_MAX_HEIGHT];
-   uint64 branch_lookups[SPLINTER_MAX_HEIGHT];
-   uint64 filter_false_positives[SPLINTER_MAX_HEIGHT];
-   uint64 filter_negatives[SPLINTER_MAX_HEIGHT];
+   uint64 filter_lookups[TRUNK_MAX_HEIGHT];
+   uint64 branch_lookups[TRUNK_MAX_HEIGHT];
+   uint64 filter_false_positives[TRUNK_MAX_HEIGHT];
+   uint64 filter_negatives[TRUNK_MAX_HEIGHT];
 
-   uint64 space_recs[SPLINTER_MAX_HEIGHT];
-   uint64 space_rec_time_ns[SPLINTER_MAX_HEIGHT];
-   uint64 space_rec_tuples_reclaimed[SPLINTER_MAX_HEIGHT];
-   uint64 tuples_reclaimed[SPLINTER_MAX_HEIGHT];
-} PLATFORM_CACHELINE_ALIGNED splinter_stats;
+   uint64 space_recs[TRUNK_MAX_HEIGHT];
+   uint64 space_rec_time_ns[TRUNK_MAX_HEIGHT];
+   uint64 space_rec_tuples_reclaimed[TRUNK_MAX_HEIGHT];
+   uint64 tuples_reclaimed[TRUNK_MAX_HEIGHT];
+} PLATFORM_CACHELINE_ALIGNED trunk_stats;
 
 // splinter refers to btrees as branches
-typedef struct splinter_branch {
+typedef struct trunk_branch {
    uint64 root_addr; // root address of point btree
-} splinter_branch;
+} trunk_branch;
 
-typedef struct splinter_handle splinter_handle;
-typedef struct splinter_compact_bundle_req splinter_compact_bundle_req;
+typedef struct trunk_handle trunk_handle;
+typedef struct trunk_compact_bundle_req trunk_compact_bundle_req;
 
-typedef struct splinter_memtable_args {
-   splinter_handle *spl;
+typedef struct trunk_memtable_args {
+   trunk_handle *spl;
    uint64           generation;
-} splinter_memtable_args;
+} trunk_memtable_args;
 
-typedef struct splinter_compacted_memtable {
-   splinter_branch              branch;
+typedef struct trunk_compacted_memtable {
+   trunk_branch              branch;
    routing_filter               filter;
    timestamp                    wait_start;
-   splinter_memtable_args       mt_args;
-   splinter_compact_bundle_req *req;
-} splinter_compacted_memtable;
+   trunk_memtable_args       mt_args;
+   trunk_compact_bundle_req *req;
+} trunk_compacted_memtable;
 
-struct splinter_handle {
+struct trunk_handle {
    uint64             root_addr;
    uint64             super_block_idx;
-   splinter_config    cfg;
+   trunk_config    cfg;
    platform_heap_id   heap_id;
 
    // space reclamation
@@ -183,7 +183,7 @@ struct splinter_handle {
    task_system       *ts;  // ALEX: currently not durable
 
    // stats
-   splinter_stats    *stats;
+   trunk_stats    *stats;
 
    // Link inside the splinter list
    List_Links         links;
@@ -200,19 +200,19 @@ struct splinter_handle {
    // space rec queue
    srq                srq;
 
-   splinter_compacted_memtable compacted_memtable[/*cfg.mt_cfg.max_memtables*/];
+   trunk_compacted_memtable compacted_memtable[/*cfg.mt_cfg.max_memtables*/];
 };
 
-typedef struct splinter_range_iterator {
+typedef struct trunk_range_iterator {
    iterator         super;
-   splinter_handle *spl;
+   trunk_handle *spl;
    uint64           num_tuples;
    uint64           num_branches;
    uint64           num_memtable_branches;
    uint64           memtable_start_gen;
    uint64           memtable_end_gen;
-   bool             compacted[SPLINTER_MAX_TOTAL_DEGREE];
-   page_handle     *meta_page[SPLINTER_MAX_TOTAL_DEGREE];
+   bool             compacted[TRUNK_MAX_TOTAL_DEGREE];
+   page_handle     *meta_page[TRUNK_MAX_TOTAL_DEGREE];
    merge_iterator  *merge_itor;
    bool             has_max_key;
    bool             at_end;
@@ -230,13 +230,13 @@ typedef struct splinter_range_iterator {
    //       if we increase significantly (or increase dynamically allcoated)
    //       we probably need to be careful about initialization
    //       to not ahve to pay cost of zeroing massive amounts of data
-   btree_iterator   btree_itor[SPLINTER_MAX_TOTAL_DEGREE];
+   btree_iterator   btree_itor[TRUNK_MAX_TOTAL_DEGREE];
    // FIXME: [yfogel 2020-07-01] this won't need to change
-   splinter_branch  branch[SPLINTER_MAX_TOTAL_DEGREE];
+   trunk_branch  branch[TRUNK_MAX_TOTAL_DEGREE];
 
    // used for merge iterator construction
-   iterator        *itor[SPLINTER_MAX_TOTAL_DEGREE];
-} splinter_range_iterator;
+   iterator        *itor[TRUNK_MAX_TOTAL_DEGREE];
+} trunk_range_iterator;
 
 
 // FIXME: [yfogel 2020-08-26] will need some extra states
@@ -257,25 +257,25 @@ typedef enum {
    async_state_unget_parent_trunk_node,
    async_state_found_final_answer_early,
    async_state_end
-} splinter_async_state;
+} trunk_async_state;
 
 typedef enum {
    async_lookup_state_pivot,
    async_lookup_state_subbundle,
    async_lookup_state_compacted_subbundle
-} splinter_async_lookup_state;
+} trunk_async_lookup_state;
 
-struct splinter_async_ctxt;
-struct splinter_pivot_data;
-struct splinter_subbundle;
+struct trunk_async_ctxt;
+struct trunk_pivot_data;
+struct trunk_subbundle;
 
-typedef void (*splinter_async_cb)(struct splinter_async_ctxt *ctxt);
-typedef struct splinter_async_ctxt {
-   splinter_async_cb            cb;            // IN: callback (requeues ctxt
+typedef void (*trunk_async_cb)(struct trunk_async_ctxt *ctxt);
+typedef struct trunk_async_ctxt {
+   trunk_async_cb            cb;            // IN: callback (requeues ctxt
                                               // for dispatch)
    // These fields are internal
-   splinter_async_state         prev_state;    // state machine's previous state
-   splinter_async_state         state;         // state machine's current state
+   trunk_async_state         prev_state;    // state machine's previous state
+   trunk_async_state         state;         // state machine's current state
    page_handle                 *mt_lock_page;  // Memtable lock page
    page_handle                 *trunk_node;    // Current trunk node
    uint16                       height;        // height of trunk_node
@@ -285,10 +285,10 @@ typedef struct splinter_async_ctxt {
                                                // exclusive
    uint16                       filter_no;     // sb filter no
 
-   splinter_async_lookup_state  lookup_state;  // Can be pivot or
+   trunk_async_lookup_state  lookup_state;  // Can be pivot or
                                                // [compacted] subbundle
-   struct splinter_subbundle   *sb;            // Subbundle
-   struct splinter_pivot_data  *pdata;         // Pivot data for next trunk node
+   struct trunk_subbundle   *sb;            // Subbundle
+   struct trunk_pivot_data  *pdata;         // Pivot data for next trunk node
    routing_filter              *filter;        // Filter for subbundle or pivot
    uint64                       found_values;  // values found in filter
    uint16                       value;         // Current value found in filter
@@ -299,13 +299,13 @@ typedef struct splinter_async_ctxt {
    bool                         found;         // If found the key
    message_type                 type;          // data_class (if found==TRUE)
    bool                         was_async;     // Did an async IO for trunk ?
-   splinter_branch             *branch;        // Current branch
+   trunk_branch             *branch;        // Current branch
    union {
       routing_async_ctxt        filter_ctxt;    // Filter async context
       btree_async_ctxt          btree_ctxt;    // Btree async context
    };
    cache_async_ctxt             cache_ctxt;    // Async cache context
-} splinter_async_ctxt;
+} trunk_async_ctxt;
 
 
 
@@ -332,100 +332,100 @@ typedef struct {
  */
 
 platform_status
-splinter_insert(splinter_handle *spl, char *key, char *data);
+trunk_insert(trunk_handle *spl, char *key, char *data);
 platform_status
-splinter_lookup(splinter_handle *spl, char *key, char *data, bool *found);
+trunk_lookup(trunk_handle *spl, char *key, char *data, bool *found);
 cache_async_result
-splinter_lookup_async(splinter_handle *    spl,
+trunk_lookup_async(trunk_handle *    spl,
                       char *               key,
                       char *               data,
                       bool *               found,
-                      splinter_async_ctxt *ctxt);
+                      trunk_async_ctxt *ctxt);
 platform_status
-splinter_range_iterator_init(splinter_handle *        spl,
-                             splinter_range_iterator *range_itor,
+trunk_range_iterator_init(trunk_handle *        spl,
+                             trunk_range_iterator *range_itor,
                              char *                   min_key,
                              char *                   max_key,
                              uint64                   num_tuples);
 void
-splinter_range_iterator_deinit(splinter_range_iterator *range_itor);
+trunk_range_iterator_deinit(trunk_range_iterator *range_itor);
 platform_status
-splinter_range(splinter_handle *spl,
+trunk_range(trunk_handle *spl,
                char *           start_key,
                uint64           num_tuples,
                uint64 *         tuples_returned,
                char *           out);
 
-splinter_handle *
-splinter_create(splinter_config * cfg,
+trunk_handle *
+trunk_create(trunk_config * cfg,
                 allocator *       al,
                 cache *           cc,
                 task_system *     ts,
                 allocator_root_id id,
                 platform_heap_id  hid);
 void
-splinter_destroy(splinter_handle *spl);
-splinter_handle *
-splinter_mount(splinter_config * cfg,
+trunk_destroy(trunk_handle *spl);
+trunk_handle *
+trunk_mount(trunk_config * cfg,
                allocator *       al,
                cache *           cc,
                task_system *     ts,
                allocator_root_id id,
                platform_heap_id  hid);
 void
-splinter_dismount(splinter_handle *spl);
+trunk_dismount(trunk_handle *spl);
 
 void
-splinter_perform_tasks(splinter_handle *spl);
+trunk_perform_tasks(trunk_handle *spl);
 
 void
-splinter_force_flush(splinter_handle *spl);
+trunk_force_flush(trunk_handle *spl);
 void
-splinter_print_insertion_stats(splinter_handle *spl);
+trunk_print_insertion_stats(trunk_handle *spl);
 void
-splinter_print_lookup_stats(splinter_handle *spl);
+trunk_print_lookup_stats(trunk_handle *spl);
 void
-splinter_reset_stats(splinter_handle *spl);
+trunk_reset_stats(trunk_handle *spl);
 
 void
-splinter_print(splinter_handle *spl);
+trunk_print(trunk_handle *spl);
 void
-splinter_print_lookup(splinter_handle *spl, char *key);
+trunk_print_lookup(trunk_handle *spl, char *key);
 void
-splinter_print_branches(splinter_handle *spl);
+trunk_print_branches(trunk_handle *spl);
 void
-splinter_print_extent_counts(splinter_handle *spl);
+trunk_print_extent_counts(trunk_handle *spl);
 void
-splinter_print_space_use(splinter_handle *spl);
+trunk_print_space_use(trunk_handle *spl);
 bool
-splinter_verify_tree(splinter_handle *spl);
+trunk_verify_tree(trunk_handle *spl);
 
 static inline uint64
-splinter_key_size(splinter_handle *spl)
+trunk_key_size(trunk_handle *spl)
 {
    return spl->cfg.data_cfg->key_size;
 }
 
 static inline uint64
-splinter_message_size(splinter_handle *spl)
+trunk_message_size(trunk_handle *spl)
 {
    return spl->cfg.data_cfg->message_size;
 }
 
 static inline uint64
-splinter_tuple_size(splinter_handle *spl)
+trunk_tuple_size(trunk_handle *spl)
 {
-   return splinter_key_size(spl) + splinter_message_size(spl);
+   return trunk_key_size(spl) + trunk_message_size(spl);
 }
 
 static inline int
-splinter_key_compare(splinter_handle *spl, const char *key1, const char *key2)
+trunk_key_compare(trunk_handle *spl, const char *key1, const char *key2)
 {
    return btree_key_compare(&spl->cfg.btree_cfg, key1, key2);
 }
 
 static inline void
-splinter_key_to_string(splinter_handle *spl,
+trunk_key_to_string(trunk_handle *spl,
                        const char *     key,
                        char             str[static 128])
 {
@@ -433,7 +433,7 @@ splinter_key_to_string(splinter_handle *spl,
 }
 
 static inline void
-splinter_message_to_string(splinter_handle *spl,
+trunk_message_to_string(trunk_handle *spl,
                            const char *     data,
                            char             str[static 128])
 {
@@ -441,7 +441,7 @@ splinter_message_to_string(splinter_handle *spl,
 }
 
 static inline void
-splinter_async_ctxt_init(splinter_async_ctxt *ctxt, splinter_async_cb cb)
+trunk_async_ctxt_init(trunk_async_ctxt *ctxt, trunk_async_cb cb)
 {
    ZERO_CONTENTS(ctxt);
    ctxt->state = async_state_start;
@@ -449,16 +449,16 @@ splinter_async_ctxt_init(splinter_async_ctxt *ctxt, splinter_async_cb cb)
 }
 
 uint64
-splinter_pivot_size(splinter_handle *spl);
+trunk_pivot_size(trunk_handle *spl);
 
 uint64
-splinter_pivot_message_size();
+trunk_pivot_message_size();
 
 uint64
-splinter_trunk_hdr_size();
+trunk_hdr_size();
 
 void
-splinter_config_init(splinter_config *splinter_cfg,
+trunk_config_init(trunk_config *trunk_cfg,
                      data_config *    data_cfg,
                      log_config *     log_cfg,
                      uint64           memtable_capacity,
@@ -473,7 +473,7 @@ splinter_config_init(splinter_config *splinter_cfg,
                      uint64           use_log,
                      uint64           use_stats);
 size_t
-splinter_get_scratch_size();
+trunk_get_scratch_size();
 
 
-#endif // __SPLINTER_H
+#endif // __TRUNK_H

--- a/test.sh
+++ b/test.sh
@@ -5,9 +5,9 @@ set -euxo pipefail
 SEED="${SEED:-135}"
 DRIVER="${DRIVER:-"${BINDIR:-bin}/driver_test"}"
 
-"$DRIVER" kvstore_test --seed "$SEED"
+"$DRIVER" splinterdb_test --seed "$SEED"
 
-"$DRIVER" kvstore_basic_test --seed "$SEED"
+"$DRIVER" splinterdb_kv_test --seed "$SEED"
 
 "$DRIVER" splinter_test --functionality 1000000 100 --seed "$SEED"
 

--- a/tests/btree_test.c
+++ b/tests/btree_test.c
@@ -1261,7 +1261,7 @@ btree_test(int argc, char *argv[])
    platform_assert_status_ok(rc);
 
    data_config *data_cfg = TYPED_MALLOC(hid, data_cfg);
-   splinter_config *cfg = TYPED_MALLOC(hid, cfg);
+   trunk_config *cfg = TYPED_MALLOC(hid, cfg);
    rc = test_parse_args(cfg, data_cfg, &io_cfg, &al_cfg, &cache_cfg,
                         &log_cfg, &seed, config_argc, config_argv);
    // FIXME: [aconway 2020-08-23] Build this into a test arg parse function

--- a/tests/cache_test.c
+++ b/tests/cache_test.c
@@ -932,7 +932,7 @@ cache_test(int argc, char *argv[])
    rc = platform_heap_create(platform_get_module_id(), 1 * GiB, &hh, &hid);
    platform_assert_status_ok(rc);
 
-   splinter_config *splinter_cfg = TYPED_MALLOC(hid, splinter_cfg);
+   trunk_config *splinter_cfg = TYPED_MALLOC(hid, splinter_cfg);
    rc = test_parse_args(splinter_cfg, &data_cfg, &io_cfg, &al_cfg, &cache_cfg,
                         &log_cfg, &seed, config_argc, config_argv);
    if (!SUCCESS(rc)) {

--- a/tests/filter_test.c
+++ b/tests/filter_test.c
@@ -290,7 +290,7 @@ filter_test(int argc, char *argv[])
    rc = platform_heap_create(platform_get_module_id(), 1 * GiB, &hh, &hid);
    platform_assert_status_ok(rc);
 
-   splinter_config *cfg = TYPED_MALLOC(hid, cfg);
+   trunk_config *cfg = TYPED_MALLOC(hid, cfg);
 
    rc = test_parse_args(cfg, &data_cfg, &io_cfg, &allocator_cfg, &cache_cfg,
                         &log_cfg, &seed, config_argc, config_argv);

--- a/tests/log_test.c
+++ b/tests/log_test.c
@@ -15,7 +15,7 @@
 #include "rc_allocator.h"
 #include "cache.h"
 #include "clockcache.h"
-#include "splinter.h"
+#include "trunk.h"
 #include "test.h"
 
 #include "poison.h"
@@ -320,7 +320,7 @@ log_test(int argc, char *argv[])
    status = platform_heap_create(platform_get_module_id(), 1 * GiB, &hh, &hid);
    platform_assert_status_ok(status);
 
-   splinter_config *cfg = TYPED_MALLOC(hid, cfg);
+   trunk_config *cfg = TYPED_MALLOC(hid, cfg);
    status = test_parse_args(cfg, &data_cfg, &io_cfg, &al_cfg, &cache_cfg,
                             &log_cfg, &seed, config_argc, config_argv);
    if (!SUCCESS(status)) {

--- a/tests/splinterdb_kv_test.c
+++ b/tests/splinterdb_kv_test.c
@@ -2,23 +2,23 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /*
- * kvstore_basic_test.c --
+ * splinterdb_kv_test.c --
  *
- *     Exercises the kvstore_basic API, which exposes keys & values
+ *     Exercises the splinterdb_kv API, which exposes keys & values
  *     instead of the keys & messages of the lower layers.
  *
  *     This test code can be easily modified to be an example of a standalone
  *     program that integrates with SplinterDB.
 
  *     To compile this into a standalone program, just rename the function
- *     kvstore_basic_test() to be main(), and ensure you've got the
- *     kvstore_basic.h header and libsplinterdb.a available for linking.
+ *     splinterdb_kv_test() to be main(), and ensure you've got the
+ *     splinterdb_kv.h header and libsplinterdb.a available for linking.
  *
  *     $ cc -L splinterdb/lib -I splinterdb/include \
  *          my_program.c -lsplinterdb -lxxhash -laio -lpthread -lm
  */
 
-#include "splinterdb/kvstore_basic.h"
+#include "splinterdb/splinterdb_kv.h"
 #include <assert.h>
 #include <errno.h>
 #include <fcntl.h>
@@ -42,14 +42,14 @@ static const char val_fmt[] = "val-%02x";
 
 // Function prototypes
 static int
-insert_keys(kvstore_basic *kvsb, const int minkey, int numkeys, const int incr);
+insert_keys(splinterdb_kv *kvsb, const int minkey, int numkeys, const int incr);
 
 static int
-setup_kvstore_basic(kvstore_basic **kvsb, kvstore_basic_cfg *cfg)
+setup_splinterdb_kv(splinterdb_kv **kvsb, splinterdb_kv_cfg *cfg)
 {
-   fprintf(stderr, "kvstore_basic_test: setup\n");
+   fprintf(stderr, "splinterdb_kv_test: setup\n");
 
-   *cfg = (kvstore_basic_cfg){
+   *cfg = (splinterdb_kv_cfg){
       .filename       = TEST_DB_NAME,
       .cache_size     = (cfg->cache_size) ? cfg->cache_size : Mega,
       .disk_size      = (cfg->disk_size) ? cfg->disk_size : 30 * Mega,
@@ -59,12 +59,12 @@ setup_kvstore_basic(kvstore_basic **kvsb, kvstore_basic_cfg *cfg)
       .key_comparator_context = cfg->key_comparator_context,
    };
 
-   int rc = kvstore_basic_create(cfg, kvsb);
+   int rc = splinterdb_kv_create(cfg, kvsb);
    if (rc != 0) {
       fprintf(stderr, "setup: init error: %d\n", rc);
       return -1;
    }
-   kvstore_basic_register_thread(*kvsb);
+   splinterdb_kv_register_thread(*kvsb);
    return 0;
 }
 
@@ -87,17 +87,17 @@ setup_kvstore_basic(kvstore_basic **kvsb, kvstore_basic_cfg *cfg)
 
 
 int
-test_kvstore_basic_flow()
+test_splinterdb_kv_flow()
 {
-   kvstore_basic *   kvsb;
-   kvstore_basic_cfg cfg = {0};
+   splinterdb_kv *   kvsb;
+   splinterdb_kv_cfg cfg = {0};
 
-   int rc = setup_kvstore_basic(&kvsb, &cfg);
+   int rc = setup_splinterdb_kv(&kvsb, &cfg);
    if (rc != 0) {
       return -1;
    }
 
-   fprintf(stderr, "kvstore_basic_test: initializing test data\n");
+   fprintf(stderr, "splinterdb_kv_test: initializing test data\n");
    char * key     = "some-key";
    size_t key_len = sizeof("some-key");
    bool   found, val_truncated;
@@ -105,8 +105,8 @@ test_kvstore_basic_flow()
    size_t val_len;
    char * large_key = calloc(1, cfg.max_key_size);
 
-   fprintf(stderr, "kvstore_basic_test: lookup non-existent key...");
-   rc = kvstore_basic_lookup(kvsb,
+   fprintf(stderr, "splinterdb_kv_test: lookup non-existent key...");
+   rc = splinterdb_kv_lookup(kvsb,
                              key,
                              key_len,
                              value,
@@ -117,13 +117,13 @@ test_kvstore_basic_flow()
    test_assert_rc(rc, "lookup non-existent key: %d", rc);
    test_assert(!found, "lookup non-existent key: unexpectedly found!");
 
-   fprintf(stderr, "kvstore_basic_test: inserting key with value some-value\n");
-   rc = kvstore_basic_insert(
+   fprintf(stderr, "splinterdb_kv_test: inserting key with value some-value\n");
+   rc = splinterdb_kv_insert(
       kvsb, key, key_len, "some-value", sizeof("some-value"));
    test_assert_rc(rc, "insert: %d", rc);
 
-   fprintf(stderr, "kvstore_basic_test: lookup #2...");
-   rc = kvstore_basic_lookup(kvsb,
+   fprintf(stderr, "splinterdb_kv_test: lookup #2...");
+   rc = splinterdb_kv_lookup(kvsb,
                              key,
                              key_len,
                              value,
@@ -139,12 +139,12 @@ test_kvstore_basic_flow()
    test_assert_rc(memcmp(value, "some-value", val_len),
                   "lookup #2: wrong value");
 
-   fprintf(stderr, "kvstore_basic_test: delete key\n");
-   rc = kvstore_basic_delete(kvsb, key, key_len);
+   fprintf(stderr, "splinterdb_kv_test: delete key\n");
+   rc = splinterdb_kv_delete(kvsb, key, key_len);
    test_assert_rc(rc, "delete: %d", rc);
 
-   fprintf(stderr, "kvstore_basic_test: lookup #3, for now-deleted key...");
-   rc = kvstore_basic_lookup(kvsb,
+   fprintf(stderr, "splinterdb_kv_test: lookup #3, for now-deleted key...");
+   rc = splinterdb_kv_lookup(kvsb,
                              key,
                              key_len,
                              value,
@@ -155,14 +155,14 @@ test_kvstore_basic_flow()
    test_assert_rc(rc, "lookup #3: %d", rc);
    test_assert(!found, "lookup #3: unexpectedly found");
 
-   fprintf(stderr, "kvstore_basic_test: add key of max length...\n");
+   fprintf(stderr, "splinterdb_kv_test: add key of max length...\n");
    memset(large_key, 7, cfg.max_key_size);
-   rc = kvstore_basic_insert(
+   rc = splinterdb_kv_insert(
       kvsb, large_key, cfg.max_key_size, "a-value", sizeof("a-value"));
    test_assert_rc(rc, "insert key with max-length");
 
-   fprintf(stderr, "kvstore_basic_test: lookup #4 for large key...\n");
-   rc = kvstore_basic_lookup(kvsb,
+   fprintf(stderr, "splinterdb_kv_test: lookup #4 for large key...\n");
+   rc = splinterdb_kv_lookup(kvsb,
                              large_key,
                              cfg.max_key_size,
                              value,
@@ -176,7 +176,7 @@ test_kvstore_basic_flow()
    fprintf(stderr, "%s: PASS\n", __FUNCTION__);
 
 cleanup:
-   kvstore_basic_close(kvsb);
+   splinterdb_kv_close(kvsb);
    if (large_key)
       free(large_key);
    if (rc) {
@@ -190,12 +190,12 @@ cleanup:
  * Exercise test case to verify core interfaces dealing with max key-size.
  */
 int
-test_kvstore_basic_large_keys()
+test_splinterdb_kv_large_keys()
 {
-   kvstore_basic *   kvsb;
-   kvstore_basic_cfg cfg = {0};
+   splinterdb_kv *   kvsb;
+   splinterdb_kv_cfg cfg = {0};
 
-   int rc = setup_kvstore_basic(&kvsb, &cfg);
+   int rc = setup_splinterdb_kv(&kvsb, &cfg);
    if (rc != 0) {
       return -1;
    }
@@ -204,7 +204,7 @@ test_kvstore_basic_large_keys()
    char *large_key = calloc(1, cfg.max_key_size);
    char *value     = calloc(1, cfg.max_value_size);
    memset(large_key, 7, cfg.max_key_size);
-   rc = kvstore_basic_insert(
+   rc = splinterdb_kv_insert(
       kvsb, large_key, cfg.max_key_size, "a-value", sizeof("a-value"));
    test_assert_rc(rc, "insert large key: %d", rc);
 
@@ -213,7 +213,7 @@ test_kvstore_basic_large_keys()
    size_t val_len;
 
    fprintf(stderr, "lookup for large key...\n");
-   rc = kvstore_basic_lookup(kvsb,
+   rc = splinterdb_kv_lookup(kvsb,
                              large_key,
                              cfg.max_key_size,
                              value,
@@ -226,7 +226,7 @@ test_kvstore_basic_large_keys()
    test_assert(val_len == sizeof("a-value"), "lookup large key: wrong length");
 
    fprintf(stderr, "lookup correct, now delete...\n");
-   rc = kvstore_basic_delete(kvsb, large_key, cfg.max_key_size);
+   rc = splinterdb_kv_delete(kvsb, large_key, cfg.max_key_size);
    test_assert_rc(rc, "delete large key: %d", rc);
    fprintf(stderr, "%s: PASS\n", __FUNCTION__);
 
@@ -235,7 +235,7 @@ cleanup:
       free(large_key);
    if (value)
       free(value);
-   kvstore_basic_close(kvsb);
+   splinterdb_kv_close(kvsb);
    if (rc) {
       fprintf(stderr, "%s: FAILED\n", __FUNCTION__);
       rc = -1;
@@ -247,12 +247,12 @@ cleanup:
  * Test case to verify core interfaces when key-size is > max key-size.
  */
 int
-test_kvstore_basic_key_size_gt_max_key_size()
+test_splinterdb_kv_key_size_gt_max_key_size()
 {
-   kvstore_basic *   kvsb;
-   kvstore_basic_cfg cfg = {0};
+   splinterdb_kv *   kvsb;
+   splinterdb_kv_cfg cfg = {0};
 
-   int rc = setup_kvstore_basic(&kvsb, &cfg);
+   int rc = setup_splinterdb_kv(&kvsb, &cfg);
    if (rc != 0) {
       return -1;
    }
@@ -262,17 +262,17 @@ test_kvstore_basic_key_size_gt_max_key_size()
    memset(too_large_key, 'a', too_large_key_len);
    char *value = calloc(1, cfg.max_value_size);
 
-   rc = kvstore_basic_insert(
+   rc = splinterdb_kv_insert(
       kvsb, too_large_key, too_large_key_len, "a-value", sizeof("a-value"));
    test_assert(rc == EINVAL, "insert too-large key: %d", rc);
 
-   rc = kvstore_basic_delete(kvsb, too_large_key, too_large_key_len);
+   rc = splinterdb_kv_delete(kvsb, too_large_key, too_large_key_len);
    test_assert(rc == EINVAL, "delete too-large key: %d", rc);
 
    bool   found;
    bool   val_truncated;
    size_t val_len;
-   rc = kvstore_basic_lookup(kvsb,
+   rc = splinterdb_kv_lookup(kvsb,
                              too_large_key,
                              too_large_key_len,
                              value,
@@ -292,7 +292,7 @@ cleanup:
    if (value)
       free(value);
 
-   kvstore_basic_close(kvsb);
+   splinterdb_kv_close(kvsb);
    if (rc) {
       fprintf(stderr, "%s: FAILED\n", __FUNCTION__);
       rc = -1;
@@ -307,12 +307,12 @@ cleanup:
  * no further need to verify the other interfaces for very-large-values.)
  */
 int
-test_kvstore_basic_value_size_gt_max_value_size()
+test_splinterdb_kv_value_size_gt_max_value_size()
 {
-   kvstore_basic *   kvsb;
-   kvstore_basic_cfg cfg = {0};
+   splinterdb_kv *   kvsb;
+   splinterdb_kv_cfg cfg = {0};
 
-   int rc = setup_kvstore_basic(&kvsb, &cfg);
+   int rc = setup_splinterdb_kv(&kvsb, &cfg);
    if (rc != 0) {
       return -1;
    }
@@ -322,7 +322,7 @@ test_kvstore_basic_value_size_gt_max_value_size()
    static const char short_key[]         = "a_short_key";
 
    memset(too_large_value, 'z', too_large_value_len);
-   rc = kvstore_basic_insert(
+   rc = splinterdb_kv_insert(
       kvsb, short_key, sizeof(short_key), too_large_value, too_large_value_len);
 
    test_assert(rc == EINVAL, "insert too-large value: %d", rc);
@@ -334,7 +334,7 @@ test_kvstore_basic_value_size_gt_max_value_size()
 cleanup:
    if (too_large_value)
       free(too_large_value);
-   kvstore_basic_close(kvsb);
+   splinterdb_kv_close(kvsb);
    if (rc) {
       fprintf(stderr, "%s: FAILED\n", __FUNCTION__);
       rc = -1;
@@ -343,12 +343,12 @@ cleanup:
 }
 
 int
-test_kvstore_basic_variable_length_values()
+test_splinterdb_kv_variable_length_values()
 {
-   kvstore_basic *   kvsb;
-   kvstore_basic_cfg cfg = {0};
+   splinterdb_kv *   kvsb;
+   splinterdb_kv_cfg cfg = {0};
 
-   int rc = setup_kvstore_basic(&kvsb, &cfg);
+   int rc = setup_splinterdb_kv(&kvsb, &cfg);
    if (rc != 0) {
       return -1;
    }
@@ -357,28 +357,28 @@ test_kvstore_basic_variable_length_values()
    const char short_string[1] = "v";
    const char long_string[]   = "some-long-value";
 
-   rc = kvstore_basic_insert(
+   rc = splinterdb_kv_insert(
       kvsb, "empty", sizeof("empty"), empty_string, sizeof(empty_string));
    test_assert_rc(rc, "insert of empty value: %d", rc);
 
-   rc = kvstore_basic_insert(
+   rc = splinterdb_kv_insert(
       kvsb, "short", sizeof("short"), short_string, sizeof(short_string));
    test_assert_rc(rc, "insert of short value: %d", rc);
 
-   rc = kvstore_basic_insert(
+   rc = splinterdb_kv_insert(
       kvsb, "long", sizeof("long"), long_string, sizeof(long_string));
    test_assert_rc(rc, "insert of long value: %d", rc);
 
    bool found, val_truncated;
 
    // add extra length so we can check for overflow
-   char found_value[KVSTORE_BASIC_MAX_VALUE_SIZE + 2];
+   char found_value[SPLINTERDB_KV_MAX_VALUE_SIZE + 2];
    memset(found_value, 'x', sizeof(found_value));
 
    size_t val_len;
 
    fprintf(stderr, "lookup tuple with empty value\n");
-   rc = kvstore_basic_lookup(kvsb,
+   rc = splinterdb_kv_lookup(kvsb,
                              "empty",
                              sizeof("empty"),
                              found_value,
@@ -394,7 +394,7 @@ test_kvstore_basic_variable_length_values()
    fprintf(
       stderr,
       "lookup tuple with value of length 1, providing sufficient buffer\n");
-   rc = kvstore_basic_lookup(kvsb,
+   rc = splinterdb_kv_lookup(kvsb,
                              "short",
                              sizeof("short"),
                              found_value,
@@ -417,7 +417,7 @@ test_kvstore_basic_variable_length_values()
 
       fprintf(stderr,
               "lookup tuple with value of length 1, providing empty buffer\n");
-   rc = kvstore_basic_lookup(kvsb,
+   rc = splinterdb_kv_lookup(kvsb,
                              "short",
                              sizeof("short"),
                              found_value,
@@ -434,7 +434,7 @@ test_kvstore_basic_variable_length_values()
                "lookup for short value, empty buffer: unexpected length");
 
    fprintf(stderr, "lookup tuple with max-sized-value\n");
-   rc = kvstore_basic_lookup(kvsb,
+   rc = splinterdb_kv_lookup(kvsb,
                              "long",
                              sizeof("long"),
                              found_value,
@@ -455,7 +455,7 @@ test_kvstore_basic_variable_length_values()
                   found_value)
 
       fprintf(stderr, "lookup tuple with max-sized-value, short buffer\n");
-   rc = kvstore_basic_lookup(kvsb,
+   rc = splinterdb_kv_lookup(kvsb,
                              "long",
                              sizeof("long"),
                              found_value,
@@ -477,7 +477,7 @@ test_kvstore_basic_variable_length_values()
    fprintf(stderr, "%s: PASS\n", __FUNCTION__);
 
 cleanup:
-   kvstore_basic_close(kvsb);
+   splinterdb_kv_close(kvsb);
    if (rc) {
       fprintf(stderr, "%s: FAILED\n", __FUNCTION__);
       rc = -1;
@@ -495,7 +495,7 @@ cleanup:
  * Returns: Return code: rc == 0 => success; anything else => failure
  */
 int
-insert_some_keys(const int num_inserts, kvstore_basic *kvsb)
+insert_some_keys(const int num_inserts, splinterdb_kv *kvsb)
 {
    int rc = 0;
    fprintf(stderr, "inserting %d keys", num_inserts);
@@ -508,7 +508,7 @@ insert_some_keys(const int num_inserts, kvstore_basic *kvsb)
       test_assert(6 == snprintf(key, sizeof(key), key_fmt, i), "key length");
       test_assert(6 == snprintf(val, sizeof(val), val_fmt, i), "val length");
 
-      rc = kvstore_basic_insert(kvsb, key, sizeof(key), val, sizeof(val));
+      rc = splinterdb_kv_insert(kvsb, key, sizeof(key), val, sizeof(val));
       test_assert_rc(rc, "insert: %d", rc);
    }
    fprintf(stderr, "\n");
@@ -532,7 +532,7 @@ cleanup:
  * Returns: Return code: rc == 0 => success; anything else => failure
  */
 static int
-insert_keys(kvstore_basic *kvsb, const int minkey, int numkeys, const int incr)
+insert_keys(splinterdb_kv *kvsb, const int minkey, int numkeys, const int incr)
 {
    int rc = -1;
 
@@ -548,7 +548,7 @@ insert_keys(kvstore_basic *kvsb, const int minkey, int numkeys, const int incr)
       snprintf(key, sizeof(key), key_fmt, kctr);
       snprintf(val, sizeof(val), val_fmt, kctr);
 
-      rc = kvstore_basic_insert(kvsb, key, sizeof(key), val, sizeof(val));
+      rc = splinterdb_kv_insert(kvsb, key, sizeof(key), val, sizeof(val));
       test_assert_rc(rc, "insert key=%d: rc=%d", kctr, rc);
    }
    rc = 0;
@@ -566,7 +566,7 @@ cleanup:
  * Returns: Return code: rc == 0 => success; anything else => failure
  */
 int
-check_current_tuple(kvstore_basic_iterator *it, const int expected_i)
+check_current_tuple(splinterdb_kv_iterator *it, const int expected_i)
 {
    int  rc               = 0;
    char expected_key[MAX_KEY_SIZE]          = {0};
@@ -582,7 +582,7 @@ check_current_tuple(kvstore_basic_iterator *it, const int expected_i)
    const char *val;
    size_t      key_len, val_len;
 
-   kvstore_basic_iter_get_current(it, &key, &key_len, &val, &val_len);
+   splinterdb_kv_iter_get_current(it, &key, &key_len, &val, &val_len);
 
    test_assert(
       TEST_INSERT_KEY_LENGTH == key_len, "wrong key length: %lu", key_len);
@@ -611,37 +611,37 @@ cleanup:
 
 
 int
-test_kvstore_basic_iterator()
+test_splinterdb_kv_iterator()
 {
-   kvstore_basic *         kvsb = NULL;
-   kvstore_basic_cfg       cfg  = {0};
-   kvstore_basic_iterator *it   = NULL;
+   splinterdb_kv *         kvsb = NULL;
+   splinterdb_kv_cfg       cfg  = {0};
+   splinterdb_kv_iterator *it   = NULL;
    int                     rc   = 0;
 
-   test_assert_rc(setup_kvstore_basic(&kvsb, &cfg), "setup");
+   test_assert_rc(setup_splinterdb_kv(&kvsb, &cfg), "setup");
 
    const int num_inserts = 50;
    test_assert_rc(insert_some_keys(num_inserts, kvsb), "inserting keys ");
    fprintf(stderr, "now using iterator:");
 
-   test_assert_rc(kvstore_basic_iter_init(kvsb, &it, NULL, 0), "init iter");
+   test_assert_rc(splinterdb_kv_iter_init(kvsb, &it, NULL, 0), "init iter");
 
    int i = 0;
-   for (; kvstore_basic_iter_valid(it); kvstore_basic_iter_next(it)) {
+   for (; splinterdb_kv_iter_valid(it); splinterdb_kv_iter_next(it)) {
       test_assert_rc(check_current_tuple(it, i), "check current");
       fprintf(stderr, ".%d.", i);
       i++;
    }
 
    fprintf(stderr, "checking status...\n");
-   test_assert_rc(kvstore_basic_iter_status(it),
+   test_assert_rc(splinterdb_kv_iter_status(it),
                   "iterator stopped with error status: %d",
                   rc);
 
    test_assert(
       i == num_inserts, "iterator stopped at %d, expected %d", i, num_inserts);
 
-   test_assert(!kvstore_basic_iter_valid(it),
+   test_assert(!splinterdb_kv_iter_valid(it),
                "iterator still valid, this should not happen");
 
    fprintf(stderr, "OK.  iterator test complete\n");
@@ -649,10 +649,10 @@ test_kvstore_basic_iterator()
 
 cleanup:
    if (it != NULL) {
-      kvstore_basic_iter_deinit(&it);
+      splinterdb_kv_iter_deinit(&it);
    }
    if (kvsb != NULL) {
-      kvstore_basic_close(kvsb);
+      splinterdb_kv_close(kvsb);
    }
    if (rc) {
       fprintf(stderr, "%s: FAILED\n", __FUNCTION__);
@@ -662,19 +662,19 @@ cleanup:
 }
 
 /*
- * Test case to exercise and verify that kvstore iterator interfaces with a
+ * Test case to exercise and verify that splinterdb iterator interfaces with a
  * non-NULL start key correctly sets up the start scan at the requested
  * initial key value.
  */
 int
-test_kvstore_iterator_with_startkey()
+test_splinterdb_iterator_with_startkey()
 {
-   kvstore_basic *         kvsb = NULL;
-   kvstore_basic_cfg       cfg  = {0};
-   kvstore_basic_iterator *it   = NULL;
+   splinterdb_kv *         kvsb = NULL;
+   splinterdb_kv_cfg       cfg  = {0};
+   splinterdb_kv_iterator *it   = NULL;
    int                     rc   = 0;
 
-   test_assert_rc(setup_kvstore_basic(&kvsb, &cfg), "setup");
+   test_assert_rc(setup_splinterdb_kv(&kvsb, &cfg), "setup");
 
    const int num_inserts = 50;
    test_assert_rc(insert_some_keys(num_inserts, kvsb), "inserting keys ");
@@ -685,24 +685,24 @@ test_kvstore_iterator_with_startkey()
 
       // Initialize the i'th key
       snprintf(key, sizeof(key), key_fmt, ictr);
-      test_assert_rc(kvstore_basic_iter_init(kvsb, &it, key, strlen(key)),
+      test_assert_rc(splinterdb_kv_iter_init(kvsb, &it, key, strlen(key)),
                      "init iter");
 
-      test_assert(kvstore_basic_iter_valid(it), "iter is valid");
+      test_assert(splinterdb_kv_iter_valid(it), "iter is valid");
 
       // Scan should have been positioned at the i'th key
       test_assert_rc(check_current_tuple(it, ictr), "check current");
 
-      kvstore_basic_iter_deinit(&it);
+      splinterdb_kv_iter_deinit(&it);
    }
    fprintf(stderr, "%s: PASS\n", __FUNCTION__);
 
 cleanup:
    if (it != NULL) {
-      kvstore_basic_iter_deinit(&it);
+      splinterdb_kv_iter_deinit(&it);
    }
    if (kvsb != NULL) {
-      kvstore_basic_close(kvsb);
+      splinterdb_kv_close(kvsb);
    }
    if (rc) {
       fprintf(stderr, "%s: FAILED\n", __FUNCTION__);
@@ -712,21 +712,21 @@ cleanup:
 }
 
 /*
- * Test case to exercise kvstore iterator with a non-NULL but non-existent
+ * Test case to exercise splinterdb iterator with a non-NULL but non-existent
  * start-key. The iterator just starts at the first key, if any, after the
  * specified start-key.
  *  . If start-key > max-key, we will find no more keys to scan.
  *  . If start-key < min-key, we will start scan from 1st key in set.
  */
 int
-test_kvstore_iterator_with_non_existent_startkey()
+test_splinterdb_iterator_with_non_existent_startkey()
 {
-   kvstore_basic *         kvsb = NULL;
-   kvstore_basic_cfg       cfg  = {0};
-   kvstore_basic_iterator *it   = NULL;
+   splinterdb_kv *         kvsb = NULL;
+   splinterdb_kv_cfg       cfg  = {0};
+   splinterdb_kv_iterator *it   = NULL;
    int                     rc   = 0;
 
-   test_assert_rc(setup_kvstore_basic(&kvsb, &cfg), "setup");
+   test_assert_rc(setup_splinterdb_kv(&kvsb, &cfg), "setup");
 
    const int num_inserts = 50;
    test_assert_rc(insert_some_keys(num_inserts, kvsb), "inserting keys ");
@@ -734,18 +734,18 @@ test_kvstore_iterator_with_non_existent_startkey()
    // start-key > max-key ('key-50')
    char *key = "unknownKey";
 
-   test_assert_rc(kvstore_basic_iter_init(kvsb, &it, key, strlen(key)),
+   test_assert_rc(splinterdb_kv_iter_init(kvsb, &it, key, strlen(key)),
                   "init iter with non-existent start key > max-key");
 
-   test_assert(!kvstore_basic_iter_valid(it), "iterator should be invalid");
+   test_assert(!splinterdb_kv_iter_valid(it), "iterator should be invalid");
 
-   kvstore_basic_iter_deinit(&it);
+   splinterdb_kv_iter_deinit(&it);
 
    // If you start with a key before min-key-value, scan will start from
    // 1st key inserted. (We do lexicographic comparison, so 'U' sorts
    // before 'key...', which is what key's format is.)
    key = "UnknownKey";
-   test_assert_rc(kvstore_basic_iter_init(kvsb, &it, key, strlen(key)),
+   test_assert_rc(splinterdb_kv_iter_init(kvsb, &it, key, strlen(key)),
                   "init iter with non-existent start key < min-key");
 
    // Iterator should be initialized to 1st key inserted, if the supplied
@@ -755,7 +755,7 @@ test_kvstore_iterator_with_non_existent_startkey()
 
    // Just to be sure, run through the set of keys, to cross-check that
    // we are getting all of them back in the right order.
-   for (; kvstore_basic_iter_valid(it); kvstore_basic_iter_next(it)) {
+   for (; splinterdb_kv_iter_valid(it); splinterdb_kv_iter_next(it)) {
       test_assert_rc(check_current_tuple(it, ictr), "check current");
       ictr++;
    }
@@ -770,10 +770,10 @@ test_kvstore_iterator_with_non_existent_startkey()
 
 cleanup:
    if (it != NULL) {
-      kvstore_basic_iter_deinit(&it);
+      splinterdb_kv_iter_deinit(&it);
    }
    if (kvsb != NULL) {
-      kvstore_basic_close(kvsb);
+      splinterdb_kv_close(kvsb);
    }
    if (rc) {
       fprintf(stderr, "%s: FAILED\n", __FUNCTION__);
@@ -783,7 +783,7 @@ cleanup:
 }
 
 /*
- * Test case to exercise kvstore iterator with a non-NULL but non-existent
+ * Test case to exercise splinterdb iterator with a non-NULL but non-existent
  * start-key.  The data in this test case is loaded such that we have a
  * sequence of key values with gaps of 2 (i.e. 1, 4, 7, 10, ...).
  *
@@ -796,14 +796,14 @@ cleanup:
  *  d) start-key beyond max-key (Scan should come out as invalid.)
  */
 int
-test_kvstore_iterator_with_missing_startkey_in_sequence()
+test_splinterdb_iterator_with_missing_startkey_in_sequence()
 {
-   kvstore_basic *         kvsb = NULL;
-   kvstore_basic_cfg       cfg  = {0};
-   kvstore_basic_iterator *it   = NULL;
+   splinterdb_kv *         kvsb = NULL;
+   splinterdb_kv_cfg       cfg  = {0};
+   splinterdb_kv_iterator *it   = NULL;
    int                     rc   = 0;
 
-   test_assert_rc(setup_kvstore_basic(&kvsb, &cfg), "setup");
+   test_assert_rc(setup_splinterdb_kv(&kvsb, &cfg), "setup");
 
    const int num_inserts = 50;
    // Should insert keys: 1, 4, 7, 10 13, 16, 19, ...
@@ -816,27 +816,27 @@ test_kvstore_iterator_with_missing_startkey_in_sequence()
    // (a) Test iter_init with a key == the min-key
    snprintf(key, sizeof(key), key_fmt, minkey);
 
-   test_assert_rc(kvstore_basic_iter_init(kvsb, &it, key, strlen(key)),
+   test_assert_rc(splinterdb_kv_iter_init(kvsb, &it, key, strlen(key)),
                   "init iter with start key == min-key");
 
-   test_assert(kvstore_basic_iter_valid(it), "iterator should be valid");
+   test_assert(splinterdb_kv_iter_valid(it), "iterator should be valid");
 
    // Iterator should be initialized to 1st key inserted, if the supplied
    // start_key is below min-key inserted thus far.
    int ictr = minkey;
    test_assert_rc(check_current_tuple(it, ictr), "check current ictr=<minkey>");
 
-   kvstore_basic_iter_deinit(&it);
+   splinterdb_kv_iter_deinit(&it);
 
    // (b) Test iter_init with a value below the min-key-value.
    int kctr = (minkey - 1);
 
    snprintf(key, sizeof(key), key_fmt, kctr);
 
-   test_assert_rc(kvstore_basic_iter_init(kvsb, &it, key, strlen(key)),
+   test_assert_rc(splinterdb_kv_iter_init(kvsb, &it, key, strlen(key)),
                   "init iter with start key less than min-key");
 
-   test_assert(kvstore_basic_iter_valid(it),
+   test_assert(splinterdb_kv_iter_valid(it),
                "iterator should be valid, kctr==(minkey - 1)");
 
    // Iterator should be initialized to 1st key inserted, if the supplied
@@ -844,43 +844,43 @@ test_kvstore_iterator_with_missing_startkey_in_sequence()
    ictr = minkey;
    test_assert_rc(check_current_tuple(it, ictr), "check current, expected 1");
 
-   kvstore_basic_iter_deinit(&it);
+   splinterdb_kv_iter_deinit(&it);
 
    // (c) Test with a non-existent value between 2 valid key values.
    kctr = 5;
    snprintf(key, sizeof(key), key_fmt, kctr);
 
-   test_assert_rc(kvstore_basic_iter_init(kvsb, &it, key, strlen(key)),
+   test_assert_rc(splinterdb_kv_iter_init(kvsb, &it, key, strlen(key)),
                   "init iter with non-existent start key");
 
-   test_assert(kvstore_basic_iter_valid(it),
+   test_assert(splinterdb_kv_iter_valid(it),
                "iterator should be valid, kctr=5");
 
    // Iterator should be initialized to next key following kctr.
    ictr = 7;
    test_assert_rc(check_current_tuple(it, ictr), "check current expected 7");
 
-   kvstore_basic_iter_deinit(&it);
+   splinterdb_kv_iter_deinit(&it);
 
    // (d) Test with a non-existent value beyond max key value.
    //     iter_init should end up as being invalid.
    kctr = -1;
    snprintf(key, sizeof(key), key_fmt, kctr);
 
-   test_assert_rc(kvstore_basic_iter_init(kvsb, &it, key, strlen(key)),
+   test_assert_rc(splinterdb_kv_iter_init(kvsb, &it, key, strlen(key)),
                   "init iter with non-existent start key beyond max-key");
 
-   test_assert(!kvstore_basic_iter_valid(it),
+   test_assert(!splinterdb_kv_iter_valid(it),
                "iterator should not be valid, kctr=-1");
 
    fprintf(stderr, "%s: PASS\n", __FUNCTION__);
 
 cleanup:
-   if ((it != NULL) && kvstore_basic_iter_valid(it)) {
-      kvstore_basic_iter_deinit(&it);
+   if ((it != NULL) && splinterdb_kv_iter_valid(it)) {
+      splinterdb_kv_iter_deinit(&it);
    }
    if (kvsb != NULL) {
-      kvstore_basic_close(kvsb);
+      splinterdb_kv_close(kvsb);
    }
    if (rc) {
       fprintf(stderr, "%s: FAILED\n", __FUNCTION__);
@@ -918,32 +918,32 @@ custom_key_comparator(const void *context,
 }
 
 int
-test_kvstore_basic_iterator_custom_comparator()
+test_splinterdb_kv_iterator_custom_comparator()
 {
-   kvstore_basic *         kvsb = NULL;
-   kvstore_basic_cfg       cfg  = {0};
-   kvstore_basic_iterator *it   = NULL;
+   splinterdb_kv *         kvsb = NULL;
+   splinterdb_kv_cfg       cfg  = {0};
+   splinterdb_kv_iterator *it   = NULL;
    int                     rc   = 0;
 
    cfg.key_comparator         = &custom_key_comparator;
    cfg.key_comparator_context = &key_comp_context;
 
-   test_assert_rc(setup_kvstore_basic(&kvsb, &cfg), "setup");
+   test_assert_rc(setup_splinterdb_kv(&kvsb, &cfg), "setup");
 
    const int num_inserts = 50;
    test_assert_rc(insert_some_keys(num_inserts, kvsb), "inserting keys ");
    fprintf(stderr, "now using iterator:");
 
-   test_assert_rc(kvstore_basic_iter_init(kvsb, &it, NULL, 0), "init iter");
+   test_assert_rc(splinterdb_kv_iter_init(kvsb, &it, NULL, 0), "init iter");
 
    int i = 0;
-   for (; kvstore_basic_iter_valid(it); kvstore_basic_iter_next(it)) {
+   for (; splinterdb_kv_iter_valid(it); splinterdb_kv_iter_next(it)) {
       test_assert_rc(check_current_tuple(it, i), "check current: %d", i);
       fprintf(stderr, ".");
       i++;
    }
 
-   test_assert_rc(kvstore_basic_iter_status(it),
+   test_assert_rc(splinterdb_kv_iter_status(it),
                   "iterator stopped with error status: %d",
                   rc);
 
@@ -954,7 +954,7 @@ test_kvstore_basic_iterator_custom_comparator()
                "key comparison count: %lu",
                key_comp_context);
 
-   test_assert(!kvstore_basic_iter_valid(it),
+   test_assert(!splinterdb_kv_iter_valid(it),
                "iterator still valid, this should not happen");
 
    fprintf(stderr, "OK.  iterator test complete\n");
@@ -963,11 +963,11 @@ test_kvstore_basic_iterator_custom_comparator()
 cleanup:
    if (it != NULL) {
       fprintf(stderr, "deinit iterator...");
-      kvstore_basic_iter_deinit(&it);
+      splinterdb_kv_iter_deinit(&it);
    }
    if (kvsb != NULL) {
-      fprintf(stderr, "deinit kvstore_basic...");
-      kvstore_basic_close(kvsb);
+      fprintf(stderr, "deinit splinterdb_kv...");
+      splinterdb_kv_close(kvsb);
    }
    if (rc) {
       fprintf(stderr, "%s: FAILED\n", __FUNCTION__);
@@ -977,17 +977,17 @@ cleanup:
 }
 
 int
-test_kvstore_basic_close_and_reopen()
+test_splinterdb_kv_close_and_reopen()
 {
-   kvstore_basic *   kvsb = NULL;
-   kvstore_basic_cfg cfg  = {0};
+   splinterdb_kv *   kvsb = NULL;
+   splinterdb_kv_cfg cfg  = {0};
    int               rc   = 0;
 
    fprintf(stderr, "remove old db...");
    test_assert(remove(TEST_DB_NAME) == 0, "removing old db");
 
    fprintf(stderr, "creating new db...");
-   test_assert_rc(setup_kvstore_basic(&kvsb, &cfg), "setup");
+   test_assert_rc(setup_splinterdb_kv(&kvsb, &cfg), "setup");
 
    char * key     = "some-key";
    size_t key_len = sizeof("some-key");
@@ -996,16 +996,16 @@ test_kvstore_basic_close_and_reopen()
    size_t val_len;
 
    fprintf(stderr, "insert...");
-   test_assert_rc(kvstore_basic_insert(
+   test_assert_rc(splinterdb_kv_insert(
                      kvsb, key, key_len, "some-value", sizeof("some-value")),
                   "insert");
 
    fprintf(stderr, "close and reopen...");
-   kvstore_basic_close(kvsb);
-   test_assert_rc(kvstore_basic_open(&cfg, &kvsb), "reopen");
+   splinterdb_kv_close(kvsb);
+   test_assert_rc(splinterdb_kv_open(&cfg, &kvsb), "reopen");
 
    fprintf(stderr, "lookup...");
-   rc = kvstore_basic_lookup(kvsb,
+   rc = splinterdb_kv_lookup(kvsb,
                              key,
                              key_len,
                              value,
@@ -1020,8 +1020,8 @@ test_kvstore_basic_close_and_reopen()
 
 cleanup:
    if (kvsb != NULL) {
-      fprintf(stderr, "deinit kvstore_basic...");
-      kvstore_basic_close(kvsb);
+      fprintf(stderr, "deinit splinterdb_kv...");
+      splinterdb_kv_close(kvsb);
    }
    if (rc) {
       fprintf(stderr, "%s: FAILED\n", __FUNCTION__);
@@ -1031,16 +1031,16 @@ cleanup:
 }
 
 int
-test_kvstore_basic_lots_of_data()
+test_splinterdb_kv_lots_of_data()
 {
-   kvstore_basic *   kvsb;
-   kvstore_basic_cfg cfg = {0};
+   splinterdb_kv *   kvsb;
+   splinterdb_kv_cfg cfg = {0};
 
    cfg.cache_size     = 200 * Mega;
    cfg.disk_size      = 900 * Mega;
    cfg.max_key_size   = 22;
    cfg.max_value_size = 116;
-   int rc             = setup_kvstore_basic(&kvsb, &cfg);
+   int rc             = setup_splinterdb_kv(&kvsb, &cfg);
    if (rc != 0) {
       return -1;
    }
@@ -1050,8 +1050,8 @@ test_kvstore_basic_lots_of_data()
       return -1;
    }
 
-   char key_buf[KVSTORE_BASIC_MAX_KEY_SIZE]     = {0};
-   char value_buf[KVSTORE_BASIC_MAX_VALUE_SIZE] = {0};
+   char key_buf[SPLINTERDB_KV_MAX_KEY_SIZE]     = {0};
+   char value_buf[SPLINTERDB_KV_MAX_VALUE_SIZE] = {0};
 
    fprintf(stderr, "writing lots of data...");
    for (uint64_t i = 0; i < 2 * Mega; i++) {
@@ -1065,14 +1065,14 @@ test_kvstore_basic_lots_of_data()
          rc = -1;
          break;
       }
-      rc = kvstore_basic_insert(
+      rc = splinterdb_kv_insert(
          kvsb, key_buf, cfg.max_key_size, value_buf, cfg.max_value_size);
       test_assert_rc(rc, "insert: %d", rc);
    }
    fprintf(stderr, "%s: PASS\n", __FUNCTION__);
 
 cleanup:
-   kvstore_basic_close(kvsb);
+   splinterdb_kv_close(kvsb);
    if (rc) {
       fprintf(stderr, "%s: FAILED\n", __FUNCTION__);
       rc = -1;
@@ -1081,54 +1081,54 @@ cleanup:
 }
 
 int
-kvstore_basic_test(int argc, char *argv[])
+splinterdb_kv_test(int argc, char *argv[])
 {
    int rc = 0;
 
-   fprintf(stderr, "\nstart: kvstore_basic flow\n");
-   test_assert_rc(test_kvstore_basic_flow(), "kvstore_basic_flow");
+   fprintf(stderr, "\nstart: splinterdb_kv flow\n");
+   test_assert_rc(test_splinterdb_kv_flow(), "splinterdb_kv_flow");
 
-   fprintf(stderr, "\nstart: kvstore_basic large keys\n");
-   test_assert_rc(test_kvstore_basic_large_keys(), "kvstore_basic_large_keys");
+   fprintf(stderr, "\nstart: splinterdb_kv large keys\n");
+   test_assert_rc(test_splinterdb_kv_large_keys(), "splinterdb_kv_large_keys");
 
-   test_assert_rc(test_kvstore_basic_key_size_gt_max_key_size(),
-                  "kvstore_basic_key_size_gt_max_key_size");
+   test_assert_rc(test_splinterdb_kv_key_size_gt_max_key_size(),
+                  "splinterdb_kv_key_size_gt_max_key_size");
 
-   test_assert_rc(test_kvstore_basic_value_size_gt_max_value_size(),
-                  "kvstore_basic_value_size_gt_max_value_size");
+   test_assert_rc(test_splinterdb_kv_value_size_gt_max_value_size(),
+                  "splinterdb_kv_value_size_gt_max_value_size");
 
-   fprintf(stderr, "\nstart: kvstore_basic variable-length values\n");
-   test_assert_rc(test_kvstore_basic_variable_length_values(),
-                  "kvstore_basic_variable_length_values");
+   fprintf(stderr, "\nstart: splinterdb_kv variable-length values\n");
+   test_assert_rc(test_splinterdb_kv_variable_length_values(),
+                  "splinterdb_kv_variable_length_values");
 
-   fprintf(stderr, "\nstart: kvstore_basic iterator\n");
-   test_assert_rc(test_kvstore_basic_iterator(), "kvstore_basic_iterator");
+   fprintf(stderr, "\nstart: splinterdb_kv iterator\n");
+   test_assert_rc(test_splinterdb_kv_iterator(), "splinterdb_kv_iterator");
 
-   fprintf(stderr, "\nstart: kvstore_basic iterator with start key\n");
-   test_assert_rc(test_kvstore_iterator_with_startkey(),
-                  "kvstore_iterator_with_startkey");
+   fprintf(stderr, "\nstart: splinterdb_kv iterator with start key\n");
+   test_assert_rc(test_splinterdb_iterator_with_startkey(),
+                  "splinterdb_iterator_with_startkey");
 
-   fprintf(stderr, "\nstart: kvstore_basic iterator with unknown start key\n");
-   test_assert_rc(test_kvstore_iterator_with_non_existent_startkey(),
-                  "kvstore_iterator_with_non_existent_startkey");
+   fprintf(stderr, "\nstart: splinterdb_kv iterator with unknown start key\n");
+   test_assert_rc(test_splinterdb_iterator_with_non_existent_startkey(),
+                  "splinterdb_iterator_with_non_existent_startkey");
 
    fprintf(stderr,
-           "\nstart: kvstore_basic iterator with unknown start key"
+           "\nstart: splinterdb_kv iterator with unknown start key"
            " from middle\n");
-   test_assert_rc(test_kvstore_iterator_with_missing_startkey_in_sequence(),
-                  "kvstore_iterator_with_missing_startkey_in_sequence");
+   test_assert_rc(test_splinterdb_iterator_with_missing_startkey_in_sequence(),
+                  "splinterdb_iterator_with_missing_startkey_in_sequence");
 
-   fprintf(stderr, "\nstart: kvstore_basic iterator with custom comparator\n");
-   test_assert_rc(test_kvstore_basic_iterator_custom_comparator(),
-                  "kvstore_basic_iterator_custom_comparator");
+   fprintf(stderr, "\nstart: splinterdb_kv iterator with custom comparator\n");
+   test_assert_rc(test_splinterdb_kv_iterator_custom_comparator(),
+                  "splinterdb_kv_iterator_custom_comparator");
 
-   fprintf(stderr, "\nstart: kvstore_basic close and re-open\n");
-   test_assert_rc(test_kvstore_basic_close_and_reopen(),
-                  "kvstore_basic_close_and_reopen");
+   fprintf(stderr, "\nstart: splinterdb_kv close and re-open\n");
+   test_assert_rc(test_splinterdb_kv_close_and_reopen(),
+                  "splinterdb_kv_close_and_reopen");
 
-   fprintf(stderr, "\nstart: kvstore_basic lots of data\n");
-   test_assert_rc(test_kvstore_basic_lots_of_data(),
-                  "kvstore_basic_lots_of_data");
+   fprintf(stderr, "\nstart: splinterdb_kv lots of data\n");
+   test_assert_rc(test_splinterdb_kv_lots_of_data(),
+                  "splinterdb_kv_lots_of_data");
 cleanup:
    if (rc == 0) {
       fprintf(stderr, "OK\n");

--- a/tests/test.h
+++ b/tests/test.h
@@ -18,7 +18,7 @@
 #include "splinterdb/data.h"
 #include "rc_allocator.h"
 #include "shard_log.h"
-#include "splinter.h"
+#include "trunk.h"
 #include "test_data.h"
 
 typedef enum test_key_type {
@@ -49,9 +49,9 @@ int
 cache_test(int argc, char *argv[]);
 
 int
-kvstore_test(int argc, char *argv[]);
+splinterdb_test(int argc, char *argv[]);
 
-int kvstore_basic_test(int argc, char *argv[]);
+int splinterdb_kv_test(int argc, char *argv[]);
 
 int util_test(int argc, char *argv[]);
 
@@ -73,7 +73,7 @@ test_init_splinter(platform_heap_id     hid,
 {
    // splinter initialization
    return task_system_create(hid, ioh, system, use_stats, use_bg_threads,
-         num_bg_threads, splinter_get_scratch_size());
+         num_bg_threads, trunk_get_scratch_size());
 }
 
 static inline void
@@ -255,7 +255,7 @@ test_btree_print_all_keys(cache        *cc,
 }
 
 static inline void
-test_config_init(splinter_config     *splinter_cfg,
+test_config_init(trunk_config     *splinter_cfg,
                  data_config         *data_cfg,
                  shard_log_config    *log_cfg,
                  clockcache_config   *cache_cfg,
@@ -282,7 +282,7 @@ test_config_init(splinter_config     *splinter_cfg,
    shard_log_config_init(log_cfg, data_cfg, master_cfg->page_size,
                          master_cfg->extent_size);
 
-   splinter_config_init(splinter_cfg, data_cfg, (log_config *)log_cfg,
+   trunk_config_init(splinter_cfg, data_cfg, (log_config *)log_cfg,
                         master_cfg->memtable_capacity,
                         master_cfg->fanout, master_cfg->max_branches_per_node,
                         master_cfg->btree_rough_count_height,
@@ -294,7 +294,7 @@ test_config_init(splinter_config     *splinter_cfg,
 }
 
 static inline platform_status
-test_parse_args_n(splinter_config     *splinter_cfg,
+test_parse_args_n(trunk_config     *splinter_cfg,
                   data_config         *data_cfg,
                   io_config           *io_cfg,
                   rc_allocator_config *allocator_cfg,
@@ -330,7 +330,7 @@ test_parse_args_n(splinter_config     *splinter_cfg,
 }
 
 static inline platform_status
-test_parse_args(splinter_config     *splinter_cfg,
+test_parse_args(trunk_config     *splinter_cfg,
                 data_config         *data_cfg,
                 io_config           *io_cfg,
                 rc_allocator_config *allocator_cfg,

--- a/tests/test_async.c
+++ b/tests/test_async.c
@@ -18,12 +18,12 @@
 
 /*
  * Callback called when an IO completes on behalf of a context used by
- * splinter_lookup_async(). This is the producer end of ready_q and
+ * trunk_lookup_async(). This is the producer end of ready_q and
  * enqueues the ctxt into it. This is called from IO completion
  * context.
  */
 static void
-test_async_callback(splinter_async_ctxt *spl_ctxt)
+test_async_callback(trunk_async_ctxt *spl_ctxt)
 {
    test_async_ctxt *ctxt = container_of(spl_ctxt, test_async_ctxt, ctxt);
 
@@ -32,7 +32,7 @@ test_async_callback(splinter_async_ctxt *spl_ctxt)
 }
 
 /*
- * Get a new context from the avail_q, for use in a splinter_lookup_async()
+ * Get a new context from the avail_q, for use in a trunk_lookup_async()
  * Returns NULL if no contexts are avaiable (max_async_inflight reached).
  */
 test_async_ctxt *
@@ -45,13 +45,13 @@ async_ctxt_get(test_async_lookup *async_lookup)
    if (!SUCCESS(rc)) {
       return NULL;
    }
-   splinter_async_ctxt_init(&ctxt->ctxt, test_async_callback);
+   trunk_async_ctxt_init(&ctxt->ctxt, test_async_callback);
 
    return ctxt;
 }
 
 /*
- * Ungets a context after splinter_lookup_async() returns success. The
+ * Ungets a context after trunk_lookup_async() returns success. The
  * context should not be in-flight. It's returned back to avail_q.
  */
 void
@@ -120,7 +120,7 @@ async_ctxt_deinit(platform_heap_id   hid,
  * and if successful, run process_cb on it.
  */
 void
-async_ctxt_process_one(splinter_handle       *spl,
+async_ctxt_process_one(trunk_handle       *spl,
                        test_async_lookup     *async_lookup,
                        test_async_ctxt       *ctxt,
                        timestamp             *latency_max,
@@ -132,7 +132,7 @@ async_ctxt_process_one(splinter_handle       *spl,
    timestamp ts;
 
    ts = platform_get_timestamp();
-   res = splinter_lookup_async(spl, ctxt->key, ctxt->data, &found,
+   res = trunk_lookup_async(spl, ctxt->key, ctxt->data, &found,
                                &ctxt->ctxt);
    ts = platform_timestamp_elapsed(ts);
    if (latency_max != NULL && *latency_max < ts) {
@@ -162,7 +162,7 @@ async_ctxt_process_one(splinter_handle       *spl,
  * Returns: TRUE if no context at all are used.
  */
 bool
-async_ctxt_process_ready(splinter_handle       *spl,
+async_ctxt_process_ready(trunk_handle       *spl,
                          test_async_lookup     *async_lookup,
                          timestamp             *latency_max,
                          async_ctxt_process_cb  process_cb,

--- a/tests/test_async.h
+++ b/tests/test_async.h
@@ -12,7 +12,7 @@
 
 #include "platform.h"
 
-#include "splinter.h"
+#include "trunk.h"
 #include "cache.h"
 #include "pcq.h"
 
@@ -21,7 +21,7 @@
 
 // A single async context
 typedef struct {
-   splinter_async_ctxt  ctxt;
+   trunk_async_ctxt  ctxt;
    pcq                 *ready_q;
    union {
       int8              refcount;      // Used by functionality test
@@ -42,13 +42,13 @@ typedef struct {
    test_async_ctxt   ctxt[];
 } test_async_lookup;
 
-typedef void (*async_ctxt_process_cb)(splinter_handle *spl, test_async_ctxt *ctxt, bool found, void *arg);
+typedef void (*async_ctxt_process_cb)(trunk_handle *spl, test_async_ctxt *ctxt, bool found, void *arg);
 
 void             async_ctxt_init         (platform_heap_id hid, uint32 max_async_inflight, uint64 data_size, test_async_lookup  **out);
 void             async_ctxt_deinit       (platform_heap_id hid, test_async_lookup  *async_lookup);
 test_async_ctxt *async_ctxt_get          (test_async_lookup *async_lookup);
 void             async_ctxt_unget        (test_async_lookup *async_lookup, test_async_ctxt *ctxt);
-void             async_ctxt_process_one  (splinter_handle *spl, test_async_lookup *async_lookup, test_async_ctxt *ctxt, timestamp *latency_max, async_ctxt_process_cb process_cb, void *process_arg);
-bool             async_ctxt_process_ready(splinter_handle *spl, test_async_lookup *async_lookup, timestamp *latency_max, async_ctxt_process_cb process_cb, void *process_arg);
+void             async_ctxt_process_one  (trunk_handle *spl, test_async_lookup *async_lookup, test_async_ctxt *ctxt, timestamp *latency_max, async_ctxt_process_cb process_cb, void *process_arg);
+bool             async_ctxt_process_ready(trunk_handle *spl, test_async_lookup *async_lookup, timestamp *latency_max, async_ctxt_process_cb process_cb, void *process_arg);
 
 #endif // __TEST_ASYNC_H_

--- a/tests/test_dispatcher.c
+++ b/tests/test_dispatcher.c
@@ -14,8 +14,8 @@ static void usage(void) {
    platform_error_log("\tsplinter_test\n");
    platform_error_log("\tlog_test\n");
    platform_error_log("\tcache_test\n");
-   platform_error_log("\tkvstore_basic_test\n");
-   platform_error_log("\tkvstore_test\n");
+   platform_error_log("\tsplinterdb_kv_test\n");
+   platform_error_log("\tsplinterdb_test\n");
    platform_error_log("\tutil_test\n");
 #ifdef PLATFORM_LINUX
    platform_error_log("\tycsb_test\n");
@@ -42,10 +42,10 @@ test_dispatcher(int argc, char *argv[])
          return log_test(argc - 1, &argv[1]);
       } else if (STRING_EQUALS_LITERAL(test_name, "cache_test")) {
          return cache_test(argc - 1, &argv[1]);
-      } else if (STRING_EQUALS_LITERAL(test_name, "kvstore_basic_test")) {
-         return kvstore_basic_test(argc - 1, &argv[1]);
-      } else if (STRING_EQUALS_LITERAL(test_name, "kvstore_test")) {
-         return kvstore_test(argc - 1, &argv[1]);
+      } else if (STRING_EQUALS_LITERAL(test_name, "splinterdb_kv_test")) {
+         return splinterdb_kv_test(argc - 1, &argv[1]);
+      } else if (STRING_EQUALS_LITERAL(test_name, "splinterdb_test")) {
+         return splinterdb_test(argc - 1, &argv[1]);
       } else if (STRING_EQUALS_LITERAL(test_name, "util_test")) {
          return util_test(argc - 1, &argv[1]);
 #ifdef PLATFORM_LINUX

--- a/tests/test_functionality.h
+++ b/tests/test_functionality.h
@@ -3,14 +3,14 @@
 
 #include "allocator.h"
 #include "cache.h"
-#include "splinter.h"
+#include "trunk.h"
 #include "platform.h"
 
 platform_status
 test_functionality(allocator            *al,
                    io_handle            *io,
                    cache                *cc[],
-                   splinter_config      *cfg,
+                   trunk_config      *cfg,
                    uint64                seed,
                    uint64                num_inserts,
                    uint64                correctness_check_frequency,


### PR DESCRIPTION
Based on conversations in Slack.

`kvstore_basic` -> `splinterdb_kv`
`kvstore` -> `splinterdb`
`splinter` -> `trunk`

used the following bash script to do this
```bash
 #!/bin/bash

 set -e -u -o pipefail


 refactor_splinter_to_trunk() {
     sed -i 's/splinter\.c/trunk.c/g' src/splinter.c src/kvstore.c
     sed -i 's/splinter_trunk_hdr/trunk_hdr/g' src/splinter.c src/splinter.h
     sed -i 's/splinter_trunk_async_callback/trunk_async_callback/g' src/splinter.c

     sed -i 's/SPLINTER_/TRUNK_/g' src/splinter.c src/splinter.h
     sed -i 's/splinter_/trunk_/g' src/splinter.c src/splinter.h src/platform_linux/platform_inline.h src/kvstore.c

     get_symbols() {
         grep "^trunk_.*(" src/splinter.h | cut -d '(' -f1
         grep "^struct trunk_.* " src/splinter.h | cut -d ' ' -f2
         grep "^typedef struct trunk_.* " src/splinter.h | cut -d ' ' -f3
         grep "^struct trunk_.*;" src/splinter.h | cut -d ';' -f1 | cut -d ' ' -f2
     }

     symbols_without_prefix() {
         get_symbols | cut -d '_' -f2-
     }
     symbols_without_prefix | while read s; do
         sed -i "s/splinter_${s}/trunk_${s}/g" tests/*.*
     done

     sed -i 's/splinter\.h/trunk.h/g' src/*.* tests/*.*
     mv src/{splinter,trunk}.c
     mv src/{splinter,trunk}.h
 }

 refactor_kvstore_basic_to_splinterdb_kv() {
     sed -i 's/KVSTORE_BASIC_/SPLINTERDB_KV_/g' src/*.* include/splinterdb/*.* tests/*.*
     sed -i 's/kvstore_basic/splinterdb_kv/g' src/*.* include/splinterdb/*.* tests/*.* test.sh docs/*.*

     mv src/{kvstore_basic,splinterdb_kv}.c
     mv include/splinterdb/{kvstore_basic,splinterdb_kv}.h
     mv tests/{kvstore_basic,splinterdb_kv}_test.c
 }

 refactor_kvstore_to_splinterdb() {
     sed -i 's/KVSTORE_/SPLINTERDB_/g' src/*.* include/splinterdb/*.* tests/*.*
     sed -i 's/kvstore/splinterdb/g' src/*.* include/splinterdb/*.* tests/*.* test.sh docs/*.*

     mv src/{kvstore,splinterdb}.c
     mv include/splinterdb/{kvstore,splinterdb}.h
     mv tests/{kvstore,splinterdb}_test.c
 }

 refactor_splinter_to_trunk
 refactor_kvstore_basic_to_splinterdb_kv
 refactor_kvstore_to_splinterdb

```