### PR TITLE
(#282) Revert from Ubuntu 22.04 to v20.04, to resolve CI-incompatibilities

### DIFF
--- a/Dockerfile.build-env
+++ b/Dockerfile.build-env
@@ -14,13 +14,28 @@
 # This file is maintained separately from the other Dockerfiles
 # to reduce build times when the SplinterDB source changes
 
-ARG base_image=library/ubuntu:22.04
+ARG base_image=library/ubuntu:20.04
 FROM $base_image
+
+# Install stuff required to install appropriate compiler versions.
 RUN /bin/bash -c ' \
 set -euo pipefail; \
 export DEBIAN_FRONTEND=noninteractive; \
-apt-get update -y; \
-apt-get install -y make libaio-dev libconfig-dev libxxhash-dev gcc clang clang-format lld curl git shellcheck yamllint;'
+apt-get update -y && apt-get install -y software-properties-common wget'
+
+# Install clang-13 for Ubuntu 20.04 (Moved to clang-format-13 formatting.)
+RUN /bin/bash -c ' \
+set -euo pipefail; \
+export DEBIAN_FRONTEND=noninteractive; \
+wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
+    && add-apt-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-13 main" \
+    && apt-get install -y clang-13 clang-format-13;'
+
+# Install remaining tools required for builds
+RUN /bin/bash -c ' \
+set -euo pipefail; \
+export DEBIAN_FRONTEND=noninteractive; \
+apt-get install -y make libaio-dev libconfig-dev libxxhash-dev gcc lld curl git shellcheck yamllint;'
 
 # shell formatter
 ENV SHFMT_VERSION 3.3.1

--- a/Dockerfile.run-env
+++ b/Dockerfile.run-env
@@ -9,7 +9,7 @@
 # It is maintained separately from the main Dockerfile
 # to reduce build-times when the splinterdb source changes
 
-ARG base_image=library/ubuntu:22.04
+ARG base_image=library/ubuntu:20.04
 FROM $base_image AS runner
 RUN /bin/bash -c ' \
 set -euo pipefail; \

--- a/ci/pipeline-funcs.lib.yml
+++ b/ci/pipeline-funcs.lib.yml
@@ -53,7 +53,7 @@ plan:
     outputs:
     - name: image
     params:
-      BUILD_ARG_base_image: harbor-repo.vmware.com/dockerhub-proxy-cache/library/ubuntu:22.04
+      BUILD_ARG_base_image: harbor-repo.vmware.com/dockerhub-proxy-cache/library/ubuntu:20.04
       DOCKERFILE: #@ "Dockerfile." + resource_name
       LABEL_created_by: "SplinterDB Concourse CI"
     run:

--- a/docs/build.md
+++ b/docs/build.md
@@ -5,11 +5,24 @@ To integrate SplinterDB into another application, see [Usage](usage.md).
 ## On Linux
 Builds are known to work on Ubuntu using recent versions of GCC and Clang.
 
-In CI, we test against the versions that Ubuntu "jammy" 22.04 provides by
-default, currently GCC 11 and Clang 13.
+In CI, we test against the default version of gcc that Ubuntu "focal" 20.04 supports,
+currently GCC 9.3.
+We use Clang 13 as the code base is formatted using clang-format-13 rules.
+
+Here are the steps we used to install `clang-13` tools on Linux.
 
 ```shell
-$ export COMPILER=gcc-11
+$ wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+
+$ sudo add-apt-repository 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-13 main'
+
+$ sudo apt-get install -y clang-13 clang-format-13
+```
+
+Here are the steps to do a full-build of the library, run smoke tests, and to install the shared libraries:
+
+```shell
+$ export COMPILER=gcc    # or clang-13
 $ sudo apt update -y
 $ sudo apt install -y libaio-dev libconfig-dev libxxhash-dev $COMPILER
 $ export CC=$COMPILER
@@ -18,6 +31,17 @@ $ make
 $ make run-tests
 $ sudo make install
 ```
+
+> Note: In CI, we also run a job to check source code formatting.
+
+Before committing your changes, run the [format-check.sh](../format-check.sh#:~:text=clang\-format\-13)
+script to verify that your code changes conform to required formatting rules.
+
+```shell
+$ format-check.sh fixall
+```
+
+Check for any files that need re-formatting, which will be edited in-place.
 
 ### Using Docker
 Docker can be used to build from source on many platforms, including Mac and Windows.
@@ -39,8 +63,9 @@ with either GCC or Clang.
 For example, from inside the running container:
 ```shell
 docker$ cd /splinterdb
-docker$ export CC=clang  # or gcc
-docker$ export LD=clang
+docker$ export CC=clang-13  # or gcc
+docker$ export CC=$COMPILER
+docker$ export LD=$COMPILER
 docker$ make
 docker$ make test
 docker$ make install


### PR DESCRIPTION
Recent upgrade to Ubuntu 22.04 _seems_ to run into some issues due to impedance with CI-test infrastructure. 
This is suspected to be the cause for some tests not working on CI, or failing to execute due to permission issues.

This commit reverts the changes done in SHA e7d0ae0 (Use Ubuntu 22.04 LTS in CI). We go back to Ubuntu 20.04 "focal"
 version, but still install gcc-11 and clang-13 for CI runs.