### PR TITLE
(#264) Fix memory leaks in unit-tests discovered by ASAN builds.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,8 +101,16 @@ endif
 DEFAULT_CFLAGS += $(LIBCONFIG_CFLAGS)
 DEFAULT_LDFLAGS += -ggdb3 -pthread
 
-# to set sanitiziers, use environment variables, e.g.
+# ##########################################################################
+# To set sanitiziers, use environment variables, e.g.
 #   DEFAULT_CFLAGS="-fsanitize=address" DEFAULT_LDFLAGS="-fsanitize=address" make debug
+# Note(s):
+#  - Address sanitizer builds: -fsanitize=address
+#     - Ctests will be silently skipped with clang builds. (Known issue.)
+#       Use gcc to build in Asan mode to run unit-tests.
+#
+#  - Memory sanitizer builds: -fsanitize=memory
+#     - Builds will fail with gcc due to compiler error. Use clang instead.
 
 CFLAGS += $(DEFAULT_CFLAGS) -Ofast -flto
 LDFLAGS += $(DEFAULT_LDFLAGS) -Ofast -flto
@@ -112,32 +120,26 @@ ifeq ($(WITH_RUST),true)
   EXTRA_TARGETS += $(BINDIR)/splinterdb-cli
 endif
 
-#*********************************************************#
+#*************************************************************#
 # Targets to track whether we have a release or debug build
-#
 all: $(LIBDIR)/libsplinterdb.so $(LIBDIR)/libsplinterdb.a $(BINDIR)/driver_test \
         unit_test $(EXTRA_TARGETS)
-	uname -a
-	$(CC) --version
 
 # Any libraries required to link test code will be built, if needed.
 tests: $(BINDIR)/driver_test unit_test
 
 release: .release all
-	rm -f .debug
-	rm -f .debug-log
+	rm -f .debug .debug-log
 
 debug: CFLAGS = -g -DSPLINTER_DEBUG $(DEFAULT_CFLAGS)
 debug: LDFLAGS = -g $(DEFAULT_LDFLAGS)
 debug: .debug all
-	rm -f .release
-	rm -f .debug-log
+	rm -f .release .debug-log
 
 debug-log: CFLAGS = -g -DDEBUG -DCC_LOG $(DEFAULT_CFLAGS)
 debug-log: LDFLAGS = -g $(DEFAULT_LDFLAGS)
 debug-log: .debug-log all
-	rm -f .release
-	rm -f .debug
+	rm -f .release .debug
 
 .release:
 	$(MAKE) clean
@@ -279,10 +281,13 @@ unit/misc_test: $(OBJDIR)/tests/unit/misc_test.o            \
 
 #*************************************************************#
 
+# Report build machine details and compiler version for troubleshooting, so
+# we see this output for clean builds, especially in CI-jobs.
 .PHONY : clean tags
 clean :
 	rm -rf $(OBJDIR)/* $(BINDIR)/* $(LIBDIR)/*
-
+	uname -a
+	$(CC) --version
 tags:
 	ctags -R src
 

--- a/include/splinterdb/splinterdb_kv.h
+++ b/include/splinterdb/splinterdb_kv.h
@@ -176,7 +176,10 @@ Sample application code:
    }
 
    // loop exit may mean error, or just that we've reached the end of the range
-   rc = splinterdb_iter_status(it); if (rc != 0) { ... handle error ... }
+   rc = splinterdb_kv_iter_status(it); if (rc != 0) { ... handle error ... }
+
+   // Release resources acquired by the iterator
+   splinterdb_kv_iter_deinit(it);
 */
 
 typedef struct splinterdb_kv_iterator splinterdb_kv_iterator;

--- a/src/btree.c
+++ b/src/btree.c
@@ -552,7 +552,7 @@ btree_create_leaf_incorporate_spec(const btree_config    *cfg,
    }
 }
 
-static void
+void
 destroy_leaf_incorporate_spec(leaf_incorporate_spec *spec)
 {
    if (spec->was_found) {

--- a/src/btree_private.h
+++ b/src/btree_private.h
@@ -146,6 +146,9 @@ btree_build_leaf_splitting_plan(const btree_config          *cfg, // IN
                                 const btree_hdr             *hdr,
                                 const leaf_incorporate_spec *spec); // IN
 
+void
+destroy_leaf_incorporate_spec(leaf_incorporate_spec *spec);
+
 /*
  * ***********************************************************
  * Inline accessor functions for different private structure.

--- a/tests/unit/btree_stress_test.c
+++ b/tests/unit/btree_stress_test.c
@@ -255,6 +255,11 @@ CTEST2(btree_stress, test_random_inserts_concurrent)
    rc = iterator_tests(
       (cache *)&data->cc, &data->dbtree_cfg, packed_root_addr, nkvs);
    ASSERT_NOT_EQUAL(0, rc, "Invalid ranges in packed tree\n");
+
+   // Release memory allocated in this test case
+   for (uint64 i = 0; i < nthreads; i++) {
+      platform_free(data->hid, params[i].scratch);
+   }
 }
 
 /*

--- a/tests/unit/btree_test.c
+++ b/tests/unit/btree_test.c
@@ -371,8 +371,10 @@ leaf_split_tests(btree_config *cfg, btree_scratch *scratch, int nkvs)
    for (uint8 i = 0; i < 2 * realnkvs + 1; i++) {
       uint64                generation;
       leaf_incorporate_spec spec;
-      slice                 key     = slice_create(1, &i);
-      bool                  success = btree_leaf_incorporate_tuple(
+
+      slice key = slice_create(1, &i);
+
+      bool success = btree_leaf_incorporate_tuple(
          cfg, scratch, hdr, key, bigger_msg, &spec, &generation);
       if (success) {
          btree_print_locked_node(cfg, 0, hdr, PLATFORM_ERR_LOG_HANDLE);
@@ -395,6 +397,8 @@ leaf_split_tests(btree_config *cfg, btree_scratch *scratch, int nkvs)
                   "realnkvs = %d, plan.split_idx = %d",
                   realnkvs,
                   plan.split_idx);
+
+      destroy_leaf_incorporate_spec(&spec);
    }
 
    return 0;

--- a/tests/unit/splinterdb_kv_test.c
+++ b/tests/unit/splinterdb_kv_test.c
@@ -437,6 +437,10 @@ CTEST2(splinterdb_kv, test_basic_iterator)
       ASSERT_EQUAL(0, rc);
       i++;
    }
+   rc = splinterdb_kv_iter_status(it);
+   ASSERT_EQUAL(0, rc);
+
+   splinterdb_kv_iter_deinit(&it);
 }
 
 /*


### PR DESCRIPTION
Few unit-tests were leaking memory as reported by Address sanitizer
builds. This commit fixes those issues, to enable activate ASAN
builds.