### PR TITLE
Test and CI tweaks: Skip slow tests by default, etc

### DIFF
--- a/ci/pipeline-funcs.lib.yml
+++ b/ci/pipeline-funcs.lib.yml
@@ -2,8 +2,12 @@
 #! SPDX-License-Identifier: Apache-2.0
 
 #@ load("@ytt:template", "template")
-#@ def default_timeout():
-#@   return "25m"
+#@ def get_task_timeout(quick=False):
+#@   if quick:
+#@     return "5m"
+#@   else:
+#@     return "55m"
+#@   end
 #@ end
 
 ---
@@ -31,7 +35,7 @@ plan:
   file: #@ resource_name + "-source/.git/ref"
   reveal: true
 - task: create-image
-  timeout: #@ default_timeout()
+  timeout: #@ get_task_timeout()
   privileged: true
   params:
     LABEL_git_sha: ((.:git-commit-sha))
@@ -89,7 +93,7 @@ params:
 
 #@ def step_build_splinterdb_image(source, compiler, git_sha=False, with_rust=False):
 task: build
-timeout: #@ default_timeout()
+timeout: #@ get_task_timeout()
 privileged: true
 #@ if git_sha:
 params:
@@ -126,7 +130,7 @@ config:
 
 #@ def step_test_with_image(with_rust=False):
 task: test
-timeout: #@ default_timeout()
+timeout: #@ get_task_timeout()
 image: image
 config:
   platform: linux
@@ -135,12 +139,13 @@ config:
     args: ["-c", "cd /splinterdb && ./test.sh"]
   params:
     TEST_RUST_CLI: #@ str(with_rust).lower()
+    INCLUDE_SLOW_TESTS: "true"
 #@ end
 
 ---
 #@ def step_collect_tags(compiler):
 task: collect-tags
-timeout: #@ default_timeout()
+timeout: #@ get_task_timeout()
 config:
   platform: linux
   image_resource:
@@ -204,9 +209,9 @@ plan:
 
 ---
 
-#@ def step_debug_build_test(compiler, input_name, with_rust=False):
+#@ def step_debug_build_test(compiler, input_name, with_rust=False, quick=False):
 task: debug-build-test
-timeout: #@ default_timeout()
+timeout: #@ get_task_timeout(quick=quick)
 image: build-env-image-latest
 config:
   platform: linux
@@ -216,6 +221,7 @@ config:
     CC: #@ compiler
     LD: #@ compiler
     WITH_RUST: #@ str(with_rust).lower()
+    INCLUDE_SLOW_TESTS: #@ str(not quick).lower()
   run:
     path: sh
     dir: #@ input_name
@@ -264,7 +270,7 @@ get_params: {skip_download: true}
 ---
 
 #! Job to run against every PR
-#@ def job_pr_check(job_name, steps, description=""):
+#@ def job_pr_check(job_name, steps, depends_on=[], description=""):
 name: #@ "pr-" + job_name
 public: true
 on_success: #@ set_pr_status(job_name, "success", description)
@@ -273,7 +279,11 @@ on_error: #@ set_pr_status(job_name, "error", description)
 plan:
 - get: github-pull-request
   trigger: true
+  #@ if depends_on:
+  passed: #@ depends_on
+  #@ else:
   version: every
+  #@ end
   params:
     list_changed_files: true
 - #@ set_pr_status(job_name, "pending", description)
@@ -300,10 +310,10 @@ plan:
 
 ---
 
-#@ def steps_pr_debug_build_test(compiler, with_rust=False):
+#@ def steps_pr_debug_build_test(compiler, with_rust=False, quick=False):
 - get: build-env-image-latest
   passed: [ recreate-build-env ]
-- #@ step_debug_build_test(compiler, "github-pull-request", with_rust=with_rust)
+- #@ step_debug_build_test(compiler, "github-pull-request", with_rust=with_rust, quick=quick)
 #@ end
 
 ---
@@ -315,7 +325,7 @@ plan:
   file: github-pull-request/.git/resource/base_sha
   reveal: true
 - task: format-check
-  timeout: #@ default_timeout()
+  timeout: #@ get_task_timeout()
   image: build-env-image-latest
   config:
     platform: linux
@@ -333,7 +343,7 @@ plan:
 - get: build-env-image-latest
   passed: [ recreate-build-env ]
 - task: check-shell-scripts
-  timeout: #@ default_timeout()
+  timeout: #@ get_task_timeout()
   image: build-env-image-latest
   config:
     platform: linux

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -90,17 +90,18 @@ jobs:
 - #@ job_debug_main_build_test("clang")
 - #@ job_debug_main_build_test("gcc")
 
-- #@ job_pr_check("clang", steps_pr_build_test("clang"), description="build and test")
-- #@ job_pr_check("gcc", steps_pr_build_test("gcc"), description="build and test")
-
 - #@ job_pr_check("clang-format", steps_pr_clang_format(), description="check C source formatting")
 - #@ job_pr_check("shell-scripts", steps_pr_shell_scripts(), description="lint and format any shell scripts")
+- #@ job_pr_check("quick-check", steps_pr_debug_build_test("clang", quick=True), description="build and run fast unit tests")
 
-- #@ job_pr_check("debug-clang", steps_pr_debug_build_test("clang"), description="debug build and test")
-- #@ job_pr_check("debug-gcc", steps_pr_debug_build_test("gcc"), description="debug build and test")
+- #@ job_pr_check("clang", steps_pr_build_test("clang"), depends_on=["pr-quick-check"], description="build and test")
+- #@ job_pr_check("gcc", steps_pr_build_test("gcc"), depends_on=["pr-quick-check"], description="build and test")
 
-- #@ job_pr_check("rust", steps_pr_build_test("clang", with_rust=True), description="rust build and test")
-- #@ job_pr_check("rust-debug", steps_pr_debug_build_test("clang", with_rust=True), description="rust debug build and test")
+- #@ job_pr_check("debug-clang", steps_pr_debug_build_test("clang"), depends_on=["pr-quick-check"], description="debug build and test")
+- #@ job_pr_check("debug-gcc", steps_pr_debug_build_test("gcc"), depends_on=["pr-quick-check"], description="debug build and test")
+
+- #@ job_pr_check("rust", steps_pr_build_test("clang", with_rust=True), depends_on=["pr-quick-check"], description="rust build and test")
+- #@ job_pr_check("rust-debug", steps_pr_debug_build_test("clang", with_rust=True), depends_on=["pr-quick-check"], description="rust debug build and test")
 
 groups:
 - name: main_branch
@@ -112,6 +113,7 @@ groups:
 
 - name: pull_requests
   jobs:
+  - pr-quick-check
   - pr-clang
   - pr-debug-clang
   - pr-gcc

--- a/test.sh
+++ b/test.sh
@@ -4,8 +4,21 @@ set -euxo pipefail
 
 SEED="${SEED:-135}"
 
+INCLUDE_SLOW_TESTS="${INCLUDE_SLOW_TESTS:-false}"
 WITH_RUST="${WITH_RUST:-false}"
 TEST_RUST_CLI="${TEST_RUST_CLI:-${WITH_RUST}}"
+
+if [ "$INCLUDE_SLOW_TESTS" != "true" ]; then
+   echo "Only running fast unit tests"
+   echo "(To run all tests, set the env var INCLUDE_SLOW_TESTS=true)"
+   bin/unit/kvstore_basic_test
+   bin/unit/kvstore_test
+   bin/unit/btree_test
+   bin/unit/util_test
+   bin/unit/misc_test
+   echo "Fast tests passed"
+   exit 0
+fi
 
 # Run all the unit-tests first, to get basic coverage
 bin/unit_test


### PR DESCRIPTION
After conversations with both @gapisback and @convolvatron , I'm thinking this would be an improvement to developer-experience.

How it works:
- By default, running `make run-tests` or `./test.sh` will only run "fast" tests, which is an explicit list of known-fast unit tests
- You can opt-in to running all tests (old behavior) via
   ```
   INCLUDE_SLOW_TESTS=true ./test.sh
   ```
- CI still runs all tests (sets that env var) and PRs can't merge until they succeed

**Updates**:
- CI jobs are now allowed to run for 55 minutes before timing out, to address the timeout issue that Aditya mentions below
- but there's also a new "quick check" CI job that only runs the fast tests, in order to give faster feedback to PR authors

I'm hopeful that this set of changes shortens the edit-debug loop for local development (since `./test.sh` now completes in a few seconds by default) without sacrificing overall quality guarantees.

It should also shorten the feedback loop for authors of obviously-broken PRs (they can see a CI failure more quickly).