### PR TITLE
(#211) Change ASSERT_EQUAL(), ASSERT_NOT_EQUAL(), ASSERT_TRUE(), ASSERT_FALSE() to accept user-supplied msgs with parameters.

### DIFF
--- a/tests/unit/btree_stress_test.c
+++ b/tests/unit/btree_stress_test.c
@@ -126,16 +126,14 @@ CTEST_SETUP(btree_stress)
        || !init_btree_config_from_master_config(
           &data->dbtree_cfg, &data->master_cfg, &data->data_cfg))
    {
-      platform_log("Failed to parse args\n");
-      ASSERT_TRUE(FALSE);
+      ASSERT_TRUE(FALSE, "Failed to parse args\n");
    }
 
    // Create a heap for io, allocator, cache and splinter
    if (!SUCCESS(platform_heap_create(
           platform_get_module_id(), 1 * GiB, &data->hh, &data->hid)))
    {
-      platform_log("Failed to init heap\n");
-      ASSERT_TRUE(FALSE);
+      ASSERT_TRUE(FALSE, "Failed to init heap\n");
    }
    // Setup execution of concurrent threads
    ZERO_ARRAY(data->num_bg_threads);
@@ -163,9 +161,9 @@ CTEST_SETUP(btree_stress)
                                    data->hid,
                                    platform_get_module_id())))
    {
-      platform_log(
+      ASSERT_TRUE(
+         FALSE,
          "Failed to init io or task system or rc_allocator or clockcache\n");
-      ASSERT_TRUE(FALSE);
    }
 }
 
@@ -225,10 +223,7 @@ CTEST2(btree_stress, test_random_inserts_concurrent)
                         PAGE_TYPE_MEMTABLE,
                         root_addr,
                         nkvs);
-   if (!rc) {
-      platform_log("invalid tree\n");
-      ASSERT_NOT_EQUAL(0, rc);
-   }
+   ASSERT_NOT_EQUAL(0, rc, "Invalid tree\n");
 
    if (!iterator_tests((cache *)&data->cc, &data->dbtree_cfg, root_addr, nkvs))
    {
@@ -241,8 +236,7 @@ CTEST2(btree_stress, test_random_inserts_concurrent)
    uint64 packed_root_addr = pack_tests(
       (cache *)&data->cc, &data->dbtree_cfg, data->hid, root_addr, nkvs);
    if (0 < nkvs && !packed_root_addr) {
-      platform_log("[%s:%d] Pack failed\n", __FILE__, __LINE__);
-      ASSERT_TRUE(FALSE);
+      ASSERT_TRUE(FALSE, "Pack failed.\n");
    }
 
    /* platform_log("\n\n\n"); */
@@ -256,17 +250,11 @@ CTEST2(btree_stress, test_random_inserts_concurrent)
                     PAGE_TYPE_BRANCH,
                     packed_root_addr,
                     nkvs);
-   if (!rc) {
-      platform_log("invalid tree\n");
-      ASSERT_NOT_EQUAL(0, rc);
-   }
+   ASSERT_NOT_EQUAL(0, rc, "Invalid tree\n");
 
    rc = iterator_tests(
       (cache *)&data->cc, &data->dbtree_cfg, packed_root_addr, nkvs);
-   if (!rc) {
-      platform_log("invalid ranges in packed tree\n");
-      ASSERT_NOT_EQUAL(0, rc);
-   }
+   ASSERT_NOT_EQUAL(0, rc, "Invalid ranges in packed tree\n");
 }
 
 /*
@@ -315,9 +303,7 @@ insert_tests(cache *          cc,
                                 &generation,
                                 &was_unique)))
       {
-         platform_log(
-            "[%s:%d] Failed to insert 4-byte %ld\n", __FILE__, __LINE__, i);
-         ASSERT_TRUE(FALSE);
+         ASSERT_TRUE(FALSE, "Failed to insert 4-byte %ld\n", i);
       }
    }
 }
@@ -378,9 +364,7 @@ query_tests(cache *          cc,
           || slice_lex_cmp(writable_buffer_to_slice(&result),
                            gen_msg(cfg, i, msgbuf)))
       {
-         platform_log("[%s:%d] Failure on lookup %lu\n", __FILE__, __LINE__, i);
-         btree_print_tree(cc, cfg, root_addr);
-         ASSERT_TRUE(FALSE);
+         ASSERT_TRUE(FALSE, "Failure on lookup %lu\n", i);
       }
    }
 
@@ -469,8 +453,7 @@ pack_tests(cache *          cc,
    btree_pack_req_init(&req, cc, cfg, iter, nkvs, NULL, 0, hid);
 
    if (!SUCCESS(btree_pack(&req))) {
-      platform_log("[%s:%d] Pack failed!\n", __FILE__, __LINE__);
-      ASSERT_TRUE(FALSE);
+      ASSERT_TRUE(FALSE, "Pack failed! req.num_tuples = %d\n", req.num_tuples);
    } else {
       platform_log("Packed %lu items ", req.num_tuples);
    }

--- a/tests/unit/btree_test.c
+++ b/tests/unit/btree_test.c
@@ -84,8 +84,7 @@ CTEST_SETUP(btree)
        || !init_btree_config_from_master_config(
           &data->dbtree_cfg, &data->master_cfg, &data->data_cfg))
    {
-      platform_log("Failed to parse args\n");
-      ASSERT_TRUE(FALSE);
+      ASSERT_TRUE(FALSE, "Failed to parse args\n");
    }
 }
 
@@ -164,11 +163,7 @@ leaf_hdr_tests(btree_config *cfg, btree_scratch *scratch)
                                 i,
                                 slice_create(i % sizeof(i), &i),
                                 slice_create(i % sizeof(i), &i));
-      if (!rv) {
-         platform_log(
-            "[%s:%d] failed to insert 4-byte %d\n", __FILE__, __LINE__, i);
-         ASSERT_TRUE(rv);
-      }
+      ASSERT_TRUE(rv, "Failed to insert 4-byte %d\n", i);
    }
 
    int cmp_rv = 0;
@@ -176,15 +171,10 @@ leaf_hdr_tests(btree_config *cfg, btree_scratch *scratch)
       slice key     = btree_get_tuple_key(cfg, hdr, i);
       slice message = btree_get_tuple_message(cfg, hdr, i);
       cmp_rv        = slice_lex_cmp(slice_create(i % sizeof(i), &i), key);
-      if (cmp_rv) {
-         platform_log("[%s:%d] bad 4-byte key %d\n", __FILE__, __LINE__, i);
-         ASSERT_EQUAL(0, cmp_rv);
-      }
+      ASSERT_EQUAL(0, cmp_rv, "Bad 4-byte key %d\n", i);
+
       cmp_rv = slice_lex_cmp(slice_create(i % sizeof(i), &i), message);
-      if (cmp_rv) {
-         platform_log("[%s:%d] bad 4-byte message %d\n", __FILE__, __LINE__, i);
-         ASSERT_EQUAL(0, cmp_rv);
-      }
+      ASSERT_EQUAL(0, cmp_rv, "Bad 4-byte message %d\n", i);
    }
 
    rv = FALSE;
@@ -194,11 +184,7 @@ leaf_hdr_tests(btree_config *cfg, btree_scratch *scratch)
                                 i,
                                 slice_create(i % sizeof(i), &i),
                                 slice_create(i % sizeof(i), &i));
-      if (!rv) {
-         platform_log(
-            "[%s:%d] failed to insert 8-byte %ld\n", __FILE__, __LINE__, i);
-         ASSERT_TRUE(rv);
-      }
+      ASSERT_TRUE(rv, "Failed to insert 8-byte %ld\n", i);
    }
 
    cmp_rv = 0;
@@ -206,16 +192,10 @@ leaf_hdr_tests(btree_config *cfg, btree_scratch *scratch)
       slice key     = btree_get_tuple_key(cfg, hdr, i);
       slice message = btree_get_tuple_message(cfg, hdr, i);
       cmp_rv        = slice_lex_cmp(slice_create(i % sizeof(i), &i), key);
-      if (cmp_rv) {
-         platform_log("[%s:%d] bad 4-byte key %ld\n", __FILE__, __LINE__, i);
-         ASSERT_EQUAL(0, cmp_rv);
-      }
+      ASSERT_EQUAL(0, cmp_rv, "Bad 4-byte key %d\n", i);
+
       cmp_rv = slice_lex_cmp(slice_create(i % sizeof(i), &i), message);
-      if (cmp_rv) {
-         platform_log(
-            "[%s:%d] bad 4-byte message %ld\n", __FILE__, __LINE__, i);
-         ASSERT_EQUAL(0, cmp_rv);
-      }
+      ASSERT_EQUAL(0, cmp_rv, "Bad 4-byte message %d\n", i);
    }
 
    btree_defragment_leaf(cfg, scratch, hdr, -1);
@@ -224,16 +204,10 @@ leaf_hdr_tests(btree_config *cfg, btree_scratch *scratch)
       slice key     = btree_get_tuple_key(cfg, hdr, i);
       slice message = btree_get_tuple_message(cfg, hdr, i);
       cmp_rv        = slice_lex_cmp(slice_create(i % sizeof(i), &i), key);
-      if (cmp_rv) {
-         platform_log("[%s:%d] bad 4-byte key %ld\n", __FILE__, __LINE__, i);
-         ASSERT_EQUAL(0, cmp_rv);
-      }
+      ASSERT_EQUAL(0, cmp_rv, "Bad 4-byte key %d\n", i);
+
       cmp_rv = slice_lex_cmp(slice_create(i % sizeof(i), &i), message);
-      if (cmp_rv) {
-         platform_log(
-            "[%s:%d] bad 4-byte message %ld\n", __FILE__, __LINE__, i);
-         ASSERT_EQUAL(0, cmp_rv);
-      }
+      ASSERT_EQUAL(0, cmp_rv, "Bad 4-byte message %d\n", i);
    }
 
    return 0;
@@ -261,30 +235,16 @@ leaf_hdr_search_tests(btree_config *cfg, platform_heap_id hid)
       leaf_incorporate_spec spec;
       bool                  result = btree_leaf_incorporate_tuple(
          cfg, hid, hdr, key, message, &spec, &generation);
-      if (!result) {
-         platform_log(
-            "[%s:%d] couldn't incorporate kv pair %d\n", __FILE__, __LINE__, i);
-         ASSERT_TRUE(result);
-      }
-      if (generation != i) {
-         platform_log("[%s:%d] bad generation %d %lu\n",
-                      __FILE__,
-                      __LINE__,
-                      i,
-                      generation);
-         ASSERT_EQUAL(i, generation);
-      }
+      ASSERT_TRUE(result, "Could not incorporate kv pair %d\n", i);
+
+      ASSERT_EQUAL(generation, i, "Bad generation=%lu, i=%d\n", generation, i);
    }
 
    for (int i = 0; i < nkvs; i++) {
       slice key    = btree_get_tuple_key(cfg, hdr, i);
       uint8 ui     = i;
       int   cmp_rv = slice_lex_cmp(slice_create(1, &ui), key);
-      if (cmp_rv) {
-         platform_log("[%s:%d] bad 4-byte key %d\n", __FILE__, __LINE__, i);
-         btree_print_locked_node(cfg, 0, hdr, PLATFORM_ERR_LOG_HANDLE);
-         ASSERT_EQUAL(0, cmp_rv);
-      }
+      ASSERT_EQUAL(0, cmp_rv, "Bad 4-byte key %d\n", i);
    }
 
    return 0;
@@ -306,49 +266,31 @@ index_hdr_tests(btree_config *cfg, btree_scratch *scratch)
    for (uint32 i = 0; i < nkvs; i++) {
       rv = btree_set_index_entry(
          cfg, hdr, i, slice_create(i % sizeof(i), &i), i, 0, 0, 0);
-      if (!rv) {
-         platform_log(
-            "[%s:%d] failed to insert 4-byte %d\n", __FILE__, __LINE__, i);
-         ASSERT_TRUE(rv);
-      }
+      ASSERT_TRUE(rv, "Failed to insert 4-byte %d\n", i);
    }
 
    for (uint32 i = 0; i < nkvs; i++) {
       slice  key       = btree_get_pivot(cfg, hdr, i);
       uint64 childaddr = btree_get_child_addr(cfg, hdr, i);
       cmp_rv           = slice_lex_cmp(slice_create(i % sizeof(i), &i), key);
-      if (cmp_rv) {
-         platform_log("[%s:%d] bad 4-byte key %d\n", __FILE__, __LINE__, i);
-         ASSERT_EQUAL(0, cmp_rv);
-      }
-      if (childaddr != i) {
-         platform_log("[%s:%d] bad childaddr %d\n", __FILE__, __LINE__, i);
-         ASSERT_EQUAL(i, childaddr);
-      }
+      ASSERT_EQUAL(0, cmp_rv, "Bad 4-byte key %d\n", i);
+
+      ASSERT_EQUAL(childaddr, i, "Bad childaddr %d\n", i);
    }
 
    for (uint64 i = 0; i < nkvs; i++) {
       rv = btree_set_index_entry(
          cfg, hdr, i, slice_create(i % sizeof(i), &i), i, 0, 0, 0);
-      if (!rv) {
-         platform_log(
-            "[%s:%d] failed to insert 8-byte %ld\n", __FILE__, __LINE__, i);
-         ASSERT_TRUE(rv);
-      }
+      ASSERT_TRUE(rv, "Failed to insert 8-byte %ld\n", i);
    }
 
    for (uint64 i = 0; i < nkvs; i++) {
       slice  key       = btree_get_pivot(cfg, hdr, i);
       uint64 childaddr = btree_get_child_addr(cfg, hdr, i);
       cmp_rv           = slice_lex_cmp(slice_create(i % sizeof(i), &i), key);
-      if (cmp_rv) {
-         platform_log("[%s:%d] bad 4-byte key %ld\n", __FILE__, __LINE__, i);
-         ASSERT_EQUAL(0, cmp_rv);
-      }
-      if (childaddr != i) {
-         platform_log("[%s:%d] bad childaddr %ld\n", __FILE__, __LINE__, i);
-         ASSERT_EQUAL(i, childaddr);
-      }
+      ASSERT_EQUAL(0, cmp_rv, "Bad 4-byte key %d\n", i);
+
+      ASSERT_EQUAL(childaddr, i, "Bad childaddr %d\n", i);
    }
 
    btree_defragment_index(cfg, scratch, hdr);
@@ -357,14 +299,9 @@ index_hdr_tests(btree_config *cfg, btree_scratch *scratch)
       slice  key       = btree_get_pivot(cfg, hdr, i);
       uint64 childaddr = btree_get_child_addr(cfg, hdr, i);
       cmp_rv           = slice_lex_cmp(slice_create(i % sizeof(i), &i), key);
-      if (cmp_rv) {
-         platform_log("[%s:%d] bad 4-byte key %ld\n", __FILE__, __LINE__, i);
-         ASSERT_EQUAL(0, cmp_rv);
-      }
-      if (childaddr != i) {
-         platform_log("[%s:%d] bad childaddr %ld\n", __FILE__, __LINE__, i);
-         ASSERT_EQUAL(i, childaddr);
-      }
+      ASSERT_EQUAL(0, cmp_rv, "Bad 4-byte key %d\n", i);
+
+      ASSERT_EQUAL(childaddr, i, "Bad childaddr %d\n", i);
    }
 
    return 0;
@@ -387,11 +324,7 @@ index_hdr_search_tests(btree_config *cfg)
       slice key = slice_create(1, &keybuf);
 
       rv = btree_set_index_entry(cfg, hdr, i / 2, key, i, 0, 0, 0);
-      if (!rv) {
-         platform_log(
-            "[%s:%d] couldn't insert pivot %d\n", __FILE__, __LINE__, i);
-         ASSERT_TRUE(rv);
-      }
+      ASSERT_TRUE(rv, "Could not insert pivot %d\n", i);
    }
 
    for (int i = 0; i < nkvs; i++) {
@@ -400,14 +333,8 @@ index_hdr_search_tests(btree_config *cfg)
       keybuf[0] = i;
       slice key = slice_create(1, &keybuf);
       int64 idx = btree_find_pivot(cfg, hdr, key, &found);
-      if (idx != i / 2) {
-         platform_log("[%s:%d] bad pivot search result %ld for %d\n",
-                      __FILE__,
-                      __LINE__,
-                      idx,
-                      i);
-         ASSERT_EQUAL((i / 2), idx);
-      }
+      ASSERT_EQUAL(
+         (i / 2), idx, "Bad pivot search result idx=%ld for i=%d\n", idx, i);
    }
 
    return 0;
@@ -448,7 +375,9 @@ leaf_split_tests(btree_config *cfg, btree_scratch *scratch, int nkvs)
       bool                  success = btree_leaf_incorporate_tuple(
          cfg, scratch, hdr, key, bigger_msg, &spec, &generation);
       if (success) {
-         platform_log("Weird.  An incorporate that was supposed to fail "
+         btree_print_locked_node(cfg, 0, hdr, PLATFORM_ERR_LOG_HANDLE);
+         ASSERT_FALSE(success,
+                      "Weird.  An incorporate that was supposed to fail "
                       "actually succeeded (nkvs=%d, realnkvs=%d, i=%d).\n",
                       nkvs,
                       realnkvs,
@@ -458,8 +387,14 @@ leaf_split_tests(btree_config *cfg, btree_scratch *scratch, int nkvs)
       }
       leaf_splitting_plan plan =
          btree_build_leaf_splitting_plan(cfg, hdr, &spec);
-      ASSERT_TRUE((realnkvs / 2 - 1) <= plan.split_idx);
-      ASSERT_TRUE((plan.split_idx) <= (realnkvs / 2 + 1));
+      ASSERT_TRUE((realnkvs / 2 - 1) <= plan.split_idx,
+                  "realnkvs = %d, plan.split_idx = %d",
+                  realnkvs,
+                  plan.split_idx);
+      ASSERT_TRUE((plan.split_idx) <= (realnkvs / 2 + 1),
+                  "realnkvs = %d, plan.split_idx = %d",
+                  realnkvs,
+                  plan.split_idx);
    }
 
    return 0;

--- a/tests/unit/kvstore_basic_test.c
+++ b/tests/unit/kvstore_basic_test.c
@@ -214,7 +214,10 @@ CTEST2(kvstore_basic, test_apis_for_max_key_length)
                              &val_truncated,
                              &found);
    ASSERT_EQUAL(0, rc);
-   ASSERT_STREQN(large_key_value, value, val_len);
+   ASSERT_STREQN(large_key_value,
+                 value,
+                 val_len,
+                 "Large key-value did not match as expected.");
    ASSERT_EQUAL(strlen(large_key_value), val_len);
    ASSERT_FALSE(val_truncated);
    ASSERT_TRUE(found);
@@ -652,7 +655,11 @@ CTEST2(kvstore_basic, test_close_and_reopen)
                              &found);
    ASSERT_EQUAL(0, rc);
    ASSERT_TRUE(found);
-   ASSERT_STREQN(val, value, val_len);
+   ASSERT_STREQN(val,
+                 value,
+                 val_len,
+                 "value found did not match expected 'val' up to %d bytes\n",
+                 val_len);
    ASSERT_FALSE(val_truncated);
 
    if (value) {


### PR DESCRIPTION
    This commit enhances following CTests-assertion checking macros, defined in ctest.h, to now, 
optionally, receive a user-supplied msg w/arguments:

- ASSERT_EQUAL(), ASSERT_STREQ(), ASSERT_STREQN()
- ASSERT_NOT_EQUAL()
- ASSERT_TRUE(), ASSERT_FALSE()

    In some test files, mainly variable_length_btree*test.c, places where these
    assertion checks were preceded by an explicit platform_log() to print a
    message are now converted to use this msg-printing facility behind the
    assertion check.

    Add TEST_ASSERT_EQUAL(), and test case test_assert_user_msg_with_params()
    to verify that message printing works for one case.