### PR TITLE
fixup make target for compile flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -316,4 +316,4 @@ install: $(LIBDIR)/libsplinterdb.so
 # to support clangd: https://clangd.llvm.org/installation.html#compile_flagstxt
 .PHONY: compile_flags.txt
 compile_flags.txt:
-	echo "$(INCLUDE)" | tr ' ' "\n" > compile_flags.txt
+	echo "$(DEFAULT_CFLAGS) $(INCLUDE)" | tr ' ' "\n" > compile_flags.txt


### PR DESCRIPTION
Pass cflags too, which will pull in the PLATFORM_DIR define and any other flags needed for compilation.

Fixes an interaction between #337 and #297.