### PR TITLE
(#218) Rework body of platform_assert() to avoid a function call.

### DIFF
--- a/src/btree.c
+++ b/src/btree.c
@@ -154,7 +154,8 @@ btree_set_index_entry(const btree_config *cfg,
                       int64               key_bytes,
                       int64               message_bytes)
 {
-   platform_assert(k <= hdr->num_entries);
+   platform_assert(
+      k <= hdr->num_entries, "k=%d, num_entries=%d\n", k, hdr->num_entries);
    uint64 new_num_entries = k < hdr->num_entries ? hdr->num_entries : k + 1;
 
    if (k < hdr->num_entries) {
@@ -319,7 +320,13 @@ btree_set_leaf_entry(const btree_config *cfg,
 
    leaf_entry *new_entry = pointer_byte_offset(
       hdr, hdr->next_entry - leaf_entry_size(new_key, new_message));
-   platform_assert((void *)&hdr->offsets[new_num_entries] <= (void *)new_entry);
+   platform_assert(
+      (void *)&hdr->offsets[new_num_entries] <= (void *)new_entry,
+      "Offset addr 0x%p for index, new_num_entries=%lu is incorrect."
+      " It should be <= new_entry=0x%p\n",
+      &hdr->offsets[new_num_entries],
+      new_num_entries,
+      new_entry);
    btree_fill_leaf_entry(cfg, hdr, new_entry, new_key, new_message);
 
    hdr->offsets[k]  = diff_ptr(hdr, new_entry);

--- a/src/platform_linux/platform.c
+++ b/src/platform_linux/platform.c
@@ -299,47 +299,34 @@ platform_condvar_broadcast(platform_condvar *cv)
 }
 
 /*
- * platform_assert_impl() -
+ * platform_assert_false() -
  *
  * Platform-specific assert implementation, with support to print an optional
- * message and arguments involved in the assertion failure.
- *
- * NOTE: Parameters 'stream' & 'do_abort' are provided as testing hooks.
- *  Test code supplies these to verify that an expected formatted message is
- *  correctly generated for a failing assertion.
+ * message and arguments involved in the assertion failure. The caller-macro
+ * ensures that this function will only be called when the 'exprval' is FALSE;
+ * i.e. the assertion is failing.
  */
-void
-platform_assert_impl(platform_stream_handle stream,
-                     const char *           filename,
-                     int                    linenumber,
-                     const char *           functionname,
-                     bool                   do_abort,
-                     const char *           expr,
-                     int                    exprval,
-                     const char *           message,
-                     ...)
+__attribute__((noreturn)) void
+platform_assert_false(platform_stream_handle stream,
+                      const char *           filename,
+                      int                    linenumber,
+                      const char *           functionname,
+                      const char *           expr,
+                      const char *           message,
+                      ...)
 {
    va_list varargs;
-   if (LIKELY(exprval)) {
-      return;
-   }
-
    va_start(varargs, message);
 
-   // Run-time assertion messages go to stderr. Test-code supplies its own
-   // output buffer to capture the generated message, for validation.
-   if (!stream) {
-      stream = Platform_stderr_fh;
-   }
+   // Run-time assertion messages go to stderr.
+   stream = Platform_stderr_fh;
    platform_assert_msg(
       stream, filename, linenumber, functionname, expr, message, varargs);
    va_end(varargs);
    platform_log_stream("\n");
    fflush(stream);
 
-   if (do_abort) {
-      abort();
-   }
+   abort();
 }
 
 /*


### PR DESCRIPTION
This commit does minor rework to the body of the platform_assert()
macro to avoid a function call. In most cases, we expect the assertion
to succeed. This rework changes the body to a ternary so we check for
the common-case first, and only then invoke the function implementing
the extra functionality of the assertion checks. Tidy-up the body
retaining the dead-code fprintf(), which is still very useful to
cross-check that print arguments match print formats in the message.