### PR TITLE
Support managing output file handle(s) for platform logging fns.

### DIFF
--- a/src/platform_linux/platform.c
+++ b/src/platform_linux/platform.c
@@ -10,6 +10,19 @@ __thread threadid xxxtid;
 bool platform_use_hugetlb = FALSE;
 bool platform_use_mlock = FALSE;
 
+// By default, currently all platform_log() messages go to stdout, and
+// platform_error_log() messages go to stderr. These can be changed to
+// module- or test-specific log files, by overriding these settings.
+FILE *platform_stdout_fh = NULL; // => Output goes to stdout
+FILE *platform_stderr_fh = NULL; // => Output goes to stderr
+
+// This function is run automatically at library-load time
+void __attribute__((constructor)) platform_init_log_file_handles(void)
+{
+   platform_stdout_fh = stdout;
+   platform_stderr_fh = stderr;
+}
+
 platform_status
 platform_heap_create(platform_module_id UNUSED_PARAM(module_id),
                      uint32 max,
@@ -18,6 +31,7 @@ platform_heap_create(platform_module_id UNUSED_PARAM(module_id),
 {
    *heap_handle = NULL;
    *heap_id = NULL;
+
    return STATUS_OK;
 }
 

--- a/src/platform_linux/platform_inline.h
+++ b/src/platform_linux/platform_inline.h
@@ -227,9 +227,14 @@ platform_status_to_string(const platform_status status)
    return strerror(status.r);
 }
 
+/* Default output file handles for different logging interfaces */
 #define PLATFORM_DEFAULT_LOG_HANDLE stdout
 #define PLATFORM_ERR_LOG_HANDLE stderr
 #define PLATFORM_CR "\r"
+
+// See platform.c
+extern FILE *platform_stdout_fh; // File handle for stdout
+extern FILE *platform_stderr_fh; // File handle for stderr
 
 #define platform_open_log_stream()              \
    char *bp;                                    \
@@ -252,9 +257,9 @@ platform_status_to_string(const platform_status status)
       fprintf(stream, __VA_ARGS__);             \
    } while (0)
 
-#define platform_log(...)                       \
-   do {                                         \
-      printf(__VA_ARGS__);                      \
+#define platform_log(...)                                                      \
+   do {                                                                        \
+      fprintf(platform_stdout_fh, __VA_ARGS__);                                \
    } while (0)
 
 #define platform_throttled_log(sec, ...)        \
@@ -268,10 +273,11 @@ platform_status_to_string(const platform_status status)
       fflush(stdout);                           \
    } while (0)
 
-#define platform_error_log(...)                 \
-   do {                                         \
-      fprintf(stderr, __VA_ARGS__);             \
-      fflush(stderr);                           \
+
+#define platform_error_log(...)                                                \
+   do {                                                                        \
+      fprintf(platform_stderr_fh, __VA_ARGS__);                                \
+      fflush(platform_stderr_fh);                                              \
    } while (0)
 
 #define platform_throttled_error_log(sec, ...)  \


### PR DESCRIPTION
This commit introduces a small infrastructure to manage the file descriptor where output from platform_log() and platform_error_log() will go to. 

Currently, this goes to stdout / stderr, respectively. This change provides the ability to swizzle the output fh for each
interface to either /dev/null, or to some user-specified logfile, depending on how the configuration is setup.

This change is introduced initially to support CTests. The goal is to leverage this fh swizzling while running CTests to redirect info-msg outputs off of stdout/stderr, so that these messages do not clutter up stdout when running tests.