### PR TITLE
CI-configuration changes to setup nightly (build &) test runs.

### DIFF
--- a/ci/jobs.lib.yml
+++ b/ci/jobs.lib.yml
@@ -7,7 +7,7 @@
 #@         "step_build_splinterdb_image",
 #@         "step_test_with_image",
 #@         "step_collect_tags",
-#@         "step_debug_build_test",
+#@         "step_build_test",
 #@         "step_set_pr_status",
 #@         "step_set_commit_status",
 #@         "get_task_timeout",
@@ -124,7 +124,7 @@ plan:
     passed: [ recreate-build-env ]
     trigger: true
 - #@ step_set_commit_status("pending", compiler + "-debug")
-- #@ step_debug_build_test(compiler, "branch-main")
+- #@ step_build_test(compiler, "branch-main", is_debug=True)
 
 #@ end
 
@@ -149,5 +149,28 @@ plan:
     list_changed_files: true
 - #@ step_set_pr_status(job_name, "pending", description)
 - #@ template.replace(sequence)
+#@ end
+
+---
+
+#! Release build and test run nightly, for extended testing
+#@ def job_nightly_main_build_test(compiler="gcc"):
+name: #@ "main-nightly-build-test-" + compiler
+public: true
+on_success: #@ step_set_commit_status("success", compiler + "-nightly")
+on_failure: #@ step_set_commit_status("failure", compiler + "-nightly")
+on_error: #@ step_set_commit_status("error", compiler + "-nightly")
+plan:
+- in_parallel:
+  - get: branch-main
+    trigger: false  #! Do not trigger on every push / commit
+  - get: build-env-image-latest
+    passed: [ recreate-build-env ]
+    trigger: false  #! Do not trigger on every change of the build-env
+  - get: nightly-timer
+    trigger: true  #! -Do- trigger every night
+- #@ step_set_commit_status("pending", compiler + "-nightly")
+- #@ step_build_test(compiler, "branch-main", is_debug=False, is_nightly=True)
+
 #@ end
 

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -24,6 +24,7 @@
 #@         "job_main_build_test_push",
 #@         "job_debug_main_build_test",
 #@         "job_pr_check",
+#@         "job_nightly_main_build_test",
 #@ )
 ---
 
@@ -82,6 +83,17 @@ resources:
     access_token: ((github-bot-access-token))
     base_branch: main
 
+#! Define nightly timer resource
+#! Ref: https://concourse-ci.org/time-trigger-example.html
+#! Ref: https://github.com/concourse/time-resource
+- name: nightly-timer
+  type: time
+  source:
+    start: 12:00 AM
+    stop: 1:00 AM
+    location: America/Los_Angeles
+
+#! List of jobs
 jobs:
 
 #! Create the container image that holds the build environment
@@ -94,6 +106,7 @@ jobs:
 
 - #@ job_debug_main_build_test("clang")
 - #@ job_debug_main_build_test("gcc")
+- #@ job_nightly_main_build_test("gcc")
 
 #! first stage of pipeline, runs a few quick jobs
 #@ stage_one = ["pr-quick-check", "pr-clang-format", "pr-shell-scripts"]
@@ -111,6 +124,7 @@ jobs:
 - #@ job_pr_check("asan", sequence_pr_debug_build_test("gcc", sanitize="asan"), depends_on=stage_one, description="address sanitizer")
 - #@ job_pr_check("msan", sequence_pr_debug_build_test("clang", sanitize="msan"), depends_on=stage_one, description="memory sanitizer")
 
+#! List of CI-groups of jobs
 groups:
 - name: main_branch
   jobs:
@@ -118,6 +132,7 @@ groups:
   - main-build-test-gcc
   - main-debug-build-test-clang
   - main-debug-build-test-gcc
+  - main-nightly-build-test-gcc
 
 - name: pull_requests
   jobs:

--- a/ci/sequences.lib.yml
+++ b/ci/sequences.lib.yml
@@ -4,7 +4,7 @@
 #@ load("steps.lib.yml",
 #@         "step_build_splinterdb_image",
 #@         "step_test_with_image",
-#@         "step_debug_build_test",
+#@         "step_build_test",
 #@         "get_task_timeout",
 #@ )
 
@@ -29,7 +29,7 @@
 #@ def sequence_pr_debug_build_test(compiler, quick=False, sanitize=None):
 - get: build-env-image-latest
   passed: [ recreate-build-env ]
-- #@ step_debug_build_test(compiler, "github-pull-request", quick=quick, sanitize=sanitize)
+- #@ step_build_test(compiler, "github-pull-request", is_debug=True, quick=quick, sanitize=sanitize)
 #@ end
 
 ---

--- a/ci/steps.lib.yml
+++ b/ci/steps.lib.yml
@@ -2,11 +2,13 @@
 #! SPDX-License-Identifier: Apache-2.0
 
 
-#@ def get_task_timeout(quick=False, sanitize=""):
+#@ def get_task_timeout(quick=False, sanitize="", is_nightly=False):
 #@   if sanitize:
 #@     return "3h"
 #@   elif quick:
 #@     return "5m"
+#@   elif is_nightly:
+#@     return "6h"
 #@   else:
 #@     return "1h"
 #@   end
@@ -85,9 +87,13 @@ config:
 
 ---
 
-#@ def step_debug_build_test(compiler, input_name, quick=False, sanitize=""):
+#@ def step_build_test(compiler, input_name, is_debug=True, quick=False, sanitize="", is_nightly=False):
+#@ if is_debug:
 task: debug-build-test
-timeout: #@ get_task_timeout(quick=quick, sanitize=sanitize)
+#@ else:
+task: release-build-test
+#@ end
+timeout: #@ get_task_timeout(quick=quick, sanitize=sanitize, is_nightly=is_nightly)
 image: build-env-image-latest
 config:
   platform: linux
@@ -97,6 +103,7 @@ config:
     CC: #@ compiler
     LD: #@ compiler
     INCLUDE_SLOW_TESTS: #@ str(not quick).lower()
+    RUN_NIGHTLY_TESTS: #@ str(is_nightly).lower()
     #@ if sanitize == "asan":
     DEFAULT_CFLAGS: "-fsanitize=address"
     DEFAULT_LDFLAGS: "-fsanitize=address"
@@ -111,7 +118,11 @@ config:
     dir: #@ input_name
     args:
     - "-c"
+    #@ if is_debug:
     - "make debug && ./test.sh"
+    #@ else:
+    - "make && ./test.sh"
+    #@ end
 #@ end
 
 ---

--- a/test.sh
+++ b/test.sh
@@ -74,6 +74,12 @@ set -x
 SEED="${SEED:-135}"
 
 INCLUDE_SLOW_TESTS="${INCLUDE_SLOW_TESTS:-false}"
+RUN_NIGHTLY_TESTS="${RUN_NIGHTLY_TESTS:-false}"
+
+if [ "$RUN_NIGHTLY_TESTS" == "true" ]; then
+   echo "$Me: Running nightly tests script ..."
+   exit 0
+fi
 
 set +x
 


### PR DESCRIPTION
Collection of yml changes to inject job definitions to run build and
tests on nightly basis. Stub-out call to [non-existent] nightly.sh which
will be added once these CI-configuration changes are seen to be stable.

Authored under the guidance of Gabriel Rosenhouse <grosenhouse@vmware.com>