### PR TITLE
Fix data leak in splinter_dismount

### DIFF
--- a/src/rc_allocator.c
+++ b/src/rc_allocator.c
@@ -667,7 +667,8 @@ rc_allocator_alloc(rc_allocator *al,   // IN
    __sync_add_and_fetch(&al->stats.extent_allocs[type], 1);
    *addr = hand * al->cfg->extent_size;
    if (SHOULD_TRACE(*addr)) {
-      platform_log("rc_allocator_alloc_extent(%lu)\n", *addr);
+      platform_log(
+         "rc_allocator_alloc_extent %12lu (%s)\n", *addr, page_type_str[type]);
    }
 
    return STATUS_OK;

--- a/src/splinter.c
+++ b/src/splinter.c
@@ -6975,6 +6975,9 @@ splinter_prepare_for_shutdown(splinter_handle *spl)
       platform_free(spl->heap_id, spl->log);
    }
 
+   // release the trunk mini allocator
+   mini_release(&spl->mini, NULL_SLICE);
+
    // flush all dirty pages in the cache
    cache_flush(spl->cc);
 }
@@ -7043,7 +7046,6 @@ splinter_destroy(splinter_handle *spl)
 
    splinter_for_each_node(spl, splinter_node_destroy, NULL);
 
-   mini_release(&spl->mini, NULL_SLICE);
    mini_unkeyed_dec_ref(spl->cc, spl->mini.meta_head, PAGE_TYPE_TRUNK);
 
    // clear out this splinter table from the meta page.


### PR DESCRIPTION
Fixes a data leak in `splinter_dismount` where `mini_release` was not
called on the trunk `mini_allocator`. This meant that the `next_extent`s
were not being deallocated and leaking.

Adds `page_type` to the `rc_allocator` logging functionality on `alloc`.

This commit resolves the data leak observed in PR #207.