### PR TITLE
(#309) Test splinter_test --semiseq_perf: Fix Floating point exception in test_key()

### DIFF
--- a/tests/functional/splinter_test.c
+++ b/tests/functional/splinter_test.c
@@ -118,19 +118,22 @@ test_trunk_insert_thread(void *arg)
 
    while (1) {
       for (uint8 spl_idx = 0; spl_idx < num_tables; spl_idx++) {
-         if (test_is_done(done, spl_idx))
+         if (test_is_done(done, spl_idx)) {
             continue;
-         platform_throttled_error_log(
-            DEFAULT_THROTTLE_INTERVAL_SEC,
-            PLATFORM_CR "inserting %3lu%% complete for table %u",
-            insert_base[spl_idx] / (total_ops[spl_idx] / 100),
-            spl_idx);
+         }
+         platform_default_log(PLATFORM_CR
+                              "inserting %3lu%% complete for table %u ... ",
+                              insert_base[spl_idx] / (total_ops[spl_idx] / 100),
+                              spl_idx);
          insert_base[spl_idx] =
             __sync_fetch_and_add(&curr_op[spl_idx], op_granularity);
-         if (insert_base[spl_idx] >= total_ops[spl_idx])
+         if (insert_base[spl_idx] >= total_ops[spl_idx]) {
             test_set_done(&done, spl_idx);
-         if (test_all_done(done, num_tables))
+         }
+         if (test_all_done(done, num_tables)) {
+            platform_default_log(" Test done for all %d tables.\n", num_tables);
             goto out;
+         }
       }
       for (uint64 op_offset = 0; op_offset != op_granularity; op_offset++) {
          for (uint8 spl_idx = 0; spl_idx < num_tables; spl_idx++) {
@@ -755,8 +758,8 @@ test_splinter_perf(trunk_config    *cfg,
                    uint8            num_caches,
                    uint64           insert_rate)
 {
-   platform_log("splinter_test: splinter performance test started with %d\
-                tables\n",
+   platform_log("splinter_test: splinter performance test started with %d"
+                " tables\n",
                 num_tables);
    trunk_handle  **spl_tables;
    platform_status rc;

--- a/tests/functional/test.h
+++ b/tests/functional/test.h
@@ -96,11 +96,13 @@ test_key(char         *key,
             platform_checksum64(&thread_id, sizeof(thread_id), 42) + idx);
          break;
       case TEST_SEMISEQ:
-         if (idx % semiseq_freq == 0)
+         if (idx % semiseq_freq == 0) {
             *(uint64 *)key = platform_checksum64(&idx, sizeof(idx), 42);
-         else
+         } else {
             *(uint64 *)key = htobe64(
                platform_checksum64(&thread_id, sizeof(thread_id), 42) + idx);
+         }
+         break;
       case TEST_PERIODIC:
       {
          uint64 period_idx = idx % period;


### PR DESCRIPTION
Test 'splinter_test --semiseq-perf' runs into a floating point exception,
caused by divide-by-zero. This occurs to runaway code due to a missing
'break', ending up accessing a variable that is 0, meant for TEST_PERIODIC
test execution. With this fix, above test moves ahead, to run into
issue #310.

--- With this fix, the test progresses somewhat more, to run into a known issue #310 ---

```
Fusion-LocalVM:[134] $ ./bin/driver_test splinter_test --semiseq-perf
./bin/driver_test: splinterdb_build_version 765ca3e6-dirty
Dispatch test splinter_test
fingerprint_size: 27
Running splinter_test with 1 caches
splinter_test: splinter performance test started with 1 tables
inserting   2% complete for table 0 ... Assertion failed at src/trunk.c:3665:trunk_bundle_build_filters(): "!req->should_build[i]".
```