### PR TITLE
(#102) Enhance assertion checks to use platform_assert_impl(), and to print user-supplied info-msg w/values.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@
 .DEFAULT_GOAL := release
 
 PLATFORM = linux
+PLATFORM_DIR = platform_$(PLATFORM)
 
 #*************************************************************#
 # DIRECTORIES, SRC, OBJ, ETC
@@ -240,6 +241,14 @@ unit/variable_length_btree_stress_test: $(OBJDIR)/tests/unit/variable_length_btr
                                  $(VARIABLE_LENGTH_BTREE_TEST_OBJS)
 	mkdir -p $(BINDIR)/unit;
 	$(LD) $(LDFLAGS) -o $(BINDIR)/$@ $^ $(LIBS)
+
+# ----
+$(BINDIR)/unit/misc_test: unit/misc_test
+unit/misc_test: $(OBJDIR)/tests/unit/misc_test.o            \
+                $(OBJDIR)/tests/unit/main.o                 \
+                $(OBJDIR)/src/$(PLATFORM_DIR)/platform.o
+	mkdir -p $(BINDIR)/unit;
+	$(LD) $(LDFLAGS) -o $(BINDIR)/$@ $^
 
 #*************************************************************#
 

--- a/src/platform_linux/platform.h
+++ b/src/platform_linux/platform.h
@@ -557,7 +557,6 @@ platform_strtok_r(char *str, const char *delim, platform_strtok_ctx *ctx);
 #include <platform_inline.h>
 
 
-
 /*
  * Section 6:
  * Non-platform-specific inline implementations

--- a/src/platform_linux/platform_inline.h
+++ b/src/platform_linux/platform_inline.h
@@ -256,6 +256,7 @@ platform_status_to_string(const platform_status status)
 #define platform_log(...)                                                      \
    do {                                                                        \
       fprintf(Platform_stdout_fh, __VA_ARGS__);                                \
+      fflush(Platform_stdout_fh);                                              \
    } while (0)
 
 #define platform_throttled_log(sec, ...)        \
@@ -286,6 +287,7 @@ platform_status_to_string(const platform_status status)
       fprintf(lh, __VA_ARGS__);                 \
       fflush(lh);                               \
    } while (0)
+
 
 #define platform_open_log_file(path, mode) ({   \
    platform_log_handle lh = fopen(path, mode);  \

--- a/src/platform_linux/platform_types.h
+++ b/src/platform_linux/platform_types.h
@@ -64,12 +64,50 @@ typedef void* List_Links;
 #define FRACTION_FMT(w, s) "%"STRINGIFY_VALUE(w)"."STRINGIFY_VALUE(s)"f"
 #define FRACTION_ARGS(f) ((double)(f).numerator / (double)(f).denominator)
 
-
 /*
  * Linux understands that you cannot continue after a failed assert already,
  * so we do not need a workaround for platform_assert in linux
  */
-#define platform_assert( expr ) assert(expr)
+void
+platform_assert_impl(platform_stream_handle stream,
+                     const char *           filename,
+                     int                    linenumber,
+                     const char *           functionname,
+                     bool                   do_abort,
+                     const char *           expr,
+                     int                    exprval,
+                     const char *           message,
+                     ...);
+
+void
+platform_assert_msg(platform_stream_handle stream,
+                    const char *           filename,
+                    int                    linenumber,
+                    const char *           functionname,
+                    const char *           expr,
+                    const char *           message,
+                    va_list                args);
+
+/*
+ * Caller-macro to invoke assertion checking.
+ */
+#define platform_assert(expr, ...)                                             \
+   do {                                                                        \
+      platform_assert_impl(NULL,                                               \
+                           __FILE__,                                           \
+                           __LINE__,                                           \
+                           __FUNCTION__,                                       \
+                           TRUE,                                               \
+                           #expr,                                              \
+                           (expr) != 0,                                        \
+                           "" __VA_ARGS__);                                    \
+      /* Provide first line of defense in case user-supplied print-format and  \
+       * argument types do not match.                                          \
+       */                                                                      \
+      if (FALSE) {                                                             \
+         fprintf(stderr, " " __VA_ARGS__);                                     \
+      }                                                                        \
+   } while (0)
 
 typedef pthread_t platform_thread;
 
@@ -111,4 +149,4 @@ typedef struct platform_condvar {
    pthread_cond_t  cond;
 } platform_condvar;
 
-#endif
+#endif /* PLATFORM_LINUX_TYPES_H */

--- a/src/splinter.c
+++ b/src/splinter.c
@@ -998,7 +998,10 @@ splinter_get_pivot(splinter_handle *spl,
                    page_handle     *node,
                    uint16           pivot_no)
 {
-   platform_assert(pivot_no < spl->cfg.max_pivot_keys);
+   platform_assert((pivot_no < spl->cfg.max_pivot_keys),
+                   "pivot_no = %d, cfg.max_pivot_keys = %lu",
+                   pivot_no,
+                   spl->cfg.max_pivot_keys);
    splinter_trunk_hdr *hdr = (splinter_trunk_hdr *)node->data;
    return ((char*)hdr) + sizeof(*hdr) + pivot_no * splinter_pivot_size(spl);
 }
@@ -1251,6 +1254,7 @@ splinter_find_pivot(splinter_handle *spl,
          return lo_idx + 1;
       default:
          platform_assert(0);
+         return (0);
    }
 }
 

--- a/tests/unit/ctest.h
+++ b/tests/unit/ctest.h
@@ -175,7 +175,8 @@ void assert_equal(intmax_t exp, intmax_t real, const char* caller, int line);
 #define ASSERT_STREQ(str1, str2) assert_equal(strcmp(str1, str2), 0, __FILE__, __LINE__)
 
 // strncmp() of 2 strings, which may not be null-terminated
-#define ASSERT_STREQN(str1, str2, n) assert_equal(strncmp(str1, str2, n), 0, __FILE__, __LINE__)
+void assert_strnequal(const char *str1, const char *str2, int n, const char* caller, int line);
+#define ASSERT_STREQN(str1, str2, n) assert_strnequal(str1, str2, n, __FILE__, __LINE__)
 
 void assert_equal_u(uintmax_t exp, uintmax_t real, const char* caller, int line);
 #define ASSERT_EQUAL_U(exp, real) assert_equal_u(exp, real, __FILE__, __LINE__)
@@ -375,6 +376,15 @@ void assert_not_equal_u(uintmax_t exp, uintmax_t real, const char* caller, int l
     if ((exp) == (real)) {
         CTEST_ERR("%s:%d  should not be %" PRIuMAX, caller, line, real);
     }
+}
+
+void assert_strnequal(const char *str1, const char *str2, int n, const char* caller, int line) {
+   if (strncmp(str1, str2, n)) {
+      CTEST_ERR("%s:%d\n"
+                "expected: '%.*s'\n"
+                "got     : '%.*s'\n",
+                caller, line, n, str1, n, str2);
+   }
 }
 
 void assert_interval(intmax_t exp1, intmax_t exp2, intmax_t real, const char* caller, int line) {

--- a/tests/unit/misc_test.c
+++ b/tests/unit/misc_test.c
@@ -1,0 +1,104 @@
+// Copyright 2021 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+ * -----------------------------------------------------------------------------
+ * misc_test.c --
+ *
+ * Miscellaneous test cases of non-core but important functionality.
+ * -----------------------------------------------------------------------------
+ */
+#include <stdarg.h>
+#include "platform.h"
+#include "unit_tests.h"
+#include "ctest.h" // This is required for all test-case files.
+
+#define ASSERT_OUTBUF_LEN 200
+
+/* String constants needed to invoke assertion macros. */
+#define MISC_MSG_WITH_NO_ARGS "Test basic assertion msg with no arguments."
+#define MISC_MSG_WITH_ARGS                                                     \
+   "Test assertion msg with arguments id = %d, name = '%s'."
+
+/*
+ * Same as platform_assert() but leverages testing hook provided
+ * by implementation, to -not- raise an abort() in case an assert fails.
+ * Test code supplies output stream in which the assertion messages will be
+ * generated, so that test-code can validate that the right parameter
+ * substitution is occurring.
+ */
+#define test_platform_assert(expr, ...)                                        \
+   platform_assert_impl(stream,                                                \
+                        __FILE__,                                              \
+                        __LINE__,                                              \
+                        __FUNCTION__,                                          \
+                        FALSE,                                                 \
+                        #expr,                                                 \
+                        (expr) != 0,                                           \
+                        "" __VA_ARGS__)
+
+/*
+ * Global data declaration macro:
+ */
+CTEST_DATA(misc){};
+
+CTEST_SETUP(misc) {}
+
+// Optional teardown function for suite, called after every test in suite
+CTEST_TEARDOWN(misc) {}
+
+/*
+ * Basic test case that exercises assertion checking code with a message
+ * but no parameters.
+ */
+CTEST2(misc, test_assert_basic_msg)
+{
+   platform_open_log_stream();
+   int lineno = __LINE__ + 1;
+   test_platform_assert(1 == 2, MISC_MSG_WITH_NO_ARGS);
+   fflush(stream);
+
+   // Construct an expected assertion message, using parts we know about.
+   char expmsg[ASSERT_OUTBUF_LEN];
+   snprintf(expmsg,
+            sizeof(expmsg),
+            "Assertion failed at %s:%d:%s(): \"1 == 2\". %s",
+            __FILE__,
+            lineno,
+            "ctest_misc_test_assert_basic_msg_run",
+            MISC_MSG_WITH_NO_ARGS);
+
+   ASSERT_STREQN(expmsg, bp, strlen(expmsg));
+   platform_close_log_stream(Platform_stderr_fh);
+}
+
+/*
+ * Basic test case that exercises assertion checking code with a message
+ * and a couple of parameters.
+ */
+CTEST2(misc, test_assert_msg_with_args)
+{
+   int   arg_id   = 42;
+   char *arg_name = "Some-name-string";
+
+   platform_open_log_stream();
+
+   int lineno = __LINE__ + 1;
+   test_platform_assert(1 == 2, MISC_MSG_WITH_ARGS, arg_id, arg_name);
+
+   fflush(stream);
+
+   // Construct an expected assertion message, using parts we know about.
+   char expmsg[ASSERT_OUTBUF_LEN];
+   snprintf(expmsg,
+            sizeof(expmsg),
+            "Assertion failed at %s:%d:%s(): \"1 == 2\". " MISC_MSG_WITH_ARGS,
+            __FILE__,
+            lineno,
+            "ctest_misc_test_assert_msg_with_args_run",
+            arg_id,
+            arg_name);
+
+   ASSERT_STREQN(expmsg, bp, strlen(expmsg));
+   platform_close_log_stream(Platform_stderr_fh);
+}


### PR DESCRIPTION
- In platform_types.h, redefine platform_assert() to become a caller-macro to platform_assert_impl(). This is a new function that checks for the assertion condition. It provides an interface to print a user-supplied informational message with parameters.

- Provide sibling macro, test_platform_assert() to produce an assertion message to an output buffer. This is used by unit-tests to verify that we will be printing the supplied messages, with appropriate arguments, as needed.

- Add CTests file, misc_test.c, with couple of small test cases,  to verify platform_assert() interface.

- Minor extension to body of platform_assert() to cross-check that the arguments and print-format string match somewhat. If there are wrong parameter types, they will get caught at compile time.