### PR TITLE
(#171) Rework Makefile rules to build standalone unit-tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,9 +28,16 @@ OBJ := $(SRC:%.c=$(OBJDIR)/%.o)
 FUNCTIONAL_TESTOBJ= $(FUNCTIONAL_TESTSRC:%.c=$(OBJDIR)/%.o)
 
 # Objects from unit-test sources in tests/unit/ sub-dir
-UNIT_TESTOBJ= $(UNIT_TESTSRC:%.c=$(OBJDIR)/%.o)
+# Resolves to a list: obj/tests/unit/a.o obj/tests/unit/b.o ...
+UNIT_TESTOBJS= $(UNIT_TESTSRC:%.c=$(OBJDIR)/%.o)
 
-UNITBINS= $(UNITSRC:%.c=$(BINDIR)/%)
+# Binaries from unit-test sources in tests/unit/ sub-dir
+# Although the sources are in, say, tests/unit/kvstore_basic_test.c, and so on ...
+# the binaries are named bin/unit/kvstore_basic_test (Drop the 'tests'.)
+# Resolves to a list: bin/unit/a bin/unit/b ...
+UNIT_TESTBINS= $(UNIT_TESTSRC:tests/%.c=$(BINDIR)/%)
+
+UNITBINS= $(UNITSRC:%.c=%)
 
 # Automatically create directories, based on
 # http://ismail.badawi.io/blog/2017/03/28/automatic-directory-creation-in-make/
@@ -98,7 +105,10 @@ LIBS = -lm -lpthread -laio -lxxhash $(LIBCONFIG_LIBS)
 # Targets to track whether we have a release or debug build
 #
 all: $(LIBDIR)/libsplinterdb.so $(LIBDIR)/libsplinterdb.a $(BINDIR)/driver_test $(UNITBINS) \
-        $(BINDIR)/unit_test
+        unit_test
+
+# Any libraries required to link test code will be built, if needed.
+tests: $(BINDIR)/driver_test $(UNITBINS) unit_test
 
 release: .release all
 	rm -f .debug
@@ -136,8 +146,10 @@ debug-log: .debug-log all
 $(BINDIR)/driver_test : $(FUNCTIONAL_TESTOBJ) $(LIBDIR)/libsplinterdb.so | $$(@D)/.
 	$(LD) $(LDFLAGS) -o $@ $^ $(LIBS)
 
-$(BINDIR)/unit_test : $(UNIT_TESTOBJ) $(LIBDIR)/libsplinterdb.so | $$(@D)/.
-	$(LD) $(LDFLAGS) -o $@ $^ $(LIBS)
+# Target will build everything needed to generate bin/unit_test along with all
+# the individual binaries for each unit-test case.
+unit_test: $(UNIT_TESTBINS) $(LIBDIR)/libsplinterdb.so
+	$(LD) $(LDFLAGS) -o $(BINDIR)/$@ $(UNIT_TESTOBJS) $(LIBDIR)/libsplinterdb.so $(LIBS)
 
 $(LIBDIR)/libsplinterdb.so : $(OBJ) | $$(@D)/.
 	$(LD) $(LDFLAGS) -shared -o $@ $^ $(LIBS)
@@ -159,23 +171,56 @@ $(OBJDIR)/%.o: %.c | $$(@D)/.
 
 -include $(SRC:%.c=$(OBJDIR)/%.d) $(TESTSRC:%.c=$(OBJDIR)/%.d)
 
-#####################################################
+# ###########################################################################
 # Unit test dependencies
 #
 # Each unit test is a self-contained binary.
 # It links only with its needed .o files
-#
+# ###########################################################################
 
-obj/unit/variable_length_btree-test.o: src/variable_length_btree.c
-bin/unit/variable_length_btree-test: obj/tests/functional/test_data.o obj/src/util.o obj/src/data_internal.o obj/src/mini_allocator.o obj/src/rc_allocator.o obj/src/config.o obj/src/clockcache.o obj/src/platform_linux/platform.o obj/src/task.o obj/src/platform_linux/laio.o
+# List the individual unit-tests that can be run standalone and are also
+# rolled-up into a single unit_test binary.
+
+$(OBJDIR)/unit/variable_length_btree-test.o: src/variable_length_btree.c
+unit/variable_length_btree-test: $(OBJDIR)/tests/functional/test_data.o     \
+                                 $(OBJDIR)/src/util.o                       \
+                                 $(OBJDIR)/src/data_internal.o              \
+                                 $(OBJDIR)/src/mini_allocator.o             \
+                                 $(OBJDIR)/src/rc_allocator.o               \
+                                 $(OBJDIR)/src/config.o                     \
+                                 $(OBJDIR)/src/clockcache.o                 \
+                                 $(OBJDIR)/src/platform_linux/platform.o    \
+                                 $(OBJDIR)/src/task.o                       \
+                                 $(OBJDIR)/src/platform_linux/laio.o        \
+                                 $(OBJDIR)/src/platform_linux/platform.o
+	mkdir -p $(BINDIR)/unit;
+	$(LD) $(LDFLAGS) -shared $^ -o $(BINDIR)/$@
+
+# ---- main() is needed to drive each standalone unit-test binary.
+$(BINDIR)/unit/main: $(OBJDIR)/tests/unit/main.o
+$(OBJDIR)/tests/unit/main.o: tests/unit/main.c
+
+# ---- Here onwards, list the rules to build each standalone unit-test binary.
+$(BINDIR)/unit/kvstore_basic_test: unit/kvstore_basic_test
+unit/kvstore_basic_test: $(OBJDIR)/tests/unit/kvstore_basic_test.o        \
+                         $(OBJDIR)/tests/unit/main.o                      \
+                         $(LIBDIR)/libsplinterdb.so
+	mkdir -p $(BINDIR)/unit;
+	$(LD) $(LDFLAGS) -o $(BINDIR)/$@ $^ $(LIBS)
+
+# ----
+$(BINDIR)/unit/kvstore_basic_stress_test: unit/kvstore_basic_stress_test
+unit/kvstore_basic_stress_test: $(OBJDIR)/tests/unit/kvstore_basic_stress_test.o       \
+                                $(OBJDIR)/tests/unit/main.o                      \
+                                $(LIBDIR)/libsplinterdb.so
+	mkdir -p $(BINDIR)/unit;
+	$(LD) $(LDFLAGS) -o $(BINDIR)/$@ $^ $(LIBS)
 
 #*************************************************************#
 
 .PHONY : clean tags
 clean :
-	rm -rf $(OBJDIR)/*
-	rm -rf $(BINDIR)/*
-	rm -f  $(LIBDIR)/*
+	rm -rf $(OBJDIR)/* $(BINDIR)/* $(LIBDIR)/*
 
 tags:
 	ctags -R src
@@ -187,8 +232,11 @@ tags:
 
 .PHONY: test install
 
-test: $(BINDIR)/driver_test $(BINDIR)/unit_test
+run-tests: $(BINDIR)/driver_test $(BINDIR)/unit_test
 	./test.sh
+
+test-results: $(BINDIR)/driver_test $(BINDIR)/unit_test
+	(./test.sh > ./test-results.out 2>&1 &) && echo "tail -f ./test-results.out "
 
 INSTALL_PATH ?= /usr/local
 

--- a/test.sh
+++ b/test.sh
@@ -8,25 +8,39 @@ TEST_RUST="${TEST_RUST:-false}"
 UNIT_TEST_DRIVER="${UNIT_TEST_DRIVER:-"${BINDIR:-bin}/unit_test"}"
 
 # Run all the unit-tests first, to get basic coverage
+echo
 "$UNIT_TEST_DRIVER"
+UNIT_TESTS_DB_DEV="unit_tests_db"
+if [ -f ${UNIT_TESTS_DB_DEV} ]; then
+    rm ${UNIT_TESTS_DB_DEV}
+fi
 
+echo
 "$DRIVER" kvstore_test --seed "$SEED"
 
+echo
 "$DRIVER" kvstore_basic_test --seed "$SEED"
 
+echo
 "$DRIVER" splinter_test --functionality 1000000 100 --seed "$SEED"
 
+echo
 "$DRIVER" splinter_test --perf --max-async-inflight 0 --num-insert-threads 4 --num-lookup-threads 4 --num-range-lookup-threads 0 --tree-size-gib 2 --cache-capacity-mib 512
 
+echo
 "$DRIVER" cache_test --seed "$SEED"
 
+echo
 "$DRIVER" btree_test --seed "$SEED"
 
+echo
 "$DRIVER" log_test --seed "$SEED"
 
+echo
 "$DRIVER" filter_test --seed "$SEED"
 
 "$DRIVER" util_test --seed "$SEED"
+echo
 
 if [ "$TEST_RUST" = "true" ]; then
    pushd rust


### PR DESCRIPTION
This commit refactors slightly the rules for building standalone unit-tests. To simplify developer usage, the target will be: `unit/<programName>`; e.g., `make unit/variable_length_btree-test`, or `make unit/kvstore_basic_test` and so on ...

Refactored rules & targets in Makefile to now support the following:

 - Build bin/unit_test and each stand-alone unit-test separately
 - New targets:
    - tests: Will rebuild only the test code
    - unit_test: Will rebuild only the unit-test code and each stand-alone unit-test binary
    - run-tests: Existing target 'test' renamed to this
    - test-results: Runs all tests and redirects output to  a file in current dir named ./test-results.out

Following usages work with these changes:

Build everything; product and test-code:
-     $ make clean; make

Build just the test-code, including driver_test and unit_test binaries:
-     $ make clean; make tests

Build just the unit-test binary; bin/unit_test:
-     $ make clean; make unit_test

Re-build just the individually named stand-alone unit-test binaries:
-     $ make clean; make unit/variable_length_btree-test
-     $ make clean; make unit/kvstore_basic_test

Following new usages / targets are now possible with this change:

To run all tests you would do:
- `$ make run-tests`

To run all tests and collect outputs to a file named ./test-results, you would do:
- `$ make test-results`