### PR TITLE
Expand assert messages to print values involved.

### DIFF
--- a/src/rc_allocator.c
+++ b/src/rc_allocator.c
@@ -618,7 +618,10 @@ rc_allocator_alloc(rc_allocator *al,   // IN
    } while (!extent_is_free
             && (hand + 1) % al->cfg->extent_capacity != first_hand);
    if (!extent_is_free) {
-      platform_log("Out of Space: allocated %lu out of %lu addrs.\n",
+      platform_log("Out of Space, while allocating an extent of type=%d (%s):"
+                   " allocated %lu out of %lu addrs.\n",
+                   type,
+                   page_type_str[type],
                    al->stats.curr_allocated,
                    al->cfg->extent_capacity);
       return STATUS_NO_SPACE;

--- a/tests/test_data.c
+++ b/tests/test_data.c
@@ -136,7 +136,10 @@ test_data_message_class(const data_config *cfg,
                         uint64             raw_data_len,
                         const void        *raw_data)
 {
-   assert(sizeof(data_handle) <= raw_data_len);
+   platform_assert((sizeof(data_handle) <= raw_data_len),
+                   "sizeof(data_handle)=%lu, raw_data_len=%lu",
+                   sizeof(data_handle),
+                   raw_data_len);
 
    const data_handle *data = raw_data;
    switch (data->message_type) {


### PR DESCRIPTION
Minor extensions to existing assert messages to report offending values. I found these to be useful when running a larger collection of tests, where these trip. Now, the tests will still fail, but you will get some reasonable additional information.