### PR TITLE
(#327) Reduce # of rows for splinter stress tests to avoid seg-fault.

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -145,6 +145,12 @@ function nightly_functionality_stress_tests() {
 
     # ----
     cache_size=1        # GiB
+
+    # Remove this block once issue #322 is fixed.
+    n_mills=1
+    num_rows=$((n_mills * 1000 * 1000))
+    nrows_h="${n_mills} mil"
+
     test_descr="${nrows_h} rows, ${ntables} tables, ${cache_size} MiB cache"
     echo "$Me: Run with ${n_mills} million rows, on ${ntables} tables, with default ${cache_size} GiB cache"
     run_with_timing "Functionality Stress test ${test_descr}" \


### PR DESCRIPTION
Nightly tests for 'splinter_test --functionality' are still failing for
cache_size 1 GiB, with 10 million rows. (Tracked by an existing issue.)
For now, as a workaround, drop the # of rows for this case to 1 mil.
This seems to work when test is run standalone outside CI-envs.

Patch-fix to workaround seg-fault seen in large stress test case. Checking this in once CI passes, in the hope that nightly builds will proceed further tonight.