### PR TITLE
Enhance command-line processing to support --config options for unit-tests.

### DIFF
--- a/tests/functional/btree_test.c
+++ b/tests/functional/btree_test.c
@@ -1506,7 +1506,8 @@ btree_test(int argc, char *argv[])
 
    data_config *    data_cfg  = TYPED_MALLOC(hid, data_cfg);
    splinter_config *cfg       = TYPED_MALLOC(hid, cfg);
-   rc                         = test_parse_args(cfg,
+
+   rc = test_parse_args(cfg,
                         data_cfg,
                         &io_cfg,
                         &al_cfg,
@@ -1515,6 +1516,7 @@ btree_test(int argc, char *argv[])
                         &seed,
                         config_argc,
                         config_argv);
+
    memtable_config *mt_cfg    = &cfg->mt_cfg;
    mt_cfg->max_memtables      = 128;
    test_btree_config test_cfg = {

--- a/tests/functional/cache_test.c
+++ b/tests/functional/cache_test.c
@@ -956,7 +956,8 @@ cache_test(int argc, char *argv[])
    platform_assert_status_ok(rc);
 
    splinter_config *splinter_cfg = TYPED_MALLOC(hid, splinter_cfg);
-   rc                            = test_parse_args(splinter_cfg,
+
+   rc = test_parse_args(splinter_cfg,
                         &data_cfg,
                         &io_cfg,
                         &al_cfg,

--- a/tests/functional/log_test.c
+++ b/tests/functional/log_test.c
@@ -284,7 +284,8 @@ log_test(int argc, char *argv[])
    platform_assert_status_ok(status);
 
    splinter_config *cfg = TYPED_MALLOC(hid, cfg);
-   status               = test_parse_args(cfg,
+
+   status = test_parse_args(cfg,
                             &data_cfg,
                             &io_cfg,
                             &al_cfg,

--- a/tests/functional/ycsb_test.c
+++ b/tests/functional/ycsb_test.c
@@ -1200,9 +1200,9 @@ ycsb_test(int argc, char *argv[])
    platform_assert_status_ok(rc);
 
    data_config *data_cfg = TYPED_MALLOC(hid, data_cfg);
-   ;
    splinter_config *splinter_cfg = TYPED_MALLOC(hid, splinter_cfg);
-   rc                            = test_parse_args(splinter_cfg,
+
+   rc = test_parse_args(splinter_cfg,
                         data_cfg,
                         &io_cfg,
                         &allocator_cfg,

--- a/tests/unit/README.md
+++ b/tests/unit/README.md
@@ -30,6 +30,12 @@ $ make clean; make [debug]
 
 # Build the unit-test binary
 $ make bin/unit_test
+
+# Build all the test sources and binaries, which will also build all unit-test binaries.
+# bin/unit_test and a collection of stand-alone module-specific unit-test binaries will
+# be generated in the bin/unit sub-directory.
+#
+$ make clean; make tests
 ```
 
 * How To Run unit-tests:
@@ -44,4 +50,18 @@ $ bin/unit_test
 
 # Run a specific suite, optionally filtering on a specific test case
 $ bin/unit_test suite-name [ <test-case-name> ]
+
+Example: Run all test cases named 'test_leaf_hdr%' from the 'btree' test suite
+
+$ bin/unit_test btree test_leaf_hdr
+
+# Run a specific unit-test binary
+$ bin/unit/kvstore_basic_test
+
+# Run all test cases named with a prefix from specific unit-test binary.
+# E.g., run all test cases named 'test_kvstore_iterator%' from kvstore_basic_test
+#
+$ bin/unit/<unit-test-binary-name> <test-case-name>
+$ bin/unit/kvstore_basic_test test_kvstore_iterator
+
 ```

--- a/tests/unit/btree_test.c
+++ b/tests/unit/btree_test.c
@@ -73,7 +73,8 @@ CTEST_SETUP(btree)
    config_set_defaults(&data->master_cfg);
    data->data_cfg = test_data_config;
 
-   if (!SUCCESS(config_parse(&data->master_cfg, 1, 0, (char **)NULL))
+   if (!SUCCESS(
+          config_parse(&data->master_cfg, 1, Ctest_argc, (char **)Ctest_argv))
        || !init_data_config_from_master_config(&data->data_cfg,
                                                &data->master_cfg)
        || !init_io_config_from_master_config(&data->io_cfg, &data->master_cfg)

--- a/tests/unit/main.c
+++ b/tests/unit/main.c
@@ -21,10 +21,111 @@ main(int argc, const char *argv[])
 }
 
 /*
+ * Identify the name of the program being executed (argv[0]). The usage will
+ * vary depending on whether the top-level 'unit_test' or a stand-alone
+ * unit-test binary is being invoked.
+ *
+ * Returns:
+ *  1 - If it is 'unit_test'
+ *  0 - For all other stand-alone unit-test binaries being invoked.
+ * -1 - For any other error / unknown conditions.
+ */
+int
+ctest_is_unit_test(const char *argv0)
+{
+   const char *unit_test_str = "unit_test";
+   const int   unit_test_len = strlen(unit_test_str);
+
+   if (!argv0) {
+      return -1;
+   }
+
+   // If we are running some other standalone program of shorter binary length.
+   if (strlen(argv0) < unit_test_len) {
+      return 0;
+   }
+
+   // Check for match of trailing portion of full binary name with 'unit_test'
+   const char *startp = (argv0 + strlen(argv0) - unit_test_len);
+   if (strncmp(unit_test_str, startp, unit_test_len) == 0) {
+      return 1;
+   }
+
+   return 0;
+}
+
+/*
+ * Process the command-line arguments. Handle the following cases:
+ *
+ * 1. We can invoke the top-level unit_test as follows:
+ *
+ *      unit_test [ --one-or-more-config options ] [ <suite-name> [
+ * <test-case-name> ] ]
+ *
+ * 2. We can invoke an individual stand-alone unit_test as follows:
+ *
+ *      sub_unit_test [ --one-or-more-config options ] [ <test-case-name> ]
+ *
+ * This routines handles both cases to identify suite_name and test-case_name.
+ *
+ * Returns:
+ *  # of trailing arguments processed. -1, in case of any usage / invocation
+ * error.
+ */
+int
+ctest_process_args(const int    argc,
+                   const char * argv[],
+                   int          program_is_unit_test,
+                   const char **suite_name,
+                   const char **testcase_name)
+{
+   if (argc <= 1) {
+      return 0;
+   }
+
+   // If the last arg is a --<arg>, then it's a config option. No need for
+   // further processing to extract "name"-args.
+   if (strncmp(argv[argc - 1], "--", 2) == 0) {
+      return 0;
+   }
+
+   // We expect up to 2 trailing "name"-args to be provided.
+   if (program_is_unit_test) {
+      *suite_name = argv[argc - 1];
+   } else {
+      *testcase_name = argv[argc - 1];
+   }
+
+   if (argc == 2) {
+      // We stripped off 1 "name"-argument from list.
+      return 1;
+   }
+   if (strncmp(argv[argc - 2], "--", 2) == 0) {
+      // We stripped off 1 "name"-argument from list.
+      return 1;
+   }
+
+   if (program_is_unit_test) {
+      *suite_name    = argv[argc - 2];
+      *testcase_name = argv[argc - 1];
+      return 2;
+   } else {
+      // It's an error to issue: sub_unit-test <suite-name> <testcase-name>
+      return -1;
+   }
+   return 0;
+}
+
+/*
  * Generate brief usage information to run CTests.
  */
 void
-ctest_usage(const char *progname)
+ctest_usage(const char *progname, int program_is_unit_test)
 {
-   printf("%s [ <suite-name> [ <test-case-name> ] ]\n", progname);
+   printf("Usage: %s [ --<config options> ]* ", progname);
+   if (program_is_unit_test) {
+      printf("[ <suite-name> [ <test-case-name> ] ]\n");
+   } else {
+      printf("[ <test-case-name> ]\n");
+   }
 }


### PR DESCRIPTION
(#210) Enhance command-line processing to support --config options for unit-tests.

    This commit updates the naiive argument processing for Ctests to now support the following syntax:

     $ unit_test [ --<config options> ]* [ <suite-name> [ <testcase-name> ] ]

     $ standalone_test [ --<config options> ]* [ <testcase-name> ]

    Currently, in unit/ tests, only btree_test.c has the ability to parse
    command-line params, via config_parse(). That ability was temporarily
    withdrawn when those tests were refactored to run under CTests.

    This commit now re-introduces that capability, and also provides similar
    support for any other unit-tests that may need to have command-line args
    to support different configurations.

    Logic to filter suite-name / test-case-name when runnning the 'unit_test'
    binary was working, but it was mishandled / broken when running a
    standalone_test. This problem is also fixed in this commit.
    Now, one can issue, e.g.

        $ ./bin/unit/btree_test test_leaf_hdr

    ... to run all test cases named 'test_leaf_hdr%' from this unit-test.

    Any --config-options provided will be applied for that collection of test-cases being executed.