### PR TITLE
Add lots of error handling for allocation failures, and add an allocation failure injection framework to the tests

### DIFF
--- a/include/splinterdb/kvstore.h
+++ b/include/splinterdb/kvstore.h
@@ -56,7 +56,7 @@ kvstore_open(const kvstore_config *cfg, kvstore **kvs);
 // Close a kvstore
 //
 // This will flush everything to disk and release all resources
-void
+int
 kvstore_close(kvstore *kvs);
 
 // Register the current thread so that it can be used with the kvstore.

--- a/src/allocator.h
+++ b/src/allocator.h
@@ -40,7 +40,7 @@ typedef struct allocator allocator;
 
 typedef platform_status (*alloc_fn)(allocator *al,
                                     uint64 *   addr,
-                                    page_type  type);
+                                    page_type  type) MUST_CHECK_RESULT;
 
 typedef uint8 (*dec_ref_fn)(allocator *al, uint64 addr, page_type type);
 typedef uint8 (*generic_ref_fn)(allocator *al, uint64 addr);
@@ -50,7 +50,7 @@ typedef platform_status (*get_super_addr_fn)(allocator *       al,
                                              uint64 *          addr);
 typedef platform_status (*alloc_super_addr_fn)(allocator *       al,
                                                allocator_root_id spl_id,
-                                               uint64 *          addr);
+                                               uint64 *addr) MUST_CHECK_RESULT;
 typedef void (*remove_super_addr_fn)(allocator *al, allocator_root_id spl_id);
 typedef uint64 (*get_size_fn)(allocator *al);
 
@@ -85,7 +85,7 @@ struct allocator {
    const allocator_ops *ops;
 };
 
-static inline platform_status
+static inline MUST_CHECK_RESULT platform_status
 allocator_alloc(allocator *al, uint64 *addr, page_type type)
 {
    return al->ops->alloc(al, addr, type);
@@ -109,13 +109,13 @@ allocator_get_ref(allocator *al, uint64 addr)
    return al->ops->get_ref(al, addr);
 }
 
-static inline platform_status
+static inline MUST_CHECK_RESULT platform_status
 allocator_get_super_addr(allocator *al, allocator_root_id spl_id, uint64 *addr)
 {
    return al->ops->get_super_addr(al, spl_id, addr);
 }
 
-static inline platform_status
+static inline MUST_CHECK_RESULT platform_status
 allocator_alloc_super_addr(allocator *       al,
                            allocator_root_id spl_id,
                            uint64 *          addr)

--- a/src/btree.c
+++ b/src/btree.c
@@ -2650,12 +2650,12 @@ btree_print_tree_stats(cache *cc,
  */
 
 uint64
-btree_space_use_in_range(cache        *cc,
+btree_space_use_in_range(cache *       cc,
                          btree_config *cfg,
                          uint64        root_addr,
                          page_type     type,
-                         const char   *start_key,
-                         const char   *end_key)
+                         const char *  start_key,
+                         const char *  end_key)
 {
    platform_assert(type == PAGE_TYPE_BRANCH);
    uint64 meta_head = btree_root_to_meta_addr(cc, cfg, root_addr, 0);

--- a/src/btree.c
+++ b/src/btree.c
@@ -2334,6 +2334,8 @@ btree_pack_loop(btree_pack_internal *tree, // IN/OUT
       iterator_advance(tree->itor);
       iterator_at_end(tree->itor, at_end);
    }
+
+   return STATUS_OK;
 }
 
 
@@ -2422,7 +2424,7 @@ btree_pack(btree_pack_req *req)
       rc =
          btree_pack_loop(&tree, slice_data(key), slice_data(message), &at_end);
       if (!SUCCESS(rc)) {
-         *(tree->num_tuples) = 0;
+         *(tree.num_tuples) = 0;
          break; // post_loop will cleanup
       }
    }

--- a/src/btree.c
+++ b/src/btree.c
@@ -972,8 +972,6 @@ btree_split_root(btree_config *  cfg,   // IN
    }
    root_node->hdr->height++;
    btree_add_pivot_at_pos(cfg, root_node, &left_node, 0, TRUE);
-   btree_node right_node;
-   btree_add_split_pivot(cc, cfg, mini, root_node, &left_node, &right_node);
 
    // release root
    btree_node_unlock(cc, cfg, root_node);
@@ -2176,7 +2174,8 @@ btree_pack_setup(btree_pack_req *req, btree_pack_internal *tree)
    if (!SUCCESS(rc)) {
       char last_key[MAX_KEY_SIZE];
       memmove(last_key, tree->cfg->data_cfg->max_key, MAX_KEY_SIZE);
-      mini_release(&tree->mini, last_key);
+      slice last_slice = slice_create(tree->cfg->data_cfg->key_size, last_key);
+      mini_release(&tree->mini, last_slice);
       btree_zap_range(
          tree->cc, tree->cfg, *(tree->root_addr), NULL, NULL, PAGE_TYPE_BRANCH);
       *(tree->root_addr) = 0;
@@ -2187,7 +2186,7 @@ btree_pack_setup(btree_pack_req *req, btree_pack_internal *tree)
    return STATUS_OK;
 }
 
-static inline MUST_CHECK_RESULT platform_status
+void
 btree_pack_loop(btree_pack_internal *tree, // IN/OUT
                 const char *         key,  // IN
                 const char *         data, // IN

--- a/src/btree.h
+++ b/src/btree.h
@@ -297,7 +297,7 @@ btree_pack_req_deinit(btree_pack_req *req, platform_heap_id hid)
    }
 }
 
-platform_status
+MUST_CHECK_RESULT platform_status
 btree_pack(btree_pack_req *req);
 
 uint64

--- a/src/btree.h
+++ b/src/btree.h
@@ -221,11 +221,8 @@ btree_lookup_async(cache *cc,
                    bool *found,
                    btree_async_ctxt *ctxt);
 
-uint64
-btree_init(cache          *cc,
-           btree_config   *cfg,
-           mini_allocator *mini,
-           bool            is_packed);
+MUST_CHECK_RESULT uint64
+btree_init(cache *cc, btree_config *cfg, mini_allocator *mini, bool is_packed);
 
 bool
 btree_zap_range(cache        *cc,

--- a/src/kvstore.c
+++ b/src/kvstore.c
@@ -309,14 +309,14 @@ kvstore_open(const kvstore_config *cfg, // IN
  *-----------------------------------------------------------------------------
  */
 
-MUST_CHECK_RESULT platform_status
+int
 kvstore_close(kvstore *kvs) // IN
 {
    platform_assert(kvs != NULL);
 
    platform_status rc = splinter_dismount(kvs->spl);
    if (!SUCCESS(rc)) {
-      return rc;
+      return platform_status_to_int(rc);
    }
    clockcache_deinit(&kvs->cache_handle);
    rc_allocator_dismount(&kvs->allocator_handle);
@@ -325,7 +325,7 @@ kvstore_close(kvstore *kvs) // IN
 
    platform_free(kvs->heap_id, kvs);
 
-   return STATUS_OK;
+   return platform_status_to_int(STATUS_OK);
 }
 
 

--- a/src/kvstore.c
+++ b/src/kvstore.c
@@ -309,18 +309,23 @@ kvstore_open(const kvstore_config *cfg, // IN
  *-----------------------------------------------------------------------------
  */
 
-void
+MUST_CHECK_RESULT platform_status
 kvstore_close(kvstore *kvs) // IN
 {
    platform_assert(kvs != NULL);
 
-   splinter_dismount(kvs->spl);
+   platform_status rc = splinter_dismount(kvs->spl);
+   if (!SUCCESS(rc)) {
+      return rc;
+   }
    clockcache_deinit(&kvs->cache_handle);
    rc_allocator_dismount(&kvs->allocator_handle);
    io_handle_deinit(&kvs->io_handle);
    task_system_destroy(kvs->heap_id, kvs->task_sys);
 
    platform_free(kvs->heap_id, kvs);
+
+   return STATUS_OK;
 }
 
 

--- a/src/log.h
+++ b/src/log.h
@@ -69,9 +69,7 @@ log_magic(log_handle *log)
    return log->ops->magic(log);
 }
 
-log_handle *
-log_create(cache      *cc,
-           log_config *cfg,
-           platform_heap_id hid);
+MUST_CHECK_RESULT log_handle *
+                  log_create(cache *cc, log_config *cfg, platform_heap_id hid);
 
 #endif //__LOG_H

--- a/src/log.h
+++ b/src/log.h
@@ -18,10 +18,10 @@ typedef struct log_handle log_handle;
 typedef struct log_iterator log_iterator;
 typedef struct log_config log_config;
 
-typedef int (*log_write_fn)(log_handle *log,
-                            const slice key,
-                            const slice data,
-                            uint64      generation);
+typedef MUST_CHECK_RESULT platform_status (*log_write_fn)(log_handle *log,
+                                                          const slice key,
+                                                          const slice data,
+                                                          uint64 generation);
 typedef void   (*log_release_fn) (log_handle *log);
 typedef uint64 (*log_addr_fn)    (log_handle *log);
 typedef uint64 (*log_magic_fn)   (log_handle *log);
@@ -39,7 +39,7 @@ struct log_handle {
    const log_ops *ops;
 };
 
-static inline int
+static inline MUST_CHECK_RESULT platform_status
 log_write(log_handle *log, const slice key, const slice data, uint64 generation)
 {
    return log->ops->write(log, key, data, generation);

--- a/src/mini_allocator.c
+++ b/src/mini_allocator.c
@@ -605,6 +605,10 @@ mini_alloc(mini_allocator *mini,
    uint64 new_next_addr = next_addr + cache_page_size(mini->cc);
    mini_unlock_batch_set_next_addr(mini, batch, new_next_addr);
    return next_addr;
+
+extent_allocation_failure:
+   mini_unlock_batch_set_next_addr(mini, batch, next_addr);
+   return 0;
 }
 
 /*

--- a/src/mini_allocator.h
+++ b/src/mini_allocator.h
@@ -32,7 +32,7 @@ typedef struct mini_allocator {
    uint64          next_extent[MINI_MAX_BATCHES];
 } mini_allocator;
 
-uint64
+MUST_CHECK_RESULT uint64
 mini_init(mini_allocator *mini,
           cache *         cc,
           data_config *   cfg,
@@ -44,7 +44,7 @@ mini_init(mini_allocator *mini,
 void
 mini_release(mini_allocator *mini, const slice key);
 
-uint64
+MUST_CHECK_RESULT uint64
 mini_alloc(mini_allocator *mini,
            uint64          batch,
            const slice     key,

--- a/src/platform_linux/platform_types.h
+++ b/src/platform_linux/platform_types.h
@@ -101,7 +101,8 @@ typedef struct {
 
 #define UNUSED_PARAM(_parm) _parm  __attribute__((__unused__))
 #define UNUSED_TYPE(_parm) UNUSED_PARAM(_parm)
-#define MUST_CHECK_RESULT   __attribute__((warn_unused_result))
+/* #define MUST_CHECK_RESULT   __attribute__((warn_unused_result)) */
+#define MUST_CHECK_RESULT
 
 #define ROUNDUP(x,y)    (((x) + (y) - 1) / (y) * (y))
 #define ROUNDDOWN(x,y)  ((x) / (y) * (y))

--- a/src/platform_linux/platform_types.h
+++ b/src/platform_linux/platform_types.h
@@ -101,6 +101,7 @@ typedef struct {
 
 #define UNUSED_PARAM(_parm) _parm  __attribute__((__unused__))
 #define UNUSED_TYPE(_parm) UNUSED_PARAM(_parm)
+#define MUST_CHECK_RESULT   __attribute__((warn_unused_result))
 
 #define ROUNDUP(x,y)    (((x) + (y) - 1) / (y) * (y))
 #define ROUNDDOWN(x,y)  ((x) / (y) * (y))

--- a/src/platform_linux/platform_types.h
+++ b/src/platform_linux/platform_types.h
@@ -101,8 +101,8 @@ typedef struct {
 
 #define UNUSED_PARAM(_parm) _parm  __attribute__((__unused__))
 #define UNUSED_TYPE(_parm) UNUSED_PARAM(_parm)
-/* #define MUST_CHECK_RESULT   __attribute__((warn_unused_result)) */
-#define MUST_CHECK_RESULT
+#define MUST_CHECK_RESULT   __attribute__((warn_unused_result))
+/* #define MUST_CHECK_RESULT */
 
 #define ROUNDUP(x,y)    (((x) + (y) - 1) / (y) * (y))
 #define ROUNDDOWN(x,y)  ((x) / (y) * (y))

--- a/src/rc_allocator.h
+++ b/src/rc_allocator.h
@@ -92,7 +92,7 @@ rc_allocator_config_init(rc_allocator_config *allocator_cfg,
                          uint64               extent_size,
                          uint64               capacity);
 
-platform_status
+MUST_CHECK_RESULT platform_status
 rc_allocator_init(rc_allocator *       al,
                   rc_allocator_config *cfg,
                   io_handle *          io,
@@ -103,7 +103,7 @@ rc_allocator_init(rc_allocator *       al,
 void
 rc_allocator_deinit(rc_allocator *al);
 
-platform_status
+MUST_CHECK_RESULT platform_status
 rc_allocator_mount(rc_allocator *       al,
                    rc_allocator_config *cfg,
                    io_handle *          io,

--- a/src/routing_filter.c
+++ b/src/routing_filter.c
@@ -447,7 +447,7 @@ routing_filter_add(cache *          cc,
    // set up the index pages
    uint64 addrs_per_page = page_size / sizeof(uint64);
    page_handle *index_page[MAX_PAGES_PER_EXTENT];
-   uint64       index_addr = mini_alloc(&mini, 0, NULL, NULL);
+   uint64       index_addr = mini_alloc(&mini, 0, NULL_SLICE, NULL);
    if (index_addr == 0 || index_addr % extent_size != 0) {
       platform_error_log("Failed to allocate first index page for filter\n");
       rc = STATUS_NO_SPACE;

--- a/src/routing_filter.h
+++ b/src/routing_filter.h
@@ -79,15 +79,15 @@ typedef struct routing_async_ctxt {
    cache_async_ctxt    *cache_ctxt;   // cache ctxt for async get
 } routing_async_ctxt;
 
-platform_status
-routing_filter_add(cache            *cc,
-                   routing_config   *cfg,
-                   platform_heap_id  hid,
-                   routing_filter   *old_filter,
-                   routing_filter   *filter,
-                   uint32           *new_fp_arr,
-                   uint64            num_new_fingerprints,
-                   uint16            value);
+MUST_CHECK_RESULT platform_status
+routing_filter_add(cache *          cc,
+                   routing_config * cfg,
+                   platform_heap_id hid,
+                   routing_filter * old_filter,
+                   routing_filter * filter,
+                   uint32 *         new_fp_arr,
+                   uint64           num_new_fingerprints,
+                   uint16           value);
 
 platform_status
 routing_filter_lookup(cache *         cc,

--- a/src/shard_log.c
+++ b/src/shard_log.c
@@ -14,7 +14,7 @@
 
 #include "poison.h"
 
-#define SHARD_WAIT 1
+#define SHARD_WAIT     1
 #define SHARD_UNMAPPED UINT64_MAX
 
 static uint64 shard_log_magic_idx = 0;
@@ -75,9 +75,9 @@ MUST_CHECK_RESULT platform_status
 shard_log_init(shard_log *log, cache *cc, shard_log_config *cfg)
 {
    memset(log, 0, sizeof(shard_log));
-   log->cc            = cc;
-   log->cfg           = cfg;
-   log->super.ops     = &shard_log_ops;
+   log->cc        = cc;
+   log->cfg       = cfg;
+   log->super.ops = &shard_log_ops;
 
    allocator *     al = cache_allocator(cc);
    platform_status rc = allocator_alloc(al, &log->meta_head, PAGE_TYPE_LOG);
@@ -107,8 +107,8 @@ shard_log_init(shard_log *log, cache *cc, shard_log_config *cfg)
 
 
    for (threadid thr_i = 0; thr_i < MAX_THREADS; thr_i++) {
-      shard_log_thread_data *thread_data
-         = shard_log_get_thread_data(log, thr_i);
+      shard_log_thread_data *thread_data =
+         shard_log_get_thread_data(log, thr_i);
       thread_data->addr   = SHARD_UNMAPPED;
       thread_data->offset = 0;
    }

--- a/src/shard_log.h
+++ b/src/shard_log.h
@@ -60,10 +60,8 @@ typedef struct shard_log_hdr {
    uint16        num_entries;
 } shard_log_hdr;
 
-platform_status
-shard_log_init(shard_log        *log,
-               cache            *cc,
-               shard_log_config *cfg);
+MUST_CHECK_RESULT platform_status
+shard_log_init(shard_log *log, cache *cc, shard_log_config *cfg);
 
 void
 shard_log_zap(shard_log *log);

--- a/src/splinter.c
+++ b/src/splinter.c
@@ -3002,7 +3002,8 @@ splinter_memtable_compact_and_build_filter(splinter_handle *spl,
       spl->stats[tid].root_compactions++;
       pack_start = platform_get_timestamp();
    }
-   btree_pack(&req);
+   platform_status rc = btree_pack(&req);
+   platform_assert_status_ok(rc);
    platform_assert(req.num_tuples <= spl->cfg.max_tuples_per_node);
    debug_assert(req.num_tuples <= spl->cfg.mt_cfg.max_tuples_per_memtable);
    if (spl->cfg.use_stats) {
@@ -3029,9 +3030,14 @@ splinter_memtable_compact_and_build_filter(splinter_handle *spl,
    uint32 *dup_fp_arr = TYPED_ARRAY_MALLOC(spl->heap_id, dup_fp_arr, req.num_tuples);
    memmove(dup_fp_arr, cmt->req->fp_arr, req.num_tuples * sizeof(uint32));
    routing_filter empty_filter = { 0 };
-   platform_status rc = routing_filter_add(spl->cc, &spl->cfg.leaf_filter_cfg,
-         spl->heap_id, &empty_filter, &cmt->filter, cmt->req->fp_arr,
-         req.num_tuples, 0);
+   rc                          = routing_filter_add(spl->cc,
+                           &spl->cfg.leaf_filter_cfg,
+                           spl->heap_id,
+                           &empty_filter,
+                           &cmt->filter,
+                           cmt->req->fp_arr,
+                           req.num_tuples,
+                           0);
    // platform_log("cre filter %lu in %lu (%u)\n",
    //      cmt->filter.addr, spl->root_addr,
    //      allocator_get_ref(spl->al, cmt->filter.addr));
@@ -4578,7 +4584,8 @@ splinter_compact_bundle(void *arg,
    if (spl->cfg.use_stats) {
       pack_start = platform_get_timestamp();
    }
-   btree_pack(&pack_req);
+   rc = btree_pack(&pack_req);
+   platform_assert_status_ok(rc);
    if (spl->cfg.use_stats) {
       spl->stats[tid].compaction_pack_time_ns[height]
          += platform_timestamp_elapsed(pack_start);

--- a/src/splinter.c
+++ b/src/splinter.c
@@ -734,11 +734,11 @@ splinter_release_super_block(splinter_handle *spl,
  *-----------------------------------------------------------------------------
  */
 
-   static inline uint16 splinter_height(splinter_handle * spl,
-                                        page_handle * node)
-   {
-      splinter_trunk_hdr *hdr = (splinter_trunk_hdr *)node->data;
-      return hdr->height;
+static inline uint16
+splinter_height(splinter_handle *spl, page_handle *node)
+{
+   splinter_trunk_hdr *hdr = (splinter_trunk_hdr *)node->data;
+   return hdr->height;
 }
 
 static inline uint16

--- a/src/splinter.h
+++ b/src/splinter.h
@@ -339,23 +339,23 @@ splinter_range(splinter_handle *spl,
                uint64 *         tuples_returned,
                char *           out);
 
-splinter_handle *
-splinter_create(splinter_config * cfg,
-                allocator *       al,
-                cache *           cc,
-                task_system *     ts,
-                allocator_root_id id,
-                platform_heap_id  hid);
+MUST_CHECK_RESULT splinter_handle *
+                  splinter_create(splinter_config * cfg,
+                                  allocator *       al,
+                                  cache *           cc,
+                                  task_system *     ts,
+                                  allocator_root_id id,
+                                  platform_heap_id  hid);
 void
 splinter_destroy(splinter_handle *spl);
-splinter_handle *
-splinter_mount(splinter_config * cfg,
-               allocator *       al,
-               cache *           cc,
-               task_system *     ts,
-               allocator_root_id id,
-               platform_heap_id  hid);
-void
+MUST_CHECK_RESULT splinter_handle *
+                  splinter_mount(splinter_config * cfg,
+                                 allocator *       al,
+                                 cache *           cc,
+                                 task_system *     ts,
+                                 allocator_root_id id,
+                                 platform_heap_id  hid);
+MUST_CHECK_RESULT platform_status
 splinter_dismount(splinter_handle *spl);
 
 void

--- a/src/variable_length_btree.c
+++ b/src/variable_length_btree.c
@@ -1313,7 +1313,7 @@ variable_length_btree_init(cache *                             cc,
    uint64          base_addr;
    platform_status rc = allocator_alloc(al, &base_addr, type);
    if (!SUCCESS(rc)) {
-      return rc;
+      return 0;
    }
    // set up the mini allocator
    uint64 first_address = mini_init(mini,
@@ -1325,7 +1325,7 @@ variable_length_btree_init(cache *                             cc,
                                     type,
                                     type == PAGE_TYPE_BRANCH);
    if (!first_address) {
-      allocator_dec_ref(al.base_addr, type);
+      allocator_dec_ref(al, base_addr, type);
       return 0;
    }
 

--- a/tests/btree_test.c
+++ b/tests/btree_test.c
@@ -857,7 +857,8 @@ test_btree_merge_basic(cache             *cc,
       btree_pack_req req;
       btree_pack_req_init(&req, cc, btree_cfg, &merge_itor->super, 0, NULL, 0,
             hid);
-      btree_pack(&req);
+      rc = btree_pack(&req);
+      platform_assert_status_ok(rc);
       output_addr[pivot_no] = req.root_addr;
 
       for (uint64 tree_no = 0; tree_no < arity; tree_no++) {
@@ -1180,7 +1181,8 @@ test_btree_merge_perf(cache             *cc,
          btree_pack_req req;
          btree_pack_req_init(&req, cc, btree_cfg, &merge_itor->super, 0, NULL, 0,
                hid);
-         btree_pack(&req);
+         rc = btree_pack(&req);
+         platform_assert_status_ok(rc);
          output_addr[merge_no * num_merges + pivot_no] = req.root_addr;
          for (uint64 tree_no = 0; tree_no < arity; tree_no++) {
             btree_iterator_deinit(&btree_itor_arr[tree_no]);

--- a/tests/fault_injection_allocator.c
+++ b/tests/fault_injection_allocator.c
@@ -1,0 +1,146 @@
+#include "fault_injection_allocator.h"
+
+static inline MUST_CHECK_RESULT platform_status
+fault_injection_allocator_alloc(allocator *al, uint64 *addr, page_type type)
+{
+   fault_injection_allocator *fia = (fault_injection_allocator *)al;
+
+   uint64 burst_size;
+   while ((burst_size = fia->current_burst_size)) {
+      bool part_of_burst = __sync_bool_compare_and_swap(
+         &fia->current_burst_size, burst_size, burst_size - 1);
+      if (part_of_burst) {
+         return STATUS_NO_SPACE;
+      }
+   }
+
+   if (random_next_uint64(&fia->rs) < fia->failure_probability) {
+      burst_size = random_next_uint64(&fia->rs) % fia->burst_size;
+      __sync_fetch_and_add(&fia->current_burst_size, burst_size);
+      return STATUS_NO_SPACE;
+   }
+
+   return allocator_alloc(fia->base, addr, type);
+}
+
+static uint8
+fault_injection_allocator_inc_ref(allocator *a, uint64 addr)
+{
+   fault_injection_allocator *fia = (fault_injection_allocator *)a;
+   return allocator_inc_ref(fia->base, addr);
+}
+
+static uint8
+fault_injection_allocator_dec_ref(allocator *a, uint64 addr, page_type type)
+{
+   fault_injection_allocator *fia = (fault_injection_allocator *)a;
+   return allocator_dec_ref(fia->base, addr, type);
+}
+
+static uint8
+fault_injection_allocator_get_ref(allocator *a, uint64 addr)
+{
+   fault_injection_allocator *fia = (fault_injection_allocator *)a;
+   return allocator_get_ref(fia->base, addr);
+}
+
+static platform_status
+fault_injection_allocator_get_super_addr(allocator *       a,
+                                         allocator_root_id spl_id,
+                                         uint64 *          addr)
+{
+   fault_injection_allocator *fia = (fault_injection_allocator *)a;
+   return allocator_get_super_addr(fia->base, spl_id, addr);
+}
+
+static platform_status
+fault_injection_allocator_alloc_super_addr(allocator *       a,
+                                           allocator_root_id spl_id,
+                                           uint64 *          addr)
+{
+   fault_injection_allocator *fia = (fault_injection_allocator *)a;
+   return allocator_alloc_super_addr(fia->base, spl_id, addr);
+}
+
+static void
+fault_injection_allocator_remove_super_addr(allocator *       a,
+                                            allocator_root_id spl_id)
+{
+   fault_injection_allocator *fia = (fault_injection_allocator *)a;
+   return allocator_remove_super_addr(fia->base, spl_id);
+}
+
+static uint64
+fault_injection_allocator_get_capacity(allocator *a)
+{
+   fault_injection_allocator *fia = (fault_injection_allocator *)a;
+   return allocator_get_capacity(fia->base);
+}
+
+static uint64
+fault_injection_allocator_extent_size(allocator *a)
+{
+   fault_injection_allocator *fia = (fault_injection_allocator *)a;
+   return allocator_extent_size(fia->base);
+}
+
+static uint64
+fault_injection_allocator_page_size(allocator *a)
+{
+   fault_injection_allocator *fia = (fault_injection_allocator *)a;
+   return allocator_page_size(fia->base);
+}
+
+static void
+fault_injection_allocator_assert_noleaks(allocator *a)
+{
+   fault_injection_allocator *fia = (fault_injection_allocator *)a;
+   return allocator_assert_noleaks(fia->base);
+}
+
+static void
+fault_injection_allocator_print_stats(allocator *a)
+{
+   fault_injection_allocator *fia = (fault_injection_allocator *)a;
+   return allocator_print_stats(fia->base);
+}
+
+static void
+fault_injection_allocator_debug_print(allocator *a)
+{
+   fault_injection_allocator *fia = (fault_injection_allocator *)a;
+   return allocator_debug_print(fia->base);
+}
+
+const static allocator_ops fault_injection_allocator_ops = {
+   .alloc             = fault_injection_allocator_alloc,
+   .inc_ref           = fault_injection_allocator_inc_ref,
+   .dec_ref           = fault_injection_allocator_dec_ref,
+   .get_ref           = fault_injection_allocator_get_ref,
+   .get_super_addr    = fault_injection_allocator_get_super_addr,
+   .alloc_super_addr  = fault_injection_allocator_alloc_super_addr,
+   .remove_super_addr = fault_injection_allocator_remove_super_addr,
+   .get_capacity      = fault_injection_allocator_get_capacity,
+   .get_extent_size   = fault_injection_allocator_extent_size,
+   .get_page_size     = fault_injection_allocator_page_size,
+   .assert_noleaks    = fault_injection_allocator_assert_noleaks,
+   .print_stats       = fault_injection_allocator_print_stats,
+   .debug_print       = fault_injection_allocator_debug_print,
+};
+
+
+MUST_CHECK_RESULT platform_status
+fault_injection_allocator_init(fault_injection_allocator *al,
+                               allocator *                base,
+                               uint64                     failure_probability,
+                               uint64                     burst_size,
+                               uint64                     seed)
+{
+   al->super.ops              = &fault_injection_allocator_ops;
+   al->base                   = base;
+   al->failure_probability    = failure_probability;
+   al->burst_size             = burst_size;
+   random_init(&al->rs, seed, 0);
+   al->current_burst_size = 0;
+   return STATUS_OK;
+}

--- a/tests/fault_injection_allocator.c
+++ b/tests/fault_injection_allocator.c
@@ -136,10 +136,10 @@ fault_injection_allocator_init(fault_injection_allocator *al,
                                uint64                     burst_size,
                                uint64                     seed)
 {
-   al->super.ops              = &fault_injection_allocator_ops;
-   al->base                   = base;
-   al->failure_probability    = failure_probability;
-   al->burst_size             = burst_size;
+   al->super.ops           = &fault_injection_allocator_ops;
+   al->base                = base;
+   al->failure_probability = failure_probability;
+   al->burst_size          = burst_size;
    random_init(&al->rs, seed, 0);
    al->current_burst_size = 0;
    return STATUS_OK;

--- a/tests/fault_injection_allocator.h
+++ b/tests/fault_injection_allocator.h
@@ -1,0 +1,22 @@
+#include "rc_allocator.h"
+#include "random.h"
+
+typedef struct fault_injection_allocator {
+   allocator  super;
+   allocator *base;
+
+   /* Configuration */
+   uint64 failure_probability;
+   uint64 burst_size;
+
+   /* State */
+   random_state rs;
+   uint64       current_burst_size;
+} fault_injection_allocator;
+
+MUST_CHECK_RESULT platform_status
+fault_injection_allocator_init(fault_injection_allocator *al,
+                               allocator *                base,
+                               uint64                     failure_probability,
+                               uint64                     burst_size,
+                               uint64                     seed);

--- a/tests/log_test.c
+++ b/tests/log_test.c
@@ -71,7 +71,8 @@ test_log_crash(clockcache *         cc,
       slice skey = slice_create(1 + (i % cfg->data_cfg->key_size), keybuffer);
       slice smessage =
          slice_create(1 + ((7 + i) % cfg->data_cfg->message_size), databuffer);
-      log_write(logh, skey, smessage, i);
+      rc = log_write(logh, skey, smessage, i);
+      platform_assert_status_ok(rc);
    }
 
    if (crash) {
@@ -157,7 +158,8 @@ test_log_thread(void *arg)
    for (i = thread_id * num_entries; i < (thread_id + 1) * num_entries; i++) {
       test_key(key, TEST_RANDOM, i, 0, 0, log->cfg->data_cfg->key_size, 0);
       test_insert_data(data, 1, &dummy, 0, log->cfg->data_cfg->message_size, MESSAGE_TYPE_INSERT);
-      log_write(logh, skey, smessage, i);
+      platform_status rc = log_write(logh, skey, smessage, i);
+      platform_assert_status_ok(rc);
    }
 
    platform_free(hid, data);

--- a/tests/splinter_test.c
+++ b/tests/splinter_test.c
@@ -2592,8 +2592,9 @@ splinter_test(int argc, char *argv[])
    }
 
    rc_allocator al;
-   rc_allocator_init(&al, &al_cfg, (io_handle *)io, hh, hid,
-                     platform_get_module_id());
+   rc = rc_allocator_init(
+      &al, &al_cfg, (io_handle *)io, hh, hid, platform_get_module_id());
+   platform_assert_status_ok(rc);
 
    platform_error_log("Running splinter_test with %d caches\n", num_caches);
    clockcache *cc = TYPED_ARRAY_MALLOC(hid, cc, num_caches);

--- a/tests/splinter_test.c
+++ b/tests/splinter_test.c
@@ -2596,7 +2596,12 @@ splinter_test(int argc, char *argv[])
       &al, &al_cfg, (io_handle *)io, hh, hid, platform_get_module_id());
    platform_assert_status_ok(rc);
    fault_injection_allocator fia;
-   rc = fault_injection_allocator_init(&fia, (allocator *)&al, 0, 0, 0);
+   rc = fault_injection_allocator_init(
+      &fia,
+      (allocator *)&al,
+      ((uint64)-1) >> test_cfg->allocator_failure_log_probability,
+      test_cfg->allocator_failure_burst_size,
+      seed);
    platform_assert_status_ok(rc);
    allocator *alp = (allocator *)&fia;
 

--- a/tests/splinter_test.h
+++ b/tests/splinter_test.h
@@ -31,13 +31,16 @@ typedef struct test_config {
    uint64        semiseq_freq; // random key every this many keys
    uint64        period;       // if TEST_PERIODIC then repeat sequence after
                                // this many keys
-   uint64        num_periods;  // if TEST_PERIODIC then repeat this many times
+   uint64 num_periods;         // if TEST_PERIODIC then repeat this many times
+   uint64 allocator_failure_log_probability;
+   uint64 allocator_failure_burst_size;
 } test_config;
 
 static inline void
 test_config_set_defaults(test_type test, test_config *cfg)
 {
-   cfg->tree_size = GiB_TO_B(40);
+   cfg->tree_size                         = GiB_TO_B(40);
+   cfg->allocator_failure_log_probability = 63;
    switch (test) {
       case perf:
          cfg->key_type = TEST_RANDOM;
@@ -111,9 +114,21 @@ test_config_parse(test_config  *cfg,
       } config_set_uint64("semiseq-freq", cfg, semiseq_freq) {
          *argc_p -= 2;
          *argv_p += 2;
-      } config_set_else {
-         goto out;
       }
+      config_set_uint64("alloc-failure-log-probability",
+                        cfg,
+                        allocator_failure_log_probability)
+      {
+         *argc_p -= 2;
+         *argv_p += 2;
+      }
+      config_set_uint64(
+         "alloc-failure-burst-size", cfg, allocator_failure_burst_size)
+      {
+         *argc_p -= 2;
+         *argv_p += 2;
+      }
+      config_set_else { goto out; }
    }
 out:
    platform_free(platform_get_heap_id(), temp_cfg);

--- a/tests/test_functionality.c
+++ b/tests/test_functionality.c
@@ -518,10 +518,9 @@ insert_random_messages(splinter_handle *          spl,
       //if (key == 0x02f90065)
       //   platform_log("Inserting message: %8d OP=%d Key=0x%08lx Value=%8d\n", i, op, key, msg->ref_count);
 
-      rc = splinter_insert(spl, keybuf, (char *)msg);
-      if (!SUCCESS(rc)) {
-         return rc;
-      }
+      do {
+         rc = splinter_insert(spl, keybuf, (char *)msg);
+      } while (!SUCCESS(rc));
 
       // Now apply same operation to the shadow
       int8 new_refcount = msg->ref_count;

--- a/tests/ycsb_test.c
+++ b/tests/ycsb_test.c
@@ -1292,7 +1292,8 @@ ycsb_test(int argc, char *argv[])
 
    run_all_ycsb_phases(spl, phases, nphases, ts, hid);
 
-   splinter_dismount(spl);
+   rc = splinter_dismount(spl);
+   platform_assert_status_ok(rc);
    clockcache_deinit(cc);
    platform_free(hid, cc);
    rc_allocator_dismount(&al);


### PR DESCRIPTION
This patch starts the work of plumbing through error handling for disk-space allocation failures.

It replaces many asserts with code to clean up and return an error.  The error handling code has not been extensively tested, but it's a start.

This patch also adds a `MUST_CHECK_RETURN` annotation for functions, indicating that it is an error to ignore their return value.  Unfortunately, gcc and clang don't require that you actually do anything useful with the return value other than save it to a local variable, but it does help find call sites that are discarding a return value.

The patch also adds a new `allocator` that wraps the existing `rc_allocator` and throws random allocation failures.  The goal of this allocator is to test the error handling in splinter.

This patch also modifies the `functionality` test to retry insertions when there is an error.  Thus, in theory, `functionality` should run and get correct results even when the fault injection allocation scheme is being used.  It does not yet pass that test, so I've not yet added it to `test.sh`.

One major outstanding item is `splinter_split_leaf`, but I am sure there are many other places that also slipped through.
