### PR TITLE
regression test for space leak

### DIFF
--- a/tests/unit/kvstore_basic_test.c
+++ b/tests/unit/kvstore_basic_test.c
@@ -661,6 +661,30 @@ CTEST2(kvstore_basic, test_close_and_reopen)
 }
 
 /*
+ * Regression test for bug where repeating a cycle of insert-close-reopen
+ * causes a space leak and eventually hits an assertion
+ * (fixed in PR #214 / commit 8b33fd149d33054173790a8a30b99e97f08ffa81)
+ */
+CTEST2(kvstore_basic, test_repeated_insert_close_reopen)
+{
+   char * key     = "some-key";
+   size_t key_len = strlen(key);
+   char * val     = "f";
+   size_t val_len = strlen(val);
+
+   for (int i = 0; i < 20; i++) {
+      int rc = kvstore_basic_insert(data->kvsb, key, key_len, val, val_len);
+      ASSERT_EQUAL(0, rc);
+      printf("insert %d success\n", i);
+
+      kvstore_basic_close(data->kvsb);
+
+      rc = kvstore_basic_open(&data->cfg, &data->kvsb);
+      ASSERT_EQUAL(0, rc);
+   }
+}
+
+/*
  * Test case to exercise APIs using custom user-defined comparator function.
  *
  * NOTE: This test case is expected to be the last one in this suite as it


### PR DESCRIPTION
**UPDATE**: @ajhconway fixed this in #214 .  So this is now just a regression test case for that fix.

Original message below

------------

Here's a test case for an assertion I hit.

```
Running 1 CTests, suite name 'kvstore_basic', test case 'test_repeated_insert_close_reopen'.
TEST 1/1 kvstore_basic:test_repeated_insert_close_reopen insert 0 success
insert 1 success
insert 2 success
insert 3 success
insert 4 success
insert 5 success
insert 6 success
insert 7 success
insert 8 success
insert 9 success
insert 10 success
insert 11 success
insert 12 success
insert 13 success
insert 14 success
insert 15 success
insert 16 success
insert 17 success
insert 18 success
kvstore_basic_test: src/mini_allocator.c:578: uint64 mini_alloc(mini_allocator *, uint64, const slice, uint64 *): Assertion `SUCCESS(rc)' failed.
[1]    920766 abort (core dumped)  bin/unit/kvstore_basic_test kvstore_basic test_repeated_insert_close_reopen
```

Not sure of the fix yet, I could use some help here.