### PR TITLE
Use Ubuntu 22.04 LTS in CI

### DIFF
--- a/Dockerfile.build-env
+++ b/Dockerfile.build-env
@@ -7,14 +7,14 @@
 # This contains the build-time dependencies for SplinterDB.
 #
 # To build this image locally:
-# $ docker build -t build-env < Dockerfile.build-env
+# $ docker build -t build-env - < Dockerfile.build-env
 # To then build SplinterDB itself from souce:
 # $ docker run -it --rm --mount type=bind,source="$PWD",target=/splinterdb build-env /bin/bash
 #
 # This file is maintained separately from the other Dockerfiles
 # to reduce build times when the SplinterDB source changes
 
-ARG base_image=library/ubuntu:20.04
+ARG base_image=library/ubuntu:22.04
 FROM $base_image
 RUN /bin/bash -c ' \
 set -euo pipefail; \

--- a/Dockerfile.run-env
+++ b/Dockerfile.run-env
@@ -9,7 +9,7 @@
 # It is maintained separately from the main Dockerfile
 # to reduce build-times when the splinterdb source changes
 
-ARG base_image=library/ubuntu:20.04
+ARG base_image=library/ubuntu:22.04
 FROM $base_image AS runner
 RUN /bin/bash -c ' \
 set -euo pipefail; \

--- a/ci/pipeline-funcs.lib.yml
+++ b/ci/pipeline-funcs.lib.yml
@@ -51,7 +51,7 @@ plan:
     outputs:
     - name: image
     params:
-      BUILD_ARG_base_image: harbor-repo.vmware.com/dockerhub-proxy-cache/library/ubuntu:20.04
+      BUILD_ARG_base_image: harbor-repo.vmware.com/dockerhub-proxy-cache/library/ubuntu:22.04
       DOCKERFILE: #@ "Dockerfile." + resource_name
       LABEL_created_by: "SplinterDB Concourse CI"
     run:

--- a/docs/build.md
+++ b/docs/build.md
@@ -5,17 +5,17 @@ To integrate SplinterDB into another application, see [Usage](usage.md).
 ## On Linux
 Builds are known to work on Ubuntu using recent versions of GCC and Clang.
 
-In CI, we test against the versions that Ubuntu "focal" 20.04 provides by
-default, currently GCC 9 and Clang 10.
+In CI, we test against the versions that Ubuntu "jammy" 22.04 provides by
+default, currently GCC 11 and Clang 13.
 
 ```shell
-$ export COMPILER=gcc-9
+$ export COMPILER=gcc-11
 $ sudo apt update -y
 $ sudo apt install -y libaio-dev libconfig-dev libxxhash-dev $COMPILER
 $ export CC=$COMPILER
 $ export LD=$COMPILER
 $ make
-$ make test
+$ make run-tests
 $ sudo make install
 ```
 


### PR DESCRIPTION
[There are now daily builds of Ubuntu 22.04](https://cloud-images.ubuntu.com/jammy/current/).  It will be officially released in April, and will be supported until April 2027.

This PR rolls our CI system forward to use that version.

It packages clang and clang-format v13 by default. 

Once this lands (and the images get re-built by CI), then we can get #247 passing using `clang-format-13`