### PR TITLE
(#272) Rework splinter_test to address slow performance of unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,15 @@ SRC := $(shell find $(SRCDIR) -name "*.c")
 COMMON_TESTSRC := $(shell find $(TESTS_DIR) -maxdepth 1 -name "*.c")
 
 FUNCTIONAL_TESTSRC := $(shell find $(FUNCTIONAL_TESTSDIR) -name "*.c")
+
+# Symbol for all unit-test sources, from which we will build standalone
+# unit-test binaries.
 UNIT_TESTSRC := $(shell find $(UNIT_TESTSDIR) -name "*.c")
+
+# Some unit-tests which are slow will be skipped from this list, as we want the
+# resulting unit_test to run as fast as it can. For now, we are just skipping one
+# test, which will have to be run stand-alone.
+FAST_UNIT_TESTSRC := $(shell find $(UNIT_TESTSDIR) -name "*.c" | egrep -v -e"splinter_test")
 
 OBJ := $(SRC:%.c=$(OBJDIR)/%.o)
 
@@ -36,9 +44,9 @@ COMMON_TESTOBJ= $(COMMON_TESTSRC:%.c=$(OBJDIR)/%.o)
 # Objects from test sources in tests/functional/ sub-dir
 FUNCTIONAL_TESTOBJ= $(FUNCTIONAL_TESTSRC:%.c=$(OBJDIR)/%.o)
 
-# Objects from unit-test sources in tests/unit/ sub-dir
+# Objects from unit-test sources in tests/unit/ sub-dir, for fast unit-tests
 # Resolves to a list: obj/tests/unit/a.o obj/tests/unit/b.o obj/tests/unit/c.o
-UNIT_TESTOBJS= $(UNIT_TESTSRC:%.c=$(OBJDIR)/%.o)
+FAST_UNIT_TESTOBJS= $(FAST_UNIT_TESTSRC:%.c=$(OBJDIR)/%.o)
 
 # ----
 # Binaries from unit-test sources in tests/unit/ sub-dir
@@ -77,14 +85,17 @@ DEFAULT_LDFLAGS += -ggdb3 -pthread
 # ##########################################################################
 # To set sanitiziers, use environment variables, e.g.
 #   DEFAULT_CFLAGS="-fsanitize=address" DEFAULT_LDFLAGS="-fsanitize=address" make debug
+#
 # Note(s):
 #  - Address sanitizer builds: -fsanitize=address
 #     - Ctests will be silently skipped with clang builds. (Known issue.)
 #       Use gcc to build in Asan mode to run unit-tests.
+#     - Tests will run slow in address sanitizer builds.
 #
 #  - Memory sanitizer builds: -fsanitize=memory
 #     - Builds will fail with gcc due to compiler error. Use clang instead.
-
+#     - Tests will run even slower in memory sanitizer builds.
+#
 CFLAGS += $(DEFAULT_CFLAGS) -Ofast -flto
 LDFLAGS += $(DEFAULT_LDFLAGS) -Ofast -flto
 LIBS = -lm -lpthread -laio -lxxhash $(LIBCONFIG_LIBS)
@@ -178,10 +189,10 @@ $(LIBDIR)/libsplinterdb.a : $(OBJ) | $$(@D)/.
 
 # Dependencies for the main executables
 $(BINDIR)/driver_test: $(FUNCTIONAL_TESTOBJ) $(COMMON_TESTOBJ) $(LIBDIR)/libsplinterdb.so
-$(BINDIR)/unit_test: $(UNIT_TESTOBJS) $(COMMON_TESTOBJ) $(LIBDIR)/libsplinterdb.so $(OBJDIR)/$(FUNCTIONAL_TESTSDIR)/test_async.o
+$(BINDIR)/unit_test: $(FAST_UNIT_TESTOBJS) $(COMMON_TESTOBJ) $(LIBDIR)/libsplinterdb.so $(OBJDIR)/$(FUNCTIONAL_TESTSDIR)/test_async.o
 
-###################################################
-# dependencies for the mini unit tests
+#################################################################
+# Dependencies for the mini unit tests
 # Each mini unit test is a self-contained binary.
 # It links only with its needed .o files
 #
@@ -228,13 +239,13 @@ BTREE_SYS = $(OBJDIR)/$(SRCDIR)/btree.o           \
             $(OBJDIR)/$(SRCDIR)/mini_allocator.o  \
             $(CLOCKCACHE_SYS)
 
-#
+#################################################################
 # The dependencies of each mini unit test.
 #
 # Note each test bin/unit/<x> also depends on obj/unit/<x>.o, as
 # defined above using unit_test_self_dependency.
 #
-$(BINDIR)/$(UNITDIR)/misc_test: $(PLATFORM_SYS)
+$(BINDIR)/$(UNITDIR)/misc_test: $(UTIL_SYS)
 
 $(BINDIR)/$(UNITDIR)/util_test: $(UTIL_SYS)
 

--- a/tests/config.h
+++ b/tests/config.h
@@ -66,8 +66,9 @@ typedef struct master_config {
    uint64 key_size;
    uint64 message_size;
 
-   // test
+   // Test-execution configuration parameters
    uint64 seed;
+   uint64 num_inserts;
 } master_config;
 
 

--- a/tests/functional/splinter_test.c
+++ b/tests/functional/splinter_test.c
@@ -2356,13 +2356,16 @@ splinter_test(int argc, char *argv[])
    data_config       *data_cfg = TYPED_ARRAY_MALLOC(hid, data_cfg, num_tables);
    clockcache_config *cache_cfg =
       TYPED_ARRAY_MALLOC(hid, cache_cfg, num_tables);
+   test_exec_config test_exec_cfg;
+   ZERO_STRUCT(test_exec_cfg);
+
    rc = test_parse_args_n(splinter_cfg,
                           data_cfg,
                           &io_cfg,
                           &al_cfg,
                           cache_cfg,
                           &log_cfg,
-                          &seed,
+                          &test_exec_cfg,
                           num_tables,
                           config_argc,
                           config_argv);
@@ -2385,6 +2388,8 @@ splinter_test(int argc, char *argv[])
       usage(argv[0]);
       goto cfg_free;
    }
+
+   seed = test_exec_cfg.seed;
 
    // Max active threads
    uint32 total_threads = num_lookup_threads;

--- a/tests/functional/splinter_test.h
+++ b/tests/functional/splinter_test.h
@@ -85,6 +85,7 @@ test_config_parse(test_config *cfg,
    temp_config *temp_cfg =
       TYPED_ARRAY_MALLOC(platform_get_heap_id(), temp_cfg, num_config);
    for (i = 0; i < argc; i++) {
+      // Don't be mislead; this is not dead-code. See the config macro expansion
       if (0) {
          config_set_mib("tree-size", cfg, tree_size)
          {

--- a/tests/functional/test.h
+++ b/tests/functional/test.h
@@ -51,7 +51,7 @@ ycsb_test(int argc, char *argv[]);
 
 /*
  * Initialization for using splinter, need to be called at the start of the test
- * main function. This initializes Splinter's task sub-system.
+ * main function. This initializes SplinterDB's task sub-system.
  */
 static inline platform_status
 test_init_task_system(platform_heap_id    hid,
@@ -147,14 +147,22 @@ test_insert_data(void        *raw_data,
    memmove(data->data, val, input_size);
 }
 
+/*
+ * test_config_init() --
+ *
+ * Initialize the configuration sub-structures for various sub-systems, using an
+ * input master configuration, master_cfg. A few command-line config parameters
+ * may have been used to setup master_cfg beyond its initial defaults.
+ */
 static inline void
-test_config_init(trunk_config        *splinter_cfg,
-                 data_config         *data_cfg,
-                 shard_log_config    *log_cfg,
-                 clockcache_config   *cache_cfg,
-                 rc_allocator_config *allocator_cfg,
-                 io_config           *io_cfg,
-                 master_config       *master_cfg)
+test_config_init(trunk_config        *splinter_cfg,  // OUT
+                 data_config         *data_cfg,      // OUT
+                 shard_log_config    *log_cfg,       // OUT
+                 clockcache_config   *cache_cfg,     // OUT
+                 rc_allocator_config *allocator_cfg, // OUT
+                 io_config           *io_cfg,        // OUT
+                 master_config       *master_cfg     // IN
+)
 {
    *data_cfg              = test_data_config;
    data_cfg->key_size     = master_cfg->key_size;
@@ -194,21 +202,42 @@ test_config_init(trunk_config        *splinter_cfg,
                      master_cfg->use_stats);
 }
 
+/*
+ * Some command-line [config] arguments become test execution parameters.
+ * Define a structure to hold these when parsing command-line arguments.
+ */
+typedef struct test_exec_config {
+   uint64 seed;
+   uint64 num_inserts;
+} test_exec_config;
+
+/*
+ * test_parse_args_n() --
+ *
+ * Driver routine to parse command-line configuration arguments, to setup the
+ * config sub-structures for all sub-systems in up to n-SplinterDB instances,
+ * given by the num_config parameter.
+ *
+ * NOTE: test_exec_cfg{} contains test-specific configuration parameters.
+ * Not all tests may need these, so this arg is optional, and can be NULL.
+ */
 static inline platform_status
-test_parse_args_n(trunk_config        *splinter_cfg,
-                  data_config         *data_cfg,
-                  io_config           *io_cfg,
-                  rc_allocator_config *allocator_cfg,
-                  clockcache_config   *cache_cfg,
-                  shard_log_config    *log_cfg,
-                  uint64              *seed,
-                  uint8                num_config,
-                  int                  argc,
-                  char                *argv[])
+test_parse_args_n(trunk_config        *splinter_cfg,  // OUT
+                  data_config         *data_cfg,      // OUT
+                  io_config           *io_cfg,        // OUT
+                  rc_allocator_config *allocator_cfg, // OUT
+                  clockcache_config   *cache_cfg,     // OUT
+                  shard_log_config    *log_cfg,       // OUT
+                  test_exec_config    *test_exec_cfg, // OUT
+                  uint8                num_config,    // IN
+                  int                  argc,          // IN
+                  char                *argv[]         // IN
+)
 {
    platform_status rc;
    uint8           i;
 
+   // Allocate memory and setup default configs for up to n-instances
    master_config *master_cfg =
       TYPED_ARRAY_MALLOC(platform_get_heap_id(), master_cfg, num_config);
    for (i = 0; i < num_config; i++) {
@@ -229,12 +258,25 @@ test_parse_args_n(trunk_config        *splinter_cfg,
                        io_cfg,
                        &master_cfg[i]);
    }
-   *seed = master_cfg[0].seed;
+
+   // All the n-SplinterDB instances will work with the same set of
+   // test execution parameters.
+   if (test_exec_cfg) {
+      test_exec_cfg->seed        = master_cfg[0].seed;
+      test_exec_cfg->num_inserts = master_cfg[0].num_inserts;
+   }
+
    platform_free(platform_get_heap_id(), master_cfg);
 
    return STATUS_OK;
 }
 
+/*
+ * test_parse_args() --
+ *
+ * Parse the command-line configuration arguments to setup the config
+ * sub-structures for individual SplinterDB sub-systems.
+ */
 static inline platform_status
 test_parse_args(trunk_config        *splinter_cfg,
                 data_config         *data_cfg,
@@ -246,16 +288,26 @@ test_parse_args(trunk_config        *splinter_cfg,
                 int                  argc,
                 char                *argv[])
 {
-   return test_parse_args_n(splinter_cfg,
-                            data_cfg,
-                            io_cfg,
-                            allocator_cfg,
-                            cache_cfg,
-                            log_cfg,
-                            seed,
-                            1,
-                            argc,
-                            argv);
+   test_exec_config test_exec_cfg;
+   ZERO_STRUCT(test_exec_cfg);
+
+   platform_status rc;
+   rc = test_parse_args_n(splinter_cfg,
+                          data_cfg,
+                          io_cfg,
+                          allocator_cfg,
+                          cache_cfg,
+                          log_cfg,
+                          &test_exec_cfg,
+                          1,
+                          argc,
+                          argv);
+   if (!SUCCESS(rc)) {
+      return rc;
+   }
+   // Most tests that parse cmdline args are only interested in this one.
+   *seed = test_exec_cfg.seed;
+   return rc;
 }
 
 // monotonically increasing counter to generate splinter id for tests.

--- a/tests/unit/btree_stress_test.c
+++ b/tests/unit/btree_stress_test.c
@@ -119,9 +119,8 @@ CTEST_SETUP(btree_stress)
    data->master_cfg.cache_capacity = GiB_TO_B(5);
    data->data_cfg                  = test_data_config;
 
-   // RESOLVE: Sort this out with RobJ about cmd line args support
-   // if (!SUCCESS(config_parse(&data->master_cfg, 1, argc - 1, argv + 1)) ||
-   if (!SUCCESS(config_parse(&data->master_cfg, 1, 0, (char **)NULL))
+   if (!SUCCESS(
+          config_parse(&data->master_cfg, 1, Ctest_argc, (char **)Ctest_argv))
        || !init_data_config_from_master_config(&data->data_cfg,
                                                &data->master_cfg)
        || !init_io_config_from_master_config(&data->io_cfg, &data->master_cfg)

--- a/tests/unit/splinter_test.c
+++ b/tests/unit/splinter_test.c
@@ -6,6 +6,16 @@
  * splinter_test.c --
  *
  *  Exercises the basic SplinterDB interfaces.
+ *
+ * NOTE: There is some duplication of the splinter_do_inserts() in the test
+ * cases which adds considerable execution times. The test_inserts() test case
+ * will run with the default test configuration, which is sufficiently large
+ * enough to trigger a compaction. The expectation is that this unit test case
+ * will be invoked on its own, with a reduced memtable capacity to invoke the
+ * lookups test case(s):
+ *
+ * $ bin/unit/splinter_test test_inserts
+ * $ bin/unit/splinter_test --memtable-capacity-mib 4 test_lookups
  * -----------------------------------------------------------------------------
  */
 #include "splinterdb/platform_public.h"
@@ -75,7 +85,6 @@ CTEST_DATA(splinter)
    // Declare head handles for io, allocator, cache and splinter allocation.
    platform_heap_handle hh;
    platform_heap_id     hid;
-   uint64               seed;
 
    // Thread-related config parameters. These don't change for unit tests
    uint32 num_insert_threads;
@@ -99,6 +108,9 @@ CTEST_DATA(splinter)
    platform_io_handle *io;
    clockcache         *clock_cache;
    task_system        *tasks;
+
+   // Test execution related configuration
+   test_exec_config test_exec_cfg;
 };
 
 /*
@@ -124,8 +136,6 @@ CTEST_SETUP(splinter)
    heap_capacity        = MIN(heap_capacity, UINT32_MAX);
    heap_capacity        = MAX(heap_capacity, 2 * GiB);
 
-   data->seed = 0;
-
    // Create a heap for io, allocator, cache and splinter
    platform_status rc = platform_heap_create(platform_get_module_id(),
                                              heap_capacity,
@@ -143,13 +153,15 @@ CTEST_SETUP(splinter)
    data->cache_cfg = TYPED_ARRAY_MALLOC(data->hid, data->cache_cfg,
                                         num_tables);
 
+   ZERO_STRUCT(data->test_exec_cfg);
+
    rc = test_parse_args_n(data->splinter_cfg,
                           data->data_cfg,
                           &data->io_cfg,
                           &data->al_cfg,
                           data->cache_cfg,
                           &data->log_cfg,
-                          &data->seed,
+                          &data->test_exec_cfg,
                           num_tables,
                           Ctest_argc,   // argc/argv globals setup by CTests
                           (char **)Ctest_argv);
@@ -250,15 +262,13 @@ CTEST_TEARDOWN(splinter)
 
 /*
  * **************************************************************************
- * Basic test case to verify trunk_insert() API and validate inserts.
- * This is a valid test case and does run successfully. However, enabling
- * this increases the execution time of this test, tipping the elapsed time
- * for debug builds over the timeout limits (25 mins, at the time of this
- * writing). The insert phase is also required, and covered, in the subsequent
- * lookups test case, hence, this test case is skipped.
+ * Basic test case to verify trunk_insert() API and validate a very large #
+ * of inserts. This test case is designed to insert enough rows to trigger
+ * compaction. (We don't, quite, actually verify that compaction has occurred
+ * but based on the default test configs, we expect that it would trigger.)
  * **************************************************************************
  */
-CTEST2_SKIP(splinter, test_inserts)
+CTEST2(splinter, test_inserts)
 {
    allocator *alp = (allocator *)&data->al;
 
@@ -270,7 +280,9 @@ CTEST2_SKIP(splinter, test_inserts)
                                     data->hid);
    ASSERT_TRUE(spl != NULL);
 
-   int    tuple_size  = 0;
+   int tuple_size = 0;
+
+   // TRUE : Also do verification-after-inserts
    uint64 num_inserts = splinter_do_inserts(data, spl, TRUE, NULL, &tuple_size);
    ASSERT_NOT_EQUAL(0,
                     num_inserts,
@@ -305,9 +317,10 @@ CTEST2(splinter, test_lookups)
    char *shadow     = NULL;
    int   tuple_size = 0;
 
-   // TRUE : Also do verification-after-inserts
+   // FALSE : No need to do verification-after-inserts, as that functionality
+   // has been tested earlier in test_inserts() case.
    uint64 num_inserts =
-      splinter_do_inserts(data, spl, TRUE, &shadow, &tuple_size);
+      splinter_do_inserts(data, spl, FALSE, &shadow, &tuple_size);
    ASSERT_NOT_EQUAL(0,
                     num_inserts,
                     "Expected to have inserted non-zero rows, num_inserts=%lu.",
@@ -533,8 +546,23 @@ splinter_do_inserts(void         *datap,
    // Cast void * datap to ptr-to-CTEST_DATA() struct in use.
    struct CTEST_IMPL_DATA_SNAME(splinter) *data =
       (struct CTEST_IMPL_DATA_SNAME(splinter) *)datap;
-   int num_inserts =
-      data->splinter_cfg[0].max_tuples_per_node * data->splinter_cfg[0].fanout;
+
+   // First see if test was invoked with --num-inserts execution parameter
+   int num_inserts = data->test_exec_cfg.num_inserts;
+
+   // If not, derive total # of rows to be inserted
+   if (!num_inserts) {
+      trunk_config *splinter_cfg = data->splinter_cfg;
+      num_inserts = splinter_cfg->max_tuples_per_node * splinter_cfg->fanout;
+   }
+
+   platform_default_log("Splinter_cfg max_tuples_per_node=%lu"
+                        ", fanout=%lu"
+                        ", max_tuples_per_memtable=%lu, num_inserts=%d. ",
+                        data->splinter_cfg[0].max_tuples_per_node,
+                        data->splinter_cfg[0].fanout,
+                        data->splinter_cfg[0].mt_cfg.max_tuples_per_memtable,
+                        num_inserts);
 
    // Debug hook: Override this to smaller value for faster test execution,
    // while doing test-dev / debugging. Default is some big value, like
@@ -596,12 +624,17 @@ splinter_do_inserts(void         *datap,
    }
 
    uint64 elapsed_ns = platform_timestamp_elapsed(start_time);
+   uint64 elapsed_s  = NSEC_TO_SEC(elapsed_ns);
 
+   // For small # of inserts, elapsed sec will be 0. Deal with it.
    platform_default_log(
-      "... tuple_size=%d, splinter insert time %lu s, per tuple %lu ns. ",
+      "... tuple_size=%d, splinter insert time %lu s, per "
+      "tuple %lu ns, %s%lu rows/sec. ",
       *tuple_size,
-      NSEC_TO_SEC(elapsed_ns),
-      (elapsed_ns / num_inserts));
+      elapsed_s,
+      (elapsed_ns / num_inserts),
+      (elapsed_s ? "" : "(n/a)"),
+      (elapsed_s ? (num_inserts / NSEC_TO_SEC(elapsed_ns)) : num_inserts));
 
    platform_assert(trunk_verify_tree(spl));
    cache_assert_free((cache *)data->clock_cache);


### PR DESCRIPTION
This commit rearranges the build logic and test-exec logic to address the slow performance of unit-tests that has been introduced by the addition of `unit/splinter_test` tests (under SHA d76be83).

- `Makefile` rules are adjusted to -not- include `splinter_test` in the `unit_test` binary. Standalone `unit/splinter_test` binary will still be built. This way the overall execution time of unit_test alone will be significantly reduced. 

- E.g. in normal builds, the execution time for just the `unit_test` binary drops from 163s to 18s.

- Fix bugs in `ctest_process_args()` which prevented specifying config params for an individual unit-test. Now, we can run `splinter_test` standalone with a reduced config (e.g. `--memtable-capacity-mib 4`).

- In the test itself, resurrect the `test_inserts()` case, which will be executed with the default test config, designed to trigger compaction.

- Update test.sh to:
   - Invoke `splinter_test test_inserts`, with the default test config
   - Invoke `splinter_test test_lookups`, with reduced memtable capacity, 4MiB

With these changes, the overall test execution times are far more acceptable.

Elapsed times of manual execution on local VM. The "With fix" times include the fast-unit-tests plus the 2 cases of splinter_test run separately.

```
                    ----------          --------          ------------------
                    Before fix          With fix          %age improvement
                    ----------          --------          ------------------
Unit-tests (Opt)   :    163s             53s (18s + 37s)  66% reduction
Unit-tests (Debug) :    459s  (7m 39s)  146s (2m 26s)     69% reduction
Unit-tests (MSAN)  :   2174s (36m 14s)  748s (12m 28s)    65% reduction
```

Update 27.Feb.2022: **Comparison of MSAN CI-runs for unit-tests** [before](https://runway-ci.eng.vmware.com/builds/9545814) / after fix (Memory sanitizer runs were the ones noticeably running very slow):

```
     **** SplinterDB Test Suite Execution Times **** 
                                             --- Before ---                  --- After ---
 All unit tests                : 5241 s [  1 h 27 m 21 s ]           259s [  0h  4m 19s ]
 Splinter inserts test    :                                           548s [  0h  9m  8s ]
 Splinter lookups test  :                                            561s [  0h  9m 21s ]
 
 All Tests                     : 8039 s [  2 h 13 m 59 s ]         3840s [  1h  4m  0s ]
```

By dropping the # of rows inserted from ~ 23 Mill to ~ 2.1 million, the total time for unit-tests drops from 1h 27m to close 10m. 