### PR TITLE
(#339) Update docs to reflect max key-size limit, and doc supported page/extent-sizes. 

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,8 @@
 
 [Testing SplinterDB](./testing.md)
 
+[Limitations](./limitations.md)
+
 [Contributing](../CONTRIBUTING.md)
 
 [Code of Conduct](../CODE-OF-CONDUCT.md)

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -1,18 +1,21 @@
 # SplinterDB Known Limitations 
 
 SplinterDB is expected to evolve its API and add significant features, and it is not recommended for production use until version 1.0.
+
 Thus, SplinterDB is provided *as-is* given the following limitations and missing features:
 
 * Data recovery is not yet implemented (see [issue](https://github.com/vmware/splinterdb/issues/236) for roadmap).
 * Public API is not yet stable. Users should expect breaking changes in future versions.
-* SplinterDB on-disk format is not versioned (data may not survive upgrades.)
-* Key and data size need to be some fraction of page size. 
+* SplinterDB on-disk format is not versioned (Data may not survive software upgrades.)
+* Single 4KiB page size, with fixed extent size of 32 pages/extent.
+* Key and value size need to be less than the page size. Key size is limited to 121 bytes.
 * The application must specify the minimum and maximum of the key range.
 * SplinterDB on-disk size is fixed at compile time.
 * SplinterDB does not expose an API to force the latest write to be durable (e.g., fsync/commit.)
-* SplinterDB disk size cannot be changed once specified.
+* SplinterDB disk size cannot be changed once configured.
 * SplinterDB does not have a public API for the experimental async features.
-* SplinterDB does not retain initialization parameters metadata (which cannot be discovered from the database.)
+* SplinterDB does not retain configuration parameters and metadata. (These cannot
+  be discovered from the database, and have to be provided for re-starting SplinterDB.)
 * Internal metrics and stats are not exposed to applications.
 * Range delete is not yet implemented.
 * Empty database (e.g. db->clear()) is not yet implemented.


### PR DESCRIPTION
    - Update the limitations to reflect max key-size limit, that was
      needed to address other physical limits on the trunk nodes.
      Explicitly state supported page-size (4K) / extent-size limits (128K)
      Minor edits to verbiage of few other limitations.
      
    ----
Fixes issue #339 