### PR TITLE
Update various docs to reflect testing interfaces. Clean-up some hyperlinks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,12 +13,13 @@ Please search through our [GitHub Issues](https://github.com/vmware/splinterdb/i
 ## Contributing code or documentation
 For small obvious fixes, follow the steps below.  For larger changes, please first [open an Issue](https://github.com/vmware/splinterdb/issues/new) that describes your need ([*talk, then code*](https://dave.cheney.net/2019/02/18/talk-then-code)).
 
-1. Follow [docs/build.md](docs/build.md) for instructions on building from source.
+1. Follow [build](docs/build.md) for instructions on building from source
+and follow [testing](docs/testing.md) for instructions on testing your changes.
 
 2. Before submitting code, please ensure that:
-    - code builds: `make`
-    - tests pass: `make run-tests`
-    - code is formatted properly: `./format-check.sh`
+    - Code builds: `$ make`
+    - [All Tests pass](./Makefile#:~:text=test%2Dresults): `$ make test-results`
+    - Code is formatted properly: `$ ./format-check.sh fixall`
 
         To get an automatic format check on every git commit, add a pre-commit hook:
         ```

--- a/Makefile
+++ b/Makefile
@@ -301,7 +301,7 @@ run-tests: $(BINDIR)/driver_test $(BINDIR)/unit_test
 	./test.sh
 
 test-results: $(BINDIR)/driver_test $(BINDIR)/unit_test
-	(./test.sh > ./test-results.out 2>&1 &) && echo "tail -f ./test-results.out "
+	(INCLUDE_SLOW_TESTS=true ./test.sh > ./test-results.out 2>&1 &) && echo "tail -f ./test-results.out "
 
 INSTALL_PATH ?= /usr/local
 

--- a/README.md
+++ b/README.md
@@ -14,3 +14,5 @@ SplinterDB is *provided as-is* and is not recommended for use in production unti
 
 ## Build
 See [Build](docs/build.md) for instructions on building SplinterDB from source.
+
+See [Documentation](docs/README.md) for preliminary documentation.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,13 @@
+# SplinterDB Documentation
+
+[Building SplinterDB](./build.md)
+
+[Docker-based development](./docker.md)
+
+[User's Guide](./usage.md)
+
+[Testing SplinterDB](./testing.md)
+
+[Contributing](../CONTRIBUTING.md)
+
+[Code of Conduct](../CODE-OF-CONDUCT.md)

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,105 @@
+# Testing SplinterDB
+
+In this section we discuss how to exercise unit, functional
+and performance benchmarking tests.
+
+_Audience: All users and contributors._
+
+
+## Testing Overview
+In CI, we execute these tests against the following build modes
+- All tests on optimized and debug builds using clang
+- All tests on optimized and debug builds using gcc
+- All tests using address-sanitizer debug builds using the clang compiler
+- All tests using memory-sanitizer debug builds using the gcc compiler
+- clang-format checks
+- [shellcheck](https://www.shellcheck.net) and shfmt checks run against shell scripts
+
+To run a small collection of unit-tests to give you a very quick
+baseline stability of the library, do: `$ make run-tests`
+
+The [`make run-tests`](../Makefile#:~:text=run%2Dtests) target invokes the
+underlying [`test.sh`](../test.sh) script to run quick tests.
+
+To execute a larger set of tests, including functional and performance tests,
+you can do one of the following:
+
+```shell
+$ make test-results
+$ INCLUDE_SLOW_TESTS=true make run-tests
+$ INCLUDE_SLOW_TESTS=true ./test.sh
+```
+
+In CI, all test execution is driven by the top-level [test.sh](../test.sh)
+script, which exercises individual build artifacts produced for testing, as
+described below.
+
+### Testing Artifacts
+
+As part of the make build output the following artifacts are produced under
+the `./bin` directory:
+- A `unit_test` binary, which runs a collection of quick-running unit tests
+- A collection of stand-alone unit-test binaries in the `./bin/unit` directory.
+- A `driver_test` binary to drive functional and performance tests
+
+-----
+The following sections describe how to execute individual testing artifacts,
+for more granular test stabilization.
+
+## Running Unit tests
+
+To run all the unit-tests, do:  `$ ./bin/unit_test`
+
+Some unit-tests are designed to run with multiple threads, and larger
+volumes of data. These are generally named as stress tests.
+
+You can run them standalone as follows: `$ ./bin/unit/btree_stress_test`
+
+See [Unit testing](../tests/unit/README.md)
+for more details on unit test development and unit testing.
+
+
+## Running Functional Tests
+
+All functional tests are executed by the `driver_test` binary
+
+```shell
+$ ./bin/driver_test --help
+Dispatch test --help
+invalid test
+List of tests:
+	btree_test
+	filter_test
+	splinter_test
+	log_test
+	cache_test
+	ycsb_test
+```
+
+Each functional test can be run with different parameters.
+Use the following syntax to get the test-specific configuration supported.
+
+` $ ./bin/driver_test <test-name> --help`
+
+```shell
+$ ./bin/driver_test btree_test --help
+$ ./bin/driver_test splinter_test --help
+```
+
+In the `test.sh` script you can find
+[examples of the command-line parameters](../test.sh#:~:text=driver%5Ftest%20splinter%5Ftest%20%2D%2Dfunctionality%201000000)
+that are commonly used for testing stability.
+
+## Running Performance Tests
+
+SplinterDB performance tests are executed by `driver_test` using the `splinter_test`
+option with the `--perf` argument.
+
+Several different options are supported to execute different performance tests.
+These can be found using:
+
+ ```$ ./bin/driver_test splinter_test --help```
+
+ An example usage of performance tests that are executed in our CI runs can be found
+ [here in test.sh](../test.sh#:~:text=%2D%2Dperf%20%2D%2Dmax%2Dasync%2Dinflight)
+

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -14,13 +14,17 @@ looks out-of-date, please open an issue or pull request.
 
 ## Program flow
 
-- Choose values for `splinterdb_config`.  For the `data_cfg` field, simple
-  applications may opt to use the `default_data_config`, provides a basic
-  key / value interface with lexicographical sorting of keys.
+- Choose values for [configuration options](../include/splinterdb/splinterdb.h#:~:text=Configuration%20options%20for%20SplinterDB)
+  defined in the `splinterdb_config{}` structure.
+  For the `data_cfg` field, simple applications may opt to use
+  the `default_data_config_init()`
+  [initializer method](../src/default_data_config.c#:~:text=default%5Fdata%5Fconfig%5Finit)
+  which provides a basic key / value interface with lexicographical
+  sorting of keys.
 
 - Call `splinterdb_create()` to create a new database in a file or block device,
   `splinterdb_open()` to open an existing database, and
-  `splinterdb_close()` to a database and flush any pending writes.
+  `splinterdb_close()` to flush any pending writes and close the database.
 
    All access to a SplinterDB database file or device must go through the
    single `splinterdb*` object returned.  It is not safe for more than one
@@ -28,17 +32,18 @@ looks out-of-date, please open an issue or pull request.
 
 - Basic key/value operations like `insert`, `delete`, point `lookup` and
   range scan using an `iterator` are available.  See the code comments
-  in `splinterdb.h`.
+  in [`splinterdb.h`](../include/splinterdb/splinterdb.h).
 
 - If an application frequently makes small modifications to existing values,
   better performance may be possible by using a custom `data_config` object
-  and the `splinterdb_insert_raw_message` function.
+  and the `splinterdb_insert_raw_message()` function.
   A raw message may encode a "blind update" to a value, for example an
   "append" or "increment" operation that may be persisted without doing a read.
   Some applications may be able to avoid a read-modify-write sequence this way.
   To use the message-oriented API, the application implements the `data_config`
-  interface defined in [`data.h`](../include/splinterdb/data.h) and sets it on
-  `splinterdb_config` when creating/opening a database.
+  interface defined in
+  [`data.h`](../include/splinterdb/data.h#:~:text=struct%20data%5Fconfig%20{))
+  and sets it on `splinterdb_config` when creating/opening a database.
 
 - SplinterDB is designed to deliver high-performance for multi-threaded
   applications, but follow these guidelines:
@@ -47,7 +52,7 @@ looks out-of-date, please open an issue or pull request.
     is called the "initial thread".
 
   - The initial thread should be the one to call `splinterdb_close()` when
-    the `splinterdb` is no longer needed.
+    the `splinterdb` instance is no longer needed.
 
   - Threads (other than the initial thread) that will use the `splinterdb`
     must be registered before use and unregistered before exiting:
@@ -65,9 +70,18 @@ looks out-of-date, please open an issue or pull request.
     available in higher-level languages.
 
 - Internally SplinterDB supports asynchronous IO, but this capability is not
-  yet documented.  Some example code for this may be found in the unit and functional tests.
+  yet documented.  Some example code for this may be found in the unit and
+  functional tests.
 
 
 ## Example programs
-- [`tests/unit/splinterdb_quick_test.c`](../tests/unit/splinterdb_quick_test.c) covers various basic operations on a single thread
+- [`tests/unit/splinterdb_quick_test.c`](../tests/unit/splinterdb_quick_test.c) covers
+   various basic operations on a single thread. The
+   [setup step](../tests/unit/splinterdb_quick_test.c#:~:text=CTEST%5FSETUP\(splinterdb%5Fquick)
+   shows how to specify a default configuration and then create a new instance.
 - [`tests/unit/splinterdb_stress_test.c`](../tests/unit/splinterdb_stress_test.c) uses multiple threads
+- [`tests/unit/splinter_test.c`](../tests/unit/splinter_test.c#:~:text=CTEST%5FSETUP\(splinter)
+  covers slightly advanced steps to create a SplinterDB instance. It covers
+  configuration of a SplinterDB instance, creating heap memory, allocating
+  memory for various sub-system configurations, and initialization of
+  individual sub-systems.

--- a/tests/unit/README.md
+++ b/tests/unit/README.md
@@ -3,8 +3,8 @@
 We have adapted the [CTest framework](https://github.com/bvdberg/ctest),
 which is a unit testing framework for software written in C/C++,
 
-See this [README.md](https://github.com/bvdberg/ctest/blob/master/README.md) file for a
-fuller description of the features of this CTest framework.
+See this [README.md](https://github.com/bvdberg/ctest/blob/master/README.md)
+file for a fuller description of the features of this CTest framework.
 
 ---
 ## Developing using CTest
@@ -15,11 +15,13 @@ fuller description of the features of this CTest framework.
   - For a source file named `<file_name>.c`, the unit-test file is named `<file_name>_test.c`
   - The test suite name used for test cases in each test file is usually the `<file_name>` prefix
     - Each test case is named `test_<something>`
-- To write a new test suite, copy the [unit_test_template_dot_c](unit_test_template_dot_c) file to
-  your new test suite. Follow the instruction given in the [splinterdb_kv_test](splinterdb_kv_test.c)
+- To write a new test suite, copy the
+  [unit_test_template_dot_c](unit_test_template_dot_c) file to your new test suite.
+- Follow the instruction given in the [splinterdb_quick_test.c](./splinterdb_quick_test.c)
   to build individual test cases using the testing framework.
-- If your new unit test is small and runs quickly (under a few seconds), consider adding
-  it here to the list of "smoke tests" in [test.sh](../../test.sh#:~:text=INCLUDE\_SLOW\_TESTS\=true).
+- If your new unit test is small and runs quickly (under a few seconds), consider
+  adding it here to the list of "smoke tests" in
+  [test.sh](../../test.sh#:~:text=Only%20running%20fast%20unit%20tests)
 
 ----
 ## How To build unit tests
@@ -47,7 +49,9 @@ Usage: ./bin/unit_test [--list [ <suite-name> ] ]
 Usage: ./bin/unit_test [ --<config options> ]* [ <suite-name> [ <test-case-name> ] ]
 ```
 
-> Note: The `[ --<config options> ]*` option allows specifying different configuration parameters for test execution. This is supported by very few unit tests and is **only** meant for internal developer-use.
+> Note: The `[ --<config options> ]*` option allows specifying different configuration
+  parameters for test execution. This is supported by very few unit tests
+  and is **only** meant for internal developer-use.
 
 
 To **list all the unit-test suites** that can be run: `$ bin/unit_test --list`
@@ -58,7 +62,8 @@ To list all the test cases from a given test suite: `$ bin/unit_test --list <sui
 
 `$ bin/unit_test --list splinterdb_quick`
 
-You can also list the test cases that can be run from an individual standalone unit-test binary with the `--list` argument.
+You can also list the test cases that can be run from an individual standalone
+unit-test binary with the `--list` argument.
 
 **Example**: List all the test cases from the [`btree`](btree_test.c) test suite using the standalone binary
 
@@ -70,11 +75,11 @@ You can also list the test cases that can be run from an individual standalone u
 
 Quick **smoke-tests** run of unit tests: `$ make run-tests`
 
-This runs a small subset of unit tests, which execute very quickly, so that you get a quick turnaround on the overall stability of any product changes.
+This runs a small subset of unit tests, which execute very quickly, so that you
+get a quick turnaround on the overall stability of your changes.
 
-You can achieve the same result by executing the following test driver script [test.sh](../../test.sh):
-
-`$ ./test.sh`
+You can achieve the same result by executing the following test driver script
+[test.sh](../../test.sh#:~:text=if%20\[%20"$INCLUDE%5FSLOW%5FTESTS"%20!=%20"true"%20\]): `$ ./test.sh`
 
 To **run** all the unit-test suites: `$ bin/unit_test`
 
@@ -92,6 +97,6 @@ To run all test cases named with a prefix from a specific unit-test binary:
 
 `$ bin/unit/<binary-name> <test-case-prefix>`
 
-**Example**: Run all SplinterDB iterator-related test cases from the [`splinterdb_kv_test`](splinterdb_kv_test.c)
+**Example**: Run all SplinterDB iterator-related test cases from the [`splinterdb_quick_test`](./splinterdb_quick_test.c#:~:text=%20test%5Fsplinterdb%5Fiterator):
 
-`$ bin/unit/splinterdb_kv_test test_splinterdb_iterator`
+`$ bin/unit/splinterdb_quick_test test_splinterdb_iterator`


### PR DESCRIPTION
Perform minor clarifying updates to the docs. Add testing.md as a top-leve
chapter on how-to test SplinterDB. Where appropriate, provide code-level
hyperlinks for contextual details. Introduce top-level Docs TOC.

--
Best way to review this work is to navigate to:

https://github.com/vmware/splinterdb/tree/agurajada/OSS-docs-updates
-> [Documentation](https://github.com/vmware/splinterdb/blob/agurajada/OSS-docs-updates/docs/README.md)

Then go to [Testing SplinterDB](https://github.com/vmware/splinterdb/blob/agurajada/OSS-docs-updates/docs/testing.md), which is a brand-new section.

Some updates / corrections / adding hyper-links has been done to the  [User's Guide](https://github.com/vmware/splinterdb/blob/agurajada/OSS-docs-updates/docs/usage.md) also, mainly to help guide the new user on configuration issues & interfaces, how-tos.

It will be helpful if you can click-through these links, and verify that the correct portion of the linked doc / code / test is showing up for you.