### PR TITLE
Code cleanup: Fix comment blocks, indentation, and coding style issues.

### DIFF
--- a/include/splinterdb/data.h
+++ b/include/splinterdb/data.h
@@ -4,7 +4,7 @@
 /*
  * data.h --
  *
- *     This file contains constants and functions the pertain to
+ *     This file contains constants and functions that pertain to
  *     keys and messages
  *
  *     A message encodes a value and an operation,

--- a/include/splinterdb/kvstore.h
+++ b/include/splinterdb/kvstore.h
@@ -38,7 +38,7 @@ typedef struct kvstore kvstore;
 // Create a new kvstore from a given config
 //
 // The library will allocate and own the memory for kvstore
-// and will free it on kvstore_close
+// and will free it on kvstore_close().
 //
 // It is ok for the caller to stack-allocate cfg, since it is not retained
 int
@@ -47,7 +47,7 @@ kvstore_create(const kvstore_config *cfg, kvstore **kvs);
 // Open an existing kvstore, using the provided config
 //
 // The library will allocate and own the memory for kvstore
-// and will free it on kvstore_close
+// and will free it on kvstore_close().
 //
 // It is ok for the caller to stack-allocate cfg, since it is not retained
 int
@@ -99,13 +99,14 @@ typedef struct kvstore_lookup_result {
    char opaque[48];
 } kvstore_lookup_result;
 
-/* Initialize a lookup result.  If buffer is provided, then the result
-   of a query will be stored in buffer if it fits.  Otherwise, it will
-   be stored in an allocated buffer.
-
-   A kvstore_lookup_result can be used for multiple queries after
-   being initialized once.
-*/
+/*
+ * Initialize a lookup result. If buffer is provided, then the result
+ * of a query will be stored in buffer if it fits. Otherwise, it will
+ * be stored in an allocated buffer.
+ *
+ * A kvstore_lookup_result can be used for multiple queries after
+ * being initialized once.
+ */
 void
 kvstore_lookup_result_init(const kvstore *        kvs,        // IN
                            kvstore_lookup_result *result,     // IN/OUT
@@ -113,8 +114,10 @@ kvstore_lookup_result_init(const kvstore *        kvs,        // IN
                            char *                 buffer      // IN
 );
 
-/* Release any resources used by result.  Note that this does _not_ deallocate
-   the buffer provided to kvstore_lookup_result_init. */
+/*
+ * Release any resources used by result. Note that this does _not_ deallocate
+ * the buffer provided to kvstore_lookup_result_init().
+ */
 void
 kvstore_lookup_result_deinit(kvstore_lookup_result *result); // IN
 
@@ -184,19 +187,19 @@ kvstore_iterator_init(const kvstore *    kvs,      // IN
 void
 kvstore_iterator_deinit(kvstore_iterator *iter);
 
-// checks that the iterator status is OK (no errors) and that get_current will
-// succeed If false, there are two possibilities:
+// Checks that the iterator status is OK (no errors) and that get_current()
+// will succeed. If false, there are two possibilities:
 // 1. Iterator has passed the final item.  In this case, status() == 0
 // 2. Iterator has encountered an error.  In this case, status() != 0
 bool
 kvstore_iterator_valid(kvstore_iterator *iter);
 
-// attempts to advance the iterator to the next item
-// any error will cause valid() == false and be visible with status()
+// Attempts to advance the iterator to the next item.
+// Any error will cause valid() == false and be visible with status()
 void
 kvstore_iterator_next(kvstore_iterator *iter);
 
-// Sets *key and *message to the locations of the current item
+// Sets *key and *message to the locations of the current item.
 // Callers must not modify that memory
 //
 // If valid() == false, then behavior is undefined.

--- a/include/splinterdb/kvstore_basic.h
+++ b/include/splinterdb/kvstore_basic.h
@@ -43,28 +43,27 @@ typedef int (*key_comparator_fn)(const void *context,
 // Configuration that the application must provide
 typedef struct {
 
-   // path to file on disk to store data in
+   // Path to file on disk to store data in
    const char *filename;
 
-   // size of in-memory cache, in bytes
+   // Size of in-memory cache, in bytes
    size_t cache_size;
 
-   // size of file to use on disk, in bytes
+   // Size of file to use on disk, in bytes
    size_t disk_size;
 
-   // maximum length of keys, in bytes.
-   // must be <= MAX_KEY_SIZE
+   // Maximum length of keys, in bytes. Must be <= MAX_KEY_SIZE
    size_t max_key_size;
 
-   // maximum length of values, in bytes.
-   // must be <= MAX_MESSAGE_SIZE - sizeof(basic_message)
+   // Maximum length of values, in bytes.
+   // Must be <= ( MAX_MESSAGE_SIZE - sizeof(basic_message) )
    size_t max_value_size;
 
-   // optional custom comparator for keys
-   // if NULL, the default comparator (memcmp-based) will be used
+   // Optional custom comparator for keys.
+   // If NULL, the default comparator (memcmp-based) will be used
    key_comparator_fn key_comparator;
 
-   // optional context to pass to key_comparator
+   // Optional context to pass to key_comparator
    void *key_comparator_context;
 
    // Reserved, set them to NULL
@@ -192,15 +191,15 @@ kvstore_basic_iter_init(const kvstore_basic *    kvsb,         // IN
 void
 kvstore_basic_iter_deinit(kvstore_basic_iterator **iterpp);
 
-// checks that the iterator status is OK (no errors) and that get_current will
-// succeed If false, there are two possibilities:
-// 1. Iterator has passed the final item.  In this case, status() == 0
-// 2. Iterator has encountered an error.  In this case, status() != 0
+// Checks that the iterator status is OK (no errors) and that get_current()
+// will succeed. If false, there are two possibilities:
+// 1. Iterator has passed the final item. In this case, status() == 0
+// 2. Iterator has encountered an error. In this case, status() != 0
 _Bool
 kvstore_basic_iter_valid(kvstore_basic_iterator *iter);
 
-// attempts to advance the iterator to the next item
-// any error will cause valid() == false and be visible with status()
+// Attempts to advance the iterator to the next item.
+// Any error will cause valid() == false and be visible with status()
 void
 kvstore_basic_iter_next(kvstore_basic_iterator *iter);
 

--- a/include/splinterdb/limits.h
+++ b/include/splinterdb/limits.h
@@ -11,8 +11,8 @@
 #ifndef __LIMITS_H__
 #define __LIMITS_H__
 
-#define MAX_KEY_SIZE     24
-#define MAX_MESSAGE_SIZE 128
-#define MAX_KEY_STR_LEN  128
+#define MAX_KEY_SIZE     24  /* bytes */
+#define MAX_MESSAGE_SIZE 128 /* bytes */
+#define MAX_KEY_STR_LEN  128 /* bytes */
 
 #endif // __LIMITS_H__

--- a/include/splinterdb/platform_public.h
+++ b/include/splinterdb/platform_public.h
@@ -4,8 +4,8 @@
 /*
  * platform_public.h --
  *
- *     Minimal common header for both external users (e.g. kvstore) and internal
- * use
+ *     Minimal common header for both external users (e.g. kvstore) and
+ *     for internal use.
  */
 
 #ifndef __PLATFORM_PUBLIC_H
@@ -26,7 +26,7 @@
  * Additionally stdint.h defines limits of integer types capable
  * of holding object pointers such as UINTPTR_MAX, the value of
  * which depends on the processor and its address range.
- * The typ and ranges are only included if they exist for the specific
+ * The type and ranges are only included if they exist for the specific
  * compiler/processor.
  */
 #include <stdint.h>

--- a/include/splinterdb/util.h
+++ b/include/splinterdb/util.h
@@ -1,3 +1,6 @@
+// Copyright 2018-2021 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 #ifndef __UTIL_H
 #define __UTIL_H
 

--- a/src/PackedArray.h
+++ b/src/PackedArray.h
@@ -8,28 +8,30 @@
 #include "poison.h"
 
 /*
-
-PackedArray principle:
-  . compact storage of <= 32 bits items
-  . items are tightly packed into a buffer of uint32 integers
-
-PackedArray requirements:
-  . you must know in advance how many bits are needed to hold a single item
-  . you must know in advance how many items you want to store
-  . when packing, behavior is undefined if items have more than bitsPerItem bits
-
-PackedArray general in memory representation:
-  |-------------------------------------------------- - - -
-  |       b0       |       b1       |       b2       |
-  |-------------------------------------------------- - - -
-  | i0 | i1 | i2 | i3 | i4 | i5 | i6 | i7 | i8 | i9 |
-  |-------------------------------------------------- - - -
-
-  . items are tightly packed together
-  . several items end up inside the same buffer cell, e.g. i0, i1, i2
-  . some items span two buffer cells, e.g. i3, i6
-
-*/
+ * -----------------------------------------------------------------------------
+ * PackedArray principle:
+ *  . Compact storage of <= 32 bits items
+ *  . Items are tightly packed into a buffer of uint32 integers
+ *
+ * PackedArray requirements:
+ *  . You must know in advance how many bits are needed to hold a single item
+ *  . You must know in advance how many items you want to store
+ *  . When packing, behavior is undefined if items have more than bitsPerItem
+ *    bits
+ *
+ * PackedArray general in memory representation:
+ *
+ *  |----------------+----------------+----------------+- - -
+ *  |       b0       |       b1       |       b2       |
+ *  |----------------+----------------+----------------+- - -
+ *  | i0 | i1 | i2 | i3 | i4 | i5 | i6 | i7 | i8 | i9 |
+ *  |-------------------------------------------------- - - -
+ *
+ * . Items are tightly packed together
+ * . Several items end up inside the same buffer cell, e.g. i0, i1, i2
+ * . Some items span two buffer cells, e.g. i3, i6
+ * -----------------------------------------------------------------------------
+ */
 
 // packing / unpacking
 // offset is expressed in number of elements

--- a/src/btree.c
+++ b/src/btree.c
@@ -1,12 +1,12 @@
-/* **********************************************************
- * Copyright 2018-2020 VMware, Inc.  All rights reserved. -- VMware Confidential
- * **********************************************************/
+// Copyright 2018-2021 VMware, Inc. All rights reserved. -- VMware Confidential
+// SPDX-License-Identifier: Apache-2.0
 
 #include "btree_private.h"
 #include "poison.h"
 
 /******************************************************************
- * Structure of a node:
+ * Structure of a BTree node:
+ *
  *                                 hdr->next_entry
  *                                               |
  *   0                                           v     page_size
@@ -31,19 +31,21 @@
 
  * A node may have free space fragmentation after some entries have
  * been replaced.  Defragmenting the node rebuilds it with no
- * free-space fragmentation.  When a node runs out of free space, we
- * measure its dead space.  If it below a threshold, we split the
- * node.  If it is above the threshhold, then we defragment the node
- * instead of splitting it.
+ * free-space fragmentation.
  *
+ * When a node runs out of free space, we measure its dead space.
+ * If dead space is:
+ *  - below a threshold, we split the node.
+ *  - above the threshold, then we defragment the node instead of splitting it.
  *******************************************************************/
 
 /* Threshold for splitting instead of defragmenting. */
 #define VARIABLE_LENGTH_BTREE_SPLIT_THRESHOLD(page_size) ((page_size) / 2)
 
 /* After a split, the free space in the left node may be fragmented.
-   If there's less than this much contiguous free space, then we also
-   defrag the left node. */
+ * If there's less than this much contiguous free space, then we also
+ * defrag the left node.
+ */
 #define VARIABLE_LENGTH_BTREE_DEFRAGMENT_THRESHOLD(page_size) ((page_size) / 4)
 
 char  positive_infinity_buffer;

--- a/src/btree_private.h
+++ b/src/btree_private.h
@@ -207,7 +207,8 @@ btree_get_leaf_entry(const btree_config *cfg,
                      table_index         k)
 {
    /* Ensure that the kth entry's header is after the end of the table and
-      before the end of the page. */
+    * before the end of the page.
+    */
    debug_assert(diff_ptr(hdr, &hdr->offsets[hdr->num_entries])
                 <= hdr->offsets[k]);
    debug_assert(hdr->offsets[k] + sizeof(leaf_entry) <= btree_page_size(cfg));
@@ -240,7 +241,8 @@ btree_get_index_entry(const btree_config *cfg,
                       table_index         k)
 {
    /* Ensure that the kth entry's header is after the end of the table and
-      before the end of the page. */
+    * before the end of the page.
+    */
    debug_assert(diff_ptr(hdr, &hdr->offsets[hdr->num_entries])
                 <= hdr->offsets[k]);
    debug_assert(hdr->offsets[k] + sizeof(index_entry) <= btree_page_size(cfg),

--- a/src/clockcache.h
+++ b/src/clockcache.h
@@ -51,6 +51,14 @@ typedef struct history_record {
 #endif
 
 
+/*
+ *-----------------------------------------------------------------------------
+ * clockcache_entry --
+ *
+ *     The meta data entry in the cache. Each entry has the underlying
+ *     page_handle together with some flags.
+ *-----------------------------------------------------------------------------
+ */
 struct clockcache_entry {
    page_handle     page;
    volatile uint32 status;
@@ -63,10 +71,7 @@ struct clockcache_entry {
 
 /*
  *----------------------------------------------------------------------
- *
- * clockcache --
- *
- *      clockcache is a multiheaded cache using a clock algorithm for eviction
+ * clockcache -- A multi-threaded cache using a clock algorithm for eviction
  *
  *      Pages are indexed by a direct mapping, cc->lookup, which is an array.
  *      For a given address, cc->lookup[addr / page_size] returns an
@@ -93,10 +98,8 @@ struct clockcache_entry {
  *      cc->cleaner_gap batches ahead of the current evictor head, so that
  *      cleaned pages have time to flush before eviction. Both cleaning and
  *      eviction use cc->batch_busy to avoid conflicts and contention.
- *
  *----------------------------------------------------------------------
  */
-
 struct clockcache {
    cache              super;
    clockcache_config *cfg;
@@ -136,9 +139,7 @@ struct clockcache {
 
 /*
  *-----------------------------------------------------------------------------
- *
  * Function declarations
- *
  *-----------------------------------------------------------------------------
  */
 

--- a/src/config.h
+++ b/src/config.h
@@ -205,4 +205,4 @@ platform_status config_parse(master_config *cfg,
 #define config_set_else } else
 
 
-#endif
+#endif // __CONFIG_H

--- a/src/kvstore.c
+++ b/src/kvstore.c
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /*
+ *-----------------------------------------------------------------------------
  * kvstore.c --
  *
  *     This file contains the implementation of external kvstore interfaces
@@ -15,6 +16,7 @@
  *
  *     For simple use cases, start with kvstore_basic, which provides
  *     a key-value abstraction.
+ *-----------------------------------------------------------------------------
  */
 
 #include "platform.h"
@@ -59,7 +61,6 @@ platform_status_to_int(const platform_status status) // IN
 
 /*
  *-----------------------------------------------------------------------------
- *
  * kvstore_init_config --
  *
  *      Translate kvstore_config to configs for individual subsystems.
@@ -69,10 +70,8 @@ platform_status_to_int(const platform_status status) // IN
  *
  * Side effects:
  *      None.
- *
  *-----------------------------------------------------------------------------
  */
-
 static platform_status
 kvstore_init_config(const kvstore_config *kvs_cfg, // IN
                     kvstore *             kvs      // OUT
@@ -154,7 +153,9 @@ kvstore_init_config(const kvstore_config *kvs_cfg, // IN
 }
 
 
-// internal function for create or open
+/*
+ * Internal function for create or open
+ */
 int
 kvstore_create_or_open(const kvstore_config *kvs_cfg,      // IN
                        kvstore **            kvs_out,      // OUT
@@ -295,7 +296,6 @@ kvstore_open(const kvstore_config *cfg, // IN
 
 /*
  *-----------------------------------------------------------------------------
- *
  * kvstore_close --
  *
  *      Close a kvstore, flushing to disk and releasing resources
@@ -305,10 +305,8 @@ kvstore_open(const kvstore_config *cfg, // IN
  *
  * Side effects:
  *      None.
- *
  *-----------------------------------------------------------------------------
  */
-
 void
 kvstore_close(kvstore *kvs) // IN
 {
@@ -326,7 +324,6 @@ kvstore_close(kvstore *kvs) // IN
 
 /*
  *-----------------------------------------------------------------------------
- *
  * kvstore_register_thread --
  *
  *      Allocate scratch space and register the current thread.
@@ -342,10 +339,8 @@ kvstore_close(kvstore *kvs) // IN
  *
  * Side effects:
  *      Allocates memory
- *
  *-----------------------------------------------------------------------------
  */
-
 void
 kvstore_register_thread(kvstore *kvs) // IN
 {
@@ -357,7 +352,6 @@ kvstore_register_thread(kvstore *kvs) // IN
 
 /*
  *-----------------------------------------------------------------------------
- *
  * kvstore_deregister_thread --
  *
  *      Free scratch space.
@@ -369,7 +363,6 @@ kvstore_register_thread(kvstore *kvs) // IN
  *
  * Side effects:
  *      Frees memory
- *
  *-----------------------------------------------------------------------------
  */
 void
@@ -383,7 +376,6 @@ kvstore_deregister_thread(kvstore *kvs)
 
 /*
  *-----------------------------------------------------------------------------
- *
  * kvstore_insert --
  *
  *      Insert a tuple into splinter
@@ -393,10 +385,8 @@ kvstore_deregister_thread(kvstore *kvs)
  *
  * Side effects:
  *      None.
- *
  *-----------------------------------------------------------------------------
  */
-
 int
 kvstore_insert(const kvstore *kvs,            // IN
                char *         key,            // IN
@@ -411,12 +401,9 @@ kvstore_insert(const kvstore *kvs,            // IN
    return platform_status_to_int(status);
 }
 
-
 /*
  *-----------------------------------------------------------------------------
- *
  * _kvstore_lookup_result structure --
- *
  *-----------------------------------------------------------------------------
  */
 typedef struct _kvstore_lookup_result {
@@ -467,7 +454,6 @@ kvstore_lookup_result_data(kvstore_lookup_result *result) // IN
 
 /*
  *-----------------------------------------------------------------------------
- *
  * kvstore_lookup --
  *
  *      Look up a key from splinter
@@ -477,10 +463,8 @@ kvstore_lookup_result_data(kvstore_lookup_result *result) // IN
  *
  * Side effects:
  *      None.
- *
  *-----------------------------------------------------------------------------
  */
-
 int
 kvstore_lookup(const kvstore *        kvs,    // IN
                char *                 key,    // IN

--- a/src/kvstore_basic.c
+++ b/src/kvstore_basic.c
@@ -2,11 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /*
+ *-----------------------------------------------------------------------------
  * kvstore_basic.c --
  *
  *     Implementation for a simplified key-value store interface.
  *
  *     API deals with keys/values rather than keys/messages.
+ *-----------------------------------------------------------------------------
  */
 
 #include "platform.h"
@@ -260,7 +262,11 @@ new_basic_data_config(const size_t max_key_size,   // IN
    return 0;
 }
 
-// Implementation of public API begins here...
+/*
+ *-----------------------------------------------------------------------------
+ * Implementation of public API begins here...
+ *-----------------------------------------------------------------------------
+ */
 
 int
 kvstore_basic_create_or_open(const kvstore_basic_cfg *cfg,      // IN
@@ -412,6 +418,7 @@ kvstore_basic_delete(const kvstore_basic *kvsb,
 }
 
 /*
+ *-----------------------------------------------------------------------------
  * kvstore_basic_lookup() - Lookup a key, returning its value.
  *
  * Parameters:
@@ -427,6 +434,7 @@ kvstore_basic_delete(const kvstore_basic *kvsb,
  * Returns:
  *  == 0, upon success. (Check booleans to see if key is found.)
  *  != 0, upon any error condition.
+ *-----------------------------------------------------------------------------
  */
 int
 kvstore_basic_lookup(const kvstore_basic *kvsb,
@@ -497,12 +505,14 @@ struct kvstore_basic_iterator {
 };
 
 /*
+ *-----------------------------------------------------------------------------
  * Initialize a KVStore iterator.
  *
  * Returns:
  *  0 - For successful initialization of the iterator.
  *  != 0 - In case of any errors
  *  ENOMEM - In case of any memory allocation errors
+ *-----------------------------------------------------------------------------
  */
 int
 kvstore_basic_iter_init(const kvstore_basic *    kvsb,         // IN

--- a/src/memtable.c
+++ b/src/memtable.c
@@ -2,9 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /*
+ *-----------------------------------------------------------------------------
  * memtable.c --
  *
  *     This file contains the implementation for the splinter memtable.
+ *-----------------------------------------------------------------------------
  */
 
 #include "platform.h"
@@ -97,6 +99,7 @@ memtable_maybe_rotate_and_get_insert_lock(memtable_context  *ctxt,
 }
 
 /*
+ *-----------------------------------------------------------------------------
  * Increments the distributed tuple counter.  Must hold a read lock on
  * insert_lock.
  *
@@ -111,6 +114,7 @@ memtable_maybe_rotate_and_get_insert_lock(memtable_context  *ctxt,
  * adds a tuple which takes its local count to
  * k * MEMTABLE_COUNT_GRANULARITY + 1. Therefore, num_tuples is an upper
  * bound except that each thread may still add 1 more tuple.
+ *-----------------------------------------------------------------------------
  */
 static inline void
 memtable_add_tuple(memtable_context *ctxt)

--- a/src/merge.c
+++ b/src/merge.c
@@ -227,7 +227,6 @@ out:
  * In the case where the two minimum iterators of the merge iterator have equal
  * keys, resolve_equal_keys will merge the data as necessary
  */
-
 static platform_status
 merge_resolve_equal_keys(merge_iterator *merge_itor)
 {
@@ -292,14 +291,12 @@ merge_resolve_equal_keys(merge_iterator *merge_itor)
 
 /*
  *-----------------------------------------------------------------------------
- *
  * if merge_itor->finalize_updates:
  *    resolves MESSAGE_TYPE_UPDATE messages into
  *       MESSAGE_TYPE_INSERT or MESSAGE_TYPE_DELETE messages
  * if merge_itor->delete_mode == dont_emit_deletes:
  *    discards MESSAGE_TYPE_DELETE messages
  * return True if it discarded a MESSAGE_TYPE_DELETE message
- *
  *-----------------------------------------------------------------------------
  */
 static inline platform_status
@@ -380,7 +377,6 @@ advance_one_loop(merge_iterator *merge_itor, bool *retry)
 
 /*
  *-----------------------------------------------------------------------------
- *
  * merge_iterator_create --
  *
  *      Initialize a merge iterator for a forest of B-trees.
@@ -390,10 +386,8 @@ advance_one_loop(merge_iterator *merge_itor, bool *retry)
  *
  * Results:
  *      0 if successful, error otherwise
- *
  *-----------------------------------------------------------------------------
  */
-
 platform_status
 merge_iterator_create(platform_heap_id hid,
                       data_config *    cfg,
@@ -524,14 +518,11 @@ out:
 
 /*
  *-----------------------------------------------------------------------------
- *
  * merge_iterator_destroy --
  *
  *      Destroys a merge iterator.
- *
  *-----------------------------------------------------------------------------
  */
-
 platform_status
 merge_iterator_destroy(platform_heap_id hid, merge_iterator **merge_itor)
 {
@@ -545,7 +536,6 @@ merge_iterator_destroy(platform_heap_id hid, merge_iterator **merge_itor)
 
 /*
  *-----------------------------------------------------------------------------
- *
  * merge_at_end --
  *
  *      Checks if more values are left in the merge itor.
@@ -555,10 +545,8 @@ merge_iterator_destroy(platform_heap_id hid, merge_iterator **merge_itor)
  *
  * Side effects:
  *      None.
- *
  *-----------------------------------------------------------------------------
  */
-
 platform_status
 merge_at_end(iterator *itor,   // IN
              bool     *at_end) // OUT
@@ -570,10 +558,8 @@ merge_at_end(iterator *itor,   // IN
    return STATUS_OK;
 }
 
-
 /*
  *-----------------------------------------------------------------------------
- *
  * merge_get_curr --
  *
  *      Returns current key and data from the merge itor.
@@ -583,10 +569,8 @@ merge_at_end(iterator *itor,   // IN
  *
  * Side effects:
  *      None.
- *
  *-----------------------------------------------------------------------------
  */
-
 void
 merge_get_curr(iterator *itor, slice *key, slice *data)
 {
@@ -598,14 +582,12 @@ merge_get_curr(iterator *itor, slice *key, slice *data)
 
 /*
  *-----------------------------------------------------------------------------
- *
  * merge_advance --
  *
  *      Merges the next key from the array of input iterators.
  *
  * Results:
  *      0 if successful, error otherwise
- *
  *-----------------------------------------------------------------------------
  */
 platform_status

--- a/src/mini_allocator.c
+++ b/src/mini_allocator.c
@@ -2,10 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /*
+ *-----------------------------------------------------------------------------
  * mini_allocator.c --
  *
  *     This file contains the implementation for an allocator which
  *     allocates individual pages from extents.
+ *-----------------------------------------------------------------------------
  */
 
 #include "platform.h"
@@ -26,15 +28,12 @@
 
 /*
  *-----------------------------------------------------------------------------
- *
  * mini_meta_hdr --
  *
  *      The header of a meta_page in a mini_allocator. Keyed mini_allocators
  *      use entry_buffer and unkeyed ones use entry.
- *
  *-----------------------------------------------------------------------------
  */
-
 typedef struct PACKED mini_meta_hdr {
    uint64 next_meta_addr;
    uint64 pos;
@@ -98,10 +97,8 @@ unkeyed_next_entry(unkeyed_meta_entry *entry)
    return entry + 1;
 }
 
-
 /*
  *-----------------------------------------------------------------------------
- *
  * mini_init_meta_page --
  *
  *      Initializes the header of the given meta_page.
@@ -111,10 +108,8 @@ unkeyed_next_entry(unkeyed_meta_entry *entry)
  *
  * Side effects:
  *      None.
- *
  *-----------------------------------------------------------------------------
  */
-
 static void
 mini_init_meta_page(mini_allocator *mini, page_handle *meta_page)
 {
@@ -126,7 +121,6 @@ mini_init_meta_page(mini_allocator *mini, page_handle *meta_page)
 
 /*
  *-----------------------------------------------------------------------------
- *
  * mini_full_[lock,unlock]_meta_tail --
  *
  *      Convenience functions to write lock/unlock the given meta_page or
@@ -138,10 +132,8 @@ mini_init_meta_page(mini_allocator *mini, page_handle *meta_page)
  *
  * Side effects:
  *      Disk allocation, standard cache side effects.
- *
  *-----------------------------------------------------------------------------
  */
-
 static page_handle *
 mini_full_lock_meta_tail(mini_allocator *mini)
 {
@@ -178,7 +170,6 @@ mini_full_unlock_meta_page(mini_allocator *mini, page_handle *meta_page)
 
 /*
  *-----------------------------------------------------------------------------
- *
  * mini_(un)get_(un)claim_meta_page --
  *
  *      Convenience functions to read lock and claim the given meta_page.
@@ -189,10 +180,8 @@ mini_full_unlock_meta_page(mini_allocator *mini, page_handle *meta_page)
  *
  * Side effects:
  *      Disk allocation, standard cache side effects.
- *
  *-----------------------------------------------------------------------------
  */
-
 static page_handle *
 mini_get_claim_meta_page(cache *cc, uint64 meta_addr, page_type type)
 {
@@ -219,26 +208,25 @@ mini_unget_unclaim_meta_page(cache *cc, page_handle *meta_page)
 
 /*
  *-----------------------------------------------------------------------------
- *
  * mini_init --
  *
  *      Initialize a new mini allocator.
  *
- *      There are two types of mini allocator, keyed and unkeyed. A keyed
- *      allocator stores a key range for each extent and allows incrementing
- *      and decrementing key ranges. An unkeyed allocator has a single ref
- *      for the whole allocator which is overloaded onto the meta_head
- *      disk-allocator ref count.
+ *      There are two types of mini allocator: keyed and unkeyed.
+ *
+ *      - A keyed allocator stores a key range for each extent and allows
+ *        incrementing and decrementing key ranges.
+ *
+ *      - An unkeyed allocator has a single ref for the whole allocator which
+ *        is overloaded onto the meta_head disk-allocator ref count.
  *
  * Results:
  *      The 0th batch next address to be allocated.
  *
  * Side effects:
  *      None.
- *
  *-----------------------------------------------------------------------------
  */
-
 uint64
 mini_init(mini_allocator *mini,
           cache *         cc,
@@ -322,7 +310,6 @@ mini_num_entries(page_handle *meta_page)
 
 /*
  *-----------------------------------------------------------------------------
- *
  * mini_keyed_[get,set]_entry --
  * mini_keyed_set_last_end_key --
  * mini_unkeyed_[get,set]_entry --
@@ -343,11 +330,8 @@ mini_num_entries(page_handle *meta_page)
  *      set: None.
  *
  * Side effects:
- *      None.
- *
  *-----------------------------------------------------------------------------
  */
-
 static bool
 entry_fits_in_page(uint64 page_size, uint64 start, uint64 entry_size)
 {
@@ -414,7 +398,6 @@ mini_unkeyed_append_entry(mini_allocator *mini,
 
 /*
  *-----------------------------------------------------------------------------
- *
  * mini_[lock,unlock]_batch_[get,set]next_addr --
  *
  *      Lock locks allocation on the given batch by replacing its next_addr
@@ -429,10 +412,8 @@ mini_unkeyed_append_entry(mini_allocator *mini,
  *
  * Side effects:
  *      None.
- *
  *-----------------------------------------------------------------------------
  */
-
 static uint64
 mini_lock_batch_get_next_addr(mini_allocator *mini, uint64 batch)
 {
@@ -461,7 +442,6 @@ mini_unlock_batch_set_next_addr(mini_allocator *mini,
 
 /*
  *-----------------------------------------------------------------------------
- *
  * mini_[get,set]_next_meta_addr --
  *
  *      Sets the next_meta_addr on meta_page to next_meta_addr. This links
@@ -473,10 +453,8 @@ mini_unlock_batch_set_next_addr(mini_allocator *mini,
  *
  * Side effects:
  *      None.
- *
  *-----------------------------------------------------------------------------
  */
-
 static uint64
 mini_get_next_meta_addr(page_handle *meta_page)
 {
@@ -546,7 +524,6 @@ mini_append_entry(mini_allocator *mini,
 
 /*
  *-----------------------------------------------------------------------------
- *
  * mini_alloc --
  *
  *      Allocate a next disk address from the mini_allocator.
@@ -563,7 +540,6 @@ mini_append_entry(mini_allocator *mini,
  *
  * Side effects:
  *      Disk allocation, standard cache side effects.
- *
  *-----------------------------------------------------------------------------
  */
 uint64
@@ -601,7 +577,6 @@ mini_alloc(mini_allocator *mini,
 
 /*
  *-----------------------------------------------------------------------------
- *
  * mini_release --
  *
  *      Called to finalize the mini_allocator. After calling, no more
@@ -616,10 +591,8 @@ mini_alloc(mini_allocator *mini,
  *
  * Side effects:
  *      Disk deallocation, standard cache side effects.
- *
  *-----------------------------------------------------------------------------
  */
-
 void
 mini_release(mini_allocator *mini, const slice key)
 {
@@ -643,7 +616,6 @@ mini_release(mini_allocator *mini, const slice key)
 
 /*
  *-----------------------------------------------------------------------------
- *
  * mini_[keyed,unkeyed]_for_each(_self_exclusive) --
  *
  *      Calls func on each extent_addr in the mini_allocator.
@@ -664,10 +636,8 @@ mini_release(mini_allocator *mini, const slice key)
  *
  * Side effects:
  *      func may store output in out.
- *
  *-----------------------------------------------------------------------------
  */
-
 
 typedef bool (*mini_for_each_fn)(cache *   cc,
                                  page_type type,
@@ -697,9 +667,10 @@ mini_unkeyed_for_each(cache *          cc,
    } while (meta_addr != 0);
 }
 
-/* The exact values of these enums is important to
-   interval_intersects_range(). See its implementation and
-   comments. */
+/*
+ * NOTE: The exact values of these enums is *** important *** to
+ * interval_intersects_range(). See its implementation and comments.
+ */
 typedef enum boundary_state {
    before_start = 1,
    in_range     = 0,
@@ -709,14 +680,15 @@ typedef enum boundary_state {
 static bool
 interval_intersects_range(boundary_state left_state, boundary_state right_state)
 {
-   /* The interval [left, right] intersects the interval [begin, end]
-      if left_state != right_state or if left_state == right_state ==
-      in_range = 0.
-
-      The predicate below works as long as
-      - in_range == 0, and
-      - before_start & after_end == 0.
- */
+   /*
+    * The interval [left, right] intersects the interval [begin, end]
+    * if left_state != right_state or if left_state == right_state ==
+    * in_range = 0.
+    *
+    * The predicate below works as long as
+    * - in_range == 0, and
+    * - before_start & after_end == 0.
+    */
    return (left_state & right_state) == 0;
 }
 
@@ -739,6 +711,7 @@ state(data_config *cfg,
 }
 
 /*
+ *-----------------------------------------------------------------------------
  * Apply func to every exent whose key range intersects [start_key, _end_key].
  *
  * Note: if start_key is null, then so must be _end_key, and func is
@@ -754,7 +727,7 @@ state(data_config *cfg,
  * Note: the last extent in each batch is treated as ending at
  * +infinity, regardless of the what key was specified as the ending
  * point passed to mini_release.
- *
+ *-----------------------------------------------------------------------------
  */
 static bool
 mini_keyed_for_each(cache *          cc,
@@ -825,6 +798,7 @@ mini_keyed_for_each(cache *          cc,
 }
 
 /*
+ *-----------------------------------------------------------------------------
  * Apply func to every exent whose key range intersects [start_key, _end_key].
  *
  * Note: if start_key is null, then so must be _end_key, and func is
@@ -840,7 +814,7 @@ mini_keyed_for_each(cache *          cc,
  * Note: the last extent in each batch is treated as ending at
  * +infinity, regardless of the what key was specified as the ending
  * point passed to mini_release.
- *
+ *-----------------------------------------------------------------------------
  */
 static bool
 mini_keyed_for_each_self_exclusive(cache *          cc,
@@ -919,7 +893,6 @@ mini_keyed_for_each_self_exclusive(cache *          cc,
 
 /*
  *-----------------------------------------------------------------------------
- *
  * mini_unkeyed_[inc,dec]_ref --
  *
  *      Increments or decrements the ref count of the unkeyed allocator. When
@@ -931,11 +904,8 @@ mini_keyed_for_each_self_exclusive(cache *          cc,
  *
  * Side effects:
  *      Deallocation/cache side effects when external ref count hits 0
- *
  *-----------------------------------------------------------------------------
  */
-
-
 uint8
 mini_unkeyed_inc_ref(cache *cc, uint64 meta_head)
 {
@@ -1013,7 +983,6 @@ mini_unkeyed_dec_ref(cache *cc, uint64 meta_head, page_type type, bool pinned)
 
 /*
  *-----------------------------------------------------------------------------
- *
  * mini_keyed_[inc,dec]_ref --
  *
  *      In keyed mini allocators, ref counts are kept on a per-extent basis,
@@ -1042,10 +1011,8 @@ mini_unkeyed_dec_ref(cache *cc, uint64 meta_head, page_type type, bool pinned)
  *
  * Side effects:
  *      Deallocation/cache side effects.
- *
  *-----------------------------------------------------------------------------
  */
-
 static bool
 mini_keyed_inc_ref_extent(cache *   cc,
                           page_type type,
@@ -1134,21 +1101,18 @@ mini_keyed_dec_ref(cache *      cc,
 
 /*
  *-----------------------------------------------------------------------------
- *
  * mini_keyed_(un)block_dec_ref --
  *
  *      Block/unblock dec_ref callers. See note in mini_keyed_dec_ref for
- *details.
+ *      details.
  *
  * Results:
  *      None
  *
  * Side effects:
  *      None
- *
  *-----------------------------------------------------------------------------
  */
-
 void
 mini_block_dec_ref(cache *cc, uint64 meta_head)
 {
@@ -1169,7 +1133,6 @@ mini_unblock_dec_ref(cache *cc, uint64 meta_head)
 
 /*
  *-----------------------------------------------------------------------------
- *
  * mini_keyed_count_extents --
  *
  *      Returns the number of extents in the mini allocator intersecting the
@@ -1180,10 +1143,8 @@ mini_unblock_dec_ref(cache *cc, uint64 meta_head)
  *
  * Side effects:
  *      None.
- *
  *-----------------------------------------------------------------------------
  */
-
 static bool
 mini_keyed_count_extents(cache *cc, page_type type, uint64 base_addr, void *out)
 {
@@ -1214,7 +1175,6 @@ mini_keyed_extent_count(cache *      cc,
 
 /*
  *-----------------------------------------------------------------------------
- *
  * mini_unkeyed_prefetch --
  *
  *      Prefetches all extents in the (unkeyed) mini allocator.
@@ -1224,10 +1184,8 @@ mini_keyed_extent_count(cache *      cc,
  *
  * Side effects:
  *      Standard cache side effects.
- *
  *-----------------------------------------------------------------------------
  */
-
 static bool
 mini_prefetch_extent(cache *cc, page_type type, uint64 base_addr, void *out)
 {
@@ -1244,7 +1202,6 @@ mini_unkeyed_prefetch(cache *cc, page_type type, uint64 meta_head)
 
 /*
  *-----------------------------------------------------------------------------
- *
  * mini_[keyed,unkeyed]_print --
  *
  *      Prints each meta_page together with all its entries to
@@ -1258,10 +1215,8 @@ mini_unkeyed_prefetch(cache *cc, page_type type, uint64 meta_head)
  *
  * Side effects:
  *      None.
- *
  *-----------------------------------------------------------------------------
  */
-
 void
 mini_unkeyed_print(cache *cc, uint64 meta_head, page_type type)
 {

--- a/src/rc_allocator.c
+++ b/src/rc_allocator.c
@@ -2,9 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /*
+ *------------------------------------------------------------------------------
  * rc_allocator.c --
  *
  *     This file contains the implementation of the ref count allocator.
+ *------------------------------------------------------------------------------
  */
 
 #include "platform.h"
@@ -36,9 +38,7 @@
 
 /*
  *------------------------------------------------------------------------------
- *
- * function declarations
- *
+ * Function declarations
  *------------------------------------------------------------------------------
  */
 
@@ -242,14 +242,11 @@ rc_allocator_init_meta_page(rc_allocator *al)
 
 /*
  *-----------------------------------------------------------------------------
- *
  * rc_allocator_config_init --
  *
  *      Initialize rc_allocator config values
- *
  *-----------------------------------------------------------------------------
  */
-
 void
 rc_allocator_config_init(rc_allocator_config *allocator_cfg,
                          uint64              page_size,
@@ -267,14 +264,11 @@ rc_allocator_config_init(rc_allocator_config *allocator_cfg,
 
 /*
  *----------------------------------------------------------------------
- *
  * rc_allocator_[de]init --
  *
  *      [de]initialize an allocator
- *
  *----------------------------------------------------------------------
  */
-
 platform_status
 rc_allocator_init(rc_allocator         *al,
                   rc_allocator_config  *cfg,
@@ -352,15 +346,12 @@ void rc_allocator_deinit(rc_allocator *al)
 
 /*
  *----------------------------------------------------------------------
- *
  * rc_allocator_[dis]mount --
  *
  *      Loads the file system from disk
  *      Write the file system to disk
- *
  *----------------------------------------------------------------------
  */
-
 platform_status
 rc_allocator_mount(rc_allocator         *al,
                    rc_allocator_config  *cfg,
@@ -447,16 +438,13 @@ rc_allocator_dismount(rc_allocator *al)
 
 /*
  *----------------------------------------------------------------------
- *
  * rc_allocator_[inc,dec,get]_ref --
  *
  *      Increments/decrements/fetches the ref count of the given address and
  *      returns the new one. If the ref_count goes to 0, then the extent is
  *      freed.
- *
  *----------------------------------------------------------------------
  */
-
 uint8
 rc_allocator_inc_ref(rc_allocator *al, uint64 addr)
 {
@@ -514,14 +502,11 @@ rc_allocator_get_ref(rc_allocator *al, uint64 addr)
 
 /*
  *----------------------------------------------------------------------
- *
  * rc_allocator_get_[capacity,super_addr] --
  *
  *      returns the struct/parameter
- *
  *----------------------------------------------------------------------
  */
-
 uint64
 rc_allocator_get_capacity(rc_allocator *al)
 {
@@ -629,14 +614,11 @@ rc_allocator_page_size(rc_allocator *al)
 
 /*
  *----------------------------------------------------------------------
- *
  * rc_allocator_alloc--
  *
  *      Allocate an extent
- *
  *----------------------------------------------------------------------
  */
-
 platform_status
 rc_allocator_alloc(rc_allocator *al,   // IN
                    uint64 *      addr, // OUT
@@ -676,14 +658,11 @@ rc_allocator_alloc(rc_allocator *al,   // IN
 
 /*
  *----------------------------------------------------------------------
- *
  * rc_allocator_in_use --
  *
  *      Returns the number of extents currently allocated
- *
  *----------------------------------------------------------------------
  */
-
 uint64
 rc_allocator_in_use(rc_allocator *al)
 {
@@ -692,15 +671,12 @@ rc_allocator_in_use(rc_allocator *al)
 
 /*
  *----------------------------------------------------------------------
- *
  * rc_allocator_assert_noleaks --
  *
  *      Asserts that the allocations of each type are completely matched by
  *      deallocations.
- *
  *----------------------------------------------------------------------
  */
-
 void
 rc_allocator_assert_noleaks(rc_allocator *al)
 {
@@ -718,19 +694,15 @@ rc_allocator_assert_noleaks(rc_allocator *al)
    }
 }
 
-
 /*
  *----------------------------------------------------------------------
- *
  * rc_allocator_print_stats --
  *
  *      Prints basic statistics about the allocator state.
  *
  *      Max allocations, and page type stats are since last mount.
- *
  *----------------------------------------------------------------------
  */
-
 void
 rc_allocator_print_stats(rc_allocator *al)
 {
@@ -776,14 +748,11 @@ rc_allocator_print_stats(rc_allocator *al)
 
 /*
  *----------------------------------------------------------------------
- *
  * rc_allocator_debug_print --
  *
  *      Prints the base addrs of all allocated extents.
- *
  *----------------------------------------------------------------------
  */
-
 void
 rc_allocator_debug_print(rc_allocator *al)
 {

--- a/src/rc_allocator.h
+++ b/src/rc_allocator.h
@@ -26,16 +26,13 @@ typedef struct rc_allocator_config {
 
 /*
  *----------------------------------------------------------------------
- *
  * rc_allocator_meta_page --
  *
  *  An on disk structure to hold the super block information about all the
  *  splinter tables using this allocator. This is persisted at
  *  offset 0 of the device.
- *
  *----------------------------------------------------------------------
  */
-
 typedef struct PACKED rc_allocator_meta_page {
    allocator_root_id splinters[RC_ALLOCATOR_MAX_ALLOCATOR_ROOT_IDS];
    checksum128       checksum;
@@ -43,12 +40,9 @@ typedef struct PACKED rc_allocator_meta_page {
 
 /*
  *----------------------------------------------------------------------
- *
  * rc_allocator_stats --
- *
  *----------------------------------------------------------------------
  */
-
 typedef struct rc_allocator_stats {
    int64 curr_allocated;
    int64 max_allocated;
@@ -58,12 +52,9 @@ typedef struct rc_allocator_stats {
 
 /*
  *----------------------------------------------------------------------
- *
  * rc_allocator --
- *
  *----------------------------------------------------------------------
  */
-
 typedef struct rc_allocator {
    allocator               super;
    rc_allocator_config    *cfg;

--- a/src/routing_filter.c
+++ b/src/routing_filter.c
@@ -2,9 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /*
+ *----------------------------------------------------------------------
  * routing_filter.c --
  *
  *     This file contains the implementation for a routing filter
+ *----------------------------------------------------------------------
  */
 
 #include "platform.h"
@@ -23,15 +25,12 @@
 
 /*
  *----------------------------------------------------------------------
- *
- * routing_hdr
+ * routing_hdr:
  *
  *       This header encodes the bucket counts for all buckets covered by a
  *       single index.
- *
  *----------------------------------------------------------------------
  */
-
 typedef struct routing_hdr {
    uint16 num_remainders;
    char   encoding[];
@@ -39,11 +38,9 @@ typedef struct routing_hdr {
 
 /*
  *----------------------------------------------------------------------
- *
  * RadixSort --
  *
  *      A fast integer sort based on https://stackoverflow.com/a/44792724
- *
  *----------------------------------------------------------------------
  */
 
@@ -211,15 +208,12 @@ routing_unlock_and_unget_page(cache       *cc,
 
 /*
  *----------------------------------------------------------------------
- *
  * routing_get_bucket_bounds
  *
  *      parses the encoding to return the start and end indices for the
  *      bucket_offset
- *
  *----------------------------------------------------------------------
  */
-
 static inline void
 routing_get_bucket_bounds(char   *encoding,
                           uint64  len,
@@ -318,7 +312,6 @@ routing_get_bucket_counts(routing_config *cfg,
 
 /*
  *----------------------------------------------------------------------
- *
  * routing_filter_add
  *
  *      Adds the fingerprints in fp_arr with value value to the
@@ -326,10 +319,8 @@ routing_get_bucket_counts(routing_config *cfg,
  *      filter_addr.
  *
  *      meta_head should be passed to routing_filter_zap
- *
  *----------------------------------------------------------------------
  */
-
 platform_status
 routing_filter_add(cache            *cc,
                    routing_config   *cfg,
@@ -792,7 +783,6 @@ routing_filter_estimate_unique_fp(cache            *cc,
 
 /*
  *----------------------------------------------------------------------
- *
  * routing_filter_lookup
  *
  *      looks for key in the filter and returns whether it was found, it's
@@ -800,10 +790,8 @@ routing_filter_estimate_unique_fp(cache            *cc,
  *
  *      IMPORTANT: If there are multiple matching values, this function returns
  *      them in the reverse order.
- *
  *----------------------------------------------------------------------
  */
-
 platform_status
 routing_filter_lookup(cache *         cc,
                       routing_config *cfg,
@@ -883,7 +871,6 @@ routing_filter_lookup(cache *         cc,
 
 /*
  *-----------------------------------------------------------------------------
- *
  * routing_async_set_state --
  *
  *      Set the state of the async filter lookup state machine.
@@ -893,10 +880,8 @@ routing_filter_lookup(cache *         cc,
  *
  * Side effects:
  *      None.
- *
  *-----------------------------------------------------------------------------
  */
-
 static inline void
 routing_async_set_state(routing_async_ctxt  *ctxt,
                         routing_async_state  new_state)
@@ -908,7 +893,6 @@ routing_async_set_state(routing_async_ctxt  *ctxt,
 
 /*
  *-----------------------------------------------------------------------------
- *
  * routing_filter_async_callback --
  *
  *      Callback that's called when the async cache get loads a page into
@@ -921,10 +905,8 @@ routing_async_set_state(routing_async_ctxt  *ctxt,
  *
  * Side effects:
  *      None.
- *
  *-----------------------------------------------------------------------------
  */
-
 static void
 routing_filter_async_callback(cache_async_ctxt *cache_ctxt)
 {
@@ -949,7 +931,6 @@ routing_filter_async_callback(cache_async_ctxt *cache_ctxt)
 
 /*
  *-----------------------------------------------------------------------------
- *
  * routing_filter_lookup_async --
  *
  *      Async filter lookup api. Returns if lookup found a key in *found.  The
@@ -973,10 +954,8 @@ routing_filter_async_callback(cache_async_ctxt *cache_ctxt)
  *
  * Side effects:
  *      None.
- *
  *-----------------------------------------------------------------------------
  */
-
 cache_async_result
 routing_filter_lookup_async(cache *             cc,
                             routing_config *    cfg,
@@ -1130,14 +1109,11 @@ routing_filter_lookup_async(cache *             cc,
 
 /*
  *----------------------------------------------------------------------
- *
  * routing_filter_zap
  *
  *      decs the ref count of the filter and destroys it if it reaches 0
- *
  *----------------------------------------------------------------------
  */
-
 void
 routing_filter_zap(cache          *cc,
                    routing_filter *filter)
@@ -1152,15 +1128,12 @@ routing_filter_zap(cache          *cc,
 
 /*
  *----------------------------------------------------------------------
- *
  * routing_filter_estimate_unique_keys
  *
  *      returns the expected number of unique input keys given the number of
  *      unique fingerprints in the filter.
- *
  *----------------------------------------------------------------------
  */
-
 uint32
 routing_filter_estimate_unique_keys_from_count(routing_config *cfg,
                                                uint64          num_unique)

--- a/src/routing_filter.h
+++ b/src/routing_filter.h
@@ -120,7 +120,6 @@ routing_filter_is_value_found(uint64 found_values,
 
 /*
  *-----------------------------------------------------------------------------
- *
  * routing_filter_ctxt_init --
  *
  *      Initialized the async context used by an async filter request.
@@ -130,10 +129,8 @@ routing_filter_is_value_found(uint64 found_values,
  *
  * Side effects:
  *      None.
- *
  *-----------------------------------------------------------------------------
  */
-
 static inline void
 routing_filter_ctxt_init(routing_async_ctxt *ctxt,       // OUT
                          cache_async_ctxt   *cache_ctxt, // IN

--- a/src/shard_log.c
+++ b/src/shard_log.c
@@ -2,9 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /*
+ *-----------------------------------------------------------------------------
  * shard_log.c --
  *
  *     This file contains the implementation for a sharded write-ahead log.
+ *-----------------------------------------------------------------------------
  */
 
 #include "platform.h"
@@ -447,14 +449,11 @@ shard_log_iterator_advance(iterator *itorh)
 
 /*
  *-----------------------------------------------------------------------------
- *
  * shard_log_config_init --
  *
  *      Initialize shard_log config values
- *
  *-----------------------------------------------------------------------------
  */
-
 void shard_log_config_init(shard_log_config *log_cfg,
                            data_config      *data_cfg,
                            uint64            page_size,

--- a/src/splinter.h
+++ b/src/splinter.h
@@ -22,16 +22,14 @@
 #include "srq.h"
 
 #define SPLINTER_MAX_HEIGHT 8
+
 #define SPLINTER_MAX_TOTAL_DEGREE 256
 
 /*
  *----------------------------------------------------------------------
- *
- * splinter --
- *
+ * Splinter Configuration structure
  *----------------------------------------------------------------------
  */
-
 typedef struct splinter_config {
    // robj: if these are redundant, maybe delete them?
    uint64               page_size;               // must match the cache/fs page_size
@@ -44,20 +42,16 @@ typedef struct splinter_config {
    uint64               max_branches_per_node;
    uint64               hard_max_branches_per_node;
    uint64               target_leaf_tuples;      // make leaves this big when splitting
-   uint64               reclaim_threshold;       // start reclaming space when free space < threshold
-
-   // stats
-   bool use_stats;
-
-   memtable_config              mt_cfg;
-   btree_config                 btree_cfg;
-   routing_config               index_filter_cfg;
-   routing_config               leaf_filter_cfg;
-
-   data_config *data_cfg;
-
+   uint64               reclaim_threshold;       // start reclaming space when
+                                                 // free space < threshold
+   bool                 use_stats;               // stats
+   memtable_config      mt_cfg;
+   btree_config         btree_cfg;
+   routing_config       index_filter_cfg;
+   routing_config       leaf_filter_cfg;
+   data_config *        data_cfg;
    bool                 use_log;
-   log_config          *log_cfg;
+   log_config *         log_cfg;
 } splinter_config;
 
 typedef struct splinter_stats {
@@ -257,6 +251,7 @@ struct splinter_pivot_data;
 struct splinter_subbundle;
 
 typedef void (*splinter_async_cb)(struct splinter_async_ctxt *ctxt);
+
 typedef struct splinter_async_ctxt {
    splinter_async_cb            cb;            // IN: callback (requeues ctxt
                                               // for dispatch)
@@ -307,7 +302,7 @@ typedef struct {
 /*
  *----------------------------------------------------------------------
  *
- * splinter API
+ * Splinter API
  *
  *----------------------------------------------------------------------
  */
@@ -475,6 +470,5 @@ splinter_config_init(splinter_config *splinter_cfg,
                      uint64           use_stats);
 size_t
 splinter_get_scratch_size();
-
 
 #endif // __SPLINTER_H

--- a/src/task.c
+++ b/src/task.c
@@ -577,12 +577,13 @@ task_perform_one(task_system *ts)
 }
 
 /*
+ * -----------------------------------------------------------------------------
  * Task system initializer. Makes sure that the initial thread has an
  * adequately sized scratch.
  * Needs to be called at the beginning of the main thread that uses splinter,
  * similar to how __attribute__((constructor)) works.
+ * -----------------------------------------------------------------------------
  */
-
 platform_status
 task_system_create(platform_heap_id     hid,
                    platform_io_handle  *ioh,

--- a/src/task.h
+++ b/src/task.h
@@ -70,6 +70,7 @@ typedef enum task_type {
 } task_type;
 
 /*
+ * ----------------------------------------------------------------------
  * Splinter specific state that gets created during initialization in
  * splinter_system_init(). Contains global state for splinter such as the
  * init thread, init thread's scratch memory, thread_id counter and an array
@@ -79,8 +80,8 @@ typedef enum task_type {
  * This structure is passed around like an opaque structure to all the
  * entities that need to access it. Some of them are task creation and
  * execution, task queue and clockcache.
+ * ----------------------------------------------------------------------
  */
-
 struct task_system {
    // array of scratch space pointers for this system.
    void *thread_scratch[MAX_THREADS];

--- a/src/util.c
+++ b/src/util.c
@@ -62,8 +62,10 @@ writable_buffer_data(writable_buffer *wb)
 }
 
 /*
+ *----------------------------------------------------------------------
  * Utility function; you should not use this directly
  * negative_limit and positive_limit are absolute values
+ *----------------------------------------------------------------------
  */
 static inline bool
 try_string_to_uint64_limit(const char *nptr,            // IN
@@ -186,6 +188,7 @@ multiple_strings:
 
 
 /*
+ *----------------------------------------------------------------------
  * try_string_to_(u)int64
  *
  * Convert a string to a (u)int64.
@@ -205,6 +208,7 @@ multiple_strings:
  * - asking for uint64 and you provide a negative number
  *
  * Base is automatically detected based on the regular expressions above
+ *----------------------------------------------------------------------
  */
 bool
 try_string_to_uint64(const char *nptr, // IN

--- a/src/util.h
+++ b/src/util.h
@@ -32,7 +32,6 @@ pointer_byte_offset(void *base, int64 offset)
 
 /*
  *-----------------------------------------------------------------------------
- *
  * int64abs --
  *
  *    This function takes an int64 value and it returns the abolute value.
@@ -44,10 +43,8 @@ pointer_byte_offset(void *base, int64 offset)
  *
  * Side effects:
  *      None.
- *
  *-----------------------------------------------------------------------------
  */
-
 static inline uint64
 int64abs(int64 j)
 {
@@ -135,33 +132,35 @@ slice_lex_cmp(const slice a, const slice b)
    }
 }
 
-/* Writable buffers can be in one of four states:
-   - uninitialized
-   - null
-     - data == NULL
-     - allocation_size == length == 0
-   - non-null
-     - data != NULL
-     - length <= allocation_size
-
-   No operation (other than destroy) ever shrinks allocation_size, so
-   writable_buffers can only go down the above list, e.g. once a
-   writable_buffer is out-of-line, it never becomes inline again.
-
-   writable_buffer_init can create any of the initialized,
-   non-user-provided-buffer states, based on the allocation_size
-   specified.
-
-   writable_buffer_destroy returns the writable_buffer to the null state.
-
-   Note that the null state is not isolated.  writable_buffer_realloc
-   can move a null writable_buffer to the inline or the platform_malloced
-   states.  Thus it is possible to, e.g. perform
-   writable_buffer_copy_slice on a null writable_buffer.
-
-   Also note that the user-provided state can move to the
-   platform-malloced state.
-*/
+/*
+ * ----------------------------------------------------------------------
+ * Writable buffers can be in one of four states:
+ * - uninitialized
+ * - null
+ *   - data == NULL
+ *   - allocation_size == length == 0
+ * - non-null
+ *   - data != NULL
+ *   - length <= allocation_size
+ *
+ * No operation (other than destroy) ever shrinks allocation_size, so
+ * writable_buffers can only go down the above list, e.g. once a
+ * writable_buffer is out-of-line, it never becomes inline again.
+ *
+ * writable_buffer_init can create any of the initialized,
+ * non-user-provided-buffer states, based on the allocation_size
+ * specified.
+ *
+ * writable_buffer_destroy returns the writable_buffer to the null state.
+ *
+ * Note that the null state is not isolated.  writable_buffer_realloc
+ * can move a null writable_buffer to the inline or the platform_malloced
+ * states.  Thus it is possible to, e.g. perform
+ * writable_buffer_copy_slice on a null writable_buffer.
+ *
+ * Also note that the user-provided state can move to the
+ * platform-malloced state.
+ */
 struct writable_buffer {
    void *           original_pointer;
    uint64           original_size;


### PR DESCRIPTION
This is a non-code-changing commit that only changes comments & prolog
banners in different files. Minor edits are done to re-indent lines
in places. Any code changes that arise are due to clang-format fixes
that come about due to rearranging comment blocks etc.