### PR TITLE
Build artifacts include git ref

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,10 @@ include .libconfig.mk
 DEFAULT_CFLAGS += -D_GNU_SOURCE -ggdb3 -Wall -pthread -Wfatal-errors -Werror
 DEFAULT_CFLAGS += -DXXH_STATIC_LINKING_ONLY -fPIC
 
+# track git ref in the built library
+GIT_VERSION := "$(shell git describe --abbrev=8 --dirty --always --tags)"
+DEFAULT_CFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
+
 cpu_arch := $(shell uname -p)
 ifeq ($(cpu_arch),x86_64)
   # not supported on ARM64

--- a/include/splinterdb/kvstore_basic.h
+++ b/include/splinterdb/kvstore_basic.h
@@ -214,4 +214,8 @@ kvstore_basic_iter_get_current(kvstore_basic_iterator *iter,    // IN
 int
 kvstore_basic_iter_status(const kvstore_basic_iterator *iter);
 
+// Returns a C string with the build version of this library
+const char *
+kvstore_basic_get_version();
+
 #endif // _KVSTORE_BASIC_H_

--- a/src/config.c
+++ b/src/config.c
@@ -3,6 +3,8 @@
 
 #include "config.h"
 
+const char *BUILD_VERSION = "splinterdb_build_version " GIT_VERSION;
+
 void
 config_set_defaults(master_config *cfg)
 {

--- a/src/config.h
+++ b/src/config.h
@@ -18,6 +18,8 @@
 #include "splinter.h"
 #include "util.h"
 
+extern const char *BUILD_VERSION;
+
 typedef struct master_config {
    uint64 page_size;
    uint64 extent_size;

--- a/src/kvstore_basic.c
+++ b/src/kvstore_basic.c
@@ -11,6 +11,7 @@
 
 #include "platform.h"
 
+#include "config.h"
 #include "splinterdb/kvstore.h"
 #include "splinterdb/kvstore_basic.h"
 #include "util.h"
@@ -543,4 +544,10 @@ kvstore_basic_iter_get_current(kvstore_basic_iterator *iter,    // IN
    *val_len                    = msg->value_length;
    *key                        = (char *)(key_enc->data);
    *value                      = (char *)(msg->value);
+}
+
+const char *
+kvstore_basic_get_version()
+{
+   return BUILD_VERSION;
 }

--- a/tests/functional/test_dispatcher.c
+++ b/tests/functional/test_dispatcher.c
@@ -28,6 +28,7 @@ usage(void)
 int
 test_dispatcher(int argc, char *argv[])
 {
+   platform_log("%s: %s\n", argv[0], BUILD_VERSION);
    // check first arg and call the appropriate test
    if (argc > 1) {
       // check test name and dispatch


### PR DESCRIPTION
With this change, the git-sha is included in build output.

So you can do things like:

```sh
$ bin/driver_test
bin/driver_test: splinterdb_build_version 393c8beb
```

or

```sh
$ strings lib/libsplinterdb.so | grep splinterdb_build
splinterdb_build_version 393c8beb
```

or

```sh
$ strings lib/libsplinterdb.a | grep splinterdb_build
splinterdb_build_version 393c8beb
```

or to find out the version of SplinterDB statically linked into another program:

```sh
$ strings kiwi | grep splinterdb_build
splinterdb_build_version d52ea9f2
```

If your build was made with uncommitted changes, you'll see `-dirty` on the end, e.g.
```sh
$ strings kiwi | grep splinterdb_build
splinterdb_build_version d52ea9f2-dirty
```