### PR TITLE
Memtable Pinning

### DIFF
--- a/src/btree.c
+++ b/src/btree.c
@@ -1072,7 +1072,7 @@ btree_zap(cache *cc, btree_config *cfg, uint64 root_addr, page_type type)
 {
    platform_assert(type == PAGE_TYPE_MEMTABLE);
    uint64 meta_head = btree_root_to_meta_addr(cc, cfg, root_addr, 0);
-   uint8  ref       = mini_unkeyed_dec_ref(cc, meta_head, type);
+   uint8  ref       = mini_unkeyed_dec_ref(cc, meta_head, type, TRUE);
    return ref == 0;
 }
 

--- a/src/clockcache.c
+++ b/src/clockcache.c
@@ -830,6 +830,17 @@ clockcache_dec_pin(clockcache *cc, uint32 entry_number)
    debug_assert(refcount != 0);
 }
 
+static inline void
+clockcache_reset_pin(clockcache *cc, uint32 entry_number)
+{
+   uint64 rc_number = clockcache_get_ref_internal(cc, entry_number);
+   debug_assert(rc_number < cc->cfg->page_capacity);
+   if (cc->pincount[rc_number] != 0) {
+      __attribute__((unused)) uint8 refcount =
+         __sync_lock_test_and_set(&cc->pincount[rc_number], 0);
+   }
+}
+
 void
 clockcache_assert_no_refs(clockcache *cc)
 {
@@ -1945,7 +1956,8 @@ clockcache_try_hard_evict(clockcache *cc, uint64 addr)
        * 4. write lock
        * 5. clear lookup, disk_addr
        * 6. set status to CC_FREE_STATUS (clears claim and write lock)
-       * 7. release read lock
+       * 7. reset pincount to zero
+       * 8. release read lock
        */
 
       //platform_assert(clockcache_get_ref(cc, entry_number, tid) == 0);
@@ -1995,7 +2007,10 @@ clockcache_try_hard_evict(clockcache *cc, uint64 addr)
       /* 6. set status to CC_FREE_STATUS (clears claim and write lock) */
       entry->status = CC_FREE_STATUS;
 
-      /* 7. release read lock */
+      /* 7. reset pincount */
+      clockcache_reset_pin(cc, entry_number);
+
+      /* 8. release read lock */
       clockcache_dec_ref(cc, entry_number, tid);
       return;
    }

--- a/src/memtable.c
+++ b/src/memtable.c
@@ -298,11 +298,13 @@ memtable_context_create(platform_heap_id  hid,
 
    page_handle *lock_page =
       cache_alloc(cc, ctxt->insert_lock_addr, PAGE_TYPE_LOCK_NO_DATA);
+   cache_pin(cc, lock_page);
    cache_unlock(cc, lock_page);
    cache_unclaim(cc, lock_page);
    cache_unget(cc, lock_page);
 
    lock_page = cache_alloc(cc, ctxt->lookup_lock_addr, PAGE_TYPE_LOCK_NO_DATA);
+   cache_pin(cc, lock_page);
    cache_unlock(cc, lock_page);
    cache_unclaim(cc, lock_page);
    cache_unget(cc, lock_page);

--- a/src/mini_allocator.h
+++ b/src/mini_allocator.h
@@ -23,6 +23,7 @@ typedef struct mini_allocator {
    cache *         cc;
    data_config *   data_cfg;
    bool            keyed;
+   bool            pinned;
    uint64          meta_head;
    volatile uint64 meta_tail;
    page_type       type;
@@ -54,7 +55,7 @@ mini_alloc(mini_allocator *mini,
 uint8
 mini_unkeyed_inc_ref(cache *cc, uint64 meta_head);
 uint8
-mini_unkeyed_dec_ref(cache *cc, uint64 meta_head, page_type type);
+mini_unkeyed_dec_ref(cache *cc, uint64 meta_head, page_type type, bool pinned);
 
 void
 mini_keyed_inc_ref(cache *      cc,

--- a/src/routing_filter.c
+++ b/src/routing_filter.c
@@ -1147,7 +1147,7 @@ routing_filter_zap(cache          *cc,
    }
 
    uint64 meta_head = filter->meta_head;
-   mini_unkeyed_dec_ref(cc, meta_head, PAGE_TYPE_FILTER);
+   mini_unkeyed_dec_ref(cc, meta_head, PAGE_TYPE_FILTER, FALSE);
 }
 
 /*

--- a/src/shard_log.c
+++ b/src/shard_log.c
@@ -120,7 +120,7 @@ shard_log_zap(shard_log *log)
       thread_data->offset = 0;
    }
 
-   mini_unkeyed_dec_ref(cc, log->meta_head, PAGE_TYPE_LOG);
+   mini_unkeyed_dec_ref(cc, log->meta_head, PAGE_TYPE_LOG, FALSE);
 }
 
 struct PACKED log_entry {

--- a/src/splinter.c
+++ b/src/splinter.c
@@ -7046,7 +7046,7 @@ splinter_destroy(splinter_handle *spl)
 
    splinter_for_each_node(spl, splinter_node_destroy, NULL);
 
-   mini_unkeyed_dec_ref(spl->cc, spl->mini.meta_head, PAGE_TYPE_TRUNK);
+   mini_unkeyed_dec_ref(spl->cc, spl->mini.meta_head, PAGE_TYPE_TRUNK, FALSE);
 
    // clear out this splinter table from the meta page.
    allocator_remove_super_addr(spl->al, spl->id);

--- a/src/variable_length_btree.c
+++ b/src/variable_length_btree.c
@@ -973,6 +973,11 @@ variable_length_btree_alloc(cache *                     cc,
    node->addr = mini_alloc(mini, height, key, next_extent);
    debug_assert(node->addr != 0);
    node->page = cache_alloc(cc, node->addr, type);
+   // If this btree is for a memetable
+   // then pin all pages belong to it
+   if (type == PAGE_TYPE_MEMTABLE) {
+      cache_pin(cc, node->page);
+   }
    node->hdr  = (variable_length_btree_hdr *)(node->page->data);
    return TRUE;
 }
@@ -1109,6 +1114,7 @@ variable_length_btree_create(cache *                             cc,
    platform_status rc = allocator_alloc(al, &base_addr, type);
    platform_assert_status_ok(rc);
    page_handle *root_page = cache_alloc(cc, base_addr, type);
+   bool         pinned    = (type == PAGE_TYPE_MEMTABLE);
 
    // set up the root
    variable_length_btree_node root;
@@ -1119,6 +1125,13 @@ variable_length_btree_create(cache *                             cc,
    variable_length_btree_init_hdr(cfg, root.hdr);
 
    cache_mark_dirty(cc, root.page);
+
+   // If this btree is for a memetable
+   // then pin all pages belong to it
+   if (pinned) {
+      cache_pin(cc, root.page);
+   }
+
    // release root
    cache_unlock(cc, root_page);
    cache_unclaim(cc, root_page);
@@ -1184,7 +1197,7 @@ variable_length_btree_dec_ref(cache *                             cc,
    platform_assert(type == PAGE_TYPE_MEMTABLE);
    uint64 meta_head =
       variable_length_btree_root_to_meta_addr(cfg, root_addr, 0);
-   uint8 ref = mini_unkeyed_dec_ref(cc, meta_head, type);
+   uint8 ref = mini_unkeyed_dec_ref(cc, meta_head, type, TRUE);
    return ref == 0;
 }
 

--- a/tests/unit/variable_length_btree_stress_test.c
+++ b/tests/unit/variable_length_btree_stress_test.c
@@ -113,6 +113,7 @@ CTEST_DATA(variable_length_btree_stress)
 CTEST_SETUP(variable_length_btree_stress)
 {
    config_set_defaults(&data->master_cfg);
+   data->master_cfg.cache_capacity = GiB_TO_B(5);
    data->data_cfg = test_data_config;
 
    // RESOLVE: Sort this out with RobJ about cmd line args support


### PR DESCRIPTION
Adds support for pinning the memtable.

1. Pin memtable pages on cache_alloc
2. Add support to mini_allocator to pin memtable mini_allocator pages
3. Modify clockcache_hard_evict to allow blindly evicting pinned pages
4. Increase default cache size for btree_stress_test to avoid stuck cache