### PR TITLE
Clean up platform_log and friends

### DIFF
--- a/include/splinterdb/platform_linux/public_platform.h
+++ b/include/splinterdb/platform_linux/public_platform.h
@@ -8,8 +8,8 @@
  *     for internal use.
  */
 
-#ifndef __PLATFORM_PUBLIC_H
-#define __PLATFORM_PUBLIC_H
+#ifndef __PUBLIC_PLATFORM_H
+#define __PUBLIC_PLATFORM_H
 
 #include <stdio.h>
 
@@ -68,7 +68,8 @@ typedef int32 bool;
 typedef uint8 bool8;
 
 // See platform.c
-extern FILE *Platform_stdout_fh; // File handle for stdout
-extern FILE *Platform_stderr_fh; // File handle for stderr
+typedef FILE                platform_log_handle;
+extern platform_log_handle *Platform_default_log_handle; // stdout FILE handle
+extern platform_log_handle *Platform_error_log_handle;   // stderr FILE handle
 
-#endif // __PLATFORM_PUBLIC_H
+#endif // __PUBLIC_PLATFORM_H

--- a/src/btree.h
+++ b/src/btree.h
@@ -391,22 +391,28 @@ btree_rough_count(cache        *cc,
                   slice         max_key);
 
 void
-btree_print_tree(cache *cc, btree_config *cfg, uint64 addr);
+btree_print_tree(platform_log_handle *log_handle,
+                 cache               *cc,
+                 btree_config        *cfg,
+                 uint64               addr);
 
 void
-btree_print_locked_node(btree_config          *cfg,
-                        uint64                 addr,
-                        btree_hdr             *hdr,
-                        platform_stream_handle stream);
+btree_print_locked_node(platform_log_handle *log_handle,
+                        btree_config        *cfg,
+                        uint64               addr,
+                        btree_hdr           *hdr);
 
 void
-btree_print_node(cache                 *cc,
-                 btree_config          *cfg,
-                 btree_node            *node,
-                 platform_stream_handle stream);
+btree_print_node(platform_log_handle *log_handle,
+                 cache               *cc,
+                 btree_config        *cfg,
+                 btree_node          *node);
 
 void
-btree_print_tree_stats(cache *cc, btree_config *cfg, uint64 addr);
+btree_print_tree_stats(platform_log_handle *log_handle,
+                       cache               *cc,
+                       btree_config        *cfg,
+                       uint64               addr);
 
 void
 btree_print_lookup(cache        *cc,

--- a/src/cache.h
+++ b/src/cache.h
@@ -185,6 +185,7 @@ typedef bool (*cache_present_fn)(cache *cc, page_handle *page);
 typedef void (*enable_sync_get_fn)(cache *cc, bool enabled);
 typedef allocator *(*cache_allocator_fn)(const cache *cc);
 typedef cache_config *(*cache_config_fn)(const cache *cc);
+typedef void (*cache_print_fn)(platform_log_handle *log_handle, cache *cc);
 
 /*
  * Cache Operations structure:
@@ -217,8 +218,8 @@ typedef struct cache_ops {
    page_valid_fn        page_valid;
    validate_page_fn     validate_page;
    cache_present_fn     cache_present;
-   cache_generic_fn     print;
-   cache_generic_fn     print_stats;
+   cache_print_fn       print;
+   cache_print_fn       print_stats;
    io_stats_fn          io_stats;
    cache_generic_fn     reset_stats;
    count_dirty_fn       count_dirty;
@@ -378,15 +379,15 @@ cache_assert_free(cache *cc)
 }
 
 static inline void
-cache_print(cache *cc)
+cache_print(platform_log_handle *log_handle, cache *cc)
 {
-   return cc->ops->print(cc);
+   return cc->ops->print(log_handle, cc);
 }
 
 static inline void
-cache_print_stats(cache *cc)
+cache_print_stats(platform_log_handle *log_handle, cache *cc)
 {
-   return cc->ops->print_stats(cc);
+   return cc->ops->print_stats(log_handle, cc);
 }
 
 static inline void

--- a/src/clockcache.c
+++ b/src/clockcache.c
@@ -214,7 +214,7 @@ void
 clockcache_assert_no_locks_held(clockcache *cc);
 
 void
-clockcache_print(clockcache *cc);
+clockcache_print(platform_log_handle *log_handle, clockcache *cc);
 
 bool
 clockcache_page_valid(clockcache *cc, uint64 addr);
@@ -223,7 +223,7 @@ void
 clockcache_validate_page(clockcache *cc, page_handle *page, uint64 addr);
 
 void
-clockcache_print_stats(clockcache *cc);
+clockcache_print_stats(platform_log_handle *log_handle, clockcache *cc);
 
 void
 clockcache_io_stats(clockcache *cc, uint64 *read_bytes, uint64 *write_bytes);
@@ -447,10 +447,10 @@ clockcache_assert_no_locks_held_virtual(cache *c)
 }
 
 void
-clockcache_print_virtual(cache *c)
+clockcache_print_virtual(platform_log_handle *log_handle, cache *c)
 {
    clockcache *cc = (clockcache *)c;
-   clockcache_print(cc);
+   clockcache_print(log_handle, cc);
 }
 
 bool
@@ -468,10 +468,10 @@ clockcache_validate_page_virtual(cache *c, page_handle *page, uint64 addr)
 }
 
 void
-clockcache_print_stats_virtual(cache *c)
+clockcache_print_stats_virtual(platform_log_handle *log_handle, cache *c)
 {
    clockcache *cc = (clockcache *)c;
-   clockcache_print_stats(cc);
+   clockcache_print_stats(log_handle, cc);
 }
 
 void
@@ -1691,10 +1691,10 @@ clockcache_get_free_page(clockcache *cc,
       max_hand = cc->per_thread[tid].free_hand;
    }
    if (blocking) {
-      platform_log("cache locked (num_passes=%lu time=%lu nsecs)\n",
-                   num_passes,
-                   platform_timestamp_elapsed(wait_start));
-      clockcache_print(cc);
+      platform_default_log("cache locked (num_passes=%lu time=%lu nsecs)\n",
+                           num_passes,
+                           platform_timestamp_elapsed(wait_start));
+      clockcache_print(Platform_default_log_handle, cc);
       platform_assert(0);
    }
 
@@ -3002,36 +3002,36 @@ clockcache_prefetch(clockcache *cc, uint64 base_addr, page_type type)
  *----------------------------------------------------------------------
  */
 void
-clockcache_print(clockcache *cc)
+clockcache_print(platform_log_handle *log_handle, clockcache *cc)
 {
    uint64   i;
    uint32   status;
    uint16   refcount;
    threadid thr_i;
 
-   platform_open_log_stream();
-   platform_log_stream("************************** CACHE CONTENTS "
-                       "**************************\n");
+   platform_log(log_handle,
+                "************************** CACHE CONTENTS "
+                "**************************\n");
    for (i = 0; i < cc->cfg->page_capacity; i++) {
       if (i != 0 && i % 16 == 0) {
-         platform_log_stream("\n");
+         platform_log(log_handle, "\n");
       }
       if (i % CC_ENTRIES_PER_BATCH == 0) {
-         platform_log_stream("Word %lu entries %lu-%lu\n",
-                             (i / CC_ENTRIES_PER_BATCH),
-                             i,
-                             i + 63);
+         platform_log(log_handle,
+                      "Word %lu entries %lu-%lu\n",
+                      (i / CC_ENTRIES_PER_BATCH),
+                      i,
+                      i + 63);
       }
       status   = cc->entry[i].status;
       refcount = 0;
       for (thr_i = 0; thr_i < CC_RC_WIDTH; thr_i++) {
          refcount += clockcache_get_ref(cc, i, thr_i);
       }
-      platform_log_stream("0x%02x-%u ", status, refcount);
+      platform_log(log_handle, "0x%02x-%u ", status, refcount);
    }
 
-   platform_log_stream("\n\n");
-   platform_close_log_stream(stdout);
+   platform_log(log_handle, "\n\n");
    return;
 }
 
@@ -3093,7 +3093,7 @@ clockcache_io_stats(clockcache *cc, uint64 *read_bytes, uint64 *write_bytes)
 }
 
 void
-clockcache_print_stats(clockcache *cc)
+clockcache_print_stats(platform_log_handle *log_handle, clockcache *cc)
 {
    uint64      i;
    page_type   type;
@@ -3136,25 +3136,25 @@ clockcache_print_stats(clockcache *cc)
                                    global_stats.writes_issued);
 
    // clang-format off
-   platform_log("Cache Statistics\n");
-   platform_log("-----------------------------------------------------------------------------------------------\n");
-   platform_log("page type       |      trunk |     branch |   memtable |     filter |        log |       misc |\n");
-   platform_log("----------------|------------|------------|------------|------------|------------|------------|\n");
-   platform_log("cache hits      | %10lu | %10lu | %10lu | %10lu | %10lu | %10lu |\n",
+   platform_log(log_handle, "Cache Statistics\n");
+   platform_log(log_handle, "-----------------------------------------------------------------------------------------------\n");
+   platform_log(log_handle, "page type       |      trunk |     branch |   memtable |     filter |        log |       misc |\n");
+   platform_log(log_handle, "----------------|------------|------------|------------|------------|------------|------------|\n");
+   platform_log(log_handle, "cache hits      | %10lu | %10lu | %10lu | %10lu | %10lu | %10lu |\n",
          global_stats.cache_hits[PAGE_TYPE_TRUNK],
          global_stats.cache_hits[PAGE_TYPE_BRANCH],
          global_stats.cache_hits[PAGE_TYPE_MEMTABLE],
          global_stats.cache_hits[PAGE_TYPE_FILTER],
          global_stats.cache_hits[PAGE_TYPE_LOG],
          global_stats.cache_hits[PAGE_TYPE_SUPERBLOCK]);
-   platform_log("cache misses    | %10lu | %10lu | %10lu | %10lu | %10lu | %10lu |\n",
+   platform_log(log_handle, "cache misses    | %10lu | %10lu | %10lu | %10lu | %10lu | %10lu |\n",
          global_stats.cache_misses[PAGE_TYPE_TRUNK],
          global_stats.cache_misses[PAGE_TYPE_BRANCH],
          global_stats.cache_misses[PAGE_TYPE_MEMTABLE],
          global_stats.cache_misses[PAGE_TYPE_FILTER],
          global_stats.cache_misses[PAGE_TYPE_LOG],
          global_stats.cache_misses[PAGE_TYPE_SUPERBLOCK]);
-   platform_log("cache miss time | " FRACTION_FMT(9, 2)"s | "
+   platform_log(log_handle, "cache miss time | " FRACTION_FMT(9, 2)"s | "
                 FRACTION_FMT(9, 2)"s | "FRACTION_FMT(9, 2)"s | "
                 FRACTION_FMT(9, 2)"s | "FRACTION_FMT(9, 2)"s | "
                 FRACTION_FMT(9, 2)"s |\n",
@@ -3164,21 +3164,21 @@ clockcache_print_stats(clockcache *cc)
                 FRACTION_ARGS(miss_time[PAGE_TYPE_FILTER]),
                 FRACTION_ARGS(miss_time[PAGE_TYPE_LOG]),
                 FRACTION_ARGS(miss_time[PAGE_TYPE_SUPERBLOCK]));
-   platform_log("pages written   | %10lu | %10lu | %10lu | %10lu | %10lu | %10lu |\n",
+   platform_log(log_handle, "pages written   | %10lu | %10lu | %10lu | %10lu | %10lu | %10lu |\n",
          global_stats.page_writes[PAGE_TYPE_TRUNK],
          global_stats.page_writes[PAGE_TYPE_BRANCH],
          global_stats.page_writes[PAGE_TYPE_MEMTABLE],
          global_stats.page_writes[PAGE_TYPE_FILTER],
          global_stats.page_writes[PAGE_TYPE_LOG],
          global_stats.page_writes[PAGE_TYPE_SUPERBLOCK]);
-   platform_log("pages read      | %10lu | %10lu | %10lu | %10lu | %10lu | %10lu |\n",
+   platform_log(log_handle, "pages read      | %10lu | %10lu | %10lu | %10lu | %10lu | %10lu |\n",
          global_stats.page_reads[PAGE_TYPE_TRUNK],
          global_stats.page_reads[PAGE_TYPE_BRANCH],
          global_stats.page_reads[PAGE_TYPE_MEMTABLE],
          global_stats.page_reads[PAGE_TYPE_FILTER],
          global_stats.page_reads[PAGE_TYPE_LOG],
          global_stats.page_reads[PAGE_TYPE_SUPERBLOCK]);
-   platform_log("avg prefetch pg |  " FRACTION_FMT(9, 2)" |  "
+   platform_log(log_handle, "avg prefetch pg |  " FRACTION_FMT(9, 2)" |  "
                 FRACTION_FMT(9, 2)" |  "FRACTION_FMT(9, 2)" |  "
                 FRACTION_FMT(9, 2)" |  "FRACTION_FMT(9, 2)" |  "
                 FRACTION_FMT(9, 2)" |\n",
@@ -3188,8 +3188,8 @@ clockcache_print_stats(clockcache *cc)
                 FRACTION_ARGS(avg_prefetch_pages[PAGE_TYPE_FILTER]),
                 FRACTION_ARGS(avg_prefetch_pages[PAGE_TYPE_LOG]),
                 FRACTION_ARGS(avg_prefetch_pages[PAGE_TYPE_SUPERBLOCK]));
-   platform_default_log("-----------------------------------------------------------------------------------------------\n");
-   platform_log("avg write pgs: "FRACTION_FMT(9,2)"\n",
+   platform_log(log_handle, "-----------------------------------------------------------------------------------------------\n");
+   platform_log(log_handle, "avg write pgs: "FRACTION_FMT(9,2)"\n",
          FRACTION_ARGS(avg_write_pages));
    // clang-format on
 

--- a/src/clockcache.h
+++ b/src/clockcache.h
@@ -120,7 +120,7 @@ struct clockcache {
    clockcache_entry    *entry;
    buffer_handle       *bh;   // actual memory for pages
    char                *data; // convenience pointer for bh
-   platform_log_handle  logfile;
+   platform_log_handle *logfile;
    platform_heap_handle heap_handle;
    platform_heap_id     heap_id;
 

--- a/src/memtable.h
+++ b/src/memtable.h
@@ -282,15 +282,15 @@ memtable_verify(cache *cc, memtable *mt)
 }
 
 static inline void
-memtable_print(cache *cc, memtable *mt)
+memtable_print(platform_log_handle *log_handle, cache *cc, memtable *mt)
 {
-   btree_print_tree(cc, mt->cfg, mt->root_addr);
+   btree_print_tree(log_handle, cc, mt->cfg, mt->root_addr);
 }
 
 static inline void
-memtable_print_stats(cache *cc, memtable *mt)
+memtable_print_stats(platform_log_handle *log_handle, cache *cc, memtable *mt)
 {
-   btree_print_tree_stats(cc, mt->cfg, mt->root_addr);
+   btree_print_tree_stats(log_handle, cc, mt->cfg, mt->root_addr);
 };
 
 static inline void

--- a/src/merge.c
+++ b/src/merge.c
@@ -401,12 +401,12 @@ merge_iterator_create(platform_heap_id hid,
    if (!out_itor || !itor_arr || !cfg || num_trees < 0
        || num_trees >= ARRAY_SIZE(merge_itor->ordered_iterator_stored))
    {
-      platform_log("merge_iterator_create: bad parameter merge_itor %p"
-                   " num_trees %d itor_arr %p cfg %p\n",
-                   out_itor,
-                   num_trees,
-                   itor_arr,
-                   cfg);
+      platform_default_log("merge_iterator_create: bad parameter merge_itor %p"
+                           " num_trees %d itor_arr %p cfg %p\n",
+                           out_itor,
+                           num_trees,
+                           itor_arr,
+                           cfg);
       return STATUS_BAD_PARAM;
    }
 
@@ -625,28 +625,28 @@ merge_iterator_print(merge_iterator *merge_itor)
    data_config *data_cfg = merge_itor->cfg;
    iterator_get_curr(&merge_itor->super, &key, &data);
 
-   platform_log("****************************************\n");
-   platform_log("** merge iterator\n");
-   platform_log("**  - trees: %u remaining: %u\n",
-                merge_itor->num_trees,
-                merge_itor->num_remaining);
-   platform_log("** curr: %s\n", key_string(data_cfg, key));
-   platform_log("----------------------------------------\n");
+   platform_default_log("****************************************\n");
+   platform_default_log("** merge iterator\n");
+   platform_default_log("**  - trees: %u remaining: %u\n",
+                        merge_itor->num_trees,
+                        merge_itor->num_remaining);
+   platform_default_log("** curr: %s\n", key_string(data_cfg, key));
+   platform_default_log("----------------------------------------\n");
    for (i = 0; i < merge_itor->num_trees; i++) {
       bool at_end;
       iterator_at_end(merge_itor->ordered_iterators[i]->itor, &at_end);
-      platform_log("%u: ", merge_itor->ordered_iterators[i]->seq);
+      platform_default_log("%u: ", merge_itor->ordered_iterators[i]->seq);
       if (at_end) {
-         platform_log("# : ");
+         platform_default_log("# : ");
       } else {
-         platform_log("_ : ");
+         platform_default_log("_ : ");
       }
       if (i < merge_itor->num_remaining) {
          iterator_get_curr(merge_itor->ordered_iterators[i]->itor, &key, &data);
-         platform_log("%s\n", key_string(data_cfg, key));
+         platform_default_log("%s\n", key_string(data_cfg, key));
       } else {
-         platform_log("\n");
+         platform_default_log("\n");
       }
    }
-   platform_log("\n");
+   platform_default_log("\n");
 }

--- a/src/mini_allocator.c
+++ b/src/mini_allocator.c
@@ -1292,30 +1292,30 @@ mini_unkeyed_print(cache *cc, uint64 meta_head, page_type type)
 {
    uint64 next_meta_addr = meta_head;
 
-   platform_log("---------------------------------------------\n");
-   platform_log("| Mini Allocator -- meta_head: %12lu |\n", meta_head);
-   platform_log("|-------------------------------------------|\n");
-   platform_log("| idx | %35s |\n", "extent_addr");
-   platform_log("|-------------------------------------------|\n");
+   platform_default_log("---------------------------------------------\n");
+   platform_default_log("| Mini Allocator -- meta_head: %12lu |\n", meta_head);
+   platform_default_log("|-------------------------------------------|\n");
+   platform_default_log("| idx | %35s |\n", "extent_addr");
+   platform_default_log("|-------------------------------------------|\n");
 
    do {
       page_handle *meta_page = cache_get(cc, next_meta_addr, TRUE, type);
 
-      platform_log("| meta addr %31lu |\n", next_meta_addr);
-      platform_log("|-------------------------------------------|\n");
+      platform_default_log("| meta addr %31lu |\n", next_meta_addr);
+      platform_default_log("|-------------------------------------------|\n");
 
       uint64              num_entries = mini_num_entries(meta_page);
       unkeyed_meta_entry *entry       = unkeyed_first_entry(meta_page);
       for (uint64 i = 0; i < num_entries; i++) {
-         platform_log("| %3lu | %35lu |\n", i, entry->extent_addr);
+         platform_default_log("| %3lu | %35lu |\n", i, entry->extent_addr);
          entry = unkeyed_next_entry(entry);
       }
-      platform_log("|-------------------------------------------|\n");
+      platform_default_log("|-------------------------------------------|\n");
 
       next_meta_addr = mini_get_next_meta_addr(meta_page);
       cache_unget(cc, meta_page);
    } while (next_meta_addr != 0);
-   platform_log("\n");
+   platform_default_log("\n");
 }
 
 void

--- a/src/platform_linux/laio.c
+++ b/src/platform_linux/laio.c
@@ -238,8 +238,9 @@ laio_read_async(io_handle     *ioh,
    io_set_callback(&req->iocb, laio_callback);
    do {
       status = io_submit(io->ctx, 1, &req->iocb_p);
-      if (status < 0)
-         platform_log("io_submit error %s\n", strerror(-status));
+      if (status < 0) {
+         platform_error_log("io_submit error %s\n", strerror(-status));
+      }
       io_cleanup(ioh, 0);
    } while (status != 1);
 
@@ -263,8 +264,9 @@ laio_write_async(io_handle     *ioh,
    io_set_callback(&req->iocb, laio_callback);
    do {
       status = io_submit(io->ctx, 1, &req->iocb_p);
-      if (status < 0)
-         platform_log("io_submit error %s\n", strerror(-status));
+      if (status < 0) {
+         platform_error_log("io_submit error %s\n", strerror(-status));
+      }
       io_cleanup(ioh, 0);
    } while (status != 1);
 
@@ -283,8 +285,8 @@ laio_cleanup(io_handle *ioh, uint64 count)
    for (i = 0; ((count == 0) || (i < count)); i++) {
       status = io_getevents(io->ctx, 0, 1, &event, NULL);
       if (status < 0) {
-         platform_log("io_getevents failed with error: %s\n",
-                      strerror(-status));
+         platform_error_log("io_getevents failed with error: %s\n",
+                            strerror(-status));
          i--;
          continue;
       }

--- a/src/platform_linux/platform.h
+++ b/src/platform_linux/platform.h
@@ -449,6 +449,42 @@ platform_sort_slow(void               *base,
 #   define MIN(a, b) ((a) < (b) ? (a) : (b))
 #endif
 
+/*
+ * Linux understands that you cannot continue after a failed assert already,
+ * so we do not need a workaround for platform_assert in linux
+ */
+__attribute__((noreturn)) void
+platform_assert_false(const char *filename,
+                      int         linenumber,
+                      const char *functionname,
+                      const char *expr,
+                      const char *message,
+                      ...);
+
+void
+platform_assert_msg(platform_log_handle *log_handle,
+                    const char          *filename,
+                    int                  linenumber,
+                    const char          *functionname,
+                    const char          *expr,
+                    const char          *message,
+                    va_list              args);
+
+/*
+ * Caller-macro to invoke assertion checking. Avoids a function call for
+ * most cases when the assertion will succeed.
+ *
+ * Note: The dangling fprintf() is really dead-code, as it executes after the
+ * "noreturn" function implementing the assertion check executes, and fails.
+ * -BUT- The fprintf() is solely there as a small compile-time check to ensure
+ * that the arguments match the print-formats in any user-supplied message.
+ */
+#define platform_assert(expr, ...)                                             \
+   ((expr) ? (void)0                                                           \
+           : (platform_assert_false(                                           \
+                 __FILE__, __LINE__, __FUNCTION__, #expr, "" __VA_ARGS__),     \
+              (void)fprintf(stderr, " " __VA_ARGS__)))
+
 static inline timestamp
 platform_get_timestamp(void);
 
@@ -485,7 +521,9 @@ void
 platform_histo_destroy(platform_heap_id heap_id, platform_histo_handle histo);
 
 void
-platform_histo_print(platform_histo_handle histo, const char *name);
+platform_histo_print(platform_histo_handle histo,
+                     const char           *name,
+                     platform_log_handle  *log_handle);
 
 static inline threadid
 platform_get_tid();

--- a/src/rc_allocator.c
+++ b/src/rc_allocator.c
@@ -395,8 +395,9 @@ rc_allocator_mount(rc_allocator        *al,
          al->stats.curr_allocated++;
       }
    }
-   platform_log("Allocated at mount: %lu MiB\n",
-                B_TO_MiB(al->stats.curr_allocated * cfg->io_cfg->extent_size));
+   platform_default_log(
+      "Allocated at mount: %lu MiB\n",
+      B_TO_MiB(al->stats.curr_allocated * cfg->io_cfg->extent_size));
    return STATUS_OK;
 }
 
@@ -406,7 +407,7 @@ rc_allocator_dismount(rc_allocator *al)
 {
    platform_status status;
 
-   platform_log(
+   platform_default_log(
       "Allocated at dismount: %lu MiB\n",
       B_TO_MiB(al->stats.curr_allocated * al->cfg->io_cfg->extent_size));
 
@@ -440,10 +441,10 @@ rc_allocator_inc_ref(rc_allocator *al, uint64 addr)
    uint8 ref_count = __sync_add_and_fetch(&al->ref_count[extent_no], 1);
    platform_assert(ref_count != 1 && ref_count != 0);
    if (SHOULD_TRACE(addr)) {
-      platform_log("rc_allocator_inc_ref(%lu): %d -> %d\n",
-                   addr,
-                   ref_count,
-                   ref_count + 1);
+      platform_default_log("rc_allocator_inc_ref(%lu): %d -> %d\n",
+                           addr,
+                           ref_count,
+                           ref_count + 1);
    }
    return ref_count;
 }
@@ -464,10 +465,10 @@ rc_allocator_dec_ref(rc_allocator *al, uint64 addr, page_type type)
       __sync_add_and_fetch(&al->stats.extent_deallocs[type], 1);
    }
    if (SHOULD_TRACE(addr)) {
-      platform_log("rc_allocator_dec_ref(%lu): %d -> %d\n",
-                   addr,
-                   ref_count,
-                   ref_count - 1);
+      platform_default_log("rc_allocator_dec_ref(%lu): %d -> %d\n",
+                           addr,
+                           ref_count,
+                           ref_count - 1);
    }
    return ref_count;
 }
@@ -618,12 +619,13 @@ rc_allocator_alloc(rc_allocator *al,   // IN
    } while (!extent_is_free
             && (hand + 1) % al->cfg->extent_capacity != first_hand);
    if (!extent_is_free) {
-      platform_log("Out of Space, while allocating an extent of type=%d (%s):"
-                   " allocated %lu out of %lu addrs.\n",
-                   type,
-                   page_type_str[type],
-                   al->stats.curr_allocated,
-                   al->cfg->extent_capacity);
+      platform_default_log(
+         "Out of Space, while allocating an extent of type=%d (%s):"
+         " allocated %lu out of %lu addrs.\n",
+         type,
+         page_type_str[type],
+         al->stats.curr_allocated,
+         al->cfg->extent_capacity);
       return STATUS_NO_SPACE;
    }
    int64 curr_allocated = __sync_add_and_fetch(&al->stats.curr_allocated, 1);
@@ -636,7 +638,7 @@ rc_allocator_alloc(rc_allocator *al,   // IN
    __sync_add_and_fetch(&al->stats.extent_allocs[type], 1);
    *addr = hand * al->cfg->io_cfg->extent_size;
    if (SHOULD_TRACE(*addr)) {
-      platform_log(
+      platform_default_log(
          "rc_allocator_alloc_extent %12lu (%s)\n", *addr, page_type_str[type]);
    }
 

--- a/src/routing_filter.c
+++ b/src/routing_filter.c
@@ -526,7 +526,7 @@ routing_filter_add(cache           *cc,
          uint32 end_bucket      = (index_no + 1) * index_size;
          uint32 new_index_count = index_count[index_no];
          uint64 header_bit      = 0;
-         // platform_log("index 0x%x start 0x%x end 0x%x\n", index_no,
+         // platform_default_log("index 0x%x start 0x%x end 0x%x\n", index_no,
          // last_bucket, end_bucket);
          uint32 last_fp_added = UINT32_MAX;
          while (new_fps_added < new_index_count
@@ -547,11 +547,11 @@ routing_filter_add(cache           *cc,
             uint32 bucket = routing_get_bucket(fp, remainder_and_value_size);
             // if (fp >> value_size == 0x4a11feb) {
             //    if (is_old) {
-            //       platform_log("old %4u 0x%08x bucket 0x%x\n", old_fps_added,
-            //       fp, bucket);
+            //       platform_default_log("old %4u 0x%08x bucket 0x%x\n",
+            //       old_fps_added, fp, bucket);
             //    } else {
-            //       platform_log("new %4u 0x%08x bucket 0x%x\n", new_fps_added,
-            //       fp, bucket);
+            //       platform_default_log("new %4u 0x%08x bucket 0x%x\n",
+            //       new_fps_added, fp, bucket);
             //    }
             // }
             if (bucket >= end_bucket) {
@@ -761,7 +761,7 @@ routing_filter_estimate_unique_fp(cache           *cc,
       fp_start[i + 1] = dst_fp_no;
    }
 
-   // platform_log("num fp %u\n", fp_start[num_filters - 1]);
+   // platform_default_log("num fp %u\n", fp_start[num_filters - 1]);
 
    uint32 idx[MAX_FILTERS] = {0};
    memmove(idx, fp_start, MAX_FILTERS * sizeof(uint32));
@@ -780,15 +780,15 @@ routing_filter_estimate_unique_fp(cache           *cc,
       if (min_fp == UINT32_MAX) {
          break;
       }
-      // platform_log("0x%08x:", min_fp);
+      // platform_default_log("0x%08x:", min_fp);
 
       for (uint64 i = 0; i < num_filters; i++) {
          if (idx[i] != fp_start[i + 1] && fp_arr[idx[i]] == min_fp) {
-            // platform_log(" %lu-%u", i, idx[i]);
+            // platform_default_log(" %lu-%u", i, idx[i]);
             idx[i]++;
          }
       }
-      // platform_log("\n");
+      // platform_default_log("\n");
       num_unique++;
    }
 
@@ -930,7 +930,8 @@ routing_filter_async_callback(cache_async_ctxt *cache_ctxt)
 
    platform_assert(SUCCESS(cache_ctxt->status));
    platform_assert(cache_ctxt->page);
-   //   platform_log("%s:%d tid %2lu: ctxt %p is callback with page %p\n",
+   //   platform_default_log("%s:%d tid %2lu: ctxt %p is callback with page
+   //   %p\n",
    //                __FILE__, __LINE__, platform_get_tid(), ctxt,
    //                cache_ctxt->page);
    ctxt->was_async = TRUE;
@@ -1031,7 +1032,7 @@ routing_filter_lookup_async(cache              *cc,
             switch (res) {
                case async_locked:
                case async_no_reqs:
-                  //            platform_log("%s:%d tid %2lu: ctxt %p is
+                  //            platform_default_log("%s:%d tid %2lu: ctxt %p is
                   //            retry\n",
                   //                         __FILE__, __LINE__,
                   //                         platform_get_tid(), ctxt);
@@ -1042,7 +1043,7 @@ routing_filter_lookup_async(cache              *cc,
                   done = TRUE;
                   break;
                case async_io_started:
-                  //            platform_log("%s:%d tid %2lu: ctxt %p is
+                  //            platform_default_log("%s:%d tid %2lu: ctxt %p is
                   //            io_started\n",
                   //                         __FILE__, __LINE__,
                   //                         platform_get_tid(), ctxt);
@@ -1190,7 +1191,7 @@ routing_filter_estimate_unique_keys_from_count(routing_config *cfg,
 uint32
 routing_filter_estimate_unique_keys(routing_filter *filter, routing_config *cfg)
 {
-   // platform_log("unique fp %u\n", filter->num_unique);
+   // platform_default_log("unique fp %u\n", filter->num_unique);
    return routing_filter_estimate_unique_keys_from_count(cfg,
                                                          filter->num_unique);
 }

--- a/src/shard_log.c
+++ b/src/shard_log.c
@@ -114,7 +114,8 @@ shard_log_init(shard_log *log, cache *cc, shard_log_config *cfg)
                          1,
                          PAGE_TYPE_LOG,
                          FALSE);
-   // platform_log("addr: %lu meta_head: %lu\n", log->addr, log->meta_head);
+   // platform_default_log("addr: %lu meta_head: %lu\n", log->addr,
+   // log->meta_head);
 
    return STATUS_OK;
 }
@@ -493,10 +494,10 @@ shard_log_print(shard_log *log)
                  !terminal_log_entry(cfg, page->data, le);
                  le = log_entry_next(le))
             {
-               platform_log("%s -- %s : %lu\n",
-                            key_string(dcfg, log_entry_key(le)),
-                            message_string(dcfg, log_entry_message(le)),
-                            le->generation);
+               platform_default_log("%s -- %s : %lu\n",
+                                    key_string(dcfg, log_entry_key(le)),
+                                    message_string(dcfg, log_entry_message(le)),
+                                    le->generation);
             }
          }
          cache_unget(cc, page);

--- a/src/splinterdb.c
+++ b/src/splinterdb.c
@@ -368,7 +368,9 @@ splinterdb_init_config(const splinterdb_config *kvs_cfg, // IN
                      cfg.filter_index_size,
                      cfg.reclaim_threshold,
                      cfg.use_log,
-                     cfg.use_stats);
+                     cfg.use_stats,
+                     FALSE,
+                     NULL);
    return STATUS_OK;
 }
 

--- a/src/srq.h
+++ b/src/srq.h
@@ -255,57 +255,57 @@ srq_print(srq *queue)
 {
    return;
    platform_mutex_lock(&queue->mutex);
-   platform_log("INDEX\n");
-   platform_log("-----------\n");
+   platform_default_log("INDEX\n");
+   platform_default_log("-----------\n");
    for (uint64 i = 0; i < SRQ_MAX_ENTRIES; i++) {
       if (queue->index[i] != SRQ_INDEX_AVAILABLE) {
-         platform_log("%4lu: %4lu\n", i, queue->index[i]);
+         platform_default_log("%4lu: %4lu\n", i, queue->index[i]);
       }
    }
 
-   platform_log("HEAP:\n");
-   platform_log("-----------\n");
+   platform_default_log("HEAP:\n");
+   platform_default_log("-----------\n");
    for (uint64 i = 0; i < queue->num_entries; i++) {
       srq_data data = queue->heap[i];
-      platform_log("%4lu: %12lu-%lu %8lu",
-                   i,
-                   data.addr,
-                   data.pivot_generation,
-                   data.priority);
+      platform_default_log("%4lu: %12lu-%lu %8lu",
+                           i,
+                           data.addr,
+                           data.pivot_generation,
+                           data.priority);
       if (queue->num_entries != 1) {
-         platform_log(" (");
+         platform_default_log(" (");
       }
       if (i != 0) {
          data = queue->heap[srq_parent(i)];
-         platform_log("parent %4lu: %12lu-%lu %8lu",
-                      srq_parent(i),
-                      data.addr,
-                      data.pivot_generation,
-                      data.priority);
+         platform_default_log("parent %4lu: %12lu-%lu %8lu",
+                              srq_parent(i),
+                              data.addr,
+                              data.pivot_generation,
+                              data.priority);
          if (srq_lchild(i) < queue->num_entries) {
-            platform_log(" ");
+            platform_default_log(" ");
          }
       }
       if (srq_lchild(i) < queue->num_entries) {
          data = queue->heap[srq_lchild(i)];
-         platform_log("lchild %4lu: %12lu-%lu %8lu",
-                      srq_lchild(i),
-                      data.addr,
-                      data.pivot_generation,
-                      data.priority);
+         platform_default_log("lchild %4lu: %12lu-%lu %8lu",
+                              srq_lchild(i),
+                              data.addr,
+                              data.pivot_generation,
+                              data.priority);
       }
       if (srq_rchild(i) < queue->num_entries) {
          data = queue->heap[srq_rchild(i)];
-         platform_log(" rchild %4lu: %12lu-%lu %8lu",
-                      srq_rchild(i),
-                      data.addr,
-                      data.pivot_generation,
-                      data.priority);
+         platform_default_log(" rchild %4lu: %12lu-%lu %8lu",
+                              srq_rchild(i),
+                              data.addr,
+                              data.pivot_generation,
+                              data.priority);
       }
       if (queue->num_entries != 1) {
-         platform_log(")");
+         platform_default_log(")");
       }
-      platform_log("\n");
+      platform_default_log("\n");
    }
    platform_mutex_unlock(&queue->mutex);
 }

--- a/src/task.c
+++ b/src/task.c
@@ -683,9 +683,9 @@ task_wait_for_completion(task_system *ts)
       uint64      outstanding_tasks = 0;
       while (group->current_outstanding_tasks != 0) {
          if (group->current_outstanding_tasks != outstanding_tasks) {
-            platform_log("waiting for %lu tasks of type %d\n",
-                         group->current_outstanding_tasks,
-                         type);
+            platform_default_log("waiting for %lu tasks of type %d\n",
+                                 group->current_outstanding_tasks,
+                                 type);
             outstanding_tasks = group->current_outstanding_tasks;
          }
          platform_sleep(1000);
@@ -697,7 +697,7 @@ static void
 task_group_print_stats(task_group *group, task_type type)
 {
    if (!group->use_stats) {
-      platform_log("no stats\n");
+      platform_default_log("no stats\n");
       return;
    }
 
@@ -716,26 +716,30 @@ task_group_print_stats(task_group *group, task_type type)
 
    switch (type) {
       case TASK_TYPE_NORMAL:
-         platform_log("\nMain Task Group Statistics\n");
+         platform_default_log("\nMain Task Group Statistics\n");
          break;
       case TASK_TYPE_MEMTABLE:
-         platform_log("\nMemtable Task Group Statistics\n");
+         platform_default_log("\nMemtable Task Group Statistics\n");
          break;
       default:
          platform_assert(0);
          break;
    }
-   platform_log("--------------------------------\n");
-   platform_log("| max runtime (ns)     : %10lu\n", global.max_runtime_ns);
-   platform_log("| max runtime func     : %10p\n", global.max_runtime_func);
-   platform_log("| total latency (ns)   : %10lu\n", global.total_latency_ns);
-   platform_log("| max latency (ns)     : %10lu\n", global.max_latency_ns);
-   platform_log("| total tasks run      : %10lu\n", global.total_tasks);
-   platform_log("| current outstanding tasks : %lu\n",
-                group->current_outstanding_tasks);
-   platform_log("| max outstanding tasks : %lu\n",
-                group->max_outstanding_tasks);
-   platform_log("\n");
+   platform_default_log("--------------------------------\n");
+   platform_default_log("| max runtime (ns)     : %10lu\n",
+                        global.max_runtime_ns);
+   platform_default_log("| max runtime func     : %10p\n",
+                        global.max_runtime_func);
+   platform_default_log("| total latency (ns)   : %10lu\n",
+                        global.total_latency_ns);
+   platform_default_log("| max latency (ns)     : %10lu\n",
+                        global.max_latency_ns);
+   platform_default_log("| total tasks run      : %10lu\n", global.total_tasks);
+   platform_default_log("| current outstanding tasks : %lu\n",
+                        group->current_outstanding_tasks);
+   platform_default_log("| max outstanding tasks : %lu\n",
+                        group->max_outstanding_tasks);
+   platform_default_log("\n");
 }
 
 void

--- a/src/trunk.h
+++ b/src/trunk.h
@@ -70,6 +70,10 @@ typedef struct trunk_config {
    data_config    *data_cfg;
    bool            use_log;
    log_config     *log_cfg;
+
+   // verbose logging
+   bool                 verbose_logging_enabled;
+   platform_log_handle *log_handle;
 } trunk_config;
 
 typedef struct trunk_stats {
@@ -384,22 +388,24 @@ trunk_perform_tasks(trunk_handle *spl);
 void
 trunk_force_flush(trunk_handle *spl);
 void
-trunk_print_insertion_stats(trunk_handle *spl);
+trunk_print_insertion_stats(platform_log_handle *log_handle, trunk_handle *spl);
 void
-trunk_print_lookup_stats(trunk_handle *spl);
+trunk_print_lookup_stats(platform_log_handle *log_handle, trunk_handle *spl);
 void
 trunk_reset_stats(trunk_handle *spl);
 
 void
-trunk_print(trunk_handle *spl);
+trunk_print(platform_log_handle *log_handle, trunk_handle *spl);
 void
-trunk_print_lookup(trunk_handle *spl, const char *key);
+trunk_print_lookup(trunk_handle        *spl,
+                   const char          *key,
+                   platform_log_handle *log_handle);
 void
-trunk_print_branches(trunk_handle *spl);
+trunk_print_branches(platform_log_handle *log_handle, trunk_handle *spl);
 void
-trunk_print_extent_counts(trunk_handle *spl);
+trunk_print_extent_counts(platform_log_handle *log_handle, trunk_handle *spl);
 void
-trunk_print_space_use(trunk_handle *spl);
+trunk_print_space_use(platform_log_handle *log_handle, trunk_handle *spl);
 bool
 trunk_verify_tree(trunk_handle *spl);
 
@@ -458,19 +464,21 @@ uint64
 trunk_hdr_size();
 
 void
-trunk_config_init(trunk_config *trunk_cfg,
-                  cache_config *cache_cfg,
-                  data_config  *data_cfg,
-                  log_config   *log_cfg,
-                  uint64        memtable_capacity,
-                  uint64        fanout,
-                  uint64        max_branches_per_node,
-                  uint64        btree_rough_count_height,
-                  uint64        filter_remainder_size,
-                  uint64        filter_index_size,
-                  uint64        reclaim_threshold,
-                  uint64        use_log,
-                  uint64        use_stats);
+trunk_config_init(trunk_config        *trunk_cfg,
+                  cache_config        *cache_cfg,
+                  data_config         *data_cfg,
+                  log_config          *log_cfg,
+                  uint64               memtable_capacity,
+                  uint64               fanout,
+                  uint64               max_branches_per_node,
+                  uint64               btree_rough_count_height,
+                  uint64               filter_remainder_size,
+                  uint64               filter_index_size,
+                  uint64               reclaim_threshold,
+                  bool                 use_log,
+                  bool                 use_stats,
+                  bool                 verbose_logging,
+                  platform_log_handle *log_handle);
 size_t
 trunk_get_scratch_size();
 

--- a/tests/config.c
+++ b/tests/config.c
@@ -67,6 +67,8 @@ config_set_defaults(master_config *cfg)
       .max_branches_per_node    = TEST_CONFIG_DEFAULT_MAX_BRANCHES_PER_NODE,
       .use_stats                = FALSE,
       .reclaim_threshold        = UINT64_MAX,
+      .verbose_logging_enabled  = FALSE,
+      .log_handle               = NULL,
       .key_size                 = TEST_CONFIG_DEFAULT_KEY_SIZE,
       .message_size             = TEST_CONFIG_DEFAULT_MESSAGE_SIZE,
       .num_inserts              = TEST_CONFIG_DEFAULT_NUM_INSERTS,
@@ -114,6 +116,8 @@ config_usage()
    platform_error_log("\t--no-stats\n");
    platform_error_log("\t--log\n");
    platform_error_log("\t--no-log\n");
+   platform_error_log("\t--verbose-logging\n");
+   platform_error_log("\t--no-verbose-logging\n");
    platform_error_log("\t--key-size (%d)\n", TEST_CONFIG_DEFAULT_KEY_SIZE);
    platform_error_log("\t--data-size (%d)\n", TEST_CONFIG_DEFAULT_MESSAGE_SIZE);
    platform_error_log("\t--num-inserts (%d)\n",
@@ -230,6 +234,23 @@ config_parse(master_config *cfg, const uint8 num_config, int argc, char *argv[])
                cfg[cfg_idx].use_log = TRUE;
             }
          }
+         config_has_option("no-log")
+         {
+            for (cfg_idx = 0; cfg_idx < num_config; cfg_idx++) {
+               cfg[cfg_idx].use_log = FALSE;
+            }
+         }
+         config_has_option("verbose-logging")
+         {
+            cfg[cfg_idx].verbose_logging_enabled = TRUE;
+            cfg[cfg_idx].log_handle              = Platform_default_log_handle;
+         }
+         config_has_option("no-verbose-logging")
+         {
+            cfg[cfg_idx].verbose_logging_enabled = FALSE;
+            cfg[cfg_idx].log_handle              = NULL;
+         }
+
          config_set_uint64("key-size", cfg, key_size) {}
          config_set_uint64("data-size", cfg, message_size) {}
 

--- a/tests/config.h
+++ b/tests/config.h
@@ -56,11 +56,13 @@ typedef struct master_config {
    bool use_log;
 
    // splinter
-   uint64 memtable_capacity;
-   uint64 fanout;
-   uint64 max_branches_per_node;
-   uint64 use_stats;
-   uint64 reclaim_threshold;
+   uint64               memtable_capacity;
+   uint64               fanout;
+   uint64               max_branches_per_node;
+   uint64               use_stats;
+   uint64               reclaim_threshold;
+   bool                 verbose_logging_enabled;
+   platform_log_handle *log_handle;
 
    // data
    uint64 key_size;

--- a/tests/functional/cache_test.c
+++ b/tests/functional/cache_test.c
@@ -97,7 +97,7 @@ cache_test_alloc_extents(cache             *cc,
 platform_status
 test_cache_basic(cache *cc, clockcache_config *cfg, platform_heap_id hid)
 {
-   platform_log("cache_test: basic test started\n");
+   platform_default_log("cache_test: basic test started\n");
    platform_status rc       = STATUS_OK;
    page_handle   **page_arr = NULL;
    uint64         *addr_arr = NULL;
@@ -286,9 +286,9 @@ exit:
    }
 
    if (SUCCESS(rc)) {
-      platform_log("cache_test: basic test passed\n");
+      platform_default_log("cache_test: basic test passed\n");
    } else {
-      platform_log("cache_test: basic test failed\n");
+      platform_default_log("cache_test: basic test failed\n");
    }
 
    return rc;
@@ -402,7 +402,7 @@ cache_test_dirty_flush(cache                 *cc,
    platform_status rc = STATUS_OK;
    timestamp       t_start;
 
-   platform_log("Running Flush %s test case ... ", testname);
+   platform_error_log("Running Flush %s test case ... ", testname);
    /*
     * Get all entries for write, mark dirty, release, and
     * flush. Verify that there are no dirty entries afterwards.
@@ -440,10 +440,11 @@ cache_test_dirty_flush(cache                 *cc,
    t_start = platform_get_timestamp();
    cache_flush(cc);
    t_start = NSEC_TO_MSEC(platform_timestamp_elapsed(t_start));
-   platform_log("took %lu msec (%lu MiB/sec)\n",
-                t_start,
-                (cfg->page_capacity << cfg->log_page_size) / MiB
-                   * SEC_TO_MSEC(1) / t_start);
+   platform_default_log("Flush %s took %lu msec (%lu MiB/sec)\n",
+                        testname,
+                        t_start,
+                        (cfg->page_capacity << cfg->log_page_size) / MiB
+                           * SEC_TO_MSEC(1) / t_start);
    uint32 dirty_count = cache_count_dirty(cc);
    if (dirty_count != 0) {
       platform_error_log("Expected no dirty entries but found: %u",
@@ -461,7 +462,7 @@ test_cache_flush(cache             *cc,
                  platform_heap_id   hid,
                  uint64             al_extent_capacity)
 {
-   platform_log("cache_test: flush test started\n");
+   platform_default_log("cache_test: flush test started\n");
    platform_status rc       = STATUS_OK;
    uint64         *addr_arr = NULL;
    timestamp       t_start;
@@ -479,18 +480,18 @@ test_cache_flush(cache             *cc,
    }
    uint32 extents_to_allocate = factor * extent_capacity;
    uint64 pages_to_allocate   = extents_to_allocate * pages_per_extent;
-   platform_log("Allocate %d extents ... ", extents_to_allocate);
+   platform_default_log("Allocate %d extents ... ", extents_to_allocate);
 
    addr_arr = TYPED_ARRAY_MALLOC(hid, addr_arr, pages_to_allocate);
    t_start  = platform_get_timestamp();
    rc       = cache_test_alloc_extents(cc, cfg, addr_arr, extents_to_allocate);
    if (!SUCCESS(rc)) {
-      platform_log("failed.\n");
+      platform_error_log("failed.\n");
       /* no need to set status because we got here from an error status */
       goto exit;
    }
-   platform_log("took %lu secs.\n",
-                NSEC_TO_SEC(platform_timestamp_elapsed(t_start)));
+   platform_default_log("Allocation took %lu secs\n",
+                        NSEC_TO_SEC(platform_timestamp_elapsed(t_start)));
 
    cache_test_index_itor itor;
 
@@ -551,8 +552,8 @@ test_cache_flush(cache             *cc,
       ref = allocator_dec_ref(al, addr, PAGE_TYPE_MISC);
       platform_assert(ref == AL_FREE);
    }
-   platform_log("Dealloc took %lu secs\n",
-                NSEC_TO_SEC(platform_timestamp_elapsed(t_start)));
+   platform_default_log("Dealloc took %lu secs\n",
+                        NSEC_TO_SEC(platform_timestamp_elapsed(t_start)));
 
 exit:
    if (addr_arr) {
@@ -560,9 +561,9 @@ exit:
    }
 
    if (SUCCESS(rc)) {
-      platform_log("cache_test: flush test passed\n");
+      platform_default_log("cache_test: flush test passed\n");
    } else {
-      platform_log("cache_test: flush test failed\n");
+      platform_default_log("cache_test: flush test failed\n");
    }
 
    return rc;
@@ -854,17 +855,17 @@ test_cache_async(cache             *cc,
        */
       platform_assert(num_writer_threads == 0);
    }
-   platform_log("cache_test: async test started with %u reader"
-                ", %u writer threads (working set=%u%%)\n",
-                num_reader_threads,
-                num_writer_threads,
-                working_set_percent);
+   platform_default_log(
+      "cache_test: async test started with %u+%u threads (ws=%u%%)\n",
+      num_reader_threads,
+      num_writer_threads,
+      working_set_percent);
    addr_arr = TYPED_ARRAY_MALLOC(hid, addr_arr, pages_to_allocate);
    rc       = cache_test_alloc_extents(cc, cfg, addr_arr, extents_to_allocate);
    if (!SUCCESS(rc)) {
       return rc;
    }
-   platform_log("cache_test: %lu pages allocated\n", pages_to_allocate);
+   platform_default_log("cache_test: %lu pages allocated\n", pages_to_allocate);
    // Start cache with a clean slate
    cache_flush(cc);
    cache_evict(cc, TRUE);
@@ -939,8 +940,8 @@ test_cache_async(cache             *cc,
    }
    platform_free(hid, addr_arr);
    platform_free(hid, params);
-   cache_print_stats(cc);
-   platform_log("\n");
+   cache_print_stats(Platform_default_log_handle, cc);
+   platform_default_log("\n");
 
    return rc;
 }
@@ -982,10 +983,10 @@ cache_test(int argc, char *argv[])
       }
    }
 
-   platform_log("\nStarted cache_test %s\n",
-                ((argc == 1) ? "basic"
-                 : benchmark ? "performance benchmarking."
-                             : "async performance."));
+   platform_default_log("\nStarted cache_test %s\n",
+                        ((argc == 1) ? "basic"
+                         : benchmark ? "performance benchmarking."
+                                     : "async performance."));
 
    // Create a heap for io, allocator, cache and splinter
    platform_heap_handle hh;

--- a/tests/functional/filter_test.c
+++ b/tests/functional/filter_test.c
@@ -27,12 +27,12 @@ test_filter_basic(cache           *cc,
                   uint64           num_fingerprints,
                   uint64           num_values)
 {
-   platform_log("filter_test: routing filter basic test started\n");
+   platform_default_log("filter_test: routing filter basic test started\n");
    platform_status rc = STATUS_OK;
 
    const uint64 key_size = cfg->data_cfg->key_size;
    if (key_size < sizeof(uint64)) {
-      platform_log("key_size %lu too small\n", key_size);
+      platform_default_log("key_size %lu too small\n", key_size);
       return STATUS_BAD_PARAM;
    }
 
@@ -75,23 +75,23 @@ test_filter_basic(cache           *cc,
                               fp_arr[i],
                               num_fingerprints,
                               i);
-      // platform_log("FILTER %lu\n", i);
+      // platform_default_log("FILTER %lu\n", i);
       // routing_filter_print(cc, cfg, &filter);
       uint32 estimated_input_keys =
          routing_filter_estimate_unique_keys(&filter[i + 1], cfg);
 
-      platform_log("num input keys %8u estimate %8u num_unique %u\n",
-                   num_input_keys[i],
-                   estimated_input_keys,
-                   filter[i + 1].num_unique);
+      platform_default_log("num input keys %8u estimate %8u num_unique %u\n",
+                           num_input_keys[i],
+                           estimated_input_keys,
+                           filter[i + 1].num_unique);
    }
 
    uint32 num_unique =
       routing_filter_estimate_unique_fp(cc, cfg, hid, filter + 1, num_values);
    num_unique = routing_filter_estimate_unique_keys_from_count(cfg, num_unique);
-   platform_log("across filters: num input keys %8u estimate %8u\n",
-                num_input_keys[num_values - 1],
-                num_unique);
+   platform_default_log("across filters: num input keys %8u estimate %8u\n",
+                        num_input_keys[num_values - 1],
+                        num_unique);
 
    platform_free(hid, num_input_keys);
 
@@ -104,9 +104,10 @@ test_filter_basic(cache           *cc,
             cc, cfg, &filter[i + 1], key_slice, &found_values);
          platform_assert_status_ok(rc);
          if (!routing_filter_is_value_found(found_values, i)) {
-            platform_log("key-value pair (%lu, %lu) not found in filter\n",
-                         (i + 1) * j,
-                         i);
+            platform_default_log(
+               "key-value pair (%lu, %lu) not found in filter\n",
+               (i + 1) * j,
+               i);
             rc = STATUS_NOT_FOUND;
             goto out;
          }
@@ -128,7 +129,7 @@ test_filter_basic(cache           *cc,
 
    fraction false_positive_rate =
       init_fraction(false_positives, num_fingerprints);
-   platform_log(
+   platform_default_log(
       "routing filter basic test: false positive rate " FRACTION_FMT(1, 4) "\n",
       FRACTION_ARGS(false_positive_rate));
 
@@ -154,12 +155,12 @@ test_filter_perf(cache           *cc,
                  uint64           num_values,
                  uint64           num_trees)
 {
-   platform_log("filter_test: routing filter perf test started\n");
+   platform_default_log("filter_test: routing filter perf test started\n");
    platform_status rc = STATUS_OK;
 
    const uint64 key_size = cfg->data_cfg->key_size;
    if (key_size < sizeof(uint64)) {
-      platform_log("key_size %lu too small\n", key_size);
+      platform_default_log("key_size %lu too small\n", key_size);
       return STATUS_BAD_PARAM;
    }
 
@@ -201,9 +202,9 @@ test_filter_perf(cache           *cc,
          filter[k] = new_filter;
       }
    }
-   platform_log("filter insert time per key %lu\n",
-                platform_timestamp_elapsed(start_time)
-                   / (num_fingerprints * num_values * num_trees));
+   platform_default_log("filter insert time per key %lu\n",
+                        platform_timestamp_elapsed(start_time)
+                           / (num_fingerprints * num_values * num_trees));
 
    start_time = platform_get_timestamp();
    for (uint64 k = 0; k < num_trees; k++) {
@@ -216,7 +217,7 @@ test_filter_perf(cache           *cc,
          platform_assert_status_ok(rc);
          if (!routing_filter_is_value_found(found_values, i / num_fingerprints))
          {
-            platform_log(
+            platform_default_log(
                "key-value pair (%lu, %lu) not found in filter %lu (%lu)\n",
                k * num_values * num_fingerprints + i,
                i / num_fingerprints,
@@ -231,9 +232,9 @@ test_filter_perf(cache           *cc,
          }
       }
    }
-   platform_log("filter positive lookup time per key %lu\n",
-                platform_timestamp_elapsed(start_time)
-                   / (num_fingerprints * num_trees * num_values));
+   platform_default_log("filter positive lookup time per key %lu\n",
+                        platform_timestamp_elapsed(start_time)
+                           / (num_fingerprints * num_trees * num_values));
 
    start_time             = platform_get_timestamp();
    uint64 unused_key      = num_values * num_fingerprints * num_trees;
@@ -252,17 +253,17 @@ test_filter_perf(cache           *cc,
       }
    }
 
-   platform_log("filter negative lookup time per key %lu\n",
-                platform_timestamp_elapsed(start_time)
-                   / (num_fingerprints * num_trees * num_values));
+   platform_default_log("filter negative lookup time per key %lu\n",
+                        platform_timestamp_elapsed(start_time)
+                           / (num_fingerprints * num_trees * num_values));
    fraction false_positive_rate =
       init_fraction(false_positives, num_fingerprints * num_trees * num_values);
-   platform_log("filter_basic_test: false positive rate " FRACTION_FMT(
-                   1, 4) " for %lu trees\n",
-                FRACTION_ARGS(false_positive_rate),
-                num_trees);
+   platform_default_log("filter_basic_test: false positive rate " FRACTION_FMT(
+                           1, 4) " for %lu trees\n",
+                        FRACTION_ARGS(false_positive_rate),
+                        num_trees);
 
-   cache_print_stats(cc);
+   cache_print_stats(Platform_default_log_handle, cc);
 
 out:
    for (uint64 i = 0; i < num_trees; i++) {

--- a/tests/functional/log_test.c
+++ b/tests/functional/log_test.c
@@ -95,20 +95,20 @@ test_log_crash(clockcache             *cc,
       if (slice_lex_cmp(skey, returned_key)
           || message_lex_cmp(mmessage, returned_message))
       {
-         platform_log("log_test_basic: key or data mismatch\n");
+         platform_default_log("log_test_basic: key or data mismatch\n");
          data_key_to_string(cfg->data_cfg, skey, key_str, 128);
          data_message_to_string(cfg->data_cfg, mmessage, data_str, 128);
-         platform_log("expected: %s -- %s\n", key_str, data_str);
+         platform_default_log("expected: %s -- %s\n", key_str, data_str);
          data_key_to_string(cfg->data_cfg, returned_key, key_str, 128);
          data_message_to_string(cfg->data_cfg, returned_message, data_str, 128);
-         platform_log("actual: %s -- %s\n", key_str, data_str);
+         platform_default_log("actual: %s -- %s\n", key_str, data_str);
          platform_assert(0);
       }
       iterator_advance(itorh);
       iterator_at_end(itorh, &at_end);
    }
 
-   platform_log("log returned %lu of %lu entries\n", i, num_entries);
+   platform_default_log("log returned %lu of %lu entries\n", i, num_entries);
 
    shard_log_iterator_deinit(hid, &itor);
    shard_log_zap(log);
@@ -196,9 +196,9 @@ test_log_perf(cache                  *cc,
       platform_thread_join(params[i].thread);
    }
 
-   platform_log("log insertion rate: %luM insertions/second\n",
-                SEC_TO_MSEC(num_entries)
-                   / platform_timestamp_elapsed(start_time));
+   platform_default_log("log insertion rate: %luM insertions/second\n",
+                        SEC_TO_MSEC(num_entries)
+                           / platform_timestamp_elapsed(start_time));
 
 cleanup:
    platform_free(hid, params);
@@ -257,7 +257,7 @@ log_test(int argc, char *argv[])
       config_argv    = argv + 1;
    }
 
-   platform_log("\nStarted log_test!!\n");
+   platform_default_log("\nStarted log_test!!\n");
 
    // Create a heap for io, allocator, cache and splinter
    platform_heap_handle hh;

--- a/tests/functional/splinter_test.c
+++ b/tests/functional/splinter_test.c
@@ -123,7 +123,7 @@ test_trunk_insert_thread(void *arg)
             continue;
          }
          platform_default_log(PLATFORM_CR
-                              "inserting %3lu%% complete for table %u ... ",
+                              "inserting %3lu%% complete for table %u",
                               insert_base[spl_idx] / (total_ops[spl_idx] / 100),
                               spl_idx);
          insert_base[spl_idx] =
@@ -746,9 +746,10 @@ test_splinter_perf(trunk_config    *cfg,
                    uint8            num_caches,
                    uint64           insert_rate)
 {
-   platform_log("splinter_test: SplinterDB performance test started with "
-                "%d tables\n",
-                num_tables);
+   platform_default_log(
+      "splinter_test: SplinterDB performance test started with "
+      "%d tables\n",
+      num_tables);
    trunk_handle  **spl_tables;
    platform_status rc;
 
@@ -847,22 +848,25 @@ test_splinter_perf(trunk_config    *cfg,
    rc = STATUS_OK;
 
    if (total_inserts > 0) {
-      platform_log("\nper-splinter per-thread insert time per tuple %lu ns\n",
-                   total_time * num_insert_threads / total_inserts);
-      platform_log("splinter total insertion rate: %lu insertions/second\n",
-                   SEC_TO_NSEC(total_inserts) / total_time);
-      platform_log("splinter bandwidth: %lu megabytes/second\n", bandwidth);
-      platform_log("splinter max insert latency: %lu msec\n",
-                   NSEC_TO_MSEC(insert_latency_max));
+      platform_default_log(
+         "\nper-splinter per-thread insert time per tuple %lu ns\n",
+         total_time * num_insert_threads / total_inserts);
+      platform_default_log(
+         "splinter total insertion rate: %lu insertions/second\n",
+         SEC_TO_NSEC(total_inserts) / total_time);
+      platform_default_log("splinter bandwidth: %lu megabytes/second\n",
+                           bandwidth);
+      platform_default_log("splinter max insert latency: %lu msec\n",
+                           NSEC_TO_MSEC(insert_latency_max));
    }
 
    for (uint8 spl_idx = 0; spl_idx < num_tables; spl_idx++) {
       trunk_handle *spl = spl_tables[spl_idx];
       cache_assert_free(spl->cc);
       platform_assert(trunk_verify_tree(spl));
-      trunk_print_insertion_stats(spl);
-      cache_print_stats(spl->cc);
-      trunk_print_space_use(spl);
+      trunk_print_insertion_stats(Platform_default_log_handle, spl);
+      cache_print_stats(Platform_default_log_handle, spl->cc);
+      trunk_print_space_use(Platform_default_log_handle, spl);
       cache_reset_stats(spl->cc);
       // trunk_print(spl);
    }
@@ -922,20 +926,21 @@ test_splinter_perf(trunk_config    *cfg,
 
       rc = STATUS_OK;
 
-      platform_log("\nper-splinter per-thread lookup time per tuple %lu ns\n",
-                   total_time * num_lookup_threads / total_inserts);
-      platform_log("splinter total lookup rate: %lu lookups/second\n",
-                   SEC_TO_NSEC(total_inserts) / total_time);
-      platform_log("%lu%% lookups were async\n",
-                   num_async_lookups * 100 / total_inserts);
-      platform_log("max lookup latency ns (sync=%lu, async=%lu)\n",
-                   sync_lookup_latency_max,
-                   async_lookup_latency_max);
+      platform_default_log(
+         "\nper-splinter per-thread lookup time per tuple %lu ns\n",
+         total_time * num_lookup_threads / total_inserts);
+      platform_default_log("splinter total lookup rate: %lu lookups/second\n",
+                           SEC_TO_NSEC(total_inserts) / total_time);
+      platform_default_log("%lu%% lookups were async\n",
+                           num_async_lookups * 100 / total_inserts);
+      platform_default_log("max lookup latency ns (sync=%lu, async=%lu)\n",
+                           sync_lookup_latency_max,
+                           async_lookup_latency_max);
       for (uint8 spl_idx = 0; spl_idx < num_tables; spl_idx++) {
          trunk_handle *spl = spl_tables[spl_idx];
          cache_assert_free(spl->cc);
-         trunk_print_lookup_stats(spl);
-         cache_print_stats(spl->cc);
+         trunk_print_lookup_stats(Platform_default_log_handle, spl);
+         cache_print_stats(Platform_default_log_handle, spl->cc);
          cache_reset_stats(spl->cc);
       }
    }
@@ -987,15 +992,16 @@ test_splinter_perf(trunk_config    *cfg,
 
       rc = STATUS_OK;
 
-      platform_log("\nper-splinter per-thread range time per tuple %lu ns\n",
-                   total_time * num_range_threads / total_ranges);
-      platform_log("splinter total range rate: %lu ops/second\n",
-                   SEC_TO_NSEC(total_ranges) / total_time);
+      platform_default_log(
+         "\nper-splinter per-thread range time per tuple %lu ns\n",
+         total_time * num_range_threads / total_ranges);
+      platform_default_log("splinter total range rate: %lu ops/second\n",
+                           SEC_TO_NSEC(total_ranges) / total_time);
       for (uint8 spl_idx = 0; spl_idx < num_tables; spl_idx++) {
          trunk_handle *spl = spl_tables[spl_idx];
          cache_assert_free(spl->cc);
-         trunk_print_lookup_stats(spl);
-         cache_print_stats(spl->cc);
+         trunk_print_lookup_stats(Platform_default_log_handle, spl);
+         cache_print_stats(Platform_default_log_handle, spl->cc);
          cache_reset_stats(spl->cc);
       }
 
@@ -1042,15 +1048,16 @@ test_splinter_perf(trunk_config    *cfg,
 
       rc = STATUS_OK;
 
-      platform_log("\nper-splinter per-thread range time per tuple %lu ns\n",
-                   total_time * num_range_threads / total_ranges);
-      platform_log("splinter total range rate: %lu ops/second\n",
-                   SEC_TO_NSEC(total_ranges) / total_time);
+      platform_default_log(
+         "\nper-splinter per-thread range time per tuple %lu ns\n",
+         total_time * num_range_threads / total_ranges);
+      platform_default_log("splinter total range rate: %lu ops/second\n",
+                           SEC_TO_NSEC(total_ranges) / total_time);
       for (uint8 spl_idx = 0; spl_idx < num_tables; spl_idx++) {
          trunk_handle *spl = spl_tables[spl_idx];
          cache_assert_free(spl->cc);
-         trunk_print_lookup_stats(spl);
-         cache_print_stats(spl->cc);
+         trunk_print_lookup_stats(Platform_default_log_handle, spl);
+         cache_print_stats(Platform_default_log_handle, spl->cc);
          cache_reset_stats(spl->cc);
       }
 
@@ -1097,24 +1104,25 @@ test_splinter_perf(trunk_config    *cfg,
 
       rc = STATUS_OK;
 
-      platform_log("\nper-splinter per-thread range time per tuple %lu ns\n",
-                   total_time * num_range_threads / total_ranges);
-      platform_log("splinter total range rate: %lu ops/second\n",
-                   SEC_TO_NSEC(total_ranges) / total_time);
+      platform_default_log(
+         "\nper-splinter per-thread range time per tuple %lu ns\n",
+         total_time * num_range_threads / total_ranges);
+      platform_default_log("splinter total range rate: %lu ops/second\n",
+                           SEC_TO_NSEC(total_ranges) / total_time);
       for (uint8 spl_idx = 0; spl_idx < num_tables; spl_idx++) {
          trunk_handle *spl = spl_tables[spl_idx];
          cache_assert_free(spl->cc);
-         trunk_print_lookup_stats(spl);
-         cache_print_stats(spl->cc);
+         trunk_print_lookup_stats(Platform_default_log_handle, spl);
+         cache_print_stats(Platform_default_log_handle, spl->cc);
          cache_reset_stats(spl->cc);
       }
    }
 
 destroy_splinter:
    test_trunk_destroy_tables(spl_tables, hid, num_tables);
-   platform_log("After destroy:\n");
+   platform_default_log("After destroy:\n");
    for (uint8 idx = 0; idx < num_caches; idx++) {
-      cache_print_stats(cc[idx]);
+      cache_print_stats(Platform_default_log_handle, cc[idx]);
    }
    platform_free(hid, params);
    platform_free(hid, curr_op);
@@ -1138,7 +1146,7 @@ test_splinter_periodic(trunk_config    *cfg,
                        uint8            num_caches,
                        uint64           insert_rate)
 {
-   platform_log(
+   platform_default_log(
       "splinter_test: SplinterDB performance test (periodic) started with "
       "%d tables\n",
       num_tables);
@@ -1239,29 +1247,32 @@ test_splinter_periodic(trunk_config    *cfg,
    rc = STATUS_OK;
 
    if (total_inserts > 0) {
-      platform_log("\nper-splinter per-thread insert time per tuple %lu ns\n",
-                   total_time * num_insert_threads / total_inserts);
-      platform_log("splinter total insertion rate: %lu insertions/second\n",
-                   SEC_TO_NSEC(total_inserts) / total_time);
-      platform_log("splinter bandwidth: %lu megabytes/second\n", bandwidth);
-      platform_log("splinter max insert latency: %lu msec\n",
-                   NSEC_TO_MSEC(insert_latency_max));
+      platform_default_log(
+         "\nper-splinter per-thread insert time per tuple %lu ns\n",
+         total_time * num_insert_threads / total_inserts);
+      platform_default_log(
+         "splinter total insertion rate: %lu insertions/second\n",
+         SEC_TO_NSEC(total_inserts) / total_time);
+      platform_default_log("splinter bandwidth: %lu megabytes/second\n",
+                           bandwidth);
+      platform_default_log("splinter max insert latency: %lu msec\n",
+                           NSEC_TO_MSEC(insert_latency_max));
    }
 
    for (uint8 spl_idx = 0; spl_idx < num_tables; spl_idx++) {
       trunk_handle *spl = spl_tables[spl_idx];
       cache_assert_free(spl->cc);
       platform_assert(trunk_verify_tree(spl));
-      trunk_print_insertion_stats(spl);
-      cache_print_stats(spl->cc);
-      trunk_print_space_use(spl);
+      trunk_print_insertion_stats(Platform_default_log_handle, spl);
+      cache_print_stats(Platform_default_log_handle, spl->cc);
+      trunk_print_space_use(Platform_default_log_handle, spl);
       cache_reset_stats(spl->cc);
    }
 
    ZERO_CONTENTS_N(curr_op, num_tables);
 
    for (uint64 repeat_round = 0; repeat_round < 10; repeat_round++) {
-      platform_log("Beginning repeat round %lu\n", repeat_round);
+      platform_default_log("Beginning repeat round %lu\n", repeat_round);
       platform_error_log("Beginning repeat round %lu\n", repeat_round);
       /*
        * **********
@@ -1306,23 +1317,25 @@ test_splinter_periodic(trunk_config    *cfg,
       rc = STATUS_OK;
 
       if (total_inserts > 0) {
-         platform_log(
+         platform_default_log(
             "\nper-splinter per-thread insert time per tuple %lu ns\n",
             total_time * num_insert_threads / total_inserts);
-         platform_log("splinter total insertion rate: %lu insertions/second\n",
-                      SEC_TO_NSEC(total_inserts) / total_time);
-         platform_log("splinter bandwidth: %lu megabytes/second\n", bandwidth);
-         platform_log("splinter max insert latency: %lu msec\n",
-                      NSEC_TO_MSEC(insert_latency_max));
+         platform_default_log(
+            "splinter total insertion rate: %lu insertions/second\n",
+            SEC_TO_NSEC(total_inserts) / total_time);
+         platform_default_log("splinter bandwidth: %lu megabytes/second\n",
+                              bandwidth);
+         platform_default_log("splinter max insert latency: %lu msec\n",
+                              NSEC_TO_MSEC(insert_latency_max));
       }
 
       for (uint8 spl_idx = 0; spl_idx < num_tables; spl_idx++) {
          trunk_handle *spl = spl_tables[spl_idx];
          cache_assert_free(spl->cc);
          platform_assert(trunk_verify_tree(spl));
-         trunk_print_insertion_stats(spl);
-         cache_print_stats(spl->cc);
-         trunk_print_space_use(spl);
+         trunk_print_insertion_stats(Platform_default_log_handle, spl);
+         cache_print_stats(Platform_default_log_handle, spl->cc);
+         trunk_print_space_use(Platform_default_log_handle, spl);
          cache_reset_stats(spl->cc);
       }
 
@@ -1387,20 +1400,21 @@ test_splinter_periodic(trunk_config    *cfg,
 
       rc = STATUS_OK;
 
-      platform_log("\nper-splinter per-thread lookup time per tuple %lu ns\n",
-                   total_time * num_lookup_threads / total_inserts);
-      platform_log("splinter total lookup rate: %lu lookups/second\n",
-                   SEC_TO_NSEC(total_inserts) / total_time);
-      platform_log("%lu%% lookups were async\n",
-                   num_async_lookups * 100 / total_inserts);
-      platform_log("max lookup latency ns (sync=%lu, async=%lu)\n",
-                   sync_lookup_latency_max,
-                   async_lookup_latency_max);
+      platform_default_log(
+         "\nper-splinter per-thread lookup time per tuple %lu ns\n",
+         total_time * num_lookup_threads / total_inserts);
+      platform_default_log("splinter total lookup rate: %lu lookups/second\n",
+                           SEC_TO_NSEC(total_inserts) / total_time);
+      platform_default_log("%lu%% lookups were async\n",
+                           num_async_lookups * 100 / total_inserts);
+      platform_default_log("max lookup latency ns (sync=%lu, async=%lu)\n",
+                           sync_lookup_latency_max,
+                           async_lookup_latency_max);
       for (uint8 spl_idx = 0; spl_idx < num_tables; spl_idx++) {
          trunk_handle *spl = spl_tables[spl_idx];
          cache_assert_free(spl->cc);
-         trunk_print_lookup_stats(spl);
-         cache_print_stats(spl->cc);
+         trunk_print_lookup_stats(Platform_default_log_handle, spl);
+         cache_print_stats(Platform_default_log_handle, spl->cc);
          cache_reset_stats(spl->cc);
       }
    }
@@ -1452,15 +1466,16 @@ test_splinter_periodic(trunk_config    *cfg,
 
       rc = STATUS_OK;
 
-      platform_log("\nper-splinter per-thread range time per tuple %lu ns\n",
-                   total_time * num_range_threads / total_ranges);
-      platform_log("splinter total range rate: %lu ops/second\n",
-                   SEC_TO_NSEC(total_ranges) / total_time);
+      platform_default_log(
+         "\nper-splinter per-thread range time per tuple %lu ns\n",
+         total_time * num_range_threads / total_ranges);
+      platform_default_log("splinter total range rate: %lu ops/second\n",
+                           SEC_TO_NSEC(total_ranges) / total_time);
       for (uint8 spl_idx = 0; spl_idx < num_tables; spl_idx++) {
          trunk_handle *spl = spl_tables[spl_idx];
          cache_assert_free(spl->cc);
-         trunk_print_lookup_stats(spl);
-         cache_print_stats(spl->cc);
+         trunk_print_lookup_stats(Platform_default_log_handle, spl);
+         cache_print_stats(Platform_default_log_handle, spl->cc);
          cache_reset_stats(spl->cc);
       }
 
@@ -1507,15 +1522,16 @@ test_splinter_periodic(trunk_config    *cfg,
 
       rc = STATUS_OK;
 
-      platform_log("\nper-splinter per-thread range time per tuple %lu ns\n",
-                   total_time * num_range_threads / total_ranges);
-      platform_log("splinter total range rate: %lu ops/second\n",
-                   SEC_TO_NSEC(total_ranges) / total_time);
+      platform_default_log(
+         "\nper-splinter per-thread range time per tuple %lu ns\n",
+         total_time * num_range_threads / total_ranges);
+      platform_default_log("splinter total range rate: %lu ops/second\n",
+                           SEC_TO_NSEC(total_ranges) / total_time);
       for (uint8 spl_idx = 0; spl_idx < num_tables; spl_idx++) {
          trunk_handle *spl = spl_tables[spl_idx];
          cache_assert_free(spl->cc);
-         trunk_print_lookup_stats(spl);
-         cache_print_stats(spl->cc);
+         trunk_print_lookup_stats(Platform_default_log_handle, spl);
+         cache_print_stats(Platform_default_log_handle, spl->cc);
          cache_reset_stats(spl->cc);
       }
 
@@ -1562,24 +1578,25 @@ test_splinter_periodic(trunk_config    *cfg,
 
       rc = STATUS_OK;
 
-      platform_log("\nper-splinter per-thread range time per tuple %lu ns\n",
-                   total_time * num_range_threads / total_ranges);
-      platform_log("splinter total range rate: %lu ops/second\n",
-                   SEC_TO_NSEC(total_ranges) / total_time);
+      platform_default_log(
+         "\nper-splinter per-thread range time per tuple %lu ns\n",
+         total_time * num_range_threads / total_ranges);
+      platform_default_log("splinter total range rate: %lu ops/second\n",
+                           SEC_TO_NSEC(total_ranges) / total_time);
       for (uint8 spl_idx = 0; spl_idx < num_tables; spl_idx++) {
          trunk_handle *spl = spl_tables[spl_idx];
          cache_assert_free(spl->cc);
-         trunk_print_lookup_stats(spl);
-         cache_print_stats(spl->cc);
+         trunk_print_lookup_stats(Platform_default_log_handle, spl);
+         cache_print_stats(Platform_default_log_handle, spl->cc);
          cache_reset_stats(spl->cc);
       }
    }
 
 destroy_splinter:
    test_trunk_destroy_tables(spl_tables, hid, num_tables);
-   platform_log("After destroy:\n");
+   platform_default_log("After destroy:\n");
    for (uint8 idx = 0; idx < num_caches; idx++) {
-      cache_print_stats(cc[idx]);
+      cache_print_stats(Platform_default_log_handle, cc[idx]);
    }
    platform_free(hid, params);
    platform_free(hid, curr_op);
@@ -1603,7 +1620,7 @@ test_splinter_parallel_perf(trunk_config    *cfg,
                             uint8            num_tables,
                             uint8            num_caches)
 {
-   platform_log(
+   platform_default_log(
       "splinter_test: SplinterDB parallel performance test started with "
       "%d tables\n",
       num_tables);
@@ -1716,20 +1733,22 @@ test_splinter_parallel_perf(trunk_config    *cfg,
    }
 
    if (num_threads > 0) {
-      platform_log("\nper-splinter per-thread insert time per tuple %lu ns\n",
-                   total_time * num_threads / total_inserts);
-      platform_log("splinter total insertion rate: %lu insertions/second\n",
-                   SEC_TO_NSEC(total_inserts) / total_time);
-      platform_log("splinter pure insertion rate: %lu insertions/second\n",
-                   SEC_TO_NSEC(total_inserts) / total_insert_duration
-                      * num_threads);
-      platform_log("splinter max insert latency: %lu msec\n",
-                   NSEC_TO_MSEC(insert_latency_max));
+      platform_default_log(
+         "\nper-splinter per-thread insert time per tuple %lu ns\n",
+         total_time * num_threads / total_inserts);
+      platform_default_log(
+         "splinter total insertion rate: %lu insertions/second\n",
+         SEC_TO_NSEC(total_inserts) / total_time);
+      platform_default_log(
+         "splinter pure insertion rate: %lu insertions/second\n",
+         SEC_TO_NSEC(total_inserts) / total_insert_duration * num_threads);
+      platform_default_log("splinter max insert latency: %lu msec\n",
+                           NSEC_TO_MSEC(insert_latency_max));
    }
 
    for (uint8 spl_idx = 0; spl_idx < num_tables; spl_idx++) {
       trunk_handle *spl = spl_tables[spl_idx];
-      trunk_print_insertion_stats(spl);
+      trunk_print_insertion_stats(Platform_default_log_handle, spl);
    }
 
    if (num_threads > 0) {
@@ -1737,34 +1756,37 @@ test_splinter_parallel_perf(trunk_config    *cfg,
          total_async_lookups_found + total_async_lookups_not_found;
       uint64 total_lookups = total_sync_lookups_found
                              + total_sync_lookups_not_found + num_async_lookups;
-      platform_log("\nper-splinter per-thread lookup time per tuple %lu ns\n",
-                   total_time * num_threads / total_lookups);
-      platform_log("splinter total lookup rate: %lu lookups/second\n",
-                   SEC_TO_NSEC(total_lookups) / total_time);
-      platform_log("splinter total lookup found: (sync=%lu, async=%lu)\n",
-                   total_sync_lookups_found,
-                   total_async_lookups_found);
-      platform_log("splinter total lookup not found: (sync=%lu, async=%lu)\n",
-                   total_sync_lookups_not_found,
-                   total_async_lookups_not_found);
-      platform_log("%lu%% lookups were async\n",
-                   num_async_lookups * 100 / total_lookups);
-      platform_log("max lookup latency ns (sync=%lu, async=%lu)\n",
-                   sync_lookup_latency_max,
-                   async_lookup_latency_max);
+      platform_default_log(
+         "\nper-splinter per-thread lookup time per tuple %lu ns\n",
+         total_time * num_threads / total_lookups);
+      platform_default_log("splinter total lookup rate: %lu lookups/second\n",
+                           SEC_TO_NSEC(total_lookups) / total_time);
+      platform_default_log(
+         "splinter total lookup found: (sync=%lu, async=%lu)\n",
+         total_sync_lookups_found,
+         total_async_lookups_found);
+      platform_default_log(
+         "splinter total lookup not found: (sync=%lu, async=%lu)\n",
+         total_sync_lookups_not_found,
+         total_async_lookups_not_found);
+      platform_default_log("%lu%% lookups were async\n",
+                           num_async_lookups * 100 / total_lookups);
+      platform_default_log("max lookup latency ns (sync=%lu, async=%lu)\n",
+                           sync_lookup_latency_max,
+                           async_lookup_latency_max);
       for (uint8 spl_idx = 0; spl_idx < num_tables; spl_idx++) {
          trunk_handle *spl = spl_tables[spl_idx];
-         trunk_print_lookup_stats(spl);
-         cache_print_stats(spl->cc);
+         trunk_print_lookup_stats(Platform_default_log_handle, spl);
+         cache_print_stats(Platform_default_log_handle, spl->cc);
          cache_reset_stats(spl->cc);
       }
    }
 
 destroy_splinter:
    test_trunk_destroy_tables(spl_tables, hid, num_tables);
-   platform_log("After destroy:\n");
+   platform_default_log("After destroy:\n");
    for (uint8 idx = 0; idx < num_caches; idx++) {
-      cache_print_stats(cc[idx]);
+      cache_print_stats(Platform_default_log_handle, cc[idx]);
    }
    platform_free(hid, params);
    platform_free(hid, curr_insert_op);
@@ -1786,9 +1808,9 @@ test_splinter_delete(trunk_config    *cfg,
                      uint8            num_caches,
                      uint64           insert_rate)
 {
-   platform_log("splinter_test: SplinterDB deletion test started with "
-                "%d tables\n",
-                num_tables);
+   platform_default_log("splinter_test: SplinterDB deletion test started with "
+                        "%d tables\n",
+                        num_tables);
    trunk_handle  **spl_tables;
    platform_status rc;
 
@@ -1856,15 +1878,17 @@ test_splinter_delete(trunk_config    *cfg,
    }
 
    total_time = platform_timestamp_elapsed(start_time);
-   platform_log("\nper-splinter per-thread insert time per tuple %lu ns\n",
-                total_time * num_insert_threads / total_inserts);
-   platform_log("splinter total insertion rate: %lu insertions/second\n",
-                SEC_TO_NSEC(total_inserts) / total_time);
-   platform_log("After inserts:\n");
+   platform_default_log(
+      "\nper-splinter per-thread insert time per tuple %lu ns\n",
+      total_time * num_insert_threads / total_inserts);
+   platform_default_log(
+      "splinter total insertion rate: %lu insertions/second\n",
+      SEC_TO_NSEC(total_inserts) / total_time);
+   platform_default_log("After inserts:\n");
    for (uint8 spl_idx = 0; spl_idx < num_tables; spl_idx++) {
       trunk_handle *spl = spl_tables[spl_idx];
-      trunk_print_insertion_stats(spl);
-      cache_print_stats(spl->cc);
+      trunk_print_insertion_stats(Platform_default_log_handle, spl);
+      cache_print_stats(Platform_default_log_handle, spl->cc);
    }
 
    for (uint64 i = 0; i < num_insert_threads; i++) {
@@ -1897,23 +1921,24 @@ test_splinter_delete(trunk_config    *cfg,
       platform_thread_join(params[i].thread);
 
    total_time = platform_timestamp_elapsed(start_time);
-   platform_log("\nper-splinter per-thread delete time per tuple %lu ns\n",
-                total_time * num_insert_threads / total_inserts);
-   platform_log("splinter total deletion rate: %lu insertions/second\n",
-                SEC_TO_NSEC(total_inserts) / total_time);
-   platform_log("After deletes:\n");
+   platform_default_log(
+      "\nper-splinter per-thread delete time per tuple %lu ns\n",
+      total_time * num_insert_threads / total_inserts);
+   platform_default_log("splinter total deletion rate: %lu insertions/second\n",
+                        SEC_TO_NSEC(total_inserts) / total_time);
+   platform_default_log("After deletes:\n");
    for (uint8 spl_idx = 0; spl_idx < num_tables; spl_idx++) {
       trunk_handle *spl = spl_tables[spl_idx];
-      trunk_print_insertion_stats(spl);
-      cache_print_stats(spl->cc);
+      trunk_print_insertion_stats(Platform_default_log_handle, spl);
+      cache_print_stats(Platform_default_log_handle, spl->cc);
    }
 
    for (uint8 spl_idx = 0; spl_idx < num_tables; spl_idx++) {
       trunk_handle *spl = spl_tables[spl_idx];
       trunk_force_flush(spl);
-      platform_log("After flushing table %d:\n", spl_idx);
-      trunk_print_insertion_stats(spl);
-      cache_print_stats(spl->cc);
+      platform_default_log("After flushing table %d:\n", spl_idx);
+      trunk_print_insertion_stats(Platform_default_log_handle, spl);
+      cache_print_stats(Platform_default_log_handle, spl->cc);
    }
 
    for (uint64 i = 0; i < num_insert_threads; i++) {
@@ -1973,23 +1998,24 @@ test_splinter_delete(trunk_config    *cfg,
 
    rc = STATUS_OK;
 
-   platform_log("\nper-splinter per-thread lookup time per tuple %lu ns\n",
-                total_time * num_lookup_threads / total_inserts);
-   platform_log("splinter total lookup rate: %lu lookups/second\n",
-                SEC_TO_NSEC(total_inserts) / total_time);
-   platform_log("%lu%% lookups were async\n",
-                num_async_lookups * 100 / total_inserts);
+   platform_default_log(
+      "\nper-splinter per-thread lookup time per tuple %lu ns\n",
+      total_time * num_lookup_threads / total_inserts);
+   platform_default_log("splinter total lookup rate: %lu lookups/second\n",
+                        SEC_TO_NSEC(total_inserts) / total_time);
+   platform_default_log("%lu%% lookups were async\n",
+                        num_async_lookups * 100 / total_inserts);
    for (uint8 spl_idx = 0; spl_idx < num_tables; spl_idx++) {
       trunk_handle *spl = spl_tables[spl_idx];
-      trunk_print_lookup_stats(spl);
-      cache_print_stats(spl->cc);
+      trunk_print_lookup_stats(Platform_default_log_handle, spl);
+      cache_print_stats(Platform_default_log_handle, spl->cc);
    }
 
 destroy_splinter:
    test_trunk_destroy_tables(spl_tables, hid, num_tables);
-   platform_log("After destroy:\n");
+   platform_default_log("After destroy:\n");
    for (uint8 idx = 0; idx < num_caches; idx++) {
-      cache_print_stats(cc[idx]);
+      cache_print_stats(Platform_default_log_handle, cc[idx]);
    }
    platform_free(hid, params);
    platform_free(hid, curr_op);
@@ -2394,13 +2420,14 @@ splinter_test(int argc, char *argv[])
    // Check if IO subsystem has enough reqs for max async IOs inflight
    if (io_cfg.async_queue_size < total_threads * max_async_inflight) {
       io_cfg.async_queue_size = ROUNDUP(total_threads * max_async_inflight, 32);
-      platform_log("Bumped up IO queue size to %lu\n", io_cfg.async_queue_size);
+      platform_default_log("Bumped up IO queue size to %lu\n",
+                           io_cfg.async_queue_size);
    }
    if (io_cfg.kernel_queue_size < total_threads * max_async_inflight) {
       io_cfg.kernel_queue_size =
          ROUNDUP(total_threads * max_async_inflight, 32);
-      platform_log("Bumped up IO queue size to %lu\n",
-                   io_cfg.kernel_queue_size);
+      platform_default_log("Bumped up IO queue size to %lu\n",
+                           io_cfg.kernel_queue_size);
    }
 
    platform_io_handle *io = TYPED_MALLOC(hid, io);

--- a/tests/functional/test.h
+++ b/tests/functional/test.h
@@ -248,7 +248,9 @@ test_config_init(trunk_config           *splinter_cfg,  // OUT
                      master_cfg->filter_index_size,
                      master_cfg->reclaim_threshold,
                      master_cfg->use_log,
-                     master_cfg->use_stats);
+                     master_cfg->use_stats,
+                     master_cfg->verbose_logging_enabled,
+                     master_cfg->log_handle);
 
    gen->type             = MESSAGE_TYPE_INSERT;
    gen->min_payload_size = GENERATOR_MIN_PAYLOAD_SIZE;

--- a/tests/functional/test_dispatcher.c
+++ b/tests/functional/test_dispatcher.c
@@ -26,12 +26,12 @@ usage(void)
 int
 test_dispatcher(int argc, char *argv[])
 {
-   platform_log("%s: %s\n", argv[0], BUILD_VERSION);
+   platform_default_log("%s: %s\n", argv[0], BUILD_VERSION);
    // check first arg and call the appropriate test
    if (argc > 1) {
       // check test name and dispatch
       char *test_name = argv[1];
-      platform_log("Dispatch test %s\n", test_name);
+      platform_default_log("Dispatch test %s\n", test_name);
 
       if (STRING_EQUALS_LITERAL(test_name, "btree_test")) {
          return btree_test(argc - 1, &argv[1]);

--- a/tests/functional/test_splinter_shadow.c
+++ b/tests/functional/test_splinter_shadow.c
@@ -103,7 +103,7 @@ test_splinter_shadow_create(test_splinter_shadow_tree **tree,
    test_splinter_shadow_tree *shadow = TYPED_ZALLOC(hid, shadow);
 
    if (shadow == NULL) {
-      platform_log("Failed to allocate memory for shadow init");
+      platform_default_log("Failed to allocate memory for shadow init");
       return STATUS_NO_MEMORY;
    }
 
@@ -118,7 +118,7 @@ test_splinter_shadow_create(test_splinter_shadow_tree **tree,
                              hh,
                              platform_get_module_id());
    if (shadow->nodes_buffer == NULL) {
-      platform_log("Failed to pre allocate nodes for shadow tree\n");
+      platform_default_log("Failed to pre allocate nodes for shadow tree\n");
       platform_free(hid, shadow);
       return STATUS_NO_MEMORY;
    }
@@ -338,7 +338,7 @@ test_splinter_build_shadow_array(test_splinter_shadow_tree  *tree,
    shadow_array->buffer =
       platform_buffer_create(totalBufferSize, hh, platform_get_module_id());
    if (shadow_array->buffer == NULL) {
-      platform_log("Failed to allocate memory for shadow array\n");
+      platform_default_log("Failed to allocate memory for shadow array\n");
       return STATUS_NO_MEMORY;
    }
    shadow_array->keys = platform_buffer_getaddr(shadow_array->buffer);

--- a/tests/functional/ycsb_test.c
+++ b/tests/functional/ycsb_test.c
@@ -177,20 +177,21 @@ latency_percentile(latency_table table, float percent)
 }
 
 void
-print_latency_table(platform_stream_handle stream, latency_table table)
+print_latency_table(latency_table table, platform_log_handle *log_handle)
 {
    uint64_t exponent;
    uint64_t mantissa;
    bool     started = 0;
    uint64_t max     = max_latency(table);
 
-   platform_log_stream("latency count\n");
+   platform_log(log_handle, "latency count\n");
    for (exponent = 0; exponent < LATENCY_EXPONENT_LIMIT; exponent++)
       for (mantissa = 0; mantissa < LATENCY_MANTISSA_LIMIT; mantissa++)
          if (started || table[exponent][mantissa]) {
-            platform_log_stream("%20lu %20lu\n",
-                                compute_latency(exponent, mantissa),
-                                table[exponent][mantissa]);
+            platform_log(log_handle,
+                         "%20lu %20lu\n",
+                         compute_latency(exponent, mantissa),
+                         table[exponent][mantissa]);
             started = 1;
             if (max == compute_latency(exponent, mantissa))
                return;
@@ -202,12 +203,12 @@ write_latency_table(char *filename, latency_table table)
 {
    FILE *stream = fopen(filename, "w");
    platform_assert(stream != NULL);
-   print_latency_table(stream, table);
+   print_latency_table(table, stream);
    fclose(stream);
 }
 
 void
-print_latency_cdf(platform_stream_handle stream, latency_table table)
+print_latency_cdf(platform_log_handle *log_handle, latency_table table)
 {
    uint64_t count_so_far = 0;
    uint64_t exponent;
@@ -217,14 +218,15 @@ print_latency_cdf(platform_stream_handle stream, latency_table table)
    if (total == 0)
       total = 1;
 
-   platform_log_stream("latency count\n");
+   platform_log(log_handle, "latency count\n");
    for (exponent = 0; exponent < LATENCY_EXPONENT_LIMIT; exponent++)
       for (mantissa = 0; mantissa < LATENCY_MANTISSA_LIMIT; mantissa++) {
          count_so_far += table[exponent][mantissa];
          if (count_so_far)
-            platform_log_stream("%20lu %f\n",
-                                compute_latency(exponent, mantissa),
-                                1.0 * count_so_far / total);
+            platform_log(log_handle,
+                         "%20lu %f\n",
+                         compute_latency(exponent, mantissa),
+                         1.0 * count_so_far / total);
          if (count_so_far == total)
             return;
       }
@@ -343,7 +345,7 @@ ycsb_thread(void *arg)
                // if (!ops->found) {
                //   char key_str[128];
                //   trunk_key_to_string(spl, ops->key, key_str);
-               //   platform_log("Key %s not found\n", key_str);
+               //   platform_default_log("Key %s not found\n", key_str);
                //   trunk_print_lookup(spl, ops->key);
                //   platform_assert(0);
                //}
@@ -508,15 +510,15 @@ run_all_ycsb_phases(trunk_handle    *spl,
 {
    uint64 i;
    for (i = 0; i < nphases; i++) {
-      platform_log("Beginning phase %lu\n", i);
+      platform_default_log("Beginning phase %lu\n", i);
       if (run_ycsb_phase(spl, &phase[i], ts, hid) < 0)
          return -1;
-      trunk_print_insertion_stats(spl);
-      trunk_print_lookup_stats(spl);
-      cache_print_stats(spl->cc);
+      trunk_print_insertion_stats(Platform_default_log_handle, spl);
+      trunk_print_lookup_stats(Platform_default_log_handle, spl);
+      cache_print_stats(Platform_default_log_handle, spl->cc);
       // trunk_reset_stats(spl);
       cache_reset_stats(spl->cc);
-      platform_log("Phase %s complete\n", phase[i].name);
+      platform_default_log("Phase %s complete\n", phase[i].name);
    }
    return 0;
 }
@@ -545,7 +547,7 @@ parse_ycsb_log_file(void *arg)
    char *filename = req->filename;
    FILE *fp       = fopen(filename, "r");
    if (fp == NULL) {
-      platform_log("failed to open file\n");
+      platform_default_log("failed to open file\n");
       *req->ycsb_ops = NULL;
       return;
    }
@@ -1016,73 +1018,72 @@ write_phase_latency_tables(ycsb_phase *phase)
 }
 
 void
-print_operation_statistics(platform_log_handle output,
-                           char               *operation_name,
-                           latency_table       table)
+print_operation_statistics(platform_log_handle *output,
+                           char                *operation_name,
+                           latency_table        table)
 {
-   platform_handle_log(
+   platform_log(
       output, "%s_count: %lu\n", operation_name, num_latencies(table));
-   platform_handle_log(
+   platform_log(
       output, "%s_total_latency: %lu\n", operation_name, total_latency(table));
-   platform_handle_log(
+   platform_log(
       output, "%s_min_latency: %lu\n", operation_name, min_latency(table));
-   platform_handle_log(
+   platform_log(
       output, "%s_mean_latency: %lf\n", operation_name, mean_latency(table));
-   platform_handle_log(output,
-                       "%s_median_latency: %lu\n",
-                       operation_name,
-                       latency_percentile(table, 50.0));
-   platform_handle_log(output,
-                       "%s_99.0_latency: %lu\n",
-                       operation_name,
-                       latency_percentile(table, 99));
-   platform_handle_log(output,
-                       "%s_99.5_latency: %lu\n",
-                       operation_name,
-                       latency_percentile(table, 99.5));
-   platform_handle_log(output,
-                       "%s_99.9_latency: %lu\n",
-                       operation_name,
-                       latency_percentile(table, 99.9));
-   platform_handle_log(
+   platform_log(output,
+                "%s_median_latency: %lu\n",
+                operation_name,
+                latency_percentile(table, 50.0));
+   platform_log(output,
+                "%s_99.0_latency: %lu\n",
+                operation_name,
+                latency_percentile(table, 99));
+   platform_log(output,
+                "%s_99.5_latency: %lu\n",
+                operation_name,
+                latency_percentile(table, 99.5));
+   platform_log(output,
+                "%s_99.9_latency: %lu\n",
+                operation_name,
+                latency_percentile(table, 99.9));
+   platform_log(
       output, "%s_max_latency: %lu\n", operation_name, max_latency(table));
 
-   platform_handle_log(
+   platform_log(
       output, "%s_000_latency: %lu\n", operation_name, min_latency(table));
    int i;
    for (i = 5; i < 100; i += 5) {
-      platform_handle_log(output,
-                          "%s_%03d_latency: %lu\n",
-                          operation_name,
-                          i,
-                          latency_percentile(table, i));
+      platform_log(output,
+                   "%s_%03d_latency: %lu\n",
+                   operation_name,
+                   i,
+                   latency_percentile(table, i));
    }
-   platform_handle_log(
+   platform_log(
       output, "%s_100_latency: %lu\n", operation_name, max_latency(table));
 }
 
 void
-print_statistics_file(platform_log_handle output,
-                      uint64_t            total_ops,
-                      running_times      *times,
-                      latency_tables     *tables)
+print_statistics_file(platform_log_handle *output,
+                      uint64_t             total_ops,
+                      running_times       *times,
+                      latency_tables      *tables)
 {
    uint64_t wall_clock_time =
       times->last_thread_finish_time - times->earliest_thread_start_time;
-   platform_handle_log(output, "total_operations: %lu\n", total_ops);
-   platform_handle_log(output, "wall_clock_time: %lu\n", wall_clock_time);
-   platform_handle_log(
+   platform_log(output, "total_operations: %lu\n", total_ops);
+   platform_log(output, "wall_clock_time: %lu\n", wall_clock_time);
+   platform_log(
       output, "sum_of_wall_clock_times: %lu\n", times->sum_of_wall_clock_times);
-   platform_handle_log(
-      output, "sum_of_cpu_times: %ld\n", times->sum_of_cpu_times);
-   platform_handle_log(
-      output,
-      "mean_overall_latency: %f\n",
-      total_ops ? 1.0 * times->sum_of_wall_clock_times / total_ops : 0);
-   platform_handle_log(
-      output,
-      "mean_overall_throughput: %f\n",
-      wall_clock_time ? 1000000000.0 * total_ops / wall_clock_time : 0);
+   platform_log(output, "sum_of_cpu_times: %ld\n", times->sum_of_cpu_times);
+   platform_log(output,
+                "mean_overall_latency: %f\n",
+                total_ops ? 1.0 * times->sum_of_wall_clock_times / total_ops
+                          : 0);
+   platform_log(output,
+                "mean_overall_throughput: %f\n",
+                wall_clock_time ? 1000000000.0 * total_ops / wall_clock_time
+                                : 0);
 
    print_operation_statistics(output, "pos_query", tables->pos_queries);
    print_operation_statistics(output, "neg_query", tables->neg_queries);
@@ -1167,10 +1168,10 @@ ycsb_test(int argc, char *argv[])
                        &log_size_bytes,
                        &memory_bytes);
    if (!SUCCESS(rc) || phases == NULL) {
-      platform_log("Failed to load ycsb logs\n");
+      platform_default_log("Failed to load ycsb logs\n");
       return -1;
    }
-   platform_log("Log size: %luMiB\n", B_TO_MiB(log_size_bytes));
+   platform_default_log("Log size: %luMiB\n", B_TO_MiB(log_size_bytes));
 
    config_argc = argc - args_consumed;
    config_argv = argv + args_consumed;
@@ -1220,9 +1221,9 @@ ycsb_test(int argc, char *argv[])
    // int64 buffer_bytes = use_existing ? MiB_TO_B(768) : MiB_TO_B(1280);
    buffer_bytes += overhead_bytes;
    buffer_bytes = ROUNDUP(buffer_bytes, 2 * MiB);
-   platform_log("overhead %lu MiB buffer %lu MiB\n",
-                B_TO_MiB(overhead_bytes),
-                B_TO_MiB(buffer_bytes));
+   platform_default_log("overhead %lu MiB buffer %lu MiB\n",
+                        B_TO_MiB(overhead_bytes),
+                        B_TO_MiB(buffer_bytes));
    cache_cfg.capacity      = memory_bytes - buffer_bytes;
    cache_cfg.page_capacity = cache_cfg.capacity / cache_cfg.io_cfg->page_size;
 
@@ -1234,10 +1235,10 @@ ycsb_test(int argc, char *argv[])
    // uint64 huge_tlb_pages = huge_tlb_memory_bytes / (2 * MiB);
    // uint64 remaining_memory_bytes =
    //   memory_bytes + log_size_bytes - huge_tlb_memory_bytes;
-   platform_log("memory: %lu MiB hugeTLB: %lu MiB cache: %lu MiB\n",
-                B_TO_MiB(memory_bytes),
-                B_TO_MiB(huge_tlb_memory_bytes),
-                B_TO_MiB(cache_cfg.capacity));
+   platform_default_log("memory: %lu MiB hugeTLB: %lu MiB cache: %lu MiB\n",
+                        B_TO_MiB(memory_bytes),
+                        B_TO_MiB(huge_tlb_memory_bytes),
+                        B_TO_MiB(cache_cfg.capacity));
 
    // char *resize_cgroup_command =
    //   TYPED_ARRAY_MALLOC(hid, resize_cgroup_command, 1024);
@@ -1345,9 +1346,9 @@ ycsb_test(int argc, char *argv[])
    // struct rusage usage;
    // sys_rc = getrusage(RUSAGE_SELF, &usage);
    // platform_assert(sys_rc == 0);
-   // platform_log("max memory usage:             %8luMiB\n",
+   // platform_default_log("max memory usage:             %8luMiB\n",
    //      B_TO_MiB(usage.ru_maxrss * KiB));
-   // platform_log("over provision for op buffer: %8luMiB\n",
+   // platform_default_log("over provision for op buffer: %8luMiB\n",
    //      B_TO_MiB(usage.ru_maxrss * KiB - log_size_bytes));
 
    compute_all_report_data(phases, nphases);

--- a/tests/test_common.c
+++ b/tests/test_common.c
@@ -31,14 +31,13 @@ verify_tuple(trunk_handle           *spl,
    if (message_is_null(data) != !expected_found) {
       char key_str[128];
       trunk_key_to_string(spl, key, key_str);
-      platform_handle_log(stderr,
-                          "(%2lu) key %lu (%s): found %d (expected:%d)\n",
-                          platform_get_tid(),
-                          lookup_num,
-                          key_str,
-                          !message_is_null(data),
-                          expected_found);
-      trunk_print_lookup(spl, key);
+      platform_error_log("(%2lu) key %lu (%s): found %d (expected:%d)\n",
+                         platform_get_tid(),
+                         lookup_num,
+                         key_str,
+                         !message_is_null(data),
+                         expected_found);
+      trunk_print_lookup(spl, key, Platform_error_log_handle);
       platform_assert(FALSE);
    }
 
@@ -50,10 +49,10 @@ verify_tuple(trunk_handle           *spl,
       if (message_lex_cmp(merge_accumulator_to_message(&expected_msg), data)
           != 0) {
          trunk_message_to_string(spl, data, data_str);
-         platform_handle_log(stderr, "key found with data: %s\n", data_str);
+         platform_error_log("key found with data: %s\n", data_str);
          trunk_message_to_string(
             spl, merge_accumulator_to_message(&expected_msg), data_str);
-         platform_handle_log(stderr, "expected data: %s\n", data_str);
+         platform_error_log("expected data: %s\n", data_str);
          platform_assert(FALSE);
       }
    }

--- a/tests/test_data.h
+++ b/tests/test_data.h
@@ -21,10 +21,14 @@ test_data_generate_message(const data_config *cfg,
                            merge_accumulator *msg);
 
 static inline void
-test_data_print_key(const void *key)
+test_data_print_key(const void *key, platform_log_handle *log_handle)
 {
    const uint64 *key_p = key;
-   platform_log("0x%016lx%016lx%016lx", be64toh(key_p[0]), key_p[1], key_p[2]);
+   platform_log(log_handle,
+                "0x%016lx%016lx%016lx",
+                be64toh(key_p[0]),
+                key_p[1],
+                key_p[2]);
 }
 
 #endif

--- a/tests/unit/btree_stress_test.c
+++ b/tests/unit/btree_stress_test.c
@@ -237,10 +237,10 @@ CTEST2(btree_stress, test_random_inserts_concurrent)
    if (!iterator_tests(
           (cache *)&data->cc, &data->dbtree_cfg, root_addr, nkvs, data->hid))
    {
-      platform_log("invalid ranges in original tree\n");
+      platform_default_log("invalid ranges in original tree\n");
    }
 
-   /* platform_log("\n\n\n"); */
+   /* platform_default_log("\n\n\n"); */
    /* btree_print_tree((cache *)&cc, &dbtree_cfg, root_addr); */
 
    uint64 packed_root_addr = pack_tests(
@@ -249,10 +249,10 @@ CTEST2(btree_stress, test_random_inserts_concurrent)
       ASSERT_TRUE(FALSE, "Pack failed.\n");
    }
 
-   /* platform_log("\n\n\n"); */
+   /* platform_default_log("\n\n\n"); */
    /* btree_print_tree((cache *)&cc, &dbtree_cfg,
     * packed_root_addr); */
-   /* platform_log("\n\n\n"); */
+   /* platform_default_log("\n\n\n"); */
 
    rc = query_tests((cache *)&data->cc,
                     &data->dbtree_cfg,
@@ -496,7 +496,7 @@ pack_tests(cache           *cc,
    if (!SUCCESS(btree_pack(&req))) {
       ASSERT_TRUE(FALSE, "Pack failed! req.num_tuples = %d\n", req.num_tuples);
    } else {
-      platform_log("Packed %lu items ", req.num_tuples);
+      platform_default_log("Packed %lu items ", req.num_tuples);
    }
 
    btree_pack_req_deinit(&req, hid);

--- a/tests/unit/btree_test.c
+++ b/tests/unit/btree_test.c
@@ -412,14 +412,14 @@ leaf_split_tests(btree_config    *cfg,
       bool success = btree_leaf_incorporate_tuple(
          cfg, scratch, hdr, key, bigger_msg, &spec, &generation);
       if (success) {
-         btree_print_locked_node(cfg, 0, hdr, PLATFORM_ERR_LOG_HANDLE);
+         btree_print_locked_node(Platform_error_log_handle, cfg, 0, hdr);
          ASSERT_FALSE(success,
                       "Weird.  An incorporate that was supposed to fail "
                       "actually succeeded (nkvs=%d, realnkvs=%d, i=%d).\n",
                       nkvs,
                       realnkvs,
                       i);
-         btree_print_locked_node(cfg, 0, hdr, PLATFORM_ERR_LOG_HANDLE);
+         btree_print_locked_node(Platform_error_log_handle, cfg, 0, hdr);
          ASSERT_FALSE(success);
       }
       leaf_splitting_plan plan =

--- a/tests/unit/splinter_test.c
+++ b/tests/unit/splinter_test.c
@@ -111,8 +111,8 @@ CTEST_DATA(splinter)
 // clang-format off
 CTEST_SETUP(splinter)
 {
-   Platform_stdout_fh = fopen("/tmp/unit_test.stdout", "a+");
-   Platform_stderr_fh = fopen("/tmp/unit_test.stderr", "a+");
+   Platform_default_log_handle = fopen("/tmp/unit_test.stdout", "a+");
+   Platform_error_log_handle = fopen("/tmp/unit_test.stderr", "a+");
 
    // Defaults: For basic unit-tests, use single threads
    data->num_insert_threads = 1;
@@ -169,12 +169,12 @@ CTEST_SETUP(splinter)
    io_config * io_cfgp = &data->io_cfg;
    if (io_cfgp->async_queue_size < total_threads * data->max_async_inflight) {
       io_cfgp->async_queue_size = ROUNDUP(total_threads * data->max_async_inflight, 32);
-      platform_log("Bumped up IO queue size to %lu\n", io_cfgp->async_queue_size);
+      platform_default_log("Bumped up IO queue size to %lu\n", io_cfgp->async_queue_size);
    }
    if (io_cfgp->kernel_queue_size < total_threads * data->max_async_inflight) {
       io_cfgp->kernel_queue_size =
          ROUNDUP(total_threads * data->max_async_inflight, 32);
-      platform_log("Bumped up IO queue size to %lu\n",
+      platform_default_log("Bumped up IO queue size to %lu\n",
                    io_cfgp->kernel_queue_size);
    }
 
@@ -764,8 +764,9 @@ shadow_check_tuple_func(slice key, message value, void *varg)
       trunk_message_to_string(arg->spl, shadow_value, expected_value);
       trunk_message_to_string(arg->spl, value, actual_value);
 
-      platform_log("expected: '%s' | '%s'\n", expected_key, expected_value);
-      platform_log("actual  : '%s' | '%s'\n", actual_key, actual_value);
+      platform_default_log(
+         "expected: '%s' | '%s'\n", expected_key, expected_value);
+      platform_default_log("actual  : '%s' | '%s'\n", actual_key, actual_value);
       arg->errors++;
    }
 

--- a/tests/unit/splinterdb_quick_test.c
+++ b/tests/unit/splinterdb_quick_test.c
@@ -99,8 +99,8 @@ CTEST_DATA(splinterdb_quick)
 // Optional setup function for suite, called before every test in suite
 CTEST_SETUP(splinterdb_quick)
 {
-   Platform_stdout_fh = fopen("/tmp/unit_test.stdout", "a+");
-   Platform_stderr_fh = fopen("/tmp/unit_test.stderr", "a+");
+   Platform_default_log_handle = fopen("/tmp/unit_test.stdout", "a+");
+   Platform_error_log_handle   = fopen("/tmp/unit_test.stderr", "a+");
 
    default_data_config_init(TEST_MAX_KEY_SIZE, &data->default_data_cfg.super);
    create_default_cfg(&data->cfg, &data->default_data_cfg.super);

--- a/tests/unit/splinterdb_stress_test.c
+++ b/tests/unit/splinterdb_stress_test.c
@@ -48,8 +48,8 @@ CTEST_DATA(splinterdb_stress)
 // Setup function for suite, called before every test in suite
 CTEST_SETUP(splinterdb_stress)
 {
-   Platform_stdout_fh = fopen("/tmp/unit_test.stdout", "a+");
-   Platform_stderr_fh = fopen("/tmp/unit_test.stderr", "a+");
+   Platform_default_log_handle = fopen("/tmp/unit_test.stdout", "a+");
+   Platform_error_log_handle   = fopen("/tmp/unit_test.stderr", "a+");
 
    data->cfg           = (splinterdb_config){.filename   = TEST_DB_NAME,
                                              .cache_size = 1000 * Mega,
@@ -120,7 +120,7 @@ CTEST2(splinterdb_stress, test_naive_range_delete)
 
    const uint32 num_inserts = 2 * 1000 * 1000;
 
-   platform_log("loading data...");
+   platform_default_log("loading data...");
    for (uint32 i = 0; i < num_inserts; i++) {
       char key_buffer[TEST_KEY_SIZE]     = {0};
       char value_buffer[TEST_VALUE_SIZE] = {0};
@@ -132,11 +132,11 @@ CTEST2(splinterdb_stress, test_naive_range_delete)
       ASSERT_EQUAL(0, rc);
    }
 
-   platform_log("loaded %u k/v pairs\n", num_inserts);
+   platform_default_log("loaded %u k/v pairs\n", num_inserts);
 
    uint32 num_rounds = 5;
    for (uint32 round = 0; round < num_rounds; round++) {
-      platform_log("range delete round %d...\n", round);
+      platform_default_log("range delete round %d...\n", round);
       char start_key_data[4];
       random_bytes(&rand_state, start_key_data, sizeof(start_key_data));
       const uint32 num_to_delete = num_inserts / num_rounds;
@@ -192,7 +192,7 @@ exec_worker_thread(void *w)
 static void
 naive_range_delete(const splinterdb *kvsb, slice start_key, uint32 count)
 {
-   platform_log("\tcollecting keys to delete...\n");
+   platform_default_log("\tcollecting keys to delete...\n");
    char *keys_to_delete = calloc(count, TEST_KEY_SIZE);
 
    splinterdb_iterator *it;
@@ -218,7 +218,7 @@ naive_range_delete(const splinterdb *kvsb, slice start_key, uint32 count)
    ASSERT_EQUAL(0, rc);
    splinterdb_iterator_deinit(it);
 
-   platform_log("\tdeleting collected keys...\n");
+   platform_default_log("\tdeleting collected keys...\n");
    for (uint32 i = 0; i < num_found; i++) {
       slice key_to_delete =
          slice_create(TEST_KEY_SIZE, keys_to_delete + i * TEST_KEY_SIZE);
@@ -226,5 +226,5 @@ naive_range_delete(const splinterdb *kvsb, slice start_key, uint32 count)
    }
 
    free(keys_to_delete);
-   platform_log("\tdeleted %u k/v pairs\n", num_found);
+   platform_default_log("\tdeleted %u k/v pairs\n", num_found);
 }


### PR DESCRIPTION
Modifies `platform_log()` to take a `platform_log_handle *` parameter. The
old functionality is now handled by `platform_default_log()`.

Changes `Platform_stdout_fh` to `Platform_default_log_handle`.
Changes `Platform_stderr_fh` to `Platform_error_log_handle`.
Removes `PLATFORM_DEFAULT_LOG_HANDLE` and `PLATFORM_ERR_LOG_HANDLE`.

Replaces many instances of `platform_log_stream` with `platform_log`.

Adds a `platform_log_handle *` parameter to `*_print_*` functions.

Adds a `platform_stream_handle` struct that holds a string, length and log handle.
Explicitly passes a stream parameter to stream printing functions.