### PR TITLE
(#225) Extend debug_assert() to print user-specified message.

### DIFF
--- a/src/btree_private.h
+++ b/src/btree_private.h
@@ -243,12 +243,27 @@ btree_get_index_entry(const btree_config *cfg,
       before the end of the page. */
    debug_assert(diff_ptr(hdr, &hdr->offsets[hdr->num_entries])
                 <= hdr->offsets[k]);
-   debug_assert(hdr->offsets[k] + sizeof(index_entry) <= btree_page_size(cfg));
+   debug_assert(hdr->offsets[k] + sizeof(index_entry) <= btree_page_size(cfg),
+                "k=%d, offsets[k]=%d, sizeof(index_entry)=%lu"
+                ", btree_page_size=%lu.",
+                k,
+                hdr->offsets[k],
+                sizeof(index_entry),
+                btree_page_size(cfg));
+
    index_entry *entry =
       (index_entry *)const_pointer_byte_offset(hdr, hdr->offsets[k]);
+
    /* Now ensure that the entire entry fits in the page. */
    debug_assert(hdr->offsets[k] + sizeof_index_entry(entry)
-                <= btree_page_size(cfg));
+                   <= btree_page_size(cfg),
+                "Offsets entry at index k=%d does not fit in the page."
+                " offsets[k]=%d, sizeof_index_entry()=%lu"
+                ", btree_page_size=%lu.",
+                k,
+                hdr->offsets[k],
+                sizeof_index_entry(entry),
+                btree_page_size(cfg));
    return entry;
 }
 

--- a/src/platform_linux/platform.h
+++ b/src/platform_linux/platform.h
@@ -185,14 +185,14 @@ extern bool platform_use_mlock;
  *   (These may be candidates to move outside of platform.h entirely)
  */
 #if SPLINTER_DEBUG
-#  define debug_assert( expr ) platform_assert(expr)
-#  define debug_only
-#  define debug_code(...) __VA_ARGS__
+#   define debug_assert(expr, ...) platform_assert(expr, __VA_ARGS__)
+#   define debug_only
+#   define debug_code(...) __VA_ARGS__
 #else
-#  define debug_assert( expr )
-#  define debug_only __attribute__((__unused__))
-#  define debug_code(...)
-#endif
+#   define debug_assert(expr, ...)
+#   define debug_only __attribute__((__unused__))
+#   define debug_code(...)
+#endif // SPLINTER_DEBUG
 
 #define platform_assert_status_ok(_s) platform_assert(SUCCESS(_s));
 


### PR DESCRIPTION
Thes debug_assert() macro is a wrapper around platform_assert() which was recently enhanced to print user-supplied messages.

This commit slightly changes debug_assert() to extend the same printing ability to this interface.