### PR TITLE
Tag disk-resident structs. Add comments. Cleanup code.

### DIFF
--- a/include/splinterdb/data.h
+++ b/include/splinterdb/data.h
@@ -18,7 +18,7 @@
 #include <string.h> // for memmove
 #include "splinterdb/limits.h"
 #include "splinterdb/platform_public.h"
-#include "splinterdb/util.h"
+#include "splinterdb/public_util.h"
 
 typedef enum message_type {
    MESSAGE_TYPE_INSERT,
@@ -68,11 +68,28 @@ typedef void (*key_or_message_to_str_fn)(const data_config *cfg,
                                          char              *str,
                                          size_t             max_len);
 
+/*
+ * ----------------------------------------------------------------------------
+ * data_config: This structure defines the handshake between a
+ * Key-Value Store application built using Splinter primitives. In order to
+ * build this integration, the application needs to tell Splinter a few
+ * different things about keys and values:
+ *
+ *  1. The sorting order of keys - defined by the key_compare function
+ *  2. How to hash keys - defined by the key_hash function
+ *  3. How to merge update messages - defined by the pair of merge_tuples* fns.
+ *  4. Few other debugging aids on how-to print & diagnose messages.
+ *
+ * splinterdb_kv.c is a reference implementation of this integration provided
+ * as a "batteries included" implementation. If any other application wishes
+ * to do something differently, it has to provide these implementations.
+ * ----------------------------------------------------------------------------
+ */
 struct data_config {
    uint64 key_size;
    uint64 message_size;
 
-   // robj: we should get rid of min/max key
+   // FIXME: Planned for deprecation.
    char min_key[MAX_KEY_SIZE];
    char max_key[MAX_KEY_SIZE];
 

--- a/include/splinterdb/public_util.h
+++ b/include/splinterdb/public_util.h
@@ -1,8 +1,8 @@
 // Copyright 2018-2021 VMware, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef __UTIL_H
-#define __UTIL_H
+#ifndef __PUBLIC_UTIL_H__
+#define __PUBLIC_UTIL_H__
 
 typedef struct writable_buffer writable_buffer;
 
@@ -13,7 +13,8 @@ writable_buffer_length(writable_buffer *wb);
 bool
 writable_buffer_set_length(writable_buffer *wb, uint64 newlength);
 
+/* Returns a ptr to the data region held by this writable_buffer */
 void *
 writable_buffer_data(writable_buffer *wb);
 
-#endif /* __UTIL_H */
+#endif /* __PUBLIC_UTIL_H__ */

--- a/include/splinterdb/splinterdb.h
+++ b/include/splinterdb/splinterdb.h
@@ -122,10 +122,15 @@ splinterdb_insert(const splinterdb *kvs,
  * Lookups
  **************/
 
+/*
+ * Lookup result buffer is sized by 6 8-byte fields, defined elsewhere.
+ */
+#define SPLINTERDB_LOOKUP_BUFSIZE (6 * sizeof(void *))
+
 /* Lookup results are stored in a splinterdb_lookup_result.
  */
 typedef struct splinterdb_lookup_result {
-   char opaque[48];
+   char opaque[SPLINTERDB_LOOKUP_BUFSIZE];
 } splinterdb_lookup_result;
 
 /*

--- a/src/allocator.h
+++ b/src/allocator.h
@@ -21,20 +21,57 @@ typedef uint64 allocator_root_id;
 #define AL_NO_REFS 1
 #define AL_FREE    0
 
+/*
+ * ----------------------------------------------------------------------------
+ * Different types of pages managed by SplinterDB:
+ * This is currently not a Disk-resident value, but different modules that
+ * access a type of a page "know" to expect a page of a specific type / format.
+ *
+ * Brief overview of the data structures involved in different page types:
+ *
+ * - PAGE_TYPE_TRUNK      : struct trunk_hdr{} + computed offsets for
+ *                          pivots / branches depending on key_size
+ *                          Following the trunk_hdr{}, we have an array of
+ *                          [<key>, struct trunk_pivot_data{} ]
+ *
+ * - PAGE_TYPE_BRANCH, PAGE_TYPE_MEMTABLE
+ *                        : struct btree_hdr{} + computed items for offsets.
+ *
+ * - PAGE_TYPE_FILTER     : Freeform, because they consist of very concise
+ *                          and heavily optimized data structures
+ *
+ * - PAGE_TYPE_LOG        : struct shard_log_hdr{} + computed offsets
+ *
+ * - PAGE_TYPE_SUPERBLOCK : struct trunk_super_block{}
+ * ----------------------------------------------------------------------------
+ */
 typedef enum page_type {
-   PAGE_TYPE_TRUNK,
+   PAGE_TYPE_FIRST = 0,
+   PAGE_TYPE_TRUNK = PAGE_TYPE_FIRST,
    PAGE_TYPE_BRANCH,
    PAGE_TYPE_MEMTABLE,
    PAGE_TYPE_FILTER,
    PAGE_TYPE_LOG,
-   PAGE_TYPE_MISC,
+   PAGE_TYPE_SUPERBLOCK,
+   PAGE_TYPE_MISC, // Used mainly as a testing hook, for cache access testing.
    PAGE_TYPE_LOCK_NO_DATA,
    NUM_PAGE_TYPES,
    PAGE_TYPE_INVALID,
 } page_type;
 
-static const char *const page_type_str[NUM_PAGE_TYPES] =
-   {"trunk", "branch", "memtable", "filter", "log", "misc", "lock"};
+static const char *const page_type_str[] = {"trunk",
+                                            "branch",
+                                            "memtable",
+                                            "filter",
+                                            "log",
+                                            "superblock",
+                                            "misc",
+                                            "lock"};
+
+// Ensure that the page-type lookup array is adequately sized.
+_Static_assert(
+   ARRAY_SIZE(page_type_str) == NUM_PAGE_TYPES,
+   "Lookup array page_type_str[] is incorrectly sized for NUM_PAGE_TYPES");
 
 typedef struct allocator allocator;
 
@@ -57,6 +94,10 @@ typedef uint64 (*get_size_fn)(allocator *al);
 typedef void (*print_fn)(allocator *al);
 typedef void (*assert_fn)(allocator *al);
 
+/*
+ * Define an abstract allocator interface, holding different allocation-related
+ * function pointers.
+ */
 typedef struct allocator_ops {
    alloc_fn alloc;
 

--- a/src/btree.c
+++ b/src/btree.c
@@ -5,7 +5,7 @@
 #include "poison.h"
 
 /******************************************************************
- * Structure of a BTree node:
+ * Structure of a BTree node: Disk-resident structure:
  *
  *                                 hdr->next_entry
  *                                               |
@@ -13,6 +13,9 @@
  *   -----------------------------------------------------------
  *   | header | offsets table ---> | empty space | <--- entries|
  *   -----------------------------------------------------------
+ *
+ *  header: struct btree_hdr{}
+ *  entry : struct leaf_entry{}
  *
  * The arrows indicate that the offsets table grows to the left
  * and the entries grow to the right.
@@ -40,13 +43,13 @@
  *******************************************************************/
 
 /* Threshold for splitting instead of defragmenting. */
-#define VARIABLE_LENGTH_BTREE_SPLIT_THRESHOLD(page_size) ((page_size) / 2)
+#define BTREE_SPLIT_THRESHOLD(page_size) ((page_size) / 2)
 
 /* After a split, the free space in the left node may be fragmented.
  * If there's less than this much contiguous free space, then we also
  * defrag the left node.
  */
-#define VARIABLE_LENGTH_BTREE_DEFRAGMENT_THRESHOLD(page_size) ((page_size) / 4)
+#define BTREE_DEFRAGMENT_THRESHOLD(page_size) ((page_size) / 4)
 
 char  positive_infinity_buffer;
 slice positive_infinity = {0, &positive_infinity_buffer};
@@ -57,9 +60,9 @@ slice positive_infinity = {0, &positive_infinity_buffer};
  * (because it is difficult to maintain this information during
  * insertion).  However, the current implementation uses the same
  * data structure for both memtables and branches.  So memtables
- * store VARIABLE_LENGTH_BTREE_UNKNOWN for these counters.
+ * store BTREE_UNKNOWN_COUNTER for these counters.
  */
-#define VARIABLE_LENGTH_BTREE_UNKNOWN (0x7fffffffUL)
+#define BTREE_UNKNOWN_COUNTER (0x7fffffffUL)
 
 
 static inline uint8
@@ -120,7 +123,6 @@ leaf_entry_message_size(const leaf_entry *entry)
    return entry->message_size;
 }
 
-
 /**************************************
  * Basic get/set on index nodes
  **************************************/
@@ -139,11 +141,11 @@ btree_fill_index_entry(const btree_config *cfg,
    debug_assert(diff_ptr(hdr, entry) + index_entry_size(new_pivot_key)
                 <= cfg->page_size);
    memcpy(entry->key, slice_data(new_pivot_key), slice_length(new_pivot_key));
-   entry->key_size                         = slice_length(new_pivot_key);
-   entry->pivot_data.child_addr            = new_addr;
-   entry->pivot_data.num_kvs_in_tree       = kv_pairs;
-   entry->pivot_data.key_bytes_in_tree     = key_bytes;
-   entry->pivot_data.message_bytes_in_tree = message_bytes;
+   entry->key_size                            = slice_length(new_pivot_key);
+   entry->pivot_data.child_addr               = new_addr;
+   entry->pivot_data.num_kvs_in_subtree       = kv_pairs;
+   entry->pivot_data.key_bytes_in_subtree     = key_bytes;
+   entry->pivot_data.message_bytes_in_subtree = message_bytes;
 }
 
 bool
@@ -174,7 +176,6 @@ btree_set_index_entry(const btree_config *cfg,
           * In this case, just reset next_entry so we can insert the new entry.
           */
          hdr->next_entry += sizeof_index_entry(old_entry);
-         /* Fall through */
       } else if (index_entry_size(new_pivot_key)
                  <= sizeof_index_entry(old_entry)) {
          /* old_entry is not the physically first in the node,
@@ -878,9 +879,9 @@ btree_split_index_build_right_node(const btree_config *cfg,        // IN
                                i,
                                index_entry_key_slice(entry),
                                index_entry_child_addr(entry),
-                               entry->pivot_data.num_kvs_in_tree,
-                               entry->pivot_data.key_bytes_in_tree,
-                               entry->pivot_data.message_bytes_in_tree);
+                               entry->pivot_data.num_kvs_in_subtree,
+                               entry->pivot_data.key_bytes_in_subtree,
+                               entry->pivot_data.message_bytes_in_subtree);
       platform_assert(succeeded);
    }
 }
@@ -908,9 +909,9 @@ btree_defragment_index(const btree_config *cfg, // IN
                                i,
                                index_entry_key_slice(entry),
                                index_entry_child_addr(entry),
-                               entry->pivot_data.num_kvs_in_tree,
-                               entry->pivot_data.key_bytes_in_tree,
-                               entry->pivot_data.message_bytes_in_tree);
+                               entry->pivot_data.num_kvs_in_subtree,
+                               entry->pivot_data.key_bytes_in_subtree,
+                               entry->pivot_data.message_bytes_in_subtree);
       platform_assert(succeeded);
    }
 }
@@ -932,9 +933,7 @@ btree_truncate_index(const btree_config *cfg, // IN
    hdr->next_entry  = new_next_entry;
    hdr->generation++;
 
-   if (new_next_entry
-       < VARIABLE_LENGTH_BTREE_DEFRAGMENT_THRESHOLD(btree_page_size(cfg)))
-   {
+   if (new_next_entry < BTREE_DEFRAGMENT_THRESHOLD(btree_page_size(cfg))) {
       btree_defragment_index(cfg, scratch, hdr);
    }
 }
@@ -1123,7 +1122,7 @@ btree_create(cache              *cc,
              cfg->data_cfg,
              root.addr + cfg->page_size,
              0,
-             VARIABLE_LENGTH_BTREE_MAX_HEIGHT,
+             BTREE_MAX_HEIGHT,
              type,
              type == PAGE_TYPE_BRANCH);
 
@@ -1266,9 +1265,9 @@ btree_split_child_leaf(cache                 *cc,
                                               index_of_child_in_parent + 1,
                                               pivot_key,
                                               right_child.addr,
-                                              VARIABLE_LENGTH_BTREE_UNKNOWN,
-                                              VARIABLE_LENGTH_BTREE_UNKNOWN,
-                                              VARIABLE_LENGTH_BTREE_UNKNOWN);
+                                              BTREE_UNKNOWN_COUNTER,
+                                              BTREE_UNKNOWN_COUNTER,
+                                              BTREE_UNKNOWN_COUNTER);
       platform_assert(success);
    }
    btree_node_full_unlock(cc, cfg, parent);
@@ -1335,9 +1334,7 @@ btree_defragment_or_split_child_leaf(cache              *cc,
       live_bytes + leaf_entry_size(spec->key, spec_message(spec))
       + (nentries + spec->was_found ? 0 : 1) * sizeof(index_entry);
 
-   if (total_space_required
-       < VARIABLE_LENGTH_BTREE_SPLIT_THRESHOLD(cfg->page_size))
-   {
+   if (total_space_required < BTREE_SPLIT_THRESHOLD(cfg->page_size)) {
       btree_node_unclaim(cc, cfg, parent);
       btree_node_unget(cc, cfg, parent);
       btree_node_lock(cc, cfg, child);
@@ -1414,9 +1411,9 @@ btree_split_child_index(cache              *cc,
                                index_of_child_in_parent + 1,
                                pivot_key,
                                right_child.addr,
-                               VARIABLE_LENGTH_BTREE_UNKNOWN,
-                               VARIABLE_LENGTH_BTREE_UNKNOWN,
-                               VARIABLE_LENGTH_BTREE_UNKNOWN);
+                               BTREE_UNKNOWN_COUNTER,
+                               BTREE_UNKNOWN_COUNTER,
+                               BTREE_UNKNOWN_COUNTER);
    }
    btree_node_full_unlock(cc, cfg, parent);
 
@@ -1481,9 +1478,7 @@ btree_defragment_or_split_child_index(cache              *cc,
    }
    uint64 total_space_required = live_bytes + nentries * sizeof(index_entry);
 
-   if (total_space_required
-       < VARIABLE_LENGTH_BTREE_SPLIT_THRESHOLD(cfg->page_size))
-   {
+   if (total_space_required < BTREE_SPLIT_THRESHOLD(cfg->page_size)) {
       btree_node_full_unlock(cc, cfg, parent);
       btree_defragment_index(cfg, scratch, child->hdr);
       *new_child = *child;
@@ -1507,11 +1502,10 @@ btree_defragment_or_split_child_index(cache              *cc,
 static inline uint64
 add_possibly_unknown(uint32 a, int32 b)
 {
-   if (a != VARIABLE_LENGTH_BTREE_UNKNOWN && b != VARIABLE_LENGTH_BTREE_UNKNOWN)
-   {
+   if (a != BTREE_UNKNOWN_COUNTER && b != BTREE_UNKNOWN_COUNTER) {
       return a + b;
    } else {
-      return VARIABLE_LENGTH_BTREE_UNKNOWN;
+      return BTREE_UNKNOWN_COUNTER;
    }
 }
 
@@ -1538,12 +1532,12 @@ accumulate_node_ranks(const btree_config *cfg,
       for (int i = from; i < to; i++) {
          index_entry *entry = btree_get_index_entry(cfg, hdr, i);
 
-         *num_kvs =
-            add_possibly_unknown(*num_kvs, entry->pivot_data.num_kvs_in_tree);
-         *key_bytes     = add_possibly_unknown(*key_bytes,
-                                           entry->pivot_data.key_bytes_in_tree);
+         *num_kvs   = add_possibly_unknown(*num_kvs,
+                                         entry->pivot_data.num_kvs_in_subtree);
+         *key_bytes = add_possibly_unknown(
+            *key_bytes, entry->pivot_data.key_bytes_in_subtree);
          *message_bytes = add_possibly_unknown(
-            *message_bytes, entry->pivot_data.message_bytes_in_tree);
+            *message_bytes, entry->pivot_data.message_bytes_in_subtree);
       }
    }
 }
@@ -1594,9 +1588,9 @@ btree_grow_root(cache              *cc,   // IN
                                           0,
                                           new_pivot,
                                           child.addr,
-                                          VARIABLE_LENGTH_BTREE_UNKNOWN,
-                                          VARIABLE_LENGTH_BTREE_UNKNOWN,
-                                          VARIABLE_LENGTH_BTREE_UNKNOWN);
+                                          BTREE_UNKNOWN_COUNTER,
+                                          BTREE_UNKNOWN_COUNTER,
+                                          BTREE_UNKNOWN_COUNTER);
    platform_assert(succeeded);
 
    btree_node_unget(cc, cfg, &child);
@@ -1689,9 +1683,9 @@ start_over:
             0,
             key,
             index_entry_child_addr(parent_entry),
-            parent_entry->pivot_data.num_kvs_in_tree,
-            parent_entry->pivot_data.key_bytes_in_tree,
-            parent_entry->pivot_data.message_bytes_in_tree);
+            parent_entry->pivot_data.num_kvs_in_subtree,
+            parent_entry->pivot_data.key_bytes_in_subtree,
+            parent_entry->pivot_data.message_bytes_in_subtree);
       }
       if (btree_index_is_full(cfg, root_node.hdr)) {
          btree_grow_root(cc, cfg, mini, &root_node);
@@ -1705,9 +1699,9 @@ start_over:
             0,
             key,
             index_entry_child_addr(parent_entry),
-            parent_entry->pivot_data.num_kvs_in_tree,
-            parent_entry->pivot_data.key_bytes_in_tree,
-            parent_entry->pivot_data.message_bytes_in_tree);
+            parent_entry->pivot_data.num_kvs_in_subtree,
+            parent_entry->pivot_data.key_bytes_in_subtree,
+            parent_entry->pivot_data.message_bytes_in_subtree);
          platform_assert(success);
       }
       btree_node_unlock(cc, cfg, &root_node);
@@ -1730,11 +1724,11 @@ start_over:
    uint64 height = btree_height(parent_node.hdr);
    while (height > 1) {
       /* loop invariant:
-         - read lock on parent_node, parent_node is an index, parent_node min
-         key is up to date, and parent_node will not need to split.
-         - read lock on child_node
-         - height >= 1
-      */
+       * - read lock on parent_node, parent_node is an index, parent_node min
+       * key is up to date, and parent_node will not need to split.
+       * - read lock on child_node
+       * - height >= 1
+       */
       int64 next_child_idx = btree_find_pivot(cfg, child_node.hdr, key, &found);
       if (next_child_idx < 0 || btree_index_is_full(cfg, child_node.hdr)) {
          if (!btree_node_claim(cc, cfg, &parent_node)) {
@@ -1763,9 +1757,9 @@ start_over:
                0,
                key,
                index_entry_child_addr(child_entry),
-               child_entry->pivot_data.num_kvs_in_tree,
-               child_entry->pivot_data.key_bytes_in_tree,
-               child_entry->pivot_data.message_bytes_in_tree);
+               child_entry->pivot_data.num_kvs_in_subtree,
+               child_entry->pivot_data.key_bytes_in_subtree,
+               child_entry->pivot_data.message_bytes_in_subtree);
          }
 
          if (btree_index_is_full(cfg, child_node.hdr)) {
@@ -1796,9 +1790,9 @@ start_over:
                0,
                key,
                index_entry_child_addr(child_entry),
-               child_entry->pivot_data.num_kvs_in_tree,
-               child_entry->pivot_data.key_bytes_in_tree,
-               child_entry->pivot_data.message_bytes_in_tree);
+               child_entry->pivot_data.num_kvs_in_subtree,
+               child_entry->pivot_data.key_bytes_in_subtree,
+               child_entry->pivot_data.message_bytes_in_subtree);
             platform_assert(success);
          }
          btree_node_unlock(cc, cfg, &parent_node);
@@ -1812,12 +1806,12 @@ start_over:
 
       child_idx    = next_child_idx;
       parent_entry = btree_get_index_entry(cfg, parent_node.hdr, child_idx);
-      debug_assert(parent_entry->pivot_data.num_kvs_in_tree
-                   == VARIABLE_LENGTH_BTREE_UNKNOWN);
-      debug_assert(parent_entry->pivot_data.key_bytes_in_tree
-                   == VARIABLE_LENGTH_BTREE_UNKNOWN);
-      debug_assert(parent_entry->pivot_data.message_bytes_in_tree
-                   == VARIABLE_LENGTH_BTREE_UNKNOWN);
+      debug_assert(parent_entry->pivot_data.num_kvs_in_subtree
+                   == BTREE_UNKNOWN_COUNTER);
+      debug_assert(parent_entry->pivot_data.key_bytes_in_subtree
+                   == BTREE_UNKNOWN_COUNTER);
+      debug_assert(parent_entry->pivot_data.message_bytes_in_subtree
+                   == BTREE_UNKNOWN_COUNTER);
       child_node.addr = index_entry_child_addr(parent_entry);
       debug_assert(cache_page_valid(cc, child_node.addr));
       btree_node_get(cc, cfg, &child_node, PAGE_TYPE_MEMTABLE);
@@ -2821,9 +2815,9 @@ btree_pack_loop(btree_pack_req *req,     // IN/OUT
    for (uint16 i = 1; i <= req->height; i++) {
       index_entry *entry = btree_get_index_entry(
          req->cfg, req->edge[i].hdr, btree_num_entries(req->edge[i].hdr) - 1);
-      entry->pivot_data.num_kvs_in_tree++;
-      entry->pivot_data.key_bytes_in_tree += slice_length(key);
-      entry->pivot_data.message_bytes_in_tree += slice_length(message);
+      entry->pivot_data.num_kvs_in_subtree++;
+      entry->pivot_data.key_bytes_in_subtree += slice_length(key);
+      entry->pivot_data.message_bytes_in_subtree += slice_length(message);
    }
 
    if (req->hash) {
@@ -3090,9 +3084,9 @@ btree_print_locked_node(btree_config          *cfg,
                              i,
                              key_string(dcfg, index_entry_key_slice(entry)),
                              entry->pivot_data.child_addr,
-                             entry->pivot_data.num_kvs_in_tree,
-                             entry->pivot_data.key_bytes_in_tree,
-                             entry->pivot_data.message_bytes_in_tree);
+                             entry->pivot_data.num_kvs_in_subtree,
+                             entry->pivot_data.key_bytes_in_subtree,
+                             entry->pivot_data.message_bytes_in_subtree);
       }
       platform_log_stream("\n");
    } else {

--- a/src/btree.h
+++ b/src/btree.h
@@ -14,10 +14,60 @@
 #include "iterator.h"
 #include "util.h"
 
-#define VARIABLE_LENGTH_BTREE_MAX_HEIGHT (8)
-#define MAX_INLINE_KEY_SIZE              (512)
-#define MAX_INLINE_MESSAGE_SIZE          (2048)
-#define MAX_NODE_SIZE                    (1ULL << 16)
+/*
+ * Max height of the BTree. This is somewhat of an arbitrary limit to size
+ * the maximum storage that can be tracked by a BTree. This constant affects
+ * the size of the BTree depending on the key-size, fanout etc. For default
+ * 4 KiB pages, with an avg row-size of ~512 bytes, we can store roughly
+ * 6-7 rows / page; round it off to 8. With max of 8 levels, that's about
+ * ( 8 ** 8) * 4KiB of storage ~= 64 GiB. This is expected to be plenty big.
+ *
+ * This limit is also related to the batching done by the mini-allocator.
+ * Finally, this is limited for convenience to allow for static allocation
+ * of some nested arrays sized by this value.
+ */
+#define BTREE_MAX_HEIGHT (8)
+
+/*
+ * Mini-allocator uses separate batches for each height of the BTree.
+ * Therefore, the max # of mini-batches that the mini-allocator can track
+ * is limited by the max height of the BTree.
+ */
+_Static_assert(BTREE_MAX_HEIGHT == MINI_MAX_BATCHES,
+               "BTREE_MAX_HEIGHT has to be == MINI_MAX_BATCHES");
+
+/*
+ * Acceptable upper-bound on amount of space to waste when deciding whether
+ * to do pre-emptive splits. Pre-emptive splitting is when we may split a
+ * BTree child node in anticipation that a subsequent split of a grand-child
+ * node may cause this child node to have to split. Pre-emptive splitting
+ * requires that we leave enough free space in each child node for at least
+ * one key + one pivot data. In such cases, we are willing to 'waste' this
+ * much of space on the child node when splitting it.
+ *
+ * In other words, this limit anticpates that a split of a grand-child node
+ * may result in an insertion of a key of this size to the child node. We,
+ * therefore, may pre-emptively split the child to provision for this much of
+ * available space to absorb inserts from the split of a grand-child.
+ *
+ * (This limit is indirectly 'disk-resident' as it affects the node's layout.
+ *  In future, this may need be made a function of the configured page size.)
+ */
+#define MAX_INLINE_KEY_SIZE (512) // Bytes
+
+/*
+ * Size of messages are limited so that a single split will always enable an
+ * index insertion to succeed. Defined currently to serve for default 4K page
+ * sizes. (This limit does not factor in the choice of pre-emptive splitting.
+ * In future, this may need be made a function of the configured page size.)
+ */
+#define MAX_INLINE_MESSAGE_SIZE (2048) // Bytes
+
+/*
+ * Used in-memory to allocate scratch buffer space for BTree splits &
+ * defragmentation.
+ */
+#define MAX_NODE_SIZE (1ULL << 16) // Bytes
 
 extern char         trace_key[24];
 extern page_handle *trace_page;
@@ -40,7 +90,7 @@ typedef struct btree_config {
    data_config *data_cfg;
 } btree_config;
 
-typedef struct PACKED btree_hdr btree_hdr;
+typedef struct ONDISK btree_hdr btree_hdr;
 
 typedef struct btree_node {
    uint64       addr;
@@ -61,13 +111,27 @@ typedef struct { // Note: not a union
    scratch_btree_defragment_node defragment_node;
 } PLATFORM_CACHELINE_ALIGNED btree_scratch;
 
-typedef struct PACKED btree_pivot_data {
+/*
+ * *************************************************************************
+ * BTree pivot data: Disk-resident structure
+ *
+ * Metadata for a pivot of an internal BTree node. Returned from an iterator
+ * of height > 0 in order to track amount of data stored in sub-trees, given
+ * by stuff like # of key/value pairs, # of bytes stored in the tree.
+ *
+ * Iterators at (height > 0) return this struct as a value for each pivot.
+ * *************************************************************************
+ */
+typedef struct ONDISK btree_pivot_data {
    uint64 child_addr;
-   uint32 num_kvs_in_tree;
-   uint32 key_bytes_in_tree;
-   uint32 message_bytes_in_tree;
+   uint32 num_kvs_in_subtree;
+   uint32 key_bytes_in_subtree;
+   uint32 message_bytes_in_subtree;
 } btree_pivot_data;
 
+/*
+ * A BTree iterator:
+ */
 typedef struct btree_iterator {
    iterator      super;
    cache        *cc;
@@ -103,7 +167,7 @@ typedef struct btree_pack_req {
    // internal data
    uint64         next_extent;
    uint16         height;
-   btree_node     edge[VARIABLE_LENGTH_BTREE_MAX_HEIGHT];
+   btree_node     edge[BTREE_MAX_HEIGHT];
    mini_allocator mini;
 
    // output of the compaction

--- a/src/btree_private.h
+++ b/src/btree_private.h
@@ -16,17 +16,24 @@
 #include "util.h"
 #include "btree.h"
 
+/*
+ * Typedefs for disk-resident index / offset / sizes of pieces of BTree row
+ * formats. These appear in other disk-resident structures defined below.
+ */
 typedef uint16 table_index; //  So we can make this bigger for bigger nodes.
 typedef uint16 node_offset; //  So we can make this bigger for bigger nodes.
 typedef node_offset table_entry;
 typedef uint16      inline_key_size;
 typedef uint16      inline_message_size;
 
-/* **********************
- * Node headers
- * *********************
+/*
+ * *************************************************************************
+ * BTree Node headers: Disk-resident structure:
+ * Stored on pages of Page Type == PAGE_TYPE_MEMTABLE, PAGE_TYPE_BRANCH
+ * See btree.c for a description of the layout of this page format.
+ * *************************************************************************
  */
-struct PACKED btree_hdr {
+struct ONDISK btree_hdr {
    uint64      next_addr;
    uint64      next_extent_addr;
    uint64      generation;
@@ -36,11 +43,12 @@ struct PACKED btree_hdr {
    table_entry offsets[];
 };
 
-/* **********************************
- * Node entries
- * *********************************
+/*
+ * *************************************************************************
+ * BTree Node index entries: Disk-resident structure
+ * *************************************************************************
  */
-typedef struct PACKED index_entry {
+typedef struct ONDISK index_entry {
    btree_pivot_data pivot_data;
    inline_key_size  key_size;
    char             key[];
@@ -53,7 +61,17 @@ _Static_assert(sizeof(index_entry)
 _Static_assert(offsetof(index_entry, key) == sizeof(index_entry),
                "index_entry key has wrong offset");
 
-typedef struct PACKED leaf_entry {
+/*
+ * *************************************************************************
+ * BTree Leaf entry: Disk-resident structure
+ *
+ * The key and message data are laid out abutting each other on the BTree
+ * leaf node. This structure describes that layout in terms of the length
+ * of the key-portion and the message-portion, following which appears
+ * the concatenated [<key>, <message>] datum.
+ * *************************************************************************
+ */
+typedef struct ONDISK leaf_entry {
    inline_key_size     key_size;
    inline_message_size message_size;
    char                key_and_message[];
@@ -102,10 +120,10 @@ typedef struct leaf_splitting_plan {
 } leaf_splitting_plan;
 
 /*
- * ************************************************************************
- * External function prototypes: Declare these first, as some inine static
+ * *************************************************************************
+ * External function prototypes: Declare these first, as some inline static
  * functions defined below may call these extern functions.
- * ************************************************************************
+ * *************************************************************************
  */
 bool
 btree_set_index_entry(const btree_config *cfg,

--- a/src/cache.h
+++ b/src/cache.h
@@ -21,6 +21,11 @@ typedef struct page_handle {
 
 typedef struct cache cache;
 
+/*
+ * Cache usage statistics structure, for different page types in the cache.
+ * An array of this structure, one for each thread configured, is stored in
+ * the global clockcache structure.
+ */
 typedef struct cache_stats {
    uint64 cache_hits[NUM_PAGE_TYPES];
    uint64 cache_misses[NUM_PAGE_TYPES];
@@ -70,7 +75,10 @@ typedef enum {
 struct cache_async_ctxt;
 typedef void (*cache_async_cb)(struct cache_async_ctxt *ctxt);
 
-// User can embed this within an user-specific context
+/*
+ * Context structure to manage async access through the cache.
+ * User can embed this within a user-specific context
+ */
 typedef struct cache_async_ctxt {
    cache          *cc;     // IN cache
    cache_async_cb  cb;     // IN callback for async_io_started
@@ -123,6 +131,11 @@ typedef void (*enable_sync_get_fn)(cache *cc, bool enabled);
 typedef allocator *(*cache_allocator_fn)(cache *cc);
 typedef uint64 (*base_addr_fn)(cache *cc, uint64 addr);
 
+/*
+ * Cache Operations structure:
+ * Defines an abstract collection of "cache operation"-function pointers
+ * for a caching system.
+ */
 typedef struct cache_ops {
    page_alloc_fn           page_alloc;
    extent_hard_evict_fn    extent_hard_evict;

--- a/src/clockcache.c
+++ b/src/clockcache.c
@@ -22,9 +22,7 @@
 
 /*
  *-----------------------------------------------------------------------------
- *
  * Constants and Fixed Parameters
- *
  *-----------------------------------------------------------------------------
  */
 
@@ -552,25 +550,18 @@ static cache_ops clockcache_ops = {
 
 /*
  *-----------------------------------------------------------------------------
- *
  * clockcache_entry --
  *
  *     The meta data entry in the cache. Each entry has the underlying
  *     page_handle together with some flags.
- *
  *-----------------------------------------------------------------------------
  */
 
 /*
  *-----------------------------------------------------------------------------
- *
- * Status Constants and Functions
- *
+ * Definitions for entry_status (clockcache_entry->status)
  *-----------------------------------------------------------------------------
  */
-
-typedef uint32 entry_status;
-
 #define CC_FREE        (1u << 0) // entry is free
 #define CC_ACCESSED    (1u << 1) // access bit prevents eviction for one cycle
 #define CC_CLEAN       (1u << 2) // page has no new changes
@@ -610,45 +601,72 @@ typedef uint32 entry_status;
 // loading for read
 #define CC_READ_LOADING_STATUS (0 | CC_ACCESSED | CC_CLEAN | CC_LOADING)
 
+/*
+ *-----------------------------------------------------------------------------
+ * Clock cache Functions
+ *-----------------------------------------------------------------------------
+ */
 /*-----------------------------------------------------------------------------
  * clockcache_{set/clear/test}_flag --
  *
  *      Atomically sets, clears or tests the given flag in the entry.
  *-----------------------------------------------------------------------------
  */
+
+/* Validate entry_number, and return addr of clockcache_entry slot */
+static inline clockcache_entry *
+clockcache_get_entry(clockcache *cc, uint32 entry_number)
+{
+   debug_assert(entry_number < cc->cfg->page_capacity,
+                "entry_number=%u is out-of-bounds. Should be < %d.",
+                entry_number,
+                cc->cfg->page_capacity);
+   return (&cc->entry[entry_number]);
+}
+
 static inline entry_status
-clockcache_set_flag(clockcache *cc, entry_status entry_number, uint32 flag)
+clockcache_set_flag(clockcache *cc, uint32 entry_number, entry_status flag)
 {
-   return flag & __sync_fetch_and_or(&cc->entry[entry_number].status, flag);
+   return flag
+          & __sync_fetch_and_or(&clockcache_get_entry(cc, entry_number)->status,
+                                flag);
 }
 
 static inline uint32
-clockcache_clear_flag(clockcache *cc, uint32 entry_number, uint32 flag)
+clockcache_clear_flag(clockcache *cc, uint32 entry_number, entry_status flag)
 {
-   return flag & __sync_fetch_and_and(&cc->entry[entry_number].status, ~flag);
+   return flag
+          & __sync_fetch_and_and(
+             &clockcache_get_entry(cc, entry_number)->status, ~flag);
 }
 
 static inline uint32
-clockcache_test_flag(clockcache *cc, uint32 entry_number, uint32 flag)
+clockcache_test_flag(clockcache *cc, uint32 entry_number, entry_status flag)
 {
-   return flag & cc->entry[entry_number].status;
+   return flag & clockcache_get_entry(cc, entry_number)->status;
 }
 
 #ifdef RECORD_ACQUISITION_STACKS
 static void
 clockcache_record_backtrace(clockcache *cc, uint32 entry_number)
 {
-   int myhistindex =
-      __sync_fetch_and_add(&cc->entry[entry_number].next_history_record, 1);
-   myhistindex               = myhistindex % 32;
+   // clang-format off
+   int myhistindex = __sync_fetch_and_add(
+                            &clockcache_get_entry(cc, entry_number)->next_history_record,
+                            1);
+   // clang-format on
+   myhistindex = myhistindex % NUM_HISTORY_RECORDS;
+
+   // entry_number is now known to be valid; offset into slot directly.
    clockcache_entry *myEntry = &cc->entry[entry_number];
 
    myEntry->history[myhistindex].status   = myEntry->status;
    myEntry->history[myhistindex].refcount = 0;
-   for (threadid i = 0; i < MAX_THREADS; i++)
+   for (threadid i = 0; i < MAX_THREADS; i++) {
       myEntry->history[myhistindex].refcount +=
          cc->refcount[i * cc->cfg->page_capacity + entry_number];
-   backtrace(myEntry->history[myhistindex].backtrace, 32);
+   }
+   backtrace(myEntry->history[myhistindex].backtrace, NUM_HISTORY_RECORDS);
 }
 #else
 #   define clockcache_record_backtrace(a, b)
@@ -678,8 +696,17 @@ clockcache_divide_by_page_size(clockcache *cc, uint64 addr)
 static inline uint32
 clockcache_lookup(clockcache *cc, uint64 addr)
 {
-   uint64 lookup_no = clockcache_divide_by_page_size(cc, addr);
-   return cc->lookup[lookup_no];
+   uint64 lookup_no    = clockcache_divide_by_page_size(cc, addr);
+   uint32 entry_number = cc->lookup[lookup_no];
+
+   debug_assert(((entry_number < cc->cfg->page_capacity)
+                 || (entry_number == CC_UNMAPPED_ENTRY)),
+                "entry_number=%u is out-of-bounds. "
+                " Should be either CC_UNMAPPED_ENTRY,"
+                " or should be < %d.",
+                entry_number,
+                cc->cfg->page_capacity);
+   return entry_number;
 }
 
 static inline clockcache_entry *
@@ -693,7 +720,8 @@ clockcache_pages_share_extent(clockcache *cc,
                               uint64      left_addr,
                               uint64      right_addr)
 {
-   return left_addr / cc->cfg->extent_size == right_addr / cc->cfg->extent_size;
+   return (left_addr / cc->cfg->extent_size)
+          == (right_addr / cc->cfg->extent_size);
 }
 
 static inline clockcache_entry *
@@ -875,8 +903,9 @@ clockcache_assert_no_locks_held(clockcache *cc)
 {
    uint64 i;
    clockcache_assert_no_refs_and_pins(cc);
-   for (i = 0; i < cc->cfg->page_capacity; i++)
+   for (i = 0; i < cc->cfg->page_capacity; i++) {
       debug_assert(!clockcache_test_flag(cc, i, CC_WRITELOCKED));
+   }
 }
 
 void
@@ -884,9 +913,10 @@ clockcache_assert_clean(clockcache *cc)
 {
    uint64 i;
 
-   for (i = 0; i < cc->cfg->page_capacity; i++)
+   for (i = 0; i < cc->cfg->page_capacity; i++) {
       debug_assert(clockcache_test_flag(cc, i, CC_FREE)
                    || clockcache_test_flag(cc, i, CC_CLEAN));
+   }
 }
 
 /*
@@ -1163,9 +1193,9 @@ clockcache_ok_to_writeback(clockcache *cc,
                            uint32      entry_number,
                            bool        with_access)
 {
-   uint32 status = cc->entry[entry_number].status;
-   return status == CC_CLEANABLE1_STATUS
-          || (with_access && status == CC_CLEANABLE2_STATUS);
+   uint32 status = clockcache_get_entry(cc, entry_number)->status;
+   return ((status == CC_CLEANABLE1_STATUS)
+           || (with_access && status == CC_CLEANABLE2_STATUS));
 }
 
 /*
@@ -1183,15 +1213,25 @@ clockcache_try_set_writeback(clockcache *cc,
                              uint32      entry_number,
                              bool        with_access)
 {
+   // Validate first, as we need access to volatile status * below.
+   debug_assert(entry_number < cc->cfg->page_capacity,
+                "entry_number=%u is out-of-bounds. Should be < %d.",
+                entry_number,
+                cc->cfg->page_capacity);
+
    volatile uint32 *status = &cc->entry[entry_number].status;
    if (__sync_bool_compare_and_swap(
           status, CC_CLEANABLE1_STATUS, CC_WRITEBACK1_STATUS))
+   {
       return TRUE;
+   }
 
    if (with_access
        && __sync_bool_compare_and_swap(
           status, CC_CLEANABLE2_STATUS, CC_WRITEBACK2_STATUS))
+   {
       return TRUE;
+   }
    return FALSE;
 }
 
@@ -1229,7 +1269,7 @@ clockcache_write_callback(void           *metadata,
    for (i = 0; i < count; i++) {
       entry_number =
          clockcache_data_to_entry_number(cc, (char *)iovec[i].iov_base);
-      entry = &cc->entry[entry_number];
+      entry = clockcache_get_entry(cc, entry_number);
       addr  = entry->page.disk_addr;
 
       clockcache_log(addr,
@@ -1369,7 +1409,7 @@ clockcache_batch_start_writeback(clockcache *cc, uint64 batch, bool is_urgent)
 static void
 clockcache_try_evict(clockcache *cc, uint32 entry_number)
 {
-   clockcache_entry *entry = &cc->entry[entry_number];
+   clockcache_entry *entry = clockcache_get_entry(cc, entry_number);
    const threadid    tid   = platform_get_tid();
 
    /* store status for testing, then clear CC_ACCESSED */
@@ -1936,7 +1976,7 @@ clockcache_try_hard_evict(clockcache *cc, uint64 addr)
          clockcache_wait(cc);
       }
 
-      clockcache_entry *entry = &cc->entry[entry_number];
+      clockcache_entry *entry = clockcache_get_entry(cc, entry_number);
 
       if (entry->page.disk_addr != addr) {
          // raced with eviction, try again
@@ -2048,7 +2088,10 @@ clockcache_get_internal(clockcache   *cc,       // IN
 
    debug_assert(allocator_get_ref(cc->al, base_addr) > 1);
 
+   // We expect entry_number to be valid, but it's still validated below
+   // in case some arithmetic goes wrong.
    entry_number = clockcache_lookup(cc, addr);
+
    if (entry_number != CC_UNMAPPED_ENTRY) {
       if (blocking) {
          if (clockcache_get_read(cc, entry_number) != GET_RC_SUCCESS) {
@@ -2060,7 +2103,7 @@ clockcache_get_internal(clockcache   *cc,       // IN
                            addr);
             return TRUE;
          }
-         if (cc->entry[entry_number].page.disk_addr != addr) {
+         if (clockcache_get_entry(cc, entry_number)->page.disk_addr != addr) {
             // this also means we raced with eviction and really lost
             clockcache_dec_ref(cc, entry_number, tid);
             return TRUE;
@@ -2085,7 +2128,8 @@ clockcache_get_internal(clockcache   *cc,       // IN
                               addr);
                return TRUE;
             case GET_RC_SUCCESS:
-               if (cc->entry[entry_number].page.disk_addr != addr) {
+               if (clockcache_get_entry(cc, entry_number)->page.disk_addr
+                   != addr) {
                   // this also means we raced with eviction and really lost
                   clockcache_dec_ref(cc, entry_number, tid);
                   return TRUE;
@@ -2099,7 +2143,7 @@ clockcache_get_internal(clockcache   *cc,       // IN
       while (clockcache_test_flag(cc, entry_number, CC_LOADING)) {
          clockcache_wait(cc);
       }
-      entry = &cc->entry[entry_number];
+      entry = clockcache_get_entry(cc, entry_number);
 
       if (cc->cfg->use_stats) {
          cc->stats[tid].cache_hits[type]++;
@@ -2121,7 +2165,7 @@ clockcache_get_internal(clockcache   *cc,       // IN
                                            CC_READ_LOADING_STATUS,
                                            TRUE,  // refcount
                                            TRUE); // blocking
-   entry        = &cc->entry[entry_number];
+   entry        = clockcache_get_entry(cc, entry_number);
    /*
     * If someone else is loading the page and has reserved the lookup, let them
     * do it.
@@ -2218,7 +2262,7 @@ clockcache_read_async_callback(void           *metadata,
 
    uint32 entry_number =
       clockcache_data_to_entry_number(cc, (char *)iovec[0].iov_base);
-   clockcache_entry *entry = &cc->entry[entry_number];
+   clockcache_entry *entry = clockcache_get_entry(cc, entry_number);
    uint64            addr  = entry->page.disk_addr;
    debug_assert(addr != CC_UNMAPPED_ADDR);
 
@@ -2306,7 +2350,7 @@ clockcache_get_async(clockcache       *cc,   // IN
                         addr);
          return async_locked;
       }
-      if (cc->entry[entry_number].page.disk_addr != addr) {
+      if (clockcache_get_entry(cc, entry_number)->page.disk_addr != addr) {
          // this also means we raced with eviction and really lost
          clockcache_dec_ref(cc, entry_number, tid);
          return async_locked;
@@ -2319,7 +2363,7 @@ clockcache_get_async(clockcache       *cc,   // IN
          clockcache_dec_ref(cc, entry_number, tid);
          return async_locked;
       }
-      entry = &cc->entry[entry_number];
+      entry = clockcache_get_entry(cc, entry_number);
 
       if (cc->cfg->use_stats) {
          cc->stats[tid].cache_hits[type]++;
@@ -2344,7 +2388,8 @@ clockcache_get_async(clockcache       *cc,   // IN
    if (entry_number == CC_UNMAPPED_ENTRY) {
       return async_locked;
    }
-   entry = &cc->entry[entry_number];
+   entry = clockcache_get_entry(cc, entry_number);
+
    /*
     * If someone else is loading the page and has reserved the lookup, let them
     * do it.
@@ -2653,16 +2698,14 @@ clockcache_page_sync(clockcache  *cc,
    }
 }
 
-
 /*
  *----------------------------------------------------------------------
  * clockcache_sync_callback --
  *
- *      internal callback for clockcache_extent_sync which decrements the pages
- *      outstanding counter
+ *      Internal callback for clockcache_extent_sync which decrements
+ *      the pages-outstanding counter.
  *----------------------------------------------------------------------
  */
-
 typedef struct clockcache_sync_callback_req {
    clockcache *cc;
    uint64     *pages_outstanding;
@@ -2725,7 +2768,8 @@ clockcache_extent_sync(clockcache *cc, uint64 addr, uint64 *pages_outstanding)
             cc_req->pages_outstanding = pages_outstanding;
             iovec                     = io_get_iovec(cc->io, io_req);
          }
-         iovec[req_count++].iov_base = cc->entry[entry_number].page.data;
+         iovec[req_count++].iov_base =
+            clockcache_get_entry(cc, entry_number)->page.data;
       } else {
          // ALEX: There is maybe a race with eviction with this assertion
          debug_assert(entry_number == CC_UNMAPPED_ENTRY
@@ -2931,11 +2975,15 @@ clockcache_print(clockcache *cc)
    platform_log_stream("************************** CACHE CONTENTS "
                        "**************************\n");
    for (i = 0; i < cc->cfg->page_capacity; i++) {
-      if (i != 0 && i % 16 == 0)
+      if (i != 0 && i % 16 == 0) {
          platform_log_stream("\n");
-      if (i % CC_ENTRIES_PER_BATCH == 0)
-         platform_log_stream(
-            "Word %lu entries %lu-%lu\n", i / CC_ENTRIES_PER_BATCH, i, i + 63);
+      }
+      if (i % CC_ENTRIES_PER_BATCH == 0) {
+         platform_log_stream("Word %lu entries %lu-%lu\n",
+                             (i / CC_ENTRIES_PER_BATCH),
+                             i,
+                             i + 63);
+      }
       status   = cc->entry[i].status;
       refcount = 0;
       for (thr_i = 0; thr_i < CC_RC_WIDTH; thr_i++) {
@@ -3060,14 +3108,14 @@ clockcache_print_stats(clockcache *cc)
          global_stats.cache_hits[PAGE_TYPE_MEMTABLE],
          global_stats.cache_hits[PAGE_TYPE_FILTER],
          global_stats.cache_hits[PAGE_TYPE_LOG],
-         global_stats.cache_hits[PAGE_TYPE_MISC]);
+         global_stats.cache_hits[PAGE_TYPE_SUPERBLOCK]);
    platform_log("cache misses    | %10lu | %10lu | %10lu | %10lu | %10lu | %10lu |\n",
          global_stats.cache_misses[PAGE_TYPE_TRUNK],
          global_stats.cache_misses[PAGE_TYPE_BRANCH],
          global_stats.cache_misses[PAGE_TYPE_MEMTABLE],
          global_stats.cache_misses[PAGE_TYPE_FILTER],
          global_stats.cache_misses[PAGE_TYPE_LOG],
-         global_stats.cache_misses[PAGE_TYPE_MISC]);
+         global_stats.cache_misses[PAGE_TYPE_SUPERBLOCK]);
    platform_log("cache miss time | " FRACTION_FMT(9, 2)"s | "
                 FRACTION_FMT(9, 2)"s | "FRACTION_FMT(9, 2)"s | "
                 FRACTION_FMT(9, 2)"s | "FRACTION_FMT(9, 2)"s | "
@@ -3077,21 +3125,21 @@ clockcache_print_stats(clockcache *cc)
                 FRACTION_ARGS(miss_time[PAGE_TYPE_MEMTABLE]),
                 FRACTION_ARGS(miss_time[PAGE_TYPE_FILTER]),
                 FRACTION_ARGS(miss_time[PAGE_TYPE_LOG]),
-                FRACTION_ARGS(miss_time[PAGE_TYPE_MISC]));
+                FRACTION_ARGS(miss_time[PAGE_TYPE_SUPERBLOCK]));
    platform_log("pages written   | %10lu | %10lu | %10lu | %10lu | %10lu | %10lu |\n",
          global_stats.page_writes[PAGE_TYPE_TRUNK],
          global_stats.page_writes[PAGE_TYPE_BRANCH],
          global_stats.page_writes[PAGE_TYPE_MEMTABLE],
          global_stats.page_writes[PAGE_TYPE_FILTER],
          global_stats.page_writes[PAGE_TYPE_LOG],
-         global_stats.page_writes[PAGE_TYPE_MISC]);
+         global_stats.page_writes[PAGE_TYPE_SUPERBLOCK]);
    platform_log("pages read      | %10lu | %10lu | %10lu | %10lu | %10lu | %10lu |\n",
          global_stats.page_reads[PAGE_TYPE_TRUNK],
          global_stats.page_reads[PAGE_TYPE_BRANCH],
          global_stats.page_reads[PAGE_TYPE_MEMTABLE],
          global_stats.page_reads[PAGE_TYPE_FILTER],
          global_stats.page_reads[PAGE_TYPE_LOG],
-         global_stats.page_reads[PAGE_TYPE_MISC]);
+         global_stats.page_reads[PAGE_TYPE_SUPERBLOCK]);
    platform_log("avg prefetch pg |  " FRACTION_FMT(9, 2)" |  "
                 FRACTION_FMT(9, 2)" |  "FRACTION_FMT(9, 2)" |  "
                 FRACTION_FMT(9, 2)" |  "FRACTION_FMT(9, 2)" |  "
@@ -3101,7 +3149,7 @@ clockcache_print_stats(clockcache *cc)
                 FRACTION_ARGS(avg_prefetch_pages[PAGE_TYPE_MEMTABLE]),
                 FRACTION_ARGS(avg_prefetch_pages[PAGE_TYPE_FILTER]),
                 FRACTION_ARGS(avg_prefetch_pages[PAGE_TYPE_LOG]),
-                FRACTION_ARGS(avg_prefetch_pages[PAGE_TYPE_MISC]));
+                FRACTION_ARGS(avg_prefetch_pages[PAGE_TYPE_SUPERBLOCK]));
    platform_default_log("-----------------------------------------------------------------------------------------------\n");
    platform_log("avg write pgs: "FRACTION_FMT(9,2)"\n",
          FRACTION_ARGS(avg_write_pages));

--- a/src/clockcache.h
+++ b/src/clockcache.h
@@ -24,6 +24,9 @@
 /* how distributed the rw locks are */
 #define CC_RC_WIDTH 4
 
+/*
+ * Configuration struct to setup the clock cache sub-system.
+ */
 typedef struct clockcache_config {
    uint64 page_size;
    uint64 log_page_size;
@@ -43,13 +46,19 @@ typedef struct clockcache       clockcache;
 typedef struct clockcache_entry clockcache_entry;
 
 #ifdef RECORD_ACQUISITION_STACKS
+
+// Provide a small number of backtrace history records.
+#   define NUM_HISTORY_RECORDS 32
+
 typedef struct history_record {
    uint32 status;
    int    refcount;
-   void  *backtrace[32];
+   void  *backtrace[NUM_HISTORY_RECORDS];
 } history_record;
-#endif
+#endif // RECORD_ACQUISITION_STACKS
 
+
+typedef uint32 entry_status; // Saved in clockcache_entry->status
 
 /*
  *-----------------------------------------------------------------------------
@@ -60,12 +69,12 @@ typedef struct history_record {
  *-----------------------------------------------------------------------------
  */
 struct clockcache_entry {
-   page_handle     page;
-   volatile uint32 status;
-   page_type       type;
+   page_handle           page;
+   volatile entry_status status;
+   page_type             type;
 #ifdef RECORD_ACQUISITION_STACKS
    int            next_history_record;
-   history_record history[32];
+   history_record history[NUM_HISTORY_RECORDS];
 #endif
 };
 

--- a/src/io.h
+++ b/src/io.h
@@ -15,6 +15,9 @@
 typedef struct io_handle    io_handle;
 typedef struct io_async_req io_async_req;
 
+/*
+ * IO Configuration structure - used to setup the run-time IO system.
+ */
 typedef struct io_config {
    uint64 async_queue_size;
    uint64 kernel_queue_size;
@@ -57,6 +60,9 @@ typedef void (*io_cleanup_all_fn)(io_handle *io);
 typedef void (*io_thread_register_fn)(io_handle *io);
 typedef bool (*io_max_latency_elapsed_fn)(io_handle *io, timestamp ts);
 
+/*
+ * An abstract IO interface, holding different IO Ops function pointers.
+ */
 typedef struct io_ops {
    io_read_fn                read;
    io_write_fn               write;
@@ -167,17 +173,14 @@ io_max_latency_elapsed(io_handle *io, timestamp ts)
 
 /*
  *-----------------------------------------------------------------------------
- *
  * io_config_init --
  *
  *      Initialize io config values
  *
  *  (Stores a copy of io_filename to io_cfg->filename, so the caller may
  *  deallocate io_filename once this returns)
- *
  *-----------------------------------------------------------------------------
  */
-
 static inline void
 io_config_init(io_config  *io_cfg,
                uint64      page_size,

--- a/src/mini_allocator.h
+++ b/src/mini_allocator.h
@@ -6,6 +6,12 @@
  *
  *     This file contains the abstract interface for an allocator which
  *     allocates individual pages from extents.
+ *
+ *     The purpose of the mini allocator is to allocate pages from extents
+ *     and to maintain a list of allocated extents for future bulk operations,
+ *     such as reference counting and deallocation. Keyed mini allocators
+ *     further associate a key range to each extent, so that these bulk
+ *     operations can be restricted to given key ranges.
  */
 
 #ifndef __MINI_ALLOCATOR_H
@@ -16,8 +22,18 @@
 #include "cache.h"
 #include "data_internal.h"
 
+/*
+ * Mini-allocator breaks extents into pages. The pages are fed out of separate
+ * batches, so that pages from each batch are contiguous within extents. This
+ * facilitates, for example, packing successive BTree leaves contiguously into
+ * extents. This batch-size is somewhat of an artificial limit to manage this
+ * contiguity.
+ */
 #define MINI_MAX_BATCHES 8
 
+/*
+ * mini_allocator: Mini-allocator context.
+ */
 typedef struct mini_allocator {
    allocator      *al;
    cache          *cc;

--- a/src/platform_linux/platform.h
+++ b/src/platform_linux/platform.h
@@ -61,6 +61,9 @@
  */
 #define ARRAY_SIZE(x) ASSERT_EXPR(IS_ARRAY(x), (sizeof(x) / sizeof((x)[0])))
 
+/* Evaluates to sizeof() a field, f, in a C-structure, s */
+#define FSIZEOF(s, f) sizeof(((typeof(s) *)NULL)->f)
+
 #define MAX_THREADS (64)
 
 #define HASH_SEED         (42)

--- a/src/rc_allocator.c
+++ b/src/rc_allocator.c
@@ -31,7 +31,6 @@
  * #define SHOULD_TRACE(addr) (1) // trace all addresses
  * #define SHOULD_TRACE(addr) ((addr) / (4096 * 32) == 339ULL) // trace extent
  * 339
- *
  */
 #define SHOULD_TRACE(addr) (0) // Do not trace anything
 
@@ -210,8 +209,6 @@ const static allocator_ops rc_allocator_ops = {
 static platform_status
 rc_allocator_init_meta_page(rc_allocator *al)
 {
-   _Static_assert(offsetof(rc_allocator_meta_page, splinters) == 0,
-                  "splinter array should be first field in meta_page struct");
    /*
     * To make it easier to do aligned i/o's we allocate the meta page to
     * always be page size. In the future we can use the remaining space
@@ -223,8 +220,7 @@ rc_allocator_init_meta_page(rc_allocator *al)
     * Ensure that the meta page and  all the super blocks will fit in one
     * extent.
     */
-   platform_assert((1 + RC_ALLOCATOR_MAX_ALLOCATOR_ROOT_IDS)
-                      * al->cfg->page_size
+   platform_assert((1 + RC_ALLOCATOR_MAX_ROOT_IDS) * al->cfg->page_size
                    <= al->cfg->extent_size);
 
    al->meta_page = platform_aligned_malloc(
@@ -319,7 +315,7 @@ rc_allocator_init(rc_allocator        *al,
    memset(al->ref_count, 0, buffer_size);
 
    // allocate the super block
-   allocator_alloc(&al->super, &addr, PAGE_TYPE_MISC);
+   allocator_alloc(&al->super, &addr, PAGE_TYPE_SUPERBLOCK);
    // super block extent should always start from address 0.
    platform_assert(addr == RC_ALLOCATOR_BASE_OFFSET);
 
@@ -330,7 +326,7 @@ rc_allocator_init(rc_allocator        *al,
    rc_extent_count =
       (buffer_size + al->cfg->extent_size - 1) / al->cfg->extent_size;
    for (uint64 i = 0; i < rc_extent_count; i++) {
-      allocator_alloc(&al->super, &addr, PAGE_TYPE_MISC);
+      allocator_alloc(&al->super, &addr, PAGE_TYPE_SUPERBLOCK);
       platform_assert(addr == cfg->extent_size * (i + 1));
    }
 
@@ -405,7 +401,7 @@ rc_allocator_mount(rc_allocator        *al,
                            sizeof(al->meta_page->splinters),
                            RC_ALLOCATOR_META_PAGE_CSUM_SEED);
    if (!platform_checksum_is_equal(al->meta_page->checksum, currChecksum)) {
-      platform_assert(0 == "Corrupt Meta Page upon mount");
+      platform_assert(0, "Corrupt Meta Page upon mount");
    }
 
    // load the ref counts from disk.
@@ -525,7 +521,7 @@ rc_allocator_get_super_addr(rc_allocator     *al,
    platform_status status = STATUS_NOT_FOUND;
 
    platform_mutex_lock(&al->lock);
-   for (uint8 idx = 0; idx < RC_ALLOCATOR_MAX_ALLOCATOR_ROOT_IDS; idx++) {
+   for (uint8 idx = 0; idx < RC_ALLOCATOR_MAX_ROOT_IDS; idx++) {
       if (al->meta_page->splinters[idx] == allocator_root_id) {
          // have already seen this table before, return existing addr.
          *addr  = (1 + idx) * al->cfg->page_size;
@@ -546,7 +542,7 @@ rc_allocator_alloc_super_addr(rc_allocator     *al,
    platform_status status = STATUS_NOT_FOUND;
 
    platform_mutex_lock(&al->lock);
-   for (uint8 idx = 0; idx < RC_ALLOCATOR_MAX_ALLOCATOR_ROOT_IDS; idx++) {
+   for (uint8 idx = 0; idx < RC_ALLOCATOR_MAX_ROOT_IDS; idx++) {
       if (al->meta_page->splinters[idx] == INVALID_ALLOCATOR_ROOT_ID) {
          // assign the first available slot and update the on disk metadata.
          al->meta_page->splinters[idx] = allocator_root_id;
@@ -569,14 +565,13 @@ rc_allocator_alloc_super_addr(rc_allocator     *al,
    return status;
 }
 
-
 void
 rc_allocator_remove_super_addr(rc_allocator     *al,
                                allocator_root_id allocator_root_id)
 {
    platform_mutex_lock(&al->lock);
 
-   for (uint8 idx = 0; idx < RC_ALLOCATOR_MAX_ALLOCATOR_ROOT_IDS; idx++) {
+   for (uint8 idx = 0; idx < RC_ALLOCATOR_MAX_ROOT_IDS; idx++) {
       /*
        * clear out the mapping for this splinter table and update on disk
        * metadata.
@@ -599,9 +594,8 @@ rc_allocator_remove_super_addr(rc_allocator     *al,
 
    platform_mutex_unlock(&al->lock);
    // Couldnt find the splinter id in the meta page.
-   platform_assert(0 == "Couldnt find existing splinter table in meta page");
+   platform_assert(0, "Couldn't find existing splinter table in meta page");
 }
-
 
 uint64
 rc_allocator_extent_size(rc_allocator *al)
@@ -679,14 +673,17 @@ rc_allocator_in_use(rc_allocator *al)
  * rc_allocator_assert_noleaks --
  *
  *      Asserts that the allocations of each type are completely matched by
- *      deallocations.
+ *      deallocations by operations that do something like create / destroy
+ *      of objects. Primitive function to do some basic cross-checking of
+ *      these operations.
  *----------------------------------------------------------------------
  */
 void
 rc_allocator_assert_noleaks(rc_allocator *al)
 {
-   for (page_type type = PAGE_TYPE_TRUNK; type != NUM_PAGE_TYPES; type++) {
-      if (type == PAGE_TYPE_LOG || type == PAGE_TYPE_MISC) {
+   for (page_type type = PAGE_TYPE_FIRST; type < NUM_PAGE_TYPES; type++) {
+      // Log pages and super-block page are never deallocated.
+      if ((type == PAGE_TYPE_LOG) || (type == PAGE_TYPE_SUPERBLOCK)) {
          continue;
       }
       if (al->stats.extent_allocs[type] != al->stats.extent_deallocs[type]) {
@@ -734,7 +731,7 @@ rc_allocator_print_stats(rc_allocator *al)
       "| Page Type | Allocations | Deallocations | Footprint (bytes)  |\n");
    platform_default_log(
       "|--------------------------------------------------------------|\n");
-   for (page_type type = PAGE_TYPE_TRUNK; type != NUM_PAGE_TYPES; type++) {
+   for (page_type type = PAGE_TYPE_FIRST; type < NUM_PAGE_TYPES; type++) {
       const char *str           = page_type_str[type];
       int64       allocs        = al->stats.extent_allocs[type];
       int64       deallocs      = al->stats.extent_deallocs[type];

--- a/src/rc_allocator.h
+++ b/src/rc_allocator.h
@@ -14,8 +14,17 @@
 #include "platform.h"
 #include "util.h"
 
-#define RC_ALLOCATOR_MAX_ALLOCATOR_ROOT_IDS (30)
+/*
+ * In the current system, every Splinter instance has a superblock, one
+ * for each table that is mapped to the Splinter instance. This limit
+ * is the max number of superblocks (special pages) that can be accessed.
+ * All of these superblocks are required to be on the 1st extent.
+ */
+#define RC_ALLOCATOR_MAX_ROOT_IDS (30)
 
+/*
+ * Configuration structure to set up the Ref Count Allocation sub-system.
+ */
 typedef struct rc_allocator_config {
    uint64 capacity;
    uint64 page_capacity;
@@ -26,17 +35,20 @@ typedef struct rc_allocator_config {
 
 /*
  *----------------------------------------------------------------------
- * rc_allocator_meta_page --
+ * rc_allocator_meta_page -- Disk-resident structure.
  *
  *  An on disk structure to hold the super block information about all the
- *  splinter tables using this allocator. This is persisted at
+ *  Splinter tables using this allocator. This is persisted at
  *  offset 0 of the device.
  *----------------------------------------------------------------------
  */
-typedef struct PACKED rc_allocator_meta_page {
-   allocator_root_id splinters[RC_ALLOCATOR_MAX_ALLOCATOR_ROOT_IDS];
+typedef struct ONDISK rc_allocator_meta_page {
+   allocator_root_id splinters[RC_ALLOCATOR_MAX_ROOT_IDS];
    checksum128       checksum;
 } rc_allocator_meta_page;
+
+_Static_assert(offsetof(rc_allocator_meta_page, splinters) == 0,
+               "splinters array should be first field in meta_page struct");
 
 /*
  *----------------------------------------------------------------------
@@ -52,7 +64,7 @@ typedef struct rc_allocator_stats {
 
 /*
  *----------------------------------------------------------------------
- * rc_allocator --
+ * rc_allocator -- Ref Count allocator context structure.
  *----------------------------------------------------------------------
  */
 typedef struct rc_allocator {

--- a/src/routing_filter.c
+++ b/src/routing_filter.c
@@ -25,13 +25,13 @@
 
 /*
  *----------------------------------------------------------------------
- * routing_hdr:
+ * routing_hdr: Disk-resident structure.
  *
  *       This header encodes the bucket counts for all buckets covered by a
- *       single index.
+ *       single index. Appears on pages of page type == PAGE_TYPE_FILTER.
  *----------------------------------------------------------------------
  */
-typedef struct routing_hdr {
+typedef struct ONDISK routing_hdr {
    uint16 num_remainders;
    char   encoding[];
 } routing_hdr;
@@ -789,8 +789,8 @@ routing_filter_estimate_unique_fp(cache           *cc,
  *----------------------------------------------------------------------
  * routing_filter_lookup
  *
- *      looks for key in the filter and returns whether it was found, it's
- *      value goes in value.
+ *      Looks for key in the filter and returns whether it was found, it's
+ *      value goes in found_values.
  *
  *      IMPORTANT: If there are multiple matching values, this function returns
  *      them in the reverse order.
@@ -938,9 +938,9 @@ routing_filter_async_callback(cache_async_ctxt *cache_ctxt)
  *-----------------------------------------------------------------------------
  * routing_filter_lookup_async --
  *
- *      Async filter lookup api. Returns if lookup found a key in *found.  The
- *      ctxt should've been initialized using routing_filter_ctxt_init().  The
- *      return value can be either of:
+ *      Async filter lookup api. Returns if lookup found a key in *found_values.
+ *      The ctxt should've been initialized using routing_filter_ctxt_init().
+ *      The return value can be either of:
  *      async_locked: A page needed by lookup is locked. User should retry
  *                    request.
  *      async_no_reqs: A page needed by lookup is not in cache and the IO
@@ -952,7 +952,7 @@ routing_filter_async_callback(cache_async_ctxt *cache_ctxt)
  *                        async lookup request for dispatch in thread context.
  *                        When it's requeued, it must use the same function
  *                        params except found.
- *      success: Results are in *found
+ *      success: Results are in *found_values
  *
  * Results:
  *      Async result.

--- a/src/routing_filter.h
+++ b/src/routing_filter.h
@@ -16,13 +16,20 @@
 #include "util.h"
 #include "platform.h"
 
+/*
+ * In Splinter, there is a strict max number of compacted tuples in a node, so
+ * we used routing filters designed for that many keys. This allows us to not
+ * worry about how many bits to store etc. MAX_FILTERS is an artificial limit
+ * on the values stored in the filters. There is a hard limit at 64 because
+ * lookups return a 64 bit bit-vector.
+ */
 #define MAX_FILTERS       32
 #define ROUTING_NOT_FOUND (UINT16_MAX)
 
-// In splinter, there is an strict max number of compacted tuples in a node, so
-// we used routing filters designed for that many keys. This allows us not to
-// worry about how many bits to store etc.
 
+/*
+ * Routing Filters Configuration structure - used to setup routing filters.
+ */
 typedef struct routing_config {
    uint32 fingerprint_size;
    uint32 index_size;
@@ -37,7 +44,13 @@ typedef struct routing_config {
    data_config *data_cfg;
 } routing_config;
 
-typedef struct PACKED routing_filter {
+/*
+ * -----------------------------------------------------------------------------
+ * Routing Filter: Disk-resident structure, on pages of type PAGE_TYPE_TRUNK.
+ * Stored in trunk nodes, and is a pointer to a routing filter.
+ * -----------------------------------------------------------------------------
+ */
+typedef struct ONDISK routing_filter {
    uint64 addr;
    uint64 meta_head;
    uint32 num_fingerprints;

--- a/src/shard_log.c
+++ b/src/shard_log.c
@@ -120,7 +120,13 @@ shard_log_zap(shard_log *log)
    mini_unkeyed_dec_ref(cc, log->meta_head, PAGE_TYPE_LOG, FALSE);
 }
 
-struct PACKED log_entry {
+/*
+ * -------------------------------------------------------------------------
+ * Header for a key/message pair stored in the sharded log: Disk-resident
+ * structure. Appears on pages of page type == PAGE_TYPE_LOG
+ * -------------------------------------------------------------------------
+ */
+struct ONDISK log_entry {
    uint64 generation;
    uint16 keylen;
    uint16 messagelen;

--- a/src/shard_log.h
+++ b/src/shard_log.h
@@ -17,6 +17,9 @@
 #include "mini_allocator.h"
 #include "task.h"
 
+/*
+ * Configuration structure to set up the sharded log sub-system.
+ */
 typedef struct shard_log_config {
    uint64 page_size;
    uint64 extent_size;
@@ -30,8 +33,11 @@ typedef struct shard_log_thread_data {
    uint64 offset;
 } PLATFORM_CACHELINE_ALIGNED shard_log_thread_data;
 
+/*
+ * Sharded log context structure.
+ */
 typedef struct shard_log {
-   log_handle            super;
+   log_handle            super; // handle to log I/O ops abstraction.
    cache                *cc;
    shard_log_config     *cfg;
    shard_log_thread_data thread_data[MAX_THREADS];
@@ -52,7 +58,13 @@ typedef struct shard_log_iterator {
    uint64            pos;
 } shard_log_iterator;
 
-typedef struct shard_log_hdr {
+/*
+ * ---------------------------------------------------------------
+ * Sharded log page header stucture: Disk-resident structure.
+ * Page Type == PAGE_TYPE_LOG
+ * ---------------------------------------------------------------
+ */
+typedef struct ONDISK shard_log_hdr {
    checksum128 checksum;
    uint64      magic;
    uint64      next_extent_addr;

--- a/src/srq.h
+++ b/src/srq.h
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /*
- * srq.h --
+ * srq.h -- Space Reclamation Queue
  *
  *     This file contains the interface for a priority queue that splinter uses
  *     to identify potential compactions to perform to reclaim space.
@@ -13,7 +13,9 @@
 
 #include "platform.h"
 
-#define SRQ_MAX_ENTRIES     8192
+// Max size of space reclamation queue (For static allocation now)
+#define SRQ_MAX_ENTRIES 8192
+
 #define SRQ_INDEX_AVAILABLE -1
 
 typedef struct srq_data {
@@ -52,21 +54,21 @@ srq_deinit(srq *queue)
 static inline int64
 srq_parent(int64 pos)
 {
-   debug_assert(pos >= 0);
+   debug_assert(pos >= 0, "pos=%ld", pos);
    return (pos - 1) / 2;
 }
 
 static inline int64
 srq_lchild(int64 pos)
 {
-   debug_assert(pos >= 0);
+   debug_assert(pos >= 0, "pos=%ld", pos);
    return 2 * pos + 1;
 }
 
 static inline int64
 srq_rchild(int64 pos)
 {
-   debug_assert(pos >= 0);
+   debug_assert(pos >= 0, "pos=%ld", pos);
    return 2 * pos + 2;
 }
 
@@ -76,8 +78,8 @@ srq_rchild(int64 pos)
 static inline bool
 srq_has_priority(srq *queue, int64 lpos, int64 rpos)
 {
-   debug_assert(lpos >= 0);
-   debug_assert(rpos >= 0);
+   debug_assert(lpos >= 0, "lpos=%ld", lpos);
+   debug_assert(rpos >= 0, "rpos=%ld", rpos);
    return queue->heap[lpos].priority > queue->heap[rpos].priority;
 }
 
@@ -107,8 +109,11 @@ srq_swap(srq *queue, int64 lpos, int64 rpos)
 static inline void
 srq_move_tail_to_pos(srq *queue, int64 pos)
 {
-   debug_assert(pos >= 0);
-   debug_assert(pos < queue->num_entries);
+   debug_assert(pos >= 0, "pos=%ld", pos);
+   debug_assert(pos < queue->num_entries,
+                "pos=%ld, num_entries=%ld",
+                pos,
+                queue->num_entries);
    int64 tail_pos = queue->num_entries - 1;
    queue->num_entries--;
    if (queue->num_entries != 0) {
@@ -120,7 +125,7 @@ srq_move_tail_to_pos(srq *queue, int64 pos)
 static inline void
 srq_rebalance_up(srq *queue, int64 pos)
 {
-   debug_assert(pos >= 0);
+   debug_assert(pos >= 0, "pos=%ld", pos);
    debug_assert(0 || (1 && queue->num_entries == 0 && pos == 0)
                 || pos < queue->num_entries);
    while (1 && pos != 0 && srq_has_priority(queue, pos, srq_parent(pos))) {
@@ -132,7 +137,7 @@ srq_rebalance_up(srq *queue, int64 pos)
 static inline void
 srq_rebalance_down(srq *queue, uint64 pos)
 {
-   debug_assert(pos >= 0);
+   debug_assert(pos >= 0, "pos=%ld", pos);
    debug_assert(0 || (1 && queue->num_entries == 0 && pos == 0)
                 || pos < queue->num_entries);
    while (0

--- a/src/task.h
+++ b/src/task.h
@@ -20,6 +20,9 @@ typedef struct task {
    timestamp    enqueue_time;
 } task;
 
+/*
+ * Run-time task-specific execution metrics structure.
+ */
 typedef struct {
    timestamp max_runtime_ns;
    void     *max_runtime_func;
@@ -44,9 +47,13 @@ typedef struct task_fg_thread_group {
    platform_mutex mutex;
 } task_fg_thread_group;
 
+/*
+ * Tasks are grouped into NUM_TASK_TYPES groups. Each group is described
+ * by a structure of this type.
+ */
 typedef struct task_group {
    task_system *ts;
-   task_queue   tq;
+   task_queue   tq; // Queue of tasks in this group, of a task type
 
    volatile uint64 current_outstanding_tasks;
    volatile uint64 max_outstanding_tasks;
@@ -64,7 +71,8 @@ typedef struct task_group {
 } task_group;
 
 typedef enum task_type {
-   TASK_TYPE_MEMTABLE,
+   TASK_TYPE_FIRST    = 0,
+   TASK_TYPE_MEMTABLE = TASK_TYPE_FIRST,
    TASK_TYPE_NORMAL,
    NUM_TASK_TYPES,
 } task_type;

--- a/src/trunk.h
+++ b/src/trunk.h
@@ -21,9 +21,29 @@
 #include "log.h"
 #include "srq.h"
 
+/*
+ * Max height of the Trunk Tree; Limited for convenience to allow for static
+ * allocation of various nested arrays. (Should be possible to increase this, if
+ * ever needed, in future w/o perf impacts.) This limit is quite large enough
+ * for most expected installations.
+ */
 #define TRUNK_MAX_HEIGHT 8
 
-#define TRUNK_MAX_TOTAL_DEGREE 256
+/*
+ * Mini-allocator uses separate batches for each height of the Trunk tree.
+ * Therefore, the max # of mini-batches that the mini-allocator can track
+ * is limited by the max height of the SplinterDB trunk.
+ */
+_Static_assert(TRUNK_MAX_HEIGHT == MINI_MAX_BATCHES,
+               "TRUNK_MAX_HEIGHT should be == MINI_MAX_BATCHES");
+
+/*
+ * Upper-bound on most number of branches that we can find our lookup-key in.
+ * (Used in the range iterator context.) A convenience limit, used mostly to
+ * size statically defined arrays.
+ */
+#define TRUNK_RANGE_ITOR_MAX_BRANCHES 256
+
 
 /*
  *----------------------------------------------------------------------
@@ -205,7 +225,7 @@ typedef struct trunk_range_iterator {
    uint64          num_memtable_branches;
    uint64          memtable_start_gen;
    uint64          memtable_end_gen;
-   bool            compacted[TRUNK_MAX_TOTAL_DEGREE];
+   bool            compacted[TRUNK_RANGE_ITOR_MAX_BRANCHES];
    merge_iterator *merge_itor;
    bool            has_max_key;
    bool            at_end;
@@ -213,11 +233,11 @@ typedef struct trunk_range_iterator {
    char            max_key[MAX_KEY_SIZE];
    char            local_max_key[MAX_KEY_SIZE];
    char            rebuild_key[MAX_KEY_SIZE];
-   btree_iterator  btree_itor[TRUNK_MAX_TOTAL_DEGREE];
-   trunk_branch    branch[TRUNK_MAX_TOTAL_DEGREE];
+   btree_iterator  btree_itor[TRUNK_RANGE_ITOR_MAX_BRANCHES];
+   trunk_branch    branch[TRUNK_RANGE_ITOR_MAX_BRANCHES];
 
    // used for merge iterator construction
-   iterator *itor[TRUNK_MAX_TOTAL_DEGREE];
+   iterator *itor[TRUNK_RANGE_ITOR_MAX_BRANCHES];
 } trunk_range_iterator;
 
 

--- a/src/util.h
+++ b/src/util.h
@@ -5,7 +5,7 @@
 #define _SPLINTER_UTIL_H_
 
 #include "platform.h"
-#include "splinterdb/util.h"
+#include "splinterdb/public_util.h"
 
 // Macros
 #ifdef IMPLIES
@@ -70,6 +70,10 @@ init_fraction(uint64 numerator, uint64 denominator)
       .denominator = 1,                                                        \
    })
 
+/*
+ * Non-disk resident descriptor for a [<length>, <value ptr>] pair handle.
+ * Used to pass-around references to keys and values of different lengths.
+ */
 typedef struct slice {
    uint64      length;
    const void *data;
@@ -296,7 +300,11 @@ try_string_to_int8(const char *nptr, // IN
 #define STRING_EQUALS_LITERAL(arg, str)                                        \
    (strncmp(arg, str, SIZEOF_STRING_LITERAL(str)) == 0)
 
+/* In-memory structures that should be packed are tagged with this. */
 #define PACKED __attribute__((__packed__))
+
+/* Disk-resident structures that should be packed are tagged with this. */
+#define ONDISK __attribute__((__packed__))
 
 // Hex-encode arbitrary bytes to a destination buffer
 //    e.g. 0xc0de4f00de
@@ -312,4 +320,4 @@ try_string_to_int8(const char *nptr, // IN
 void
 debug_hex_encode(char *dst, size_t dst_len, const char *data, size_t data_len);
 
-#endif
+#endif // _SPLINTER_UTIL_H_

--- a/tests/config.h
+++ b/tests/config.h
@@ -18,6 +18,15 @@
 #include "trunk.h"
 #include "util.h"
 
+extern const char *BUILD_VERSION;
+
+/*
+ * --------------------------------------------------------------------------
+ * Convenience structure to hold configuration options for all sub-systems.
+ * Command-line parsing routines parse config params into these structs.
+ * Mostly needed for testing interfaces.
+ * --------------------------------------------------------------------------
+ */
 typedef struct master_config {
    uint64 page_size;
    uint64 extent_size;
@@ -39,7 +48,7 @@ typedef struct master_config {
    // btree
    uint64 btree_rough_count_height;
 
-   // filter
+   // routing filter
    uint64 filter_remainder_size;
    uint64 filter_index_size;
 

--- a/tests/functional/btree_test.c
+++ b/tests/functional/btree_test.c
@@ -1272,7 +1272,8 @@ test_btree_rough_iterator(cache             *cc,
                       btree_cfg->data_cfg->key_size);
       }
       if (slice_length(dummy_data) != sizeof(btree_pivot_data)) {
-         platform_log("Weird data length: %lu should be: %lu\n",
+         platform_log("Weird data length: %lu should be == "
+                      "sizeof(btree_pivot_data), %lu\n",
                       slice_length(dummy_data),
                       sizeof(btree_pivot_data));
       }

--- a/tests/functional/test_functionality.c
+++ b/tests/functional/test_functionality.c
@@ -669,7 +669,7 @@ test_functionality(allocator           *al,
          trunk_create(&cfg[idx], al, cache_to_use, state, splinters[idx], hid);
       if (spl_tables[idx] == NULL) {
          status = STATUS_NO_MEMORY;
-         platform_error_log("Sumpin failed.\n");
+         platform_error_log("splinter_create() failed for index=%d.\n", idx);
          goto cleanup;
       }
    }


### PR DESCRIPTION
Fix comments & prolog banners in different files.
Comment sections in mini_allocator.h/c. Add static asserts.
Cleanup comments in external .h files.
Add comments to improve understnding and to describe structures;

**NOTE TO THE REVIEWERS**:

I scanned through all the .h / .c files chasing down stuff (structures, enum-type values) etc. that are, or seem like are, disk-resident. Part of this change is to augment and better document the code to tag exactly what things are disk-resident.

A good understanding of those items will help solidify our in-flight design investigations for versioning support.

Another set of changes is to simply clean-up code comments, formatting, indentation, prolog banners and so on. This in inline with what I had done few weeks ago to splinter.c and few other .h files, mainly to keep the code commenting looking consistent and tight.

I have also left a few RESOLVE comments -- mainly as a way of asking questions, asking for suggestions on how-to document these areas. With your feedback, and suggestions, I will rephrase these RESOLVE comments / questions to be more meaningful.

There are, perhaps, only 2-3 actual code changes, but I have tried to make sure that they are non-logic-changes and should be risk free. I have annotated such items, for your quick look.

**Updated**:  As the change-set has lots of minor / comment-only diffs, I went thru the diffs and have ear marked the ones needing your attention / response.

As a a quick reference, here are the main files / change chunks that you may wish to walk-thru and respond to my comments, where I'm mainly asking for clarify / confirmation on disk-resident artifacts in the code.

- https://github.com/vmware/splinterdb/pull/230/files#:~:text=include/splinterdb/data.h
- https://github.com/vmware/splinterdb/pull/230/files#r796231588
- https://github.com/vmware/splinterdb/pull/230/files#r796232233
- https://github.com/vmware/splinterdb/pull/230/files#r796232502
- https://github.com/vmware/splinterdb/pull/230/files#r796232788
- https://github.com/vmware/splinterdb/pull/230/files#r796232988 (and subsequent code chunks in this area)
- https://github.com/vmware/splinterdb/pull/230/files#r796233282
- https://github.com/vmware/splinterdb/pull/230/files#r796691738
- https://github.com/vmware/splinterdb/pull/230/files#r796234078 [ Paranoia? ]
- https://github.com/vmware/splinterdb/pull/230/files#r796234798
- https://github.com/vmware/splinterdb/pull/230/files#r796235231
- https://github.com/vmware/splinterdb/pull/230/files#r796235599
- https://github.com/vmware/splinterdb/pull/230/files#r796236061
- https://github.com/vmware/splinterdb/pull/230/files#r796236175
- https://github.com/vmware/splinterdb/pull/230/files#r796236327
- https://github.com/vmware/splinterdb/pull/230/files#r796696050
- https://github.com/vmware/splinterdb/pull/230/files#r796697012
- https://github.com/vmware/splinterdb/pull/230/files#r796236666
- https://github.com/vmware/splinterdb/pull/230/files#r796236826
- https://github.com/vmware/splinterdb/pull/230/files#r796236985

The rest of the diff-chunks are minor; and. you can probably ignore them (if you don't have time to walk thru them all).