### PR TITLE
(#274) Support --list arg to list unit-test suite-names & test-case names

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -73,6 +73,20 @@ echo "      **** SplinterDB Test Suite Execution Times **** " > "${test_exec_log
 echo >> "${test_exec_log_file}"
 
 if [ "$INCLUDE_SLOW_TESTS" != "true" ]; then
+   # For some coverage, exercise --help, --list args for unit test binaries
+   set -x
+   bin/unit_test --help
+
+   bin/unit_test --list
+
+   bin/unit_test --list splinterdb
+
+   bin/unit/btree_test --help
+
+   bin/unit/splinterdb_test --list
+
+   set +x
+
    echo
    echo "NOTE: **** Only running fast unit tests ****"
    echo "To run all tests, set the env var, and re-run: $ INCLUDE_SLOW_TESTS=true $Me"

--- a/tests/unit/README.md
+++ b/tests/unit/README.md
@@ -1,4 +1,4 @@
-# SplinterDB Unit-Testing
+# SplinterDB Unit Testing
 
 We have adapted the [CTest framework](https://github.com/bvdberg/ctest),
 which is a unit testing framework for software written in C/C++,
@@ -9,59 +9,89 @@ fuller description of the features of this CTest framework.
 ---
 ## Developing using CTest
 
-* All unit-test code lives under the test/unit/ sub-directory
-* Naming Conventions:
+- All unit-test code lives under the `tests/unit/` sub-directory
+- Naming Conventions:
 
-    * For a source file named `<fileName>.c`, the unit-test file is named `<fileName>_test.c`
-    * The test suite name used for test cases in each test file is usually the `<fileName>` prefix
-    * Each test case is named `test_<something>`
+  - For a source file named `<file_name>.c`, the unit-test file is named `<file_name>_test.c`
+  - The test suite name used for test cases in each test file is usually the `<file_name>` prefix
+    - Each test case is named `test_<something>`
+- To write a new test suite, copy the [unit_test_template_dot_c](unit_test_template_dot_c) file to
+  your new test suite. Follow the instruction given in the [splinterdb_kv_test](splinterdb_kv_test.c)
+  to build individual test cases using the testing framework.
+- If your new unit test is small and runs quickly (under a few seconds), consider adding
+  it here to the list of "smoke tests" in [test.sh](../../test.sh#:~:text=INCLUDE\_SLOW\_TESTS\=true).
 
+----
+## How To build unit tests
 
+Build directives are defined in the top-level `Makefile`. After the initial [build setup](../../docs/build.md), build unit tests as follows.
 
-* How To Build unit-tests:
+Build the SplinterDB library and all test code: `$ make clean && make`
 
-    * Build directives are defined in the top-level Makefile. Build as follows:
+The unit test driver program `bin/unit_test` and all standalone unit test binaries will be generated, including other test drivers.
+
+Rebuild all the test binaries:  `$ make  tests`
+
+Rebuild just the unit test binaries: `$ make unit_test`
+
+To build debug versions of tests: `$ make debug tests` or  `$ make debug unit_test`
+
+----
+## Basic help / usage
+
+To get **basic help / usage** information: `$ bin/unit_test --help`
 
 ```shell
-$ cd /splinterdb
-
-# Build the SplinterDB library first. 'make' will rebuild bin/unit_test also.
-$ make clean; make [debug]
-
-# Build the unit-test binary
-$ make bin/unit_test
-
-# Build all the test sources and binaries, which will also build all unit-test binaries.
-# bin/unit_test and a collection of stand-alone module-specific unit-test binaries will
-# be generated in the bin/unit sub-directory.
-#
-$ make clean; make tests
+$ ./bin/unit_test --help
+Usage: ./bin/unit_test [--list [ <suite-name> ] ]
+Usage: ./bin/unit_test [ --<config options> ]* [ <suite-name> [ <test-case-name> ] ]
 ```
 
-* How To Run unit-tests:
+> Note: The `[ --<config options> ]*` option allows specifying different configuration parameters for test execution. This is supported by very few unit tests and is **only** meant for internal developer-use.
 
-```shell
 
-# Get help/usage information
-$ bin/unit_test --help
+To **list all the unit-test suites** that can be run: `$ bin/unit_test --list`
 
-# Run all the unit test suites
-$ bin/unit_test
+To list all the test cases from a given test suite: `$ bin/unit_test --list <suite-name>`
 
-# Run a specific suite, optionally filtering on a specific test case
-$ bin/unit_test suite-name [ <test-case-name> ]
+**Example**: List all test cases from the [`splinterdb`](splinterdb_test.c) test suite.
 
-Example: Run all test cases named 'test_leaf_hdr%' from the 'btree' test suite
+`$ bin/unit_test --list splinterdb`
 
-$ bin/unit_test btree test_leaf_hdr
+You can also list the test cases that can be run from an individual standalone unit-test binary with the `--list` argument.
 
-# Run a specific unit-test binary
-$ bin/unit/splinterdb_kv_test
+**Example**: List all the test cases from the [`btree`](btree_test.c) test suite using the standalone binary
 
-# Run all test cases named with a prefix from specific unit-test binary.
-# E.g., run all test cases named 'test_splinterdb_iterator%' from splinterdb_kv_test
-#
-$ bin/unit/<unit-test-binary-name> <test-case-name>
-$ bin/unit/splinterdb_kv_test test_splinterdb_iterator
+`$ bin/unit/btree_test --list`
 
-```
+
+----
+## How To Run unit-tests
+
+Quick **smoke-tests** run of unit tests: `$ make run-tests`
+
+This runs a small subset of unit tests, which execute very quickly, so that you get a quick turnaround on the overall stability of any product changes.
+
+You can achieve the same result by executing the following test driver script [test.sh](../../test.sh):
+
+`$ ./test.sh`
+
+To **run** all the unit-test suites: `$ bin/unit_test`
+
+To run a specific suite, optionally filtering on a specific test case:
+
+`$ bin/unit_test <suite-name> [ <test-case-name> ]`
+
+**Example**: Run all test cases named `test_leaf_hdr*` from the `btree_test` suite
+
+`$ bin/unit_test btree test_leaf_hdr`
+
+To run all test cases from a specific unit-test binary:[ `$ bin/unit/splinter_test`](splinter_test.c)
+
+To run all test cases named with a prefix from a specific unit-test binary:
+
+`$ bin/unit/<binary-name> <test-case-prefix>`
+
+**Example**: Run all SplinterDB iterator-related test cases from the [`splinterdb_kv_test`](splinterdb_kv_test.c)
+
+`$ bin/unit/splinterdb_kv_test test_splinterdb_iterator`

--- a/tests/unit/ctest.h
+++ b/tests/unit/ctest.h
@@ -66,8 +66,8 @@ union ctest_run_func_union {
  * ************************************************************************
  */
 struct ctest {
-   const char                *ssname; // suite name
-   const char                *ttname; // test name
+   const char                *ssname; // test suite name
+   const char                *ttname; // test case name
    union ctest_run_func_union run;
 
    void                *data;


### PR DESCRIPTION
This commit adds the `--list` argument which can be used to list all the suite-names that can be run from the `unit_test` binary. It can also be used to list the test case names for a specific suite-name, or for a standalone unit-test binary. 

Overhaul the unit-test `README.md` docs to reflect the current state of unit testing build and test execution interfaces.

The updated unit test README layout can be found here:

https://github.com/vmware/splinterdb/blob/agurajada/274-unit_test-args/tests/unit/README.md

-----
HI, @rosenhouse @carlosgarciaalvarado - The main change here is to add the `--list` arg. 

For your understanding, here are sample outputs with this arg, and how these will be useful for users / devs to run unit-tests in more controlled manner:

- If you run this on the top-level `unit_test` binary:

```
Fusion-LocalVM:[76] $ ./bin/unit_test --list

List of test suites that can be run:
  splinter
  suite              <<< This should not come out; looks like a bug. Will chase it down.
  splinterdb
  misc
  splinterdb_kv
  util
  btree
  splinterdb_kv_stress
  btree_stress
```
The user can use this info to just run the one suite of interest. (Right now the list of test suites is small, but I can see this growing over time.)

**Update**: The <<<'ed bug is now fixed with recent commits. Fix is applied to `print_test_suite_names()` in `unit/main.c` .

`$ ./bin/unit_test splinterdb`

- If you run this on a standalone binary, say, `splinterdb_kv_test` which has lots of test cases:

```
Fusion-LocalVM:[77] $ ./bin/unit/splinterdb_kv_test --list

List of test cases that can be run:
  test_basic_flow
  test_apis_for_max_key_length
  test_key_size_gt_max_key_size
  test_value_size_gt_max_value_size
  test_variable_length_values
  test_basic_iterator
  test_splinterdb_iterator_with_startkey
  test_splinterdb_iterator_with_non_existent_startkey
  test_splinterdb_iterator_with_missing_startkey_in_sequence
  test_close_and_reopen
  test_repeated_insert_close_reopen
  test_iterator_custom_comparator
```

The user can use the individual test case name to run it by itself:

`$ ./bin/unit/splinterdb_kv_test test_splinterdb_iterator_with_startkey`