### PR TITLE
Platformize public API

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,8 +38,8 @@ RUN $compiler --version \
 FROM $run_env_image
 
 # Put the library and headers in the standard location
-COPY --from=build /splinterdb-install/lib/* /usr/local/lib/
-COPY --from=build /splinterdb-install/include/splinterdb/* /usr/local/include/splinterdb/
+COPY --from=build /splinterdb-install/lib/ /usr/local/lib/
+COPY --from=build /splinterdb-install/include/splinterdb/ /usr/local/include/splinterdb/
 
 # Copy over the test binaries under bin/ (recursively) and the test script
 COPY --from=build /splinterdb-src/bin/ /splinterdb/bin/

--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,7 @@ INCLUDE = -I $(INCDIR) -I $(SRCDIR) -I $(SRCDIR)/platform_$(PLATFORM) -I $(TESTS
 
 DEFAULT_CFLAGS += -D_GNU_SOURCE -ggdb3 -Wall -pthread -Wfatal-errors -Werror -Wvla
 DEFAULT_CFLAGS += -DXXH_STATIC_LINKING_ONLY -fPIC
+DEFAULT_CFLAGS += -DSPLINTERDB_PLATFORM_DIR=$(PLATFORM_DIR)
 
 # track git ref in the built library
 GIT_VERSION := "$(shell git describe --abbrev=8 --dirty --always --tags)"
@@ -310,8 +311,7 @@ install: $(LIBDIR)/libsplinterdb.so
 
 	# -p retains the timestamp of the file being copied over
 	cp -p $(LIBDIR)/libsplinterdb.so $(LIBDIR)/libsplinterdb.a $(INSTALL_PATH)/lib
-	cp -p $(INCDIR)/splinterdb/*.h $(INSTALL_PATH)/include/splinterdb/
-
+	cp -p -r $(INCDIR)/splinterdb/ $(INSTALL_PATH)/include/
 
 # to support clangd: https://clangd.llvm.org/installation.html#compile_flagstxt
 .PHONY: compile_flags.txt

--- a/include/splinterdb/data.h
+++ b/include/splinterdb/data.h
@@ -21,7 +21,7 @@
 #define __DATA_H
 
 #include "splinterdb/limits.h"
-#include "splinterdb/platform_public.h"
+#include "splinterdb/public_platform.h"
 #include "splinterdb/public_util.h"
 
 typedef enum message_type {

--- a/include/splinterdb/platform_linux/public_platform.h
+++ b/include/splinterdb/platform_linux/public_platform.h
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /*
- * platform_public.h --
+ * public_platform.h --
  *
  *     Minimal common header for both external users (e.g. splinterdb) and
  *     for internal use.

--- a/include/splinterdb/public_platform.h
+++ b/include/splinterdb/public_platform.h
@@ -1,0 +1,46 @@
+// Copyright 2018-2021 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+
+SplinterDB uses a platform layer to abstract away non-portable definitions
+and functionality.
+
+For a platform X, the public API headers live at
+   include/splinterdb/platform_X/public_platform.h
+and the internal headers are at
+   src/platform_X
+
+The external definitions include:
+- uint64, which is used for buffer sizes, etc.
+- bool, typedef'd to int32 on linux
+
+Programs linking against SplinterDB should define SPLINTERDB_PLATFORM_DIR
+before including any SplinterDB headers.  For example, to set it at
+compile time for the linux platform, you might
+  cc -DSPLINTERDB_PLATFORM_DIR=platform_linux -I splinterdb-src/include ...
+
+*/
+
+#ifndef __SPLINTERDB_PUBLIC_PLATFORM_H
+#define __SPLINTERDB_PUBLIC_PLATFORM_H
+
+#ifndef SPLINTERDB_PLATFORM_DIR
+#   error Define SPLINTERDB_PLATFORM_DIR for your target, e.g. compile with flag -DSPLINTERDB_PLATFORM_DIR=platform_linux
+#endif
+
+// Build an include path from the PLATFORM_DIR define
+// see: https://gcc.gnu.org/onlinedocs/cpp/Stringizing.html
+#define TEMP_XSTRINGIFY(s) TEMP_STRINGIFY(s)
+#define TEMP_STRINGIFY(s)  #s
+// clang-format off
+#define PUBLIC_PLATFORM_H TEMP_XSTRINGIFY(splinterdb/SPLINTERDB_PLATFORM_DIR/public_platform.h)
+// clang-format on
+
+#include PUBLIC_PLATFORM_H
+
+#undef PUBLIC_PLATFORM_H
+#undef TEMP_STRINGIFY
+#undef TEMP_XSTRINGIFY
+
+#endif // __SPLINTERDB_PUBLIC_PLATFORM_H

--- a/src/btree_private.h
+++ b/src/btree_private.h
@@ -11,7 +11,7 @@
 #ifndef __BTREE_PRIVATE_H__
 #define __BTREE_PRIVATE_H__
 
-#include "splinterdb/platform_public.h"
+#include "splinterdb/public_platform.h"
 #include "splinterdb/data.h"
 #include "util.h"
 #include "btree.h"

--- a/src/platform_linux/platform.h
+++ b/src/platform_linux/platform.h
@@ -4,7 +4,7 @@
 #ifndef PLATFORM_H
 #define PLATFORM_H
 
-#include "splinterdb/platform_public.h"
+#include "splinterdb/public_platform.h"
 
 /*
  * Platform directory is chosen via -I include options to compiler.

--- a/tests/test_common.c
+++ b/tests/test_common.c
@@ -8,7 +8,7 @@
  * Module contains functions shared between functional/ and unit/ test sources.
  * -----------------------------------------------------------------------------
  */
-#include "splinterdb/platform_public.h"
+#include "splinterdb/public_platform.h"
 #include "trunk.h"
 #include "functional/test.h"
 #include "functional/test_async.h"

--- a/tests/unit/btree_stress_test.c
+++ b/tests/unit/btree_stress_test.c
@@ -13,7 +13,7 @@
 #include <fcntl.h>
 #include <pthread.h>
 
-#include "splinterdb/platform_public.h"
+#include "splinterdb/public_platform.h"
 #include "unit_tests.h"
 #include "ctest.h" // This is required for all test-case files.
 

--- a/tests/unit/btree_test.c
+++ b/tests/unit/btree_test.c
@@ -9,7 +9,7 @@
  *  files. Validates correctness of variable key-value size support in BTree.
  * -----------------------------------------------------------------------------
  */
-#include "splinterdb/platform_public.h"
+#include "splinterdb/public_platform.h"
 #include "unit_tests.h"
 #include "ctest.h" // This is required for all test-case files.
 

--- a/tests/unit/splinter_test.c
+++ b/tests/unit/splinter_test.c
@@ -18,7 +18,7 @@
  * $ bin/unit/splinter_test --memtable-capacity-mib 4 test_lookups
  * -----------------------------------------------------------------------------
  */
-#include "splinterdb/platform_public.h"
+#include "splinterdb/public_platform.h"
 #include "trunk.h"
 #include "clockcache.h"
 #include "allocator.h"

--- a/tests/unit/splinterdb_quick_test.c
+++ b/tests/unit/splinterdb_quick_test.c
@@ -29,7 +29,7 @@
 #include <errno.h>
 
 #include "splinterdb/data.h"
-#include "splinterdb/platform_public.h"
+#include "splinterdb/public_platform.h"
 #include "splinterdb/default_data_config.h"
 #include "splinterdb/splinterdb.h"
 #include "unit_tests.h"

--- a/tests/unit/splinterdb_stress_test.c
+++ b/tests/unit/splinterdb_stress_test.c
@@ -10,7 +10,7 @@
 #include <fcntl.h>
 #include <pthread.h>
 
-#include "splinterdb/platform_public.h"
+#include "splinterdb/public_platform.h"
 #include "splinterdb/default_data_config.h"
 #include "splinterdb/splinterdb.h"
 #include "unit_tests.h"


### PR DESCRIPTION
Applications now need to compile with 
```
-DSPLINTERDB_PLATFORM_DIR=platform_linux
```
but can still get away with a single `-I` flag on their compile line.