### PR TITLE
Extend test.sh to run a small collection of stress / performance tests on nightly basis.

### DIFF
--- a/tests/functional/splinter_test.c
+++ b/tests/functional/splinter_test.c
@@ -758,8 +758,8 @@ test_splinter_perf(trunk_config    *cfg,
                    uint8            num_caches,
                    uint64           insert_rate)
 {
-   platform_log("splinter_test: splinter performance test started with %d"
-                " tables\n",
+   platform_log("splinter_test: SplinterDB performance test started with "
+                "%d tables\n",
                 num_tables);
    trunk_handle  **spl_tables;
    platform_status rc;
@@ -1152,9 +1152,10 @@ test_splinter_periodic(trunk_config    *cfg,
                        uint8            num_caches,
                        uint64           insert_rate)
 {
-   platform_log("splinter_test: splinter performance test started with %d\
-                tables\n",
-                num_tables);
+   platform_log(
+      "splinter_test: SplinterDB performance test (periodic) started with "
+      "%d tables\n",
+      num_tables);
    trunk_handle  **spl_tables;
    platform_status rc;
 
@@ -1618,9 +1619,10 @@ test_splinter_parallel_perf(trunk_config    *cfg,
                             uint8            num_tables,
                             uint8            num_caches)
 {
-   platform_log("splinter_test: splinter performance test started with %d\
-                tables\n",
-                num_tables);
+   platform_log(
+      "splinter_test: SplinterDB parallel performance test started with "
+      "%d tables\n",
+      num_tables);
    trunk_handle  **spl_tables;
    platform_status rc;
 
@@ -1803,8 +1805,8 @@ test_splinter_delete(trunk_config    *cfg,
                      uint8            num_caches,
                      uint64           insert_rate)
 {
-   platform_log("splinter_test: splinter deletion test started with %d\
-                tables\n",
+   platform_log("splinter_test: SplinterDB deletion test started with "
+                "%d tables\n",
                 num_tables);
    trunk_handle  **spl_tables;
    platform_status rc;


### PR DESCRIPTION
Extend `test.sh` to run new tests under `RUN_NIGHTLY_TESTS=true` env-var.

(Will fill out the description later ... just getting this into review.)

Status:

1. Tests passed on Nimbus-VM overnight
2. Rerunning on Fusion-VM (locally on my Mac) and on Nimbus right now.

Run outputs:

**Nimbus**:
```
      **** SplinterDB Nightly Test Suite Execution Times ****

Functionality Stress test 10 mil rows, 1 tables, 4 GiB cache                    :   71s [  0h  1m 11s ]
Functionality Stress test 10 mil rows, 2 tables, 4 GiB cache                    :  135s [  0h  2m 15s ]
Functionality Stress test 10 mil rows, 2 tables, 1 MiB cache                    :  126s [  0h  2m  6s ]
Functionality Stress test 10 mil rows, 4 tables, 1 MiB cache                    :   30s [  0h  0m 30s ]
Performance (sync) test 10 insert, 10 lookup, 5 range lookup threads            : 2056s [  0h 34m 16s ]
Parallel Performance (sync) test 10 pthreads                                    :  818s [  0h 13m 38s ]

test.sh: Fri Mar  4 16:52:30 UTC 2022 End SplinterDB Test Suite Execution.
```

**On my Fusion-VM on my Mac**:

```
      **** SplinterDB Nightly Test Suite Execution Times ****

Functionality Stress test 10 mil rows, 1 tables, 4 GiB cache                    :   44s [  0h  0m 44s ]
Functionality Stress test 10 mil rows, 2 tables, 4 GiB cache                    :   89s [  0h  1m 29s ]
Functionality Stress test 10 mil rows, 2 tables, 1 MiB cache                    :   84s [  0h  1m 24s ]
Functionality Stress test 10 mil rows, 4 tables, 1 MiB cache                    :   18s [  0h  0m 18s ]
Performance (sync) test 10 insert, 10 lookup, 5 range lookup threads            :  245s [  0h  4m  5s ]
Parallel Performance (sync) test 10 pthreads                                    : 2830s [  0h 47m 10s ]

test.sh: Fri Mar  4 16:53:33 UTC 2022 End SplinterDB Test Suite Execution.
```

**Added brief usage message**:

```
Fusion-LocalVM:[232] $ ./test.sh --help
Usage: test.sh [--help]
To run quick smoke tests        : ./test.sh
To run CI-regression tests      : INCLUDE_SLOW_TESTS=true ./test.sh
To run nightly regression tests : RUN_NIGHTLY_TESTS=true ./test.sh
```