### PR TITLE
ci: all first-stage jobs block all second-stage jobs

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -90,18 +90,21 @@ jobs:
 - #@ job_debug_main_build_test("clang")
 - #@ job_debug_main_build_test("gcc")
 
+#! first stage of pipeline, runs a few quick jobs
+#@ stage_one = ["pr-quick-check", "pr-clang-format", "pr-shell-scripts"]
 - #@ job_pr_check("clang-format", steps_pr_clang_format(), description="check C source formatting")
 - #@ job_pr_check("shell-scripts", steps_pr_shell_scripts(), description="lint and format any shell scripts")
 - #@ job_pr_check("quick-check", steps_pr_debug_build_test("clang", quick=True), description="build and run fast unit tests")
 
-- #@ job_pr_check("clang", steps_pr_build_test("clang"), depends_on=["pr-quick-check"], description="build and test")
-- #@ job_pr_check("gcc", steps_pr_build_test("gcc"), depends_on=["pr-quick-check"], description="build and test")
+#! second stage of pipeline, only triggers if all of the first-stage passes
+- #@ job_pr_check("clang", steps_pr_build_test("clang"), depends_on=stage_one, description="build and test")
+- #@ job_pr_check("gcc", steps_pr_build_test("gcc"), depends_on=stage_one, description="build and test")
 
-- #@ job_pr_check("debug-clang", steps_pr_debug_build_test("clang"), depends_on=["pr-quick-check"], description="debug build and test")
-- #@ job_pr_check("debug-gcc", steps_pr_debug_build_test("gcc"), depends_on=["pr-quick-check"], description="debug build and test")
+- #@ job_pr_check("debug-clang", steps_pr_debug_build_test("clang"), depends_on=stage_one, description="debug build and test")
+- #@ job_pr_check("debug-gcc", steps_pr_debug_build_test("gcc"), depends_on=stage_one, description="debug build and test")
 
-- #@ job_pr_check("rust", steps_pr_build_test("clang", with_rust=True), depends_on=["pr-quick-check"], description="rust build and test")
-- #@ job_pr_check("rust-debug", steps_pr_debug_build_test("clang", with_rust=True), depends_on=["pr-quick-check"], description="rust debug build and test")
+- #@ job_pr_check("rust", steps_pr_build_test("clang", with_rust=True), depends_on=stage_one, description="rust build and test")
+- #@ job_pr_check("rust-debug", steps_pr_debug_build_test("clang", with_rust=True), depends_on=stage_one, description="rust debug build and test")
 
 groups:
 - name: main_branch


### PR DESCRIPTION
simplifying CI flow: don't trigger fan-out if any of the following jobs fails:
- `pr-quick-check` (debug build + fast unit tests)
- `pr-clang-format`
- `pr-shell-scripts`

I've already made this change, just recording it here.