### PR TITLE
Bugfix for Type Assertion in `trunk_async_lookup`

### DIFF
--- a/src/trunk.c
+++ b/src/trunk.c
@@ -6647,7 +6647,8 @@ trunk_lookup_async(trunk_handle     *spl,  // IN
             slice message = writable_buffer_to_slice(data);
             if (!writable_buffer_is_null(data)) {
                message_type type = data_message_class(data_cfg, message);
-               debug_assert(type == MESSAGE_TYPE_DELETE || type == MESSAGE_TYPE_INSERT);
+               debug_assert(type == MESSAGE_TYPE_DELETE
+                            || type == MESSAGE_TYPE_INSERT);
                if (type == MESSAGE_TYPE_DELETE) {
                   writable_buffer_reinit(data);
                }


### PR DESCRIPTION
Fixes a bug where an assertion that `type` is not update would be hit in
`trunk_async_lookup` on function exit. This could happen when an update
message is found, but there is still further IO required to finish the
lookup.

This fix moves the relevent code, including the assertion, into the
`async_state_end` state.

Observed with `bin/driver_test splinter_test --functionality 10000000 1 --max-async-inflight 8 --set-mlock --set-O_DIRECT --db-capacity-gib 50 --key-size 135 --data-size 40 --memtable-capacity-mib 56`