### PR TITLE
Avoid calling memmove with an invalid source pointer

### DIFF
--- a/src/kvstore_basic.c
+++ b/src/kvstore_basic.c
@@ -183,6 +183,10 @@ encode_value(void *       msg_buffer,
    platform_assert(value_len <= UINT32_MAX &&
                    value_len <= KVSTORE_BASIC_MAX_VALUE_SIZE);
    msg->value_length = value_len;
+   if (!value) {
+      assert(value_len == 0);
+      return;
+   }
    memmove(&(msg->value), value, value_len);
 }
 


### PR DESCRIPTION
While it's legal to pass zero as the `n` parameter to `memmove()`, it is not legal to pass a `NULL` pointer.  Per the C11 standard 7.24.1/2:

> "Where an argument declared as size_t n specifies the length of the array for a function, n can have the value zero on a call to that function.  Unless explicitly stated otherwise in the description of a particular function in this subclause, pointer arguments on such a call shall still have valid values, as described in 7.1.4."


Skip the call to `memmove()` when value isn't set, saving a useless syscall in the process.  This applies to encoding `MESSAGE_TYPE_DELETE` messages.