### PR TITLE
(#308) Fix btree_test --perf checks to get it running w/min 4 GiB cache

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -383,6 +383,8 @@ run_with_timing "Cache test" bin/driver_test cache_test --seed "$SEED"
 
 run_with_timing "BTree test" bin/driver_test btree_test --seed "$SEED"
 
+run_with_timing "BTree Perf test" bin/driver_test btree_test --perf --cache-capacity-gib 4 --seed "$SEED"
+
 run_with_timing "Log test" bin/driver_test log_test --seed "$SEED"
 
 run_with_timing "Filter test" bin/driver_test filter_test --seed "$SEED"

--- a/tests/functional/btree_test.c
+++ b/tests/functional/btree_test.c
@@ -1533,6 +1533,22 @@ btree_test(int argc, char *argv[])
       goto cleanup;
    }
 
+   if (run_perf_test) {
+      // For default test execution parameters, we need a reasonably big
+      // enough cache to handle the Memtable being pinned.
+      int reqd_cache_GiB = 4;
+      if (cache_cfg.capacity < (reqd_cache_GiB * GiB)) {
+         platform_log("Warning! Your configured cache size, %lu GiB, may be "
+                      "insufficient to run the 'btree_test --perf' test. "
+                      "Recommend a minimum of '--cache-capacity-gib %d' GiB. "
+                      "If you change the key / message size, or the number "
+                      "of inserts, you may also need to increase the cache "
+                      "size appropriately.\n",
+                      B_TO_GiB(cache_cfg.capacity),
+                      reqd_cache_GiB);
+      }
+   }
+
    platform_io_handle *io = TYPED_MALLOC(hid, io);
    platform_assert(io != NULL);
    rc = io_handle_init(io, &io_cfg, hh, hid);


### PR DESCRIPTION
Existing test 'splinter_test btree_test --perf' runs into hard cache manager
errors with an under-configured cache. This commit:

- Adds checks in the test for min cache-size reqd, and will fail to run.
  Empirically, 4 GiB seems to suffice.
- Include this test in set of PR-CI test-cases to run. Adds < 1 min.

Fixes issue #308 