### PR TITLE
(#348) Include few test cases to exercise max and some small key-size

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -51,7 +51,7 @@ function record_elapsed_time() {
       # Provide wider test-tag for nightly tests which print verbose descriptions
       fmtstr="%-80s""${fmtstr}"
    else
-      fmtstr="%-40s""${fmtstr}"
+      fmtstr="%-50s""${fmtstr}"
    fi
 
    # Log a line in the /tmp log-file; for future cat of summary output
@@ -381,13 +381,25 @@ if [ -f ${UNIT_TESTS_DB_DEV} ]; then
     rm ${UNIT_TESTS_DB_DEV}
 fi
 
-run_with_timing "Functionality test" bin/driver_test splinter_test --functionality 1000000 100 --seed "$SEED"
+key_size=8
+run_with_timing "Functionality test, key size=${key_size} bytes" bin/driver_test splinter_test --functionality 1000000 100 --key-size ${key_size} --seed "$SEED"
+
+run_with_timing "Functionality test, with default key size" bin/driver_test splinter_test --functionality 1000000 100 --seed "$SEED"
+
+max_key_size=121
+run_with_timing "Functionality test, key size=maximum (${max_key_size} bytes)" bin/driver_test splinter_test --functionality 1000000 100 --key-size ${max_key_size} --seed "$SEED"
 
 run_with_timing "Performance test" bin/driver_test splinter_test --perf --max-async-inflight 0 --num-insert-threads 4 --num-lookup-threads 4 --num-range-lookup-threads 0 --tree-size-gib 2 --cache-capacity-mib 512
 
 run_with_timing "Cache test" bin/driver_test cache_test --seed "$SEED"
 
-run_with_timing "BTree test" bin/driver_test btree_test --seed "$SEED"
+key_size=8
+run_with_timing "BTree test, key size=${key_size} bytes" bin/driver_test btree_test --key-size ${key_size} --seed "$SEED"
+
+run_with_timing "BTree test, with default key size" bin/driver_test btree_test --seed "$SEED"
+
+key_size=100
+run_with_timing "BTree test, key size=${key_size} bytes" bin/driver_test btree_test --key-size ${key_size} --seed "$SEED"
 
 run_with_timing "BTree Perf test" bin/driver_test btree_test --perf --cache-capacity-gib 4 --seed "$SEED"
 


### PR DESCRIPTION
Extend test.sh to verify that splinter_test runs with max key-size
as documented. Exercise couple of tests with few diff key-size values,
for additional coverage.

--
This change set has been pulled-out of PR #345 to now only contain the new tests added to `test.sh`.

Here's the output of the test run w/ these changes:

```
Sun Mar 13 01:34:45 UTC 2022 **** SplinterDB Test Suite Execution Times ****

Fast unit tests                                   :   13s [  0h  0m 13s ]
Splinter inserts test                             :   20s [  0h  0m 20s ]
Splinter lookups test                             :   38s [  0h  0m 38s ]
Functionality test, key size=8 bytes              :    8s [  0h  0m  8s ] <<<<
Functionality test, with default key size         :    9s [  0h  0m  9s ]
Functionality test, key size=maximum (121 bytes)  :    9s [  0h  0m  9s ] <<<<
Performance test                                  :   94s [  0h  1m 34s ]
Cache test                                        :    4s [  0h  0m  4s ]
BTree test, key size=8 bytes                      :   28s [  0h  0m 28s ] <<<<
BTree test, with default key size                 :   23s [  0h  0m 23s ] 
BTree test, key size=100 bytes                    :   15s [  0h  0m 15s ] <<<<
BTree Perf test                                   :   13s [  0h  0m 13s ]
Log test                                          :    0s [  0h  0m  0s ]
Filter test                                       :    1s [  0h  0m  1s ]
All Tests                                         :  275s [  0h  4m 35s ]

Sun Mar 13 01:39:20 UTC 2022 End SplinterDB Test Suite Execution.
```

The test-runs marked `<<<<` are new in this list, adding a little under 1m of execution time on Nimbus-VMs.