### PR TITLE
Public API works with slices

### DIFF
--- a/include/splinterdb/data.h
+++ b/include/splinterdb/data.h
@@ -33,28 +33,21 @@ typedef enum message_type {
 
 typedef struct data_config data_config;
 
-typedef int (*key_compare_fn)(const data_config *cfg,
-                              uint64             key1_len,
-                              const void        *key1,
-                              uint64             key2_len,
-                              const void        *key2);
+typedef int (*key_compare_fn)(const data_config *cfg, slice key1, slice key2);
 
 typedef uint32 (*key_hash_fn)(const void *input, size_t length, uint32 seed);
 
 typedef message_type (*message_class_fn)(const data_config *cfg,
-                                         uint64             raw_message_len,
-                                         const void        *raw_message);
+                                         slice              raw_message);
 
 // Given two messages, old_message and new_message, merge them
 // and return the result in new_raw_message.
 //
 // Returns 0 on success.  non-zero indicates an internal error.
 typedef int (*merge_tuple_fn)(const data_config *cfg,
-                              uint64             key_len,
-                              const void        *key,
-                              uint64             old_message_len,
-                              const void        *old_message,
-                              writable_buffer   *new_message); // IN/OUT
+                              slice              key,         // IN
+                              slice              old_message, // IN
+                              writable_buffer   *new_message);  // IN/OUT
 
 // Called for non-MESSAGE_TYPE_INSERT messages when they are
 // determined to be the oldest message Can change data_class or
@@ -67,8 +60,7 @@ typedef int (*merge_tuple_final_fn)(const data_config *cfg,
                                     writable_buffer   *oldest_message);
 
 typedef void (*key_or_message_to_str_fn)(const data_config *cfg,
-                                         uint64             key_or_message_len,
-                                         const void        *key_or_message,
+                                         slice              key_or_msg,
                                          char              *str,
                                          uint64             max_len);
 
@@ -77,8 +69,7 @@ typedef void (*key_or_message_to_str_fn)(const data_config *cfg,
 // Returns the length of the fully-encoded message via out_encoded_len
 // Is allowed to fail by returning a non-zero exit code
 typedef int (*encode_message_fn)(message_type type,
-                                 uint64       value_len,
-                                 const void  *value,
+                                 slice        in_value,
                                  uint64       dst_msg_buffer_len,
                                  void        *dst_msg_buffer,
                                  uint64      *out_encoded_len);
@@ -86,8 +77,7 @@ typedef int (*encode_message_fn)(message_type type,
 // Extract the value from a message
 // This shouldn't need to do any allocation or copying, just pointer arithmetic
 // Is allowed to fail by returning a non-zero exit code
-typedef int (*decode_message_fn)(uint64       msg_buffer_len,
-                                 const void  *msg_buffer,
+typedef int (*decode_message_fn)(slice        in_buffer,
                                  uint64      *out_value_len,
                                  const char **out_value);
 

--- a/include/splinterdb/public_util.h
+++ b/include/splinterdb/public_util.h
@@ -4,6 +4,10 @@
 #ifndef __PUBLIC_UTIL_H__
 #define __PUBLIC_UTIL_H__
 
+#include "splinterdb/public_platform.h"
+
+/* Opaque resiable buffer.
+ * Internally, it may allocate and deallocate memory. */
 typedef struct writable_buffer writable_buffer;
 
 uint64
@@ -16,5 +20,44 @@ writable_buffer_set_length(writable_buffer *wb, uint64 newlength);
 /* Returns a ptr to the data region held by this writable_buffer */
 void *
 writable_buffer_data(writable_buffer *wb);
+
+
+/*
+ * Non-disk resident descriptor for a [<length>, <value ptr>] pair
+ * Used to pass-around references to keys and values of different lengths.
+ *
+ * Avoid accessing these fields directly.
+ * Instead, use the slice_length and slice_data accessor functions.
+ */
+typedef struct slice {
+   uint64      length;
+   const void *data;
+} slice;
+
+extern const slice NULL_SLICE;
+
+static inline bool
+slice_is_null(const slice b)
+{
+   return b.length == 0 && b.data == NULL;
+}
+
+static inline slice
+slice_create(uint64 len, const void *data)
+{
+   return (slice){.length = len, .data = data};
+}
+
+static inline uint64
+slice_length(const slice b)
+{
+   return b.length;
+}
+
+static inline const void *
+slice_data(const slice b)
+{
+   return b.data;
+}
 
 #endif /* __PUBLIC_UTIL_H__ */

--- a/include/splinterdb/splinterdb.h
+++ b/include/splinterdb/splinterdb.h
@@ -128,11 +128,7 @@ splinterdb_deregister_thread(splinterdb *kvs);
 // Insert a key and value.
 // Relies on data_config->encode_message
 int
-splinterdb_insert(const splinterdb *kvsb,
-                  uint64            key_len,
-                  const char       *key,
-                  uint64            val_len,
-                  const char       *value);
+splinterdb_insert(const splinterdb *kvsb, slice key, slice value);
 
 // Insert a raw message at the given key.
 //
@@ -141,15 +137,13 @@ splinterdb_insert(const splinterdb *kvsb,
 // These can be stored without doing a read of the current value.
 int
 splinterdb_insert_raw_message(const splinterdb *kvs,
-                              uint64            key_length,
-                              const char       *key,
-                              uint64            raw_message_length,
-                              const char       *raw_message);
+                              slice             key,
+                              slice             raw_message);
 
 
 // Delete a given key and any associated value / messages
 int
-splinterdb_delete(const splinterdb *kvsb, uint64 key_len, const char *key);
+splinterdb_delete(const splinterdb *kvsb, slice key);
 
 
 // Lookups
@@ -193,8 +187,7 @@ splinterdb_lookup_found(const splinterdb_lookup_result *result); // IN
 int
 splinterdb_lookup_result_value(const splinterdb               *kvs,
                                const splinterdb_lookup_result *result, // IN
-                               uint64      *value_size,                // OUT
-                               const char **value                      // OUT
+                               slice                          *value   // OUT
 );
 
 
@@ -202,10 +195,9 @@ splinterdb_lookup_result_value(const splinterdb               *kvs,
 //
 // result must have first been initialized using splinterdb_lookup_result_init
 int
-splinterdb_lookup(const splinterdb         *kvs,        // IN
-                  uint64                    key_length, // IN
-                  const char               *key,        // IN
-                  splinterdb_lookup_result *result      // IN/OUT
+splinterdb_lookup(const splinterdb         *kvs,   // IN
+                  slice                     key,   // IN
+                  splinterdb_lookup_result *result // IN/OUT
 );
 
 
@@ -242,17 +234,13 @@ Known issue: a live iterator may block inserts and deletes from the same thread.
 Sample application code:
 
    splinterdb_iterator* it;
-   int rc = splinterdb_iterator_init(kvs, &it, 0, NULL);
+   int rc = splinterdb_iterator_init(kvs, &it, NULL_SLICE);
    if (rc != 0) { ... handle error ... }
 
-   uint64 key_len;
-   const char* key;
-
-   uint64 value_len;
-   const char* value;
+   slice key, value;
 
    for(; splinterdb_iterator_valid(it); splinterdb_iterator_next(it)) {
-      splinterdb_iterator_get_current(it, &key_len, &key, &value_len, &value);
+      splinterdb_iterator_get_current(it, &key, &value);
       // do something with key and value...
    }
 
@@ -269,12 +257,11 @@ typedef struct splinterdb_iterator splinterdb_iterator;
 
 // Initialize a new iterator, starting at the given key
 //
-// If start_key is NULL, the iterator will start before the minimum key
+// If start_key is NULL_SLICE, the iterator will start before the minimum key
 int
-splinterdb_iterator_init(const splinterdb     *kvs,              // IN
-                         splinterdb_iterator **iter,             // OUT
-                         uint64                start_key_length, // IN
-                         const char           *start_key         // IN
+splinterdb_iterator_init(const splinterdb     *kvs,      // IN
+                         splinterdb_iterator **iter,     // OUT
+                         slice                 start_key // IN
 );
 
 // Deinitialize an iterator
@@ -296,16 +283,14 @@ void
 splinterdb_iterator_next(splinterdb_iterator *iter);
 
 // Sets *key and *value to the locations of the current item
-// Callers must not modify that memory.
+// Callers must not modify that memory pointed to by the slice
 //
 // If valid() == false, then behavior is undefined.
 // Always check valid() before calling this function.
 void
-splinterdb_iterator_get_current(splinterdb_iterator *iter,    // IN
-                                uint64              *key_len, // OUT
-                                const char         **key,     // OUT
-                                uint64              *val_len, // OUT
-                                const char         **value    // OUT
+splinterdb_iterator_get_current(splinterdb_iterator *iter, // IN
+                                slice               *key,  // OUT
+                                slice               *value // OUT
 );
 
 // Returns an error encountered from iteration, or 0 if successful.

--- a/src/data_internal.h
+++ b/src/data_internal.h
@@ -16,18 +16,13 @@
 static inline int
 data_key_compare(const data_config *cfg, const slice key1, const slice key2)
 {
-   return cfg->key_compare(cfg,
-                           slice_length(key1),
-                           slice_data(key1),
-                           slice_length(key2),
-                           slice_data(key2));
+   return cfg->key_compare(cfg, key1, key2);
 }
 
 static inline message_type
 data_message_class(const data_config *cfg, const slice raw_message)
 {
-   return cfg->message_class(
-      cfg, slice_length(raw_message), slice_data(raw_message));
+   return cfg->message_class(cfg, raw_message);
 }
 
 static inline int
@@ -36,12 +31,7 @@ data_merge_tuples(const data_config *cfg,
                   const slice        old_raw_message,
                   writable_buffer   *new_message)
 {
-   return cfg->merge_tuples(cfg,
-                            slice_length(key),
-                            slice_data(key),
-                            slice_length(old_raw_message),
-                            slice_data(old_raw_message),
-                            new_message);
+   return cfg->merge_tuples(cfg, key, old_raw_message, new_message);
 }
 
 static inline int
@@ -59,7 +49,7 @@ data_key_to_string(const data_config *cfg,
                    char              *str,
                    size_t             size)
 {
-   cfg->key_to_string(cfg, slice_length(key), slice_data(key), str, size);
+   cfg->key_to_string(cfg, key, str, size);
 }
 
 #define key_string(cfg, key)                                                   \
@@ -77,8 +67,7 @@ data_message_to_string(const data_config *cfg,
                        char              *str,
                        size_t             size)
 {
-   cfg->message_to_string(
-      cfg, slice_length(message), slice_data(message), str, size);
+   cfg->message_to_string(cfg, message, str, size);
 }
 
 #define message_string(cfg, key)                                               \

--- a/src/default_data_config.c
+++ b/src/default_data_config.c
@@ -21,24 +21,19 @@ typedef struct ONDISK {
 } message_encoding;
 
 static int
-key_compare(const data_config *cfg,
-            uint64             key1_len,
-            const void        *key1,
-            uint64             key2_len,
-            const void        *key2)
+key_compare(const data_config *cfg, slice key1, slice key2)
 {
-   platform_assert(key1 != NULL);
-   platform_assert(key2 != NULL);
+   platform_assert(slice_data(key1) != NULL);
+   platform_assert(slice_data(key2) != NULL);
 
-   return slice_lex_cmp(slice_create(key1_len, key1),
-                        slice_create(key2_len, key2));
+   return slice_lex_cmp(key1, key2);
 }
 
 
 static message_type
-message_class(const data_config *cfg, uint64 raw_msg_len, const void *raw_msg)
+message_class(const data_config *cfg, slice raw_msg)
 {
-   const message_encoding *msg = raw_msg;
+   const message_encoding *msg = slice_data(raw_msg);
    switch (msg->type) {
       case MESSAGE_TYPE_INSERT:
          return MESSAGE_TYPE_INSERT;
@@ -52,10 +47,8 @@ message_class(const data_config *cfg, uint64 raw_msg_len, const void *raw_msg)
 
 static int
 merge_tuples(const data_config *cfg,
-             uint64             key_len,
-             const void        *key,
-             uint64             old_raw_data_len,
-             const void        *old_raw_data,
+             const slice        key,
+             const slice        old_raw_message,
              writable_buffer   *new_data)
 {
    // we don't implement UPDATEs, so this is a no-op:
@@ -78,57 +71,53 @@ merge_tuples_final(const data_config *cfg,
 
 static void
 key_or_message_to_string(const data_config *cfg,
-                         uint64             raw_data_len,
-                         const void        *raw_data,
+                         const slice        key_or_msg,
                          char              *str,
                          size_t             max_len)
 {
-   debug_hex_encode(str, max_len, raw_data, raw_data_len);
+   debug_hex_encode(
+      str, max_len, slice_data(key_or_msg), slice_length(key_or_msg));
 }
 
 
 static int
 encode_message(message_type type,
-               size_t       value_len,
-               const void  *value,
+               slice        in_value,
                size_t       dst_msg_buffer_len,
                void        *dst_msg_buffer,
                size_t      *out_encoded_len)
 {
    message_encoding *msg = (message_encoding *)dst_msg_buffer;
    msg->type             = type;
-   if (value_len + sizeof(message_encoding) > dst_msg_buffer_len) {
-      platform_error_log(
-         "encode_message: "
-         "value_len %lu + encoding header %lu exceeds buffer size %lu bytes.",
-         value_len,
-         sizeof(message_encoding),
-         dst_msg_buffer_len);
+   if (slice_length(in_value) + sizeof(message_encoding) > dst_msg_buffer_len) {
+      platform_error_log("encode_message: "
+                         "length of value %lu + encoding header %lu exceeds "
+                         "buffer size %lu bytes.",
+                         slice_length(in_value),
+                         sizeof(message_encoding),
+                         dst_msg_buffer_len);
       return EINVAL;
    }
-   if (value_len > 0) {
-      memmove(&(msg->value), value, value_len);
+   if (slice_length(in_value) > 0) {
+      memmove(&(msg->value), slice_data(in_value), slice_length(in_value));
    }
-   *out_encoded_len = sizeof(message_encoding) + value_len;
+   *out_encoded_len = sizeof(message_encoding) + slice_length(in_value);
    return 0;
 }
 
 static int
-decode_message(size_t       msg_buffer_len,
-               const void  *msg_buffer,
-               size_t      *out_value_len,
-               const char **out_value)
+decode_message(slice in_msg, size_t *out_value_len, const char **out_value)
 {
-   if (msg_buffer_len < sizeof(message_encoding)) {
+   if (slice_length(in_msg) < sizeof(message_encoding)) {
       platform_error_log("decode_message: message_buffer_len=%lu must be "
                          "at least %lu bytes.",
-                         msg_buffer_len,
+                         slice_length(in_msg),
                          sizeof(message_encoding));
       return EINVAL;
    }
-   const message_encoding *msg = (const message_encoding *)msg_buffer;
-   *out_value_len              = msg_buffer_len - sizeof(message_encoding);
-   *out_value                  = (const void *)(msg->value);
+   const message_encoding *msg = (const message_encoding *)slice_data(in_msg);
+   *out_value_len = slice_length(in_msg) - sizeof(message_encoding);
+   *out_value     = (const void *)(msg->value);
    return 0;
 }
 

--- a/src/splinterdb.c
+++ b/src/splinterdb.c
@@ -143,11 +143,10 @@ splinterdb_validate_app_data_config(const data_config *cfg)
                    cfg->min_key_length,
                    cfg->key_size);
 
-   int min_max_cmp = cfg->key_compare(cfg,
-                                      cfg->min_key_length,
-                                      cfg->min_key,
-                                      cfg->max_key_length,
-                                      cfg->max_key);
+   int min_max_cmp =
+      cfg->key_compare(cfg,
+                       slice_create(cfg->min_key_length, cfg->min_key),
+                       slice_create(cfg->max_key_length, cfg->max_key));
    platform_assert(min_max_cmp < 0, "min_key must compare < max_key");
 }
 
@@ -167,26 +166,23 @@ static_assert((SPLINTERDB_MAX_KEY_SIZE <= UINT8_MAX),
               "Variable-length key support is currently cappted at 255 bytes");
 
 static int
-encode_key(void       *key_buffer,
-           uint64      key_buffer_len,
-           const void *key,
-           uint64      key_len)
+encode_key(uint64 out_key_buffer_len, void *out_key_buffer, slice in_key)
 {
-   if (key_len > SPLINTERDB_MAX_KEY_SIZE) {
+   if (slice_length(in_key) > SPLINTERDB_MAX_KEY_SIZE) {
       platform_error_log("splinterdb.encode_key requires "
                          "key_len (%lu) <= SPLINTERDB_MAX_KEY_SIZE (%u)\n",
-                         key_len,
+                         slice_length(in_key),
                          SPLINTERDB_MAX_KEY_SIZE);
       return EINVAL;
    }
-   platform_assert(key_buffer_len == MAX_KEY_SIZE,
+   platform_assert(out_key_buffer_len == MAX_KEY_SIZE,
                    "key buffer must always be of size MAX_KEY_SIZE");
 
-   memset(key_buffer, 0, key_buffer_len);
-   var_len_key_encoding *key_enc = (var_len_key_encoding *)key_buffer;
-   key_enc->length               = (uint8)key_len;
-   if (key_len > 0) {
-      memmove(key_enc->data, key, key_len);
+   memset(out_key_buffer, 0, out_key_buffer_len);
+   var_len_key_encoding *key_enc = (var_len_key_encoding *)out_key_buffer;
+   key_enc->length               = (uint8)slice_length(in_key);
+   if (slice_length(in_key) > 0) {
+      memmove(key_enc->data, slice_data(in_key), slice_length(in_key));
    }
    return 0;
 }
@@ -194,49 +190,40 @@ encode_key(void       *key_buffer,
 
 static int
 splinterdb_shim_key_compare(const data_config *cfg,
-                            uint64             unused_key1_raw_len,
-                            const void        *key1_raw,
-                            uint64             unused_key2_raw_len,
-                            const void        *key2_raw)
+                            slice              key1_raw,
+                            slice              key2_raw)
 {
-   var_len_key_encoding *key1 = (var_len_key_encoding *)key1_raw;
-   var_len_key_encoding *key2 = (var_len_key_encoding *)key2_raw;
+   var_len_key_encoding *key1 = (var_len_key_encoding *)slice_data(key1_raw);
+   var_len_key_encoding *key2 = (var_len_key_encoding *)slice_data(key2_raw);
 
    platform_assert(key1->length <= SPLINTERDB_MAX_KEY_SIZE);
    platform_assert(key2->length <= SPLINTERDB_MAX_KEY_SIZE);
 
    data_config *app_cfg = (data_config *)(cfg->context);
-   return app_cfg->key_compare(
-      app_cfg, key1->length, key1->data, key2->length, key2->data);
+   return app_cfg->key_compare(app_cfg,
+                               slice_create(key1->length, key1->data),
+                               slice_create(key2->length, key2->data));
 }
 
 static message_type
-splinterdb_shim_message_class(const data_config *cfg,
-                              uint64             raw_message_len,
-                              const void        *raw_message)
+splinterdb_shim_message_class(const data_config *cfg, slice raw_message)
 {
    data_config *app_cfg = (data_config *)(cfg->context);
-   return app_cfg->message_class(app_cfg, raw_message_len, raw_message);
+   return app_cfg->message_class(app_cfg, raw_message);
 }
 
 static int
 splinterdb_shim_merge_tuple(const data_config *cfg,
-                            uint64             unused_key_len,
-                            const void        *key_raw,
-                            uint64             old_message_len,
-                            const void        *old_message,
+                            const slice        key_raw,
+                            const slice        old_message,
                             writable_buffer   *new_message)
 {
    data_config          *app_cfg = (data_config *)(cfg->context);
-   var_len_key_encoding *key     = (var_len_key_encoding *)key_raw;
+   var_len_key_encoding *key     = (var_len_key_encoding *)slice_data(key_raw);
 
    platform_assert(key->length <= SPLINTERDB_MAX_KEY_SIZE);
-   return app_cfg->merge_tuples(app_cfg,
-                                key->length,
-                                key->data,
-                                old_message_len,
-                                old_message,
-                                new_message);
+   return app_cfg->merge_tuples(
+      app_cfg, slice_create(key->length, key->data), old_message, new_message);
 }
 
 static int
@@ -255,17 +242,17 @@ splinterdb_shim_merge_tuple_final(const data_config *cfg,
 
 static void
 splinterdb_shim_key_to_string(const data_config *cfg,
-                              uint64             unused_key_len,
-                              const void        *key_raw,
+                              const slice        key_raw,
                               char              *str,
                               uint64             max_len)
 {
 
    data_config          *app_cfg = (data_config *)(cfg->context);
-   var_len_key_encoding *key     = (var_len_key_encoding *)key_raw;
+   var_len_key_encoding *key     = (var_len_key_encoding *)slice_data(key_raw);
 
    platform_assert(key->length <= SPLINTERDB_MAX_KEY_SIZE);
-   app_cfg->key_to_string(app_cfg, key->length, key->data, str, max_len);
+   app_cfg->key_to_string(
+      app_cfg, slice_create(key->length, key->data), str, max_len);
 }
 
 
@@ -279,19 +266,17 @@ splinterdb_shim_data_config(const data_config *app_cfg, data_config *out_shim)
    shim.key_size     = app_cfg->key_size + sizeof(var_len_key_encoding);
    shim.message_size = app_cfg->message_size;
 
-   int rc = encode_key(shim.min_key,
-                       sizeof(shim.min_key),
-                       app_cfg->min_key,
-                       app_cfg->min_key_length);
+   int rc = encode_key(sizeof(shim.min_key),
+                       shim.min_key,
+                       slice_create(app_cfg->min_key_length, app_cfg->min_key));
    if (rc != 0) {
       return rc;
    }
    shim.min_key_length = 0; // lower layer ignores this
 
-   rc = encode_key(shim.max_key,
-                   sizeof(shim.max_key),
-                   app_cfg->max_key,
-                   app_cfg->max_key_length);
+   rc = encode_key(sizeof(shim.max_key),
+                   shim.max_key,
+                   slice_create(app_cfg->max_key_length, app_cfg->max_key));
    if (rc != 0) {
       return rc;
    }
@@ -637,58 +622,30 @@ validate_key_length(const splinterdb *kvs, uint64 key_length)
  *-----------------------------------------------------------------------------
  */
 int
-splinterdb_insert_raw_message(const splinterdb *kvs,            // IN
-                              uint64            key_length,     // IN
-                              const char       *key,            // IN
-                              uint64            message_length, // IN
-                              const char       *message         // IN
+splinterdb_insert_raw_message(const splinterdb *kvs,        // IN
+                              slice             key,        // IN
+                              slice             raw_message // IN
 )
 {
    platform_assert(kvs != NULL);
-   int rc = validate_key_length(kvs, key_length);
+   int rc = validate_key_length(kvs, slice_length(key));
    if (rc != 0) {
       return rc;
    }
-
-   slice message_slice = slice_create(message_length, message);
 
    char key_buffer[MAX_KEY_SIZE] = {0};
-   rc = encode_key(key_buffer, sizeof(key_buffer), key, key_length);
+
+   rc = encode_key(sizeof(key_buffer), key_buffer, key);
    if (rc != 0) {
       return rc;
    }
 
-   platform_status status = trunk_insert(kvs->spl, key_buffer, message_slice);
+   platform_status status = trunk_insert(kvs->spl, key_buffer, raw_message);
    return platform_status_to_int(status);
 }
 
 int
-splinterdb_insert(const splinterdb *kvsb,
-                  uint64            key_len,
-                  const char       *key,
-                  uint64            val_len,
-                  const char       *value)
-{
-   platform_assert(kvsb->app_data_cfg.encode_message != NULL);
-
-   uint64 max_msg_len                  = kvsb->app_data_cfg.message_size;
-   char   msg_buffer[MAX_MESSAGE_SIZE] = {0};
-   uint64 encoded_len;
-   int    rc = kvsb->app_data_cfg.encode_message(MESSAGE_TYPE_INSERT,
-                                              val_len,
-                                              value,
-                                              max_msg_len,
-                                              msg_buffer,
-                                              &encoded_len);
-   if (rc != 0) {
-      return rc;
-   }
-   return splinterdb_insert_raw_message(
-      kvsb, key_len, key, encoded_len, msg_buffer);
-}
-
-int
-splinterdb_delete(const splinterdb *kvsb, uint64 key_len, const char *key)
+splinterdb_insert(const splinterdb *kvsb, slice key, slice value)
 {
    platform_assert(kvsb->app_data_cfg.encode_message != NULL);
 
@@ -696,12 +653,29 @@ splinterdb_delete(const splinterdb *kvsb, uint64 key_len, const char *key)
    char   msg_buffer[MAX_MESSAGE_SIZE] = {0};
    uint64 encoded_len;
    int    rc = kvsb->app_data_cfg.encode_message(
-      MESSAGE_TYPE_DELETE, 0, NULL, max_msg_len, msg_buffer, &encoded_len);
+      MESSAGE_TYPE_INSERT, value, max_msg_len, msg_buffer, &encoded_len);
    if (rc != 0) {
       return rc;
    }
    return splinterdb_insert_raw_message(
-      kvsb, key_len, key, encoded_len, msg_buffer);
+      kvsb, key, slice_create(encoded_len, msg_buffer));
+}
+
+int
+splinterdb_delete(const splinterdb *kvsb, slice key)
+{
+   platform_assert(kvsb->app_data_cfg.encode_message != NULL);
+
+   uint64 max_msg_len                  = kvsb->app_data_cfg.message_size;
+   char   msg_buffer[MAX_MESSAGE_SIZE] = {0};
+   uint64 encoded_len;
+   int    rc = kvsb->app_data_cfg.encode_message(
+      MESSAGE_TYPE_DELETE, NULL_SLICE, max_msg_len, msg_buffer, &encoded_len);
+   if (rc != 0) {
+      return rc;
+   }
+   return splinterdb_insert_raw_message(
+      kvsb, key, slice_create(encoded_len, msg_buffer));
 }
 
 /*
@@ -759,19 +733,26 @@ splinterdb_lookup_result_data(const splinterdb_lookup_result *result) // IN
 int
 splinterdb_lookup_result_value(const splinterdb               *kvs,
                                const splinterdb_lookup_result *result, // IN
-                               uint64      *value_size,                // OUT
-                               const char **value)
+                               slice                          *value)
 {
 
    if (!splinterdb_lookup_found(result)) {
       return EINVAL;
    }
 
-   return kvs->app_data_cfg.decode_message(
-      splinterdb_lookup_result_size(result),
-      splinterdb_lookup_result_data(result),
-      value_size,
-      value);
+   size_t      value_size;
+   const char *value_data;
+
+   slice msg = slice_create(splinterdb_lookup_result_size(result),
+                            splinterdb_lookup_result_data(result));
+
+   int rc = kvs->app_data_cfg.decode_message(msg, &value_size, &value_data);
+   if (rc != 0) {
+      return rc;
+   }
+
+   *value = slice_create(value_size, value_data);
+   return 0;
 }
 
 /*
@@ -795,12 +776,11 @@ splinterdb_lookup_result_value(const splinterdb               *kvs,
  *-----------------------------------------------------------------------------
  */
 int
-splinterdb_lookup(const splinterdb         *kvs,        // IN
-                  uint64                    key_length, // IN
-                  const char               *key,        // IN
-                  splinterdb_lookup_result *result)     // IN/OUT
+splinterdb_lookup(const splinterdb         *kvs, // IN
+                  slice                     key,
+                  splinterdb_lookup_result *result) // IN/OUT
 {
-   int rc = validate_key_length(kvs, key_length);
+   int rc = validate_key_length(kvs, slice_length(key));
    if (rc != 0) {
       return rc;
    }
@@ -810,7 +790,8 @@ splinterdb_lookup(const splinterdb         *kvs,        // IN
 
    platform_assert(kvs != NULL);
    char key_buffer[MAX_KEY_SIZE] = {0};
-   rc = encode_key(key_buffer, sizeof(key_buffer), key, key_length);
+
+   rc = encode_key(sizeof(key_buffer), key_buffer, key);
    if (rc != 0) {
       return rc;
    }
@@ -827,10 +808,9 @@ struct splinterdb_iterator {
 };
 
 int
-splinterdb_iterator_init(const splinterdb     *kvs,              // IN
-                         splinterdb_iterator **iter,             // OUT
-                         uint64                start_key_length, // IN
-                         const char           *start_key         // IN
+splinterdb_iterator_init(const splinterdb     *kvs,      // IN
+                         splinterdb_iterator **iter,     // OUT
+                         slice                 start_key // IN
 )
 {
    splinterdb_iterator *it = TYPED_MALLOC(kvs->spl->heap_id, it);
@@ -843,11 +823,8 @@ splinterdb_iterator_init(const splinterdb     *kvs,              // IN
    trunk_range_iterator *range_itor = &(it->sri);
 
    char start_key_buffer[MAX_KEY_SIZE] = {0};
-   if (start_key) {
-      int rc = encode_key(start_key_buffer,
-                          sizeof(start_key_buffer),
-                          start_key,
-                          start_key_length);
+   if (!slice_is_null(start_key)) {
+      int rc = encode_key(MAX_KEY_SIZE, start_key_buffer, start_key);
       if (rc != 0) {
          return rc;
       }
@@ -905,11 +882,9 @@ splinterdb_iterator_status(const splinterdb_iterator *iter)
 }
 
 void
-splinterdb_iterator_get_current(splinterdb_iterator *iter,    // IN
-                                uint64              *key_len, // OUT
-                                const char         **key,     // OUT
-                                uint64              *val_len, // OUT
-                                const char         **value    // OUT
+splinterdb_iterator_get_current(splinterdb_iterator *iter, // IN
+                                slice               *key,  // OUT
+                                slice               *value // OUT
 )
 {
    platform_assert(iter->parent->app_data_cfg.decode_message != NULL);
@@ -923,14 +898,10 @@ splinterdb_iterator_get_current(splinterdb_iterator *iter,    // IN
    var_len_key_encoding *kenc = (var_len_key_encoding *)(slice_data(key_slice));
    platform_assert(kenc->length <= SPLINTERDB_MAX_KEY_SIZE);
 
-   *key     = (const char *)(&kenc->data);
-   *key_len = kenc->length;
-
-   uint64      message_length = slice_length(message_slice);
-   const char *message_buffer = slice_data(message_slice);
+   *key = slice_create(kenc->length, kenc->data);
 
    int rc = iter->parent->app_data_cfg.decode_message(
-      message_length, message_buffer, val_len, value);
+      message_slice, &(value->length), (const char **)&(value->data));
    if (rc != 0) {
       iter->last_rc = STATUS_BAD_PARAM;
    }

--- a/src/trunk.c
+++ b/src/trunk.c
@@ -8310,11 +8310,10 @@ trunk_validate_data_config(const data_config *cfg)
    platform_assert(cfg->key_compare != NULL);
 
    // basic check of key comparison
-   int min_max_cmp = cfg->key_compare(cfg,
-                                      cfg->min_key_length,
-                                      cfg->min_key,
-                                      cfg->max_key_length,
-                                      cfg->max_key);
+   int min_max_cmp =
+      cfg->key_compare(cfg,
+                       slice_create(cfg->min_key_length, cfg->min_key),
+                       slice_create(cfg->max_key_length, cfg->max_key));
    platform_assert(min_max_cmp < 0, "min_key must compare < max_key");
 }
 

--- a/src/util.h
+++ b/src/util.h
@@ -70,40 +70,6 @@ init_fraction(uint64 numerator, uint64 denominator)
       .denominator = 1,                                                        \
    })
 
-/*
- * Non-disk resident descriptor for a [<length>, <value ptr>] pair handle.
- * Used to pass-around references to keys and values of different lengths.
- */
-typedef struct slice {
-   uint64      length;
-   const void *data;
-} slice;
-
-extern const slice NULL_SLICE;
-
-static inline bool
-slice_is_null(const slice b)
-{
-   return b.length == 0 && b.data == NULL;
-}
-
-static inline slice
-slice_create(uint64 len, const void *data)
-{
-   return (slice){.length = len, .data = data};
-}
-
-static inline uint64
-slice_length(const slice b)
-{
-   return b.length;
-}
-
-static inline const void *
-slice_data(const slice b)
-{
-   return b.data;
-}
 
 static inline slice
 slice_copy_contents(void *dst, const slice src)

--- a/tests/unit/splinterdb_quick_test.c
+++ b/tests/unit/splinterdb_quick_test.c
@@ -64,11 +64,7 @@ check_current_tuple(splinterdb_iterator *it, const int expected_i);
 static uint64_t key_comp_context = 0;
 
 static int
-custom_key_comparator(const data_config *cfg,
-                      uint64             key1_len,
-                      const void        *key1,
-                      uint64             key2_len,
-                      const void        *key2);
+custom_key_comparator(const data_config *cfg, slice key1, slice key2);
 
 /*
  * Global data declaration macro:
@@ -129,44 +125,45 @@ CTEST_TEARDOWN(splinterdb_quick)
  */
 CTEST2(splinterdb_quick, test_basic_flow)
 {
-   char  *key     = "some-key";
-   size_t key_len = sizeof("some-key");
+   char  *key_data = "some-key";
+   size_t key_len  = sizeof("some-key");
+   slice  key      = slice_create(key_len, key_data);
 
    splinterdb_lookup_result result;
    splinterdb_lookup_result_init(data->kvsb, &result, 0, NULL);
 
-   int rc = splinterdb_lookup(data->kvsb, key_len, key, &result);
+   int rc = splinterdb_lookup(data->kvsb, key, &result);
    ASSERT_EQUAL(0, rc);
 
-   size_t      val_len;
-   const char *value;
 
    // Lookup of a non-existent key should return not-found.
    ASSERT_FALSE(splinterdb_lookup_found(&result));
 
-   static char *to_insert = "some-value";
+   static char *to_insert_data = "some-value";
+   size_t       to_insert_len  = strlen(to_insert_data);
+   slice        to_insert      = slice_create(to_insert_len, to_insert_data);
 
    // Basic insert of new key should succeed.
-   rc =
-      splinterdb_insert(data->kvsb, key_len, key, strlen(to_insert), to_insert);
+   rc = splinterdb_insert(data->kvsb, key, to_insert);
    ASSERT_EQUAL(0, rc);
 
    // Lookup of inserted key should succeed.
-   rc = splinterdb_lookup(data->kvsb, key_len, key, &result);
+   rc = splinterdb_lookup(data->kvsb, key, &result);
    ASSERT_EQUAL(0, rc);
    ASSERT_TRUE(splinterdb_lookup_found(&result));
 
-   rc = splinterdb_lookup_result_value(data->kvsb, &result, &val_len, &value);
+   slice value;
+   rc = splinterdb_lookup_result_value(data->kvsb, &result, &value);
    ASSERT_EQUAL(0, rc);
-   ASSERT_EQUAL(strlen(to_insert), val_len);
-   ASSERT_STREQN(to_insert, value, val_len);
+   ASSERT_EQUAL(to_insert_len, slice_length(value));
+   ASSERT_STREQN(to_insert_data, slice_data(value), slice_length(value));
 
    // Delete key
-   rc = splinterdb_delete(data->kvsb, key_len, key);
+   rc = splinterdb_delete(data->kvsb, key);
    ASSERT_EQUAL(0, rc);
 
    // Deleted key should not be found
-   rc = splinterdb_lookup(data->kvsb, key_len, key, &result);
+   rc = splinterdb_lookup(data->kvsb, key, &result);
    ASSERT_EQUAL(0, rc);
    ASSERT_FALSE(splinterdb_lookup_found(&result));
 
@@ -179,43 +176,43 @@ CTEST2(splinterdb_quick, test_basic_flow)
  */
 CTEST2(splinterdb_quick, test_apis_for_max_key_length)
 {
-   char large_key[TEST_MAX_KEY_SIZE];
-   memset(large_key, 'a', TEST_MAX_KEY_SIZE);
+   char   large_key_data[TEST_MAX_KEY_SIZE];
+   size_t large_key_len = TEST_MAX_KEY_SIZE;
+   memset(large_key_data, 'a', TEST_MAX_KEY_SIZE);
+   slice large_key = slice_create(large_key_len, large_key_data);
 
-   static char *large_key_value = "a-value";
+
+   static char *to_insert_data = "a-value";
+   size_t       to_insert_len  = strlen(to_insert_data);
+   slice        to_insert      = slice_create(to_insert_len, to_insert_data);
 
    // **** Insert of a max-size key should succeed.
-   int rc = splinterdb_insert(data->kvsb,
-                              TEST_MAX_KEY_SIZE,
-                              large_key,
-                              strlen(large_key_value),
-                              large_key_value);
+   int rc = splinterdb_insert(data->kvsb, large_key, to_insert);
    ASSERT_EQUAL(0, rc);
 
    splinterdb_lookup_result result;
    splinterdb_lookup_result_init(data->kvsb, &result, 0, NULL);
 
    // **** Lookup of max-size key should return correct value
-   rc = splinterdb_lookup(data->kvsb, TEST_MAX_KEY_SIZE, large_key, &result);
+   rc = splinterdb_lookup(data->kvsb, large_key, &result);
    ASSERT_EQUAL(0, rc);
    ASSERT_TRUE(splinterdb_lookup_found(&result));
 
-   size_t      val_len;
-   const char *value;
-   rc = splinterdb_lookup_result_value(data->kvsb, &result, &val_len, &value);
+   slice value;
+   rc = splinterdb_lookup_result_value(data->kvsb, &result, &value);
    ASSERT_EQUAL(0, rc);
 
-   ASSERT_EQUAL(strlen(large_key_value), val_len);
-   ASSERT_STREQN(large_key_value,
-                 value,
-                 val_len,
+   ASSERT_EQUAL(strlen(to_insert_data), slice_length(value));
+   ASSERT_STREQN(to_insert_data,
+                 slice_data(value),
+                 slice_length(value),
                  "Large key-value did not match as expected.");
 
-   rc = splinterdb_delete(data->kvsb, TEST_MAX_KEY_SIZE, large_key);
+   rc = splinterdb_delete(data->kvsb, large_key);
    ASSERT_EQUAL(0, rc);
 
    // **** Should not find this large-key once it's deleted
-   rc = splinterdb_lookup(data->kvsb, TEST_MAX_KEY_SIZE, large_key, &result);
+   rc = splinterdb_lookup(data->kvsb, large_key, &result);
    ASSERT_EQUAL(0, rc);
    ASSERT_FALSE(splinterdb_lookup_found(&result));
 }
@@ -225,36 +222,25 @@ CTEST2(splinterdb_quick, test_apis_for_max_key_length)
  */
 CTEST2(splinterdb_quick, test_key_size_gt_max_key_size)
 {
-   size_t too_large_key_len = TEST_MAX_KEY_SIZE + 1;
-   char  *too_large_key     = calloc(1, too_large_key_len);
-   memset(too_large_key, 'a', too_large_key_len);
-   char *value = calloc(1, TEST_MAX_VALUE_SIZE);
+   char   too_large_key_data[TEST_MAX_KEY_SIZE + 1];
+   size_t too_large_key_len = sizeof(too_large_key_data);
+   memset(too_large_key_data, 'a', too_large_key_len);
+   slice too_large_key = slice_create(too_large_key_len, too_large_key_data);
 
-   int rc = splinterdb_insert(data->kvsb,
-                              too_large_key_len,
-                              too_large_key,
-                              sizeof("a-value"),
-                              "a-value");
+   int rc = splinterdb_insert(
+      data->kvsb, too_large_key, slice_create(sizeof("foo"), "foo"));
    ASSERT_EQUAL(EINVAL, rc);
 
    splinterdb_lookup_result result;
    splinterdb_lookup_result_init(data->kvsb, &result, 0, NULL);
 
-   rc =
-      splinterdb_lookup(data->kvsb, too_large_key_len, too_large_key, &result);
+   rc = splinterdb_lookup(data->kvsb, too_large_key, &result);
    ASSERT_EQUAL(EINVAL, rc);
 
-   rc = splinterdb_delete(data->kvsb, too_large_key_len, too_large_key);
+   rc = splinterdb_delete(data->kvsb, too_large_key);
    ASSERT_EQUAL(EINVAL, rc);
 
    splinterdb_lookup_result_deinit(&result);
-
-   if (too_large_key) {
-      free(too_large_key);
-   }
-   if (value) {
-      free(value);
-   }
 }
 
 /*
@@ -265,21 +251,16 @@ CTEST2(splinterdb_quick, test_key_size_gt_max_key_size)
  */
 CTEST2(splinterdb_quick, test_value_size_gt_max_value_size)
 {
-   size_t            too_large_value_len = TEST_MAX_VALUE_SIZE + 1;
-   char             *too_large_value     = calloc(1, too_large_value_len);
-   static const char short_key[]         = "a_short_key";
+   char   too_large_value_data[TEST_MAX_VALUE_SIZE + 1];
+   size_t too_large_value_len = sizeof(too_large_value_data);
+   memset(too_large_value_data, 'z', too_large_value_len);
+   slice too_large_value =
+      slice_create(too_large_value_len, too_large_value_data);
 
-   memset(too_large_value, 'z', too_large_value_len);
-   int rc = splinterdb_insert(data->kvsb,
-                              sizeof(short_key),
-                              short_key,
-                              too_large_value_len,
-                              too_large_value);
+   int rc = splinterdb_insert(
+      data->kvsb, slice_create(sizeof("foo"), "foo"), too_large_value);
 
    ASSERT_EQUAL(EINVAL, rc);
-   if (too_large_value) {
-      free(too_large_value);
-   }
 }
 
 /*
@@ -290,36 +271,39 @@ CTEST2(splinterdb_quick, test_value_size_gt_max_value_size)
  */
 CTEST2(splinterdb_quick, test_variable_length_values)
 {
+   slice      key_empty = slice_create(sizeof("empty"), "empty");
    const char empty_string[0];
+
+   slice      key_short       = slice_create(sizeof("short"), "short");
    const char short_string[1] = "v";
 
-   char almost_max_length_string[TEST_MAX_VALUE_SIZE - 1];
+   slice key_long = slice_create(sizeof("long"), "long");
+   char  almost_max_length_string[TEST_MAX_VALUE_SIZE - 1];
    memset(almost_max_length_string, 'a', TEST_MAX_VALUE_SIZE - 1);
 
-   char max_length_string[TEST_MAX_VALUE_SIZE];
+   slice key_max = slice_create(sizeof("max"), "max");
+   char  max_length_string[TEST_MAX_VALUE_SIZE];
    memset(max_length_string, 'b', TEST_MAX_VALUE_SIZE);
 
    // Insert keys with different value (lengths)
    int rc = splinterdb_insert(
-      data->kvsb, sizeof("empty"), "empty", sizeof(empty_string), empty_string);
+      data->kvsb, key_empty, slice_create(sizeof(empty_string), empty_string));
    ASSERT_EQUAL(0, rc);
 
    rc = splinterdb_insert(
-      data->kvsb, sizeof("short"), "short", sizeof(short_string), short_string);
+      data->kvsb, key_short, slice_create(sizeof(short_string), short_string));
    ASSERT_EQUAL(0, rc);
 
-   rc = splinterdb_insert(data->kvsb,
-                          sizeof("long"),
-                          "long",
-                          sizeof(almost_max_length_string),
-                          almost_max_length_string);
+   rc = splinterdb_insert(
+      data->kvsb,
+      key_long,
+      slice_create(sizeof(almost_max_length_string), almost_max_length_string));
    ASSERT_EQUAL(0, rc);
 
-   rc = splinterdb_insert(data->kvsb,
-                          sizeof("max"),
-                          "max",
-                          sizeof(max_length_string),
-                          max_length_string);
+   rc = splinterdb_insert(
+      data->kvsb,
+      key_max,
+      slice_create(sizeof(max_length_string), max_length_string));
    ASSERT_EQUAL(0, rc);
 
 
@@ -327,47 +311,47 @@ CTEST2(splinterdb_quick, test_variable_length_values)
    char big_buffer[2 * TEST_MAX_VALUE_SIZE];
    memset(big_buffer, 'x', sizeof(big_buffer));
 
-   size_t                   val_len;
-   const char              *value;
    splinterdb_lookup_result result;
+   slice                    value;
 
    // allocate a result that has full access to the buffer
    splinterdb_lookup_result_init(
       data->kvsb, &result, sizeof(big_buffer), big_buffer);
 
    // look up a 0-length value
-   rc = splinterdb_lookup(data->kvsb, sizeof("empty"), "empty", &result);
+   rc = splinterdb_lookup(data->kvsb, key_empty, &result);
    ASSERT_EQUAL(0, rc);
    ASSERT_TRUE(splinterdb_lookup_found(&result));
-   rc = splinterdb_lookup_result_value(data->kvsb, &result, &val_len, &value);
+   rc = splinterdb_lookup_result_value(data->kvsb, &result, &value);
    ASSERT_EQUAL(0, rc);
-   ASSERT_EQUAL(0, val_len);
+   ASSERT_EQUAL(0, slice_length(value));
 
    // lookup tuple with value of length 1, providing sufficient buffer
-   rc = splinterdb_lookup(data->kvsb, sizeof("short"), "short", &result);
+   rc = splinterdb_lookup(data->kvsb, key_short, &result);
    ASSERT_EQUAL(0, rc);
    ASSERT_TRUE(splinterdb_lookup_found(&result));
-   rc = splinterdb_lookup_result_value(data->kvsb, &result, &val_len, &value);
+   rc = splinterdb_lookup_result_value(data->kvsb, &result, &value);
    ASSERT_EQUAL(0, rc);
-   ASSERT_EQUAL(1, val_len);
+   ASSERT_EQUAL(1, slice_length(value));
 
    // lookup tuple with almost max-sized-value
-   rc = splinterdb_lookup(data->kvsb, sizeof("long"), "long", &result);
+   rc = splinterdb_lookup(data->kvsb, key_long, &result);
    ASSERT_EQUAL(0, rc);
    ASSERT_TRUE(splinterdb_lookup_found(&result));
-   rc = splinterdb_lookup_result_value(data->kvsb, &result, &val_len, &value);
+   rc = splinterdb_lookup_result_value(data->kvsb, &result, &value);
    ASSERT_EQUAL(0, rc);
-   ASSERT_EQUAL(TEST_MAX_VALUE_SIZE - 1, val_len);
-   ASSERT_STREQN(almost_max_length_string, value, val_len);
+   ASSERT_EQUAL(TEST_MAX_VALUE_SIZE - 1, slice_length(value));
+   ASSERT_STREQN(
+      almost_max_length_string, slice_data(value), slice_length(value));
 
    // lookup tuple with max-sized-value
-   rc = splinterdb_lookup(data->kvsb, sizeof("max"), "max", &result);
+   rc = splinterdb_lookup(data->kvsb, key_max, &result);
    ASSERT_EQUAL(0, rc);
    ASSERT_TRUE(splinterdb_lookup_found(&result));
-   rc = splinterdb_lookup_result_value(data->kvsb, &result, &val_len, &value);
+   rc = splinterdb_lookup_result_value(data->kvsb, &result, &value);
    ASSERT_EQUAL(0, rc);
-   ASSERT_EQUAL(TEST_MAX_VALUE_SIZE, val_len);
-   ASSERT_STREQN(max_length_string, value, val_len);
+   ASSERT_EQUAL(TEST_MAX_VALUE_SIZE, slice_length(value));
+   ASSERT_STREQN(max_length_string, slice_data(value), slice_length(value));
 
    // done with the big buffer
    splinterdb_lookup_result_deinit(&result);
@@ -380,16 +364,16 @@ CTEST2(splinterdb_quick, test_variable_length_values)
       data->kvsb, &result, TEST_MAX_VALUE_SIZE / 2, big_buffer);
 
    // lookup tuple with max-sized-value, passing it the short buffer
-   rc = splinterdb_lookup(data->kvsb, sizeof("max"), "max", &result);
+   rc = splinterdb_lookup(data->kvsb, key_max, &result);
    ASSERT_EQUAL(0, rc);
    ASSERT_TRUE(splinterdb_lookup_found(&result));
 
-   rc = splinterdb_lookup_result_value(data->kvsb, &result, &val_len, &value);
+   rc = splinterdb_lookup_result_value(data->kvsb, &result, &value);
    ASSERT_EQUAL(0, rc);
    // we get the full result back, because internally splinterdb did an
    // allocation
-   ASSERT_EQUAL(TEST_MAX_VALUE_SIZE, val_len);
-   ASSERT_STREQN(max_length_string, value, TEST_MAX_VALUE_SIZE);
+   ASSERT_EQUAL(TEST_MAX_VALUE_SIZE, slice_length(value));
+   ASSERT_STREQN(max_length_string, slice_data(value), slice_length(value));
 
    // our buffer is untouched
    ASSERT_STREQN(
@@ -403,15 +387,15 @@ CTEST2(splinterdb_quick, test_variable_length_values)
    // init another result, but don't give it a buffer
    splinterdb_lookup_result_init(data->kvsb, &result, 0, NULL);
    // lookup, see we get the full result back
-   rc = splinterdb_lookup(data->kvsb, sizeof("max"), "max", &result);
+   rc = splinterdb_lookup(data->kvsb, key_max, &result);
    ASSERT_EQUAL(0, rc);
    ASSERT_TRUE(splinterdb_lookup_found(&result));
-   rc = splinterdb_lookup_result_value(data->kvsb, &result, &val_len, &value);
+   rc = splinterdb_lookup_result_value(data->kvsb, &result, &value);
    ASSERT_EQUAL(0, rc);
    // we get the full result back, because internally splinterdb did an
    // allocation
-   ASSERT_EQUAL(TEST_MAX_VALUE_SIZE, val_len);
-   ASSERT_STREQN(max_length_string, value, TEST_MAX_VALUE_SIZE);
+   ASSERT_EQUAL(TEST_MAX_VALUE_SIZE, slice_length(value));
+   ASSERT_STREQN(max_length_string, slice_data(value), slice_length(value));
 
    // we can de-init the result, and it doesn't crash
    splinterdb_lookup_result_deinit(&result);
@@ -430,7 +414,7 @@ CTEST2(splinterdb_quick, test_basic_iterator)
 
    splinterdb_iterator *it = NULL;
 
-   rc = splinterdb_iterator_init(data->kvsb, &it, 0, NULL);
+   rc = splinterdb_iterator_init(data->kvsb, &it, NULL_SLICE);
    ASSERT_EQUAL(0, rc);
 
    for (; splinterdb_iterator_valid(it); splinterdb_iterator_next(it)) {
@@ -462,7 +446,8 @@ CTEST2(splinterdb_quick, test_splinterdb_iterator_with_startkey)
 
       // Initialize the i'th key
       snprintf(key, sizeof(key), key_fmt, ictr);
-      rc = splinterdb_iterator_init(data->kvsb, &it, strlen(key), key);
+      slice start_key = slice_create(strlen(key), key);
+      rc              = splinterdb_iterator_init(data->kvsb, &it, start_key);
       ASSERT_EQUAL(0, rc);
 
       bool is_valid = splinterdb_iterator_valid(it);
@@ -495,7 +480,8 @@ CTEST2(splinterdb_quick, test_splinterdb_iterator_with_non_existent_startkey)
    // start-key > max-key ('key-50')
    char *key = "unknownKey";
 
-   rc = splinterdb_iterator_init(data->kvsb, &it, strlen(key), key);
+   slice start_key = slice_create(strlen(key), key);
+   rc              = splinterdb_iterator_init(data->kvsb, &it, start_key);
 
    // Iterator should be invalid, as lookup key is non-existent.
    bool is_valid = splinterdb_iterator_valid(it);
@@ -506,8 +492,9 @@ CTEST2(splinterdb_quick, test_splinterdb_iterator_with_non_existent_startkey)
    // If you start with a key before min-key-value, scan will start from
    // 1st key inserted. (We do lexicographic comparison, so 'U' sorts
    // before 'key...', which is what key's format is.)
-   key = "UnknownKey";
-   rc  = splinterdb_iterator_init(data->kvsb, &it, strlen(key), key);
+   key       = "UnknownKey";
+   start_key = slice_create(strlen(key), key);
+   rc        = splinterdb_iterator_init(data->kvsb, &it, start_key);
    ASSERT_EQUAL(0, rc);
 
    int ictr = 0;
@@ -558,8 +545,9 @@ CTEST2(splinterdb_quick,
    // (a) Test iter_init with a key == the min-key
    snprintf(key, sizeof(key), key_fmt, minkey);
 
-   splinterdb_iterator *it = NULL;
-   rc = splinterdb_iterator_init(data->kvsb, &it, strlen(key), key);
+   splinterdb_iterator *it        = NULL;
+   slice                start_key = slice_create(strlen(key), key);
+   rc = splinterdb_iterator_init(data->kvsb, &it, start_key);
    ASSERT_EQUAL(0, rc);
 
    bool is_valid = splinterdb_iterator_valid(it);
@@ -577,8 +565,8 @@ CTEST2(splinterdb_quick,
    int kctr = (minkey - 1);
 
    snprintf(key, sizeof(key), key_fmt, kctr);
-
-   rc = splinterdb_iterator_init(data->kvsb, &it, strlen(key), key);
+   start_key = slice_create(strlen(key), key);
+   rc        = splinterdb_iterator_init(data->kvsb, &it, start_key);
    ASSERT_EQUAL(0, rc);
 
    is_valid = splinterdb_iterator_valid(it);
@@ -595,8 +583,8 @@ CTEST2(splinterdb_quick,
    // (c) Test with a non-existent value between 2 valid key values.
    kctr = 5;
    snprintf(key, sizeof(key), key_fmt, kctr);
-
-   rc = splinterdb_iterator_init(data->kvsb, &it, strlen(key), key);
+   start_key = slice_create(strlen(key), key);
+   rc        = splinterdb_iterator_init(data->kvsb, &it, start_key);
    ASSERT_EQUAL(0, rc);
 
    is_valid = splinterdb_iterator_valid(it);
@@ -613,8 +601,8 @@ CTEST2(splinterdb_quick,
    //     iter_init should end up as being invalid.
    kctr = -1;
    snprintf(key, sizeof(key), key_fmt, kctr);
-
-   rc = splinterdb_iterator_init(data->kvsb, &it, strlen(key), key);
+   start_key = slice_create(strlen(key), key);
+   rc        = splinterdb_iterator_init(data->kvsb, &it, start_key);
    ASSERT_EQUAL(0, rc);
 
    is_valid = splinterdb_iterator_valid(it);
@@ -632,13 +620,12 @@ CTEST2(splinterdb_quick,
  */
 CTEST2(splinterdb_quick, test_close_and_reopen)
 {
-   const char  *key     = "some-key";
-   const size_t key_len = strlen(key);
+   slice        key     = slice_create(strlen("some-key"), "some-key");
    const char  *val     = "some-value";
    const size_t val_len = strlen(val);
 
 
-   int rc = splinterdb_insert(data->kvsb, key_len, key, val_len, val);
+   int rc = splinterdb_insert(data->kvsb, key, slice_create(val_len, val));
    ASSERT_EQUAL(0, rc);
 
    // Close and re-open the database
@@ -646,23 +633,21 @@ CTEST2(splinterdb_quick, test_close_and_reopen)
    rc = splinterdb_open(&data->cfg, &data->kvsb);
    ASSERT_EQUAL(0, rc);
 
-   const char *value;
-   size_t      result_val_len;
+   slice value;
 
    splinterdb_lookup_result result;
    splinterdb_lookup_result_init(data->kvsb, &result, 0, NULL);
 
-   rc = splinterdb_lookup(data->kvsb, key_len, key, &result);
+   rc = splinterdb_lookup(data->kvsb, key, &result);
    ASSERT_EQUAL(0, rc);
 
    ASSERT_TRUE(splinterdb_lookup_found(&result));
-   rc = splinterdb_lookup_result_value(
-      data->kvsb, &result, &result_val_len, &value);
+   rc = splinterdb_lookup_result_value(data->kvsb, &result, &value);
    ASSERT_EQUAL(0, rc);
-   ASSERT_EQUAL(val_len, result_val_len);
+   ASSERT_EQUAL(val_len, slice_length(value));
    ASSERT_STREQN(val,
-                 value,
-                 val_len,
+                 slice_data(value),
+                 slice_length(value),
                  "value found did not match expected 'val' up to %d bytes\n",
                  val_len);
 
@@ -682,7 +667,8 @@ CTEST2(splinterdb_quick, test_repeated_insert_close_reopen)
    size_t val_len = strlen(val);
 
    for (int i = 0; i < 20; i++) {
-      int rc = splinterdb_insert(data->kvsb, key_len, key, val_len, val);
+      int rc = splinterdb_insert(
+         data->kvsb, slice_create(key_len, key), slice_create(val_len, val));
       ASSERT_EQUAL(0, rc, "Insert is expected to pass, iter=%d.", i);
 
       splinterdb_close(data->kvsb);
@@ -705,24 +691,24 @@ CTEST2(splinterdb_quick, test_custom_data_config)
    int rc = splinterdb_create(&data->cfg, &data->kvsb);
    ASSERT_EQUAL(0, rc);
 
-   const size_t key_len = 3;
-   const char  *key     = "foo";
-   rc                   = splinterdb_insert(data->kvsb, key_len, key, 3, "bar");
+   const size_t key_len  = 3;
+   const char  *key_data = "foo";
+   slice        key      = slice_create(key_len, key_data);
    ASSERT_EQUAL(0, rc);
+   rc = splinterdb_insert(data->kvsb, key, slice_create(3, "bar"));
 
    // confirm its there
    splinterdb_lookup_result result;
    splinterdb_lookup_result_init(data->kvsb, &result, 0, NULL);
-   rc = splinterdb_lookup(data->kvsb, key_len, key, &result);
+   rc = splinterdb_lookup(data->kvsb, key, &result);
    ASSERT_EQUAL(0, rc);
    ASSERT_TRUE(splinterdb_lookup_found(&result));
 
-   size_t      val_len;
-   const char *val;
-   rc = splinterdb_lookup_result_value(data->kvsb, &result, &val_len, &val);
+   slice value;
+   rc = splinterdb_lookup_result_value(data->kvsb, &result, &value);
    ASSERT_EQUAL(0, rc);
-   ASSERT_EQUAL(3, val_len);
-   ASSERT_EQUAL(0, memcmp(val, "bar", 3));
+   ASSERT_EQUAL(3, slice_length(value));
+   ASSERT_EQUAL(0, memcmp(slice_data(value), "bar", 3));
 
    // insert a message that adds to the refcount
    char         msg_buffer[sizeof(data_handle)] = {0};
@@ -730,40 +716,38 @@ CTEST2(splinterdb_quick, test_custom_data_config)
    msg->message_type                            = MESSAGE_TYPE_UPDATE;
    msg->ref_count                               = 5;
    rc                                           = splinterdb_insert_raw_message(
-      data->kvsb, key_len, key, sizeof(msg_buffer), msg_buffer);
+      data->kvsb, key, slice_create(sizeof(msg_buffer), msg_buffer));
    ASSERT_EQUAL(0, rc);
 
    // check still found
-   rc = splinterdb_lookup(data->kvsb, key_len, key, &result);
+   rc = splinterdb_lookup(data->kvsb, key, &result);
    ASSERT_EQUAL(0, rc);
    ASSERT_TRUE(splinterdb_lookup_found(&result));
-   rc = splinterdb_lookup_result_value(data->kvsb, &result, &val_len, &val);
-   ASSERT_EQUAL(0, rc);
 
    // insert a message that drops the refcount to zero
    msg->message_type = MESSAGE_TYPE_UPDATE;
    msg->ref_count    = -6;
    rc                = splinterdb_insert_raw_message(
-      data->kvsb, key_len, key, sizeof(msg_buffer), msg_buffer);
+      data->kvsb, key, slice_create(sizeof(msg_buffer), msg_buffer));
    ASSERT_EQUAL(0, rc);
 
    // on lookup, merge will decide the tuple is deleted
-   rc = splinterdb_lookup(data->kvsb, key_len, key, &result);
+   rc = splinterdb_lookup(data->kvsb, key, &result);
    ASSERT_EQUAL(0, rc);
    ASSERT_FALSE(splinterdb_lookup_found(&result));
 
    // add it back as a value
-   rc = splinterdb_insert(data->kvsb, key_len, key, 3, "bar");
+   rc = splinterdb_insert(data->kvsb, key, slice_create(3, "bar"));
    ASSERT_EQUAL(0, rc);
 
    // delete it using a raw message
    msg->message_type = MESSAGE_TYPE_DELETE;
    rc                = splinterdb_insert_raw_message(
-      data->kvsb, key_len, key, sizeof(msg_buffer), msg_buffer);
+      data->kvsb, key, slice_create(sizeof(msg_buffer), msg_buffer));
    ASSERT_EQUAL(0, rc);
 
    // on lookup, it should not be found
-   rc = splinterdb_lookup(data->kvsb, key_len, key, &result);
+   rc = splinterdb_lookup(data->kvsb, key, &result);
    ASSERT_EQUAL(0, rc);
    ASSERT_FALSE(splinterdb_lookup_found(&result));
 }
@@ -792,7 +776,7 @@ CTEST2(splinterdb_quick, test_iterator_custom_comparator)
    ASSERT_EQUAL(0, rc);
 
    splinterdb_iterator *it = NULL;
-   rc                      = splinterdb_iterator_init(data->kvsb, &it, 0, NULL);
+   rc = splinterdb_iterator_init(data->kvsb, &it, NULL_SLICE);
    ASSERT_EQUAL(0, rc);
 
    int i = 0;
@@ -855,7 +839,8 @@ insert_some_keys(const int num_inserts, splinterdb *kvsb)
       ASSERT_EQUAL(6, snprintf(key, sizeof(key), key_fmt, i));
       ASSERT_EQUAL(6, snprintf(val, sizeof(val), val_fmt, i));
 
-      rc = splinterdb_insert(kvsb, sizeof(key), key, sizeof(val), val);
+      rc = splinterdb_insert(
+         kvsb, slice_create(sizeof(key), key), slice_create(sizeof(val), val));
       ASSERT_EQUAL(0, rc);
    }
 
@@ -893,7 +878,8 @@ insert_keys(splinterdb *kvsb, const int minkey, int numkeys, const int incr)
       snprintf(key, sizeof(key), key_fmt, kctr);
       snprintf(val, sizeof(val), val_fmt, kctr);
 
-      rc = splinterdb_insert(kvsb, sizeof(key), key, sizeof(val), val);
+      rc = splinterdb_insert(
+         kvsb, slice_create(sizeof(key), key), slice_create(sizeof(val), val));
       ASSERT_EQUAL(0, rc);
    }
    return rc;
@@ -919,17 +905,15 @@ check_current_tuple(splinterdb_iterator *it, const int expected_i)
    ASSERT_EQUAL(
       6, snprintf(expected_val, sizeof(expected_val), val_fmt, expected_i));
 
-   const char *key;
-   const char *val;
-   size_t      key_len, val_len;
+   slice key, value;
 
-   splinterdb_iterator_get_current(it, &key_len, &key, &val_len, &val);
+   splinterdb_iterator_get_current(it, &key, &value);
 
-   ASSERT_EQUAL(TEST_INSERT_KEY_LENGTH, key_len);
-   ASSERT_EQUAL(TEST_INSERT_VAL_LENGTH, val_len);
+   ASSERT_EQUAL(TEST_INSERT_KEY_LENGTH, slice_length(key));
+   ASSERT_EQUAL(TEST_INSERT_VAL_LENGTH, slice_length(value));
 
-   int key_cmp = memcmp(expected_key, key, key_len);
-   int val_cmp = memcmp(expected_val, val, val_len);
+   int key_cmp = memcmp(expected_key, slice_data(key), slice_length(key));
+   int val_cmp = memcmp(expected_val, slice_data(value), slice_length(value));
    ASSERT_EQUAL(0, key_cmp);
    ASSERT_EQUAL(0, val_cmp);
 
@@ -938,17 +922,12 @@ check_current_tuple(splinterdb_iterator *it, const int expected_i)
 
 // A user-specified spy comparator
 static int
-custom_key_comparator(const data_config *cfg,
-                      uint64             key1_len,
-                      const void        *key1,
-                      uint64             key2_len,
-                      const void        *key2)
+custom_key_comparator(const data_config *cfg, slice key1, slice key2)
 {
-   platform_assert(key1 != NULL);
-   platform_assert(key2 != NULL);
+   platform_assert(slice_data(key1) != NULL);
+   platform_assert(slice_data(key2) != NULL);
 
-   int r =
-      slice_lex_cmp(slice_create(key1_len, key1), slice_create(key2_len, key2));
+   int r = slice_lex_cmp(key1, key2);
 
    // record that this spy was called
    uint64_t *counter = (uint64_t *)(cfg->context);

--- a/tests/unit/splinterdb_stress_test.c
+++ b/tests/unit/splinterdb_stress_test.c
@@ -130,8 +130,9 @@ exec_worker_thread(void *w)
       result = read(random_data, value_buf, sizeof value_buf);
       ASSERT_TRUE(result >= 0);
 
-      rc = splinterdb_insert(
-         kvsb, TEST_KEY_SIZE, key_buf, TEST_VALUE_SIZE, value_buf);
+      rc = splinterdb_insert(kvsb,
+                             slice_create(TEST_KEY_SIZE, key_buf),
+                             slice_create(TEST_VALUE_SIZE, value_buf));
       ASSERT_EQUAL(0, rc);
 
       if (i && (i % 100000 == 0)) {

--- a/tests/unit/unit_test_template_dot_c
+++ b/tests/unit/unit_test_template_dot_c
@@ -9,7 +9,7 @@
  *  This is just a template file. Fill it out for your specific test suite.
  * -----------------------------------------------------------------------------
  */
-#include "splinterdb/platform_public.h"
+#include "splinterdb/public_platform.h"
 #include "unit_tests.h"
 #include "ctest.h" // This is required for all test-case files.
 


### PR DESCRIPTION
This exposes the `slice` type in the public API, replacing `length, pointer` pairs.