### PR TITLE
fix divide-by-zero in splinter_split_leaf

### DIFF
--- a/src/splinter.c
+++ b/src/splinter.c
@@ -5062,10 +5062,11 @@ splinter_split_leaf(splinter_handle *spl,
    }
    splinter_compaction_type comp_type = SPLINTER_COMPACTION_TYPE_LEAF_SPLIT;
    uint64 target_num_leaves = estimated_unique_keys / spl->cfg.target_leaf_tuples;
-   if (target_num_leaves == 1) {
+   if (target_num_leaves <= 1) {
       if (estimated_unique_keys > splinter_single_leaf_threshold(spl)) {
          target_num_leaves = 2;
       } else {
+         target_num_leaves = 1;
          comp_type = SPLINTER_COMPACTION_TYPE_SINGLE_LEAF_SPLIT;
          if (spl->cfg.use_stats) {
             spl->stats[tid].single_leaf_splits++;


### PR DESCRIPTION
I hit this while testing an integration

```
Process 1767920 stopped
* thread #5, name = 'app-wr', stop reason = signal SIGFPE: integer divide by zero
    frame #0: 0x000055e7ada92c1a appserver`splinter_split_leaf(spl=0x00007f9d7da21a40, parent=0x00007f9d7d981180, leaf=0x00007f9d7d9812b8, child_idx=0) at splinter.c:5020:43
   5017          }
   5018       }
   5019    }
-> 5020    uint64 target_leaf_tuples = num_tuples / target_num_leaves;
   5021    uint64 target_num_pivots =
   5022       (target_leaf_tuples - 1) / spl->cfg.btree_cfg.tuples_per_leaf + 1;
   5023    uint16 num_leaves;
```
with
```
(lldb) frame variable num_tuples
(uint64) num_tuples = 2489500
(lldb) frame variable target_num_leaves
(uint64) target_num_leaves = 0
(lldb) frame variable estimated_unique_keys
(uint64) estimated_unique_keys = 434270
(lldb) frame variable spl->cfg.target_leaf_tuples
(uint64) spl->cfg.target_leaf_tuples = 662256
```

 @ajhconway suggested the fix in this commit.

I don't see an easy way to cover this with a test: the reproducer relied on the workload of the integrated app; a unit test would require some deeper refactoring.