### PR TITLE
(#341) Add tests to verify that various hard-limits are enforced.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -383,6 +383,10 @@ $(BINDIR)/$(UNITDIR)/splinterdb_stress_test: $(COMMON_TESTOBJ)                  
 
 $(BINDIR)/$(UNITDIR)/writable_buffer_test: $(UTIL_SYS)
 
+$(BINDIR)/$(UNITDIR)/limitations_test: $(COMMON_TESTOBJ)            \
+                                       $(OBJDIR)/$(FUNCTIONAL_TESTSDIR)/test_async.o \
+                                       $(LIBDIR)/libsplinterdb.so
+
 ########################################
 # Convenience targets
 unit/util_test:                    $(BINDIR)/$(UNITDIR)/util_test

--- a/src/default_data_config.c
+++ b/src/default_data_config.c
@@ -76,7 +76,7 @@ default_data_config_init(const size_t max_key_size, // IN
 {
    platform_assert(max_key_size <= SPLINTERDB_MAX_KEY_SIZE && max_key_size > 0,
                    "default_data_config_init: must have 0 < max_key_size (%lu) "
-                   "< SPLINTERDB_MAX_KEY_SIZE (%d)",
+                   "<= SPLINTERDB_MAX_KEY_SIZE (%d)",
                    max_key_size,
                    SPLINTERDB_MAX_KEY_SIZE);
 

--- a/src/platform_linux/laio.h
+++ b/src/platform_linux/laio.h
@@ -14,6 +14,19 @@
 #include "task.h"
 #include <libaio.h>
 
+/*
+ * SplinterDB can be configured with different page-sizes, given by these
+ * min & max values. But for now, these are defined to just the one page
+ * size currently supported.
+ */
+#define LAIO_MIN_PAGE_SIZE (4096)
+#define LAIO_MAX_PAGE_SIZE (4096)
+
+#define LAIO_DEFAULT_PAGE_SIZE        LAIO_MIN_PAGE_SIZE
+#define LAIO_DEFAULT_PAGES_PER_EXTENT 32
+#define LAIO_DEFAULT_EXTENT_SIZE                                               \
+   (LAIO_DEFAULT_PAGES_PER_EXTENT * LAIO_DEFAULT_PAGE_SIZE)
+
 struct io_async_req {
    struct iocb    iocb;         // laio callback
    struct iocb   *iocb_p;       // laio callback pointer
@@ -37,5 +50,8 @@ typedef struct laio_handle {
    uint64           req_hand[MAX_THREADS];
    platform_heap_id heap_id;
 } laio_handle;
+
+platform_status
+laio_config_valid(io_config *cfg);
 
 #endif //__LAIO_H

--- a/src/trunk.c
+++ b/src/trunk.c
@@ -7025,6 +7025,16 @@ trunk_create(trunk_config     *cfg,
    trunk_handle *spl = TYPED_FLEXIBLE_STRUCT_ZALLOC(
       hid, spl, compacted_memtable, TRUNK_NUM_MEMTABLES);
    memmove(&spl->cfg, cfg, sizeof(*cfg));
+
+   // Validate configured key-size is within limits.
+   if (trunk_key_size(spl) > MAX_KEY_SIZE) {
+      platform_error_log("Trunk create failed. Configured key size, %lu, is "
+                         "greater than the max key-size supported, %d bytes.\n",
+                         trunk_key_size(spl),
+                         MAX_KEY_SIZE);
+      platform_free(hid, spl);
+      return (trunk_handle *)NULL;
+   }
    spl->al = al;
    spl->cc = cc;
    debug_assert(id != INVALID_ALLOCATOR_ROOT_ID);
@@ -7132,6 +7142,16 @@ trunk_mount(trunk_config     *cfg,
    trunk_handle *spl = TYPED_FLEXIBLE_STRUCT_ZALLOC(
       hid, spl, compacted_memtable, TRUNK_NUM_MEMTABLES);
    memmove(&spl->cfg, cfg, sizeof(*cfg));
+
+   // Validate configured key-size is within limits.
+   if (trunk_key_size(spl) > MAX_KEY_SIZE) {
+      platform_error_log("Trunk mount failed. Configured key size, %lu, is "
+                         "greater than the max key-size supported, %d bytes.\n",
+                         trunk_key_size(spl),
+                         MAX_KEY_SIZE);
+      platform_free(hid, spl);
+      return (trunk_handle *)NULL;
+   }
    spl->al = al;
    spl->cc = cc;
    debug_assert(id != INVALID_ALLOCATOR_ROOT_ID);
@@ -7156,7 +7176,8 @@ trunk_mount(trunk_config     *cfg,
       trunk_release_super_block(spl, super_page);
    }
    if (spl->root_addr == 0) {
-      return NULL;
+      platform_free(hid, spl);
+      return (trunk_handle *)NULL;
    }
    uint64 meta_head = spl->root_addr + trunk_page_size(&spl->cfg);
 

--- a/test.sh
+++ b/test.sh
@@ -321,6 +321,51 @@ function run_nightly_perf_tests() {
 
 }
 
+# Method to check that the command actually does fail; Otherwise it's an error.
+function run_check_rc() {
+    echo
+    set +e
+    "$@"
+    local rc=$?
+    set -e
+    if [ "$rc" -eq 0 ]; then
+        echo "$Me: Test is expected to fail, but did not:" "$@"
+        exit 1
+   fi
+}
+
+# ##################################################################
+# Exercise some common testing programs to validate that certain
+# hard-limits are being correctly enforced. These don't change
+# very often, so it's sufficient to test them in nightly runs.
+# ##################################################################
+function nightly_test_limitations() {
+
+    # All these invocations are expected to raise an error. If they
+    # sneak-through that's a test failure.
+    run_check_rc bin/driver_test splinter_test --page-size 1024
+    run_check_rc bin/driver_test splinter_test --page-size 2000
+    run_check_rc bin/driver_test splinter_test --page-size 2048
+    run_check_rc bin/driver_test splinter_test --page-size 8192
+
+    # Only --extent-size 131072 (i.e. 32 pages/extent) is valid.
+    run_check_rc bin/driver_test splinter_test --extent-size 2048
+    run_check_rc bin/driver_test splinter_test --extent-size 4096
+    run_check_rc bin/driver_test splinter_test --extent-size 40960
+    run_check_rc bin/driver_test splinter_test --extent-size 8192
+    run_check_rc bin/driver_test splinter_test --extent-size 135168
+    run_check_rc bin/driver_test splinter_test --extent-size 262144
+
+    # Validate that test-configs honor min / max key-sizes
+    run_check_rc bin/driver_test splinter_test --key-size 0
+    run_check_rc bin/driver_test splinter_test --key-size 7
+    run_check_rc bin/driver_test splinter_test --key-size 122
+    run_check_rc bin/driver_test splinter_test --key-size 200
+
+    # Invoke help usage; to confirm that it still works.
+    bin/driver_test splinter_test --help
+}
+
 # ##################################################################
 # main() begins here
 # ##################################################################
@@ -353,6 +398,8 @@ echo >> "${test_exec_log_file}"
 if [ "$RUN_NIGHTLY_TESTS" == "true" ]; then
 
     set +e
+    run_with_timing "Check limits, error conditions." nightly_test_limitations
+
     run_nightly_stress_tests
 
     run_nightly_perf_tests
@@ -386,6 +433,7 @@ if [ "$INCLUDE_SLOW_TESTS" != "true" ]; then
    "$BINDIR"/unit/btree_test
    "$BINDIR"/unit/util_test
    "$BINDIR"/unit/misc_test
+   "$BINDIR"/unit/limitations_test
    set +x
 
    echo "Fast tests passed"

--- a/tests/config.c
+++ b/tests/config.c
@@ -7,18 +7,10 @@
  * --------------------------------------------------------------------------
  * Default test configuration settings. These will be used by
  * config_set_defaults() to initialize test-execution configuration in the
- * master_config used to run tests.
+ * master_config used to run tests. See also config.h, where few default
+ * config limits used outside this file are defined.
  * --------------------------------------------------------------------------
  */
-#define TEST_CONFIG_DEFAULT_PAGE_SIZE 4096 // bytes
-
-#define TEST_CONFIG_DEFAULT_PAGES_PER_EXTENT 32
-_Static_assert(TEST_CONFIG_DEFAULT_PAGES_PER_EXTENT <= MAX_PAGES_PER_EXTENT,
-               "Invalid TEST_CONFIG_DEFAULT_PAGES_PER_EXTENT value");
-
-#define TEST_CONFIG_DEFAULT_EXTENT_SIZE                                        \
-   (TEST_CONFIG_DEFAULT_PAGES_PER_EXTENT * TEST_CONFIG_DEFAULT_PAGE_SIZE)
-
 // Determined empirically ... nothing scientific here
 #define TEST_CONFIG_DEFAULT_IO_ASYNC_Q_DEPTH 256
 
@@ -81,8 +73,8 @@ void
 config_usage()
 {
    platform_error_log("Configuration: (default)\n");
-   platform_error_log("\t--page_size (%d)\n", TEST_CONFIG_DEFAULT_PAGE_SIZE);
-   platform_error_log("\t--extent_size (%d)\n",
+   platform_error_log("\t--page-size (%d)\n", TEST_CONFIG_DEFAULT_PAGE_SIZE);
+   platform_error_log("\t--extent-size (%d)\n",
                       TEST_CONFIG_DEFAULT_EXTENT_SIZE);
    platform_error_log("\t--set-hugetlb\n");
    platform_error_log("\t--unset-hugetlb\n");
@@ -144,19 +136,35 @@ config_parse(master_config *cfg, const uint8 num_config, int argc, char *argv[])
          {
             for (cfg_idx = 0; cfg_idx < num_config; cfg_idx++) {
                if (cfg[cfg_idx].page_size != TEST_CONFIG_DEFAULT_PAGE_SIZE) {
-                  platform_error_log("page_size must be %d for now\n",
+                  platform_error_log("Currently, configuration parameter '%s' "
+                                     "is restricted to %d bytes.\n",
+                                     "--page-size",
                                      TEST_CONFIG_DEFAULT_PAGE_SIZE);
                   platform_error_log("config: failed to parse page-size\n");
                   return STATUS_BAD_PARAM;
                }
+               // Really dead-code for now; Leave it for future enablement.
                if (!IS_POWER_OF_2(cfg[cfg_idx].page_size)) {
-                  platform_error_log("page_size must be a power of 2\n");
+                  platform_error_log("Configuration parameter '%s' must be "
+                                     "a power of 2.\n",
+                                     "--page-size");
                   platform_error_log("config: failed to parse page-size\n");
                   return STATUS_BAD_PARAM;
                }
             }
          }
-         config_set_uint64("extent-size", cfg, extent_size) {}
+         config_set_uint64("extent-size", cfg, extent_size)
+         {
+            for (cfg_idx = 0; cfg_idx < num_config; cfg_idx++) {
+               if (!IS_POWER_OF_2(cfg[cfg_idx].extent_size)) {
+                  platform_error_log("Configuration parameter '%s' must be "
+                                     "a power of 2.\n",
+                                     "--extent-size");
+                  platform_error_log("config: failed to parse page-size\n");
+                  return STATUS_BAD_PARAM;
+               }
+            }
+         }
          config_has_option("set-hugetlb")
          {
             platform_use_hugetlb = TRUE;
@@ -266,16 +274,27 @@ config_parse(master_config *cfg, const uint8 num_config, int argc, char *argv[])
       }
       for (cfg_idx = 0; cfg_idx < num_config; cfg_idx++) {
          if (cfg[cfg_idx].extent_size % cfg[cfg_idx].page_size != 0) {
-            platform_error_log(
-               "config: extent_size is not a multiple of page_size\n");
+            platform_error_log("Configured extent-size, %lu, is not a multiple "
+                               "of page-size, %lu bytes.\n",
+                               cfg[cfg_idx].extent_size,
+                               cfg[cfg_idx].page_size);
             return STATUS_BAD_PARAM;
          }
          if (cfg[cfg_idx].extent_size / cfg[cfg_idx].page_size
-             > MAX_PAGES_PER_EXTENT) {
-            platform_error_log("config: pages per extent too high: %lu > %lu\n",
-                               cfg[cfg_idx].extent_size
-                                  / cfg[cfg_idx].page_size,
-                               MAX_PAGES_PER_EXTENT);
+             != MAX_PAGES_PER_EXTENT) {
+            int npages = (cfg[cfg_idx].extent_size / cfg[cfg_idx].page_size);
+            platform_error_log("For the configured page-size, %lu bytes, "
+                               "the '%s' argument, %lu, results in %d "
+                               "pages per extent which is not the "
+                               "supported value, %lu. "
+                               "Valid value for %s is %lu.\n",
+                               cfg[cfg_idx].page_size,
+                               "--extent-size",
+                               cfg[cfg_idx].extent_size,
+                               npages,
+                               MAX_PAGES_PER_EXTENT,
+                               "--extent-size",
+                               (MAX_PAGES_PER_EXTENT * cfg[cfg_idx].page_size));
             return STATUS_BAD_PARAM;
          }
          if (cfg[cfg_idx].key_size < TEST_CONFIG_MIN_KEY_SIZE) {
@@ -288,7 +307,7 @@ config_parse(master_config *cfg, const uint8 num_config, int argc, char *argv[])
          }
          if (cfg[cfg_idx].key_size > MAX_KEY_SIZE) {
             platform_error_log("Configured key-size, %lu bytes, is larger than "
-                               "the MAX_KEY_SIZE=%d.\n",
+                               "the MAX_KEY_SIZE=%d bytes.\n",
                                cfg[cfg_idx].key_size,
                                MAX_KEY_SIZE);
             return STATUS_BAD_PARAM;

--- a/tests/config.h
+++ b/tests/config.h
@@ -22,6 +22,22 @@ extern const char *BUILD_VERSION;
 
 /*
  * --------------------------------------------------------------------------
+ * Default test configuration settings. These will be used by
+ * config_set_defaults() to initialize test-execution configuration in the
+ * master_config used to run tests.
+ * --------------------------------------------------------------------------
+ */
+#define TEST_CONFIG_DEFAULT_PAGE_SIZE LAIO_DEFAULT_PAGE_SIZE // bytes
+
+#define TEST_CONFIG_DEFAULT_PAGES_PER_EXTENT LAIO_DEFAULT_PAGES_PER_EXTENT
+_Static_assert(TEST_CONFIG_DEFAULT_PAGES_PER_EXTENT <= MAX_PAGES_PER_EXTENT,
+               "Invalid TEST_CONFIG_DEFAULT_PAGES_PER_EXTENT value");
+
+#define TEST_CONFIG_DEFAULT_EXTENT_SIZE                                        \
+   (TEST_CONFIG_DEFAULT_PAGES_PER_EXTENT * TEST_CONFIG_DEFAULT_PAGE_SIZE)
+
+/*
+ * --------------------------------------------------------------------------
  * Convenience structure to hold configuration options for all sub-systems.
  * Command-line parsing routines parse config params into these structs.
  * Mostly needed for testing interfaces.

--- a/tests/functional/splinter_test.c
+++ b/tests/functional/splinter_test.c
@@ -2400,6 +2400,10 @@ splinter_test(int argc, char *argv[])
    /*
     * 1. Parse splinter_test options, see usage()
     */
+   if (argc > 1 && strncmp(argv[1], "--help", sizeof("--help")) == 0) {
+      usage(argv[0]);
+      return 0;
+   }
    if (argc > 1 && strncmp(argv[1], "--perf", sizeof("--perf")) == 0) {
       test                     = perf;
       config_argc              = argc - 2;
@@ -2617,9 +2621,10 @@ splinter_test(int argc, char *argv[])
       rc = STATUS_BAD_PARAM;
    }
    if (!SUCCESS(rc)) {
-      platform_error_log("splinter_test: failed to parse config: %s\n",
+      platform_error_log("Failed to parse config arguments. See "
+                         "'driver_test %s --help' for usage information: %s\n",
+                         argv[0],
                          platform_status_to_string(rc));
-      usage(argv[0]);
       goto cfg_free;
    }
 

--- a/tests/unit/limitations_test.c
+++ b/tests/unit/limitations_test.c
@@ -1,0 +1,521 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+ * -----------------------------------------------------------------------------
+ * limitations_test.c --
+ *
+ * Exercises SplinterDB configuration interfaces with unsupported parameters
+ * and confirm that we are not able to sneak-through. This would, otherwise,
+ * lead to configuring Splinter instance with parameters that are either
+ * unworkable, or currently unsupported.
+ * -----------------------------------------------------------------------------
+ */
+#include "splinterdb/public_platform.h"
+#include "trunk.h"
+#include "clockcache.h"
+#include "allocator.h"
+#include "platform.h"
+#include "task.h"
+#include "functional/test.h"
+#include "functional/test_async.h"
+#include "splinterdb/splinterdb.h"
+#include "splinterdb/default_data_config.h"
+#include "unit_tests.h"
+#include "ctest.h" // This is required for all test-case files.
+
+#define TEST_MAX_KEY_SIZE 13
+
+static void
+create_default_cfg(splinterdb_config *out_cfg, data_config *default_data_cfg);
+
+static platform_status
+splinter_init_subsystems(void *arg);
+
+static void
+splinter_deinit_subsystems(void *arg);
+
+/*
+ * Global data declaration macro:
+ */
+CTEST_DATA(limitations)
+{
+   // Declare head handles for io, allocator, cache and splinter allocation.
+   platform_heap_handle hh;
+   platform_heap_id     hid;
+
+   // Config structs required, as per splinter_test() setup work.
+   io_config           io_cfg;
+   rc_allocator_config al_cfg;
+   shard_log_config    log_cfg;
+
+   rc_allocator al;
+
+   uint8 num_bg_threads[NUM_TASK_TYPES];
+
+   // Following get setup pointing to allocated memory
+   trunk_config          *splinter_cfg;
+   data_config           *data_cfg;
+   clockcache_config     *cache_cfg;
+   platform_io_handle    *io;
+   clockcache            *clock_cache;
+   task_system           *tasks;
+   test_message_generator gen;
+
+   // Test execution related configuration
+   test_exec_config test_exec_cfg;
+};
+
+/*
+ * Setup heap memory to be used later to test Splinter configuration.
+ * splinter_test().
+ */
+// clang-format off
+CTEST_SETUP(limitations)
+{
+   Platform_default_log_handle = fopen("/tmp/unit_test.stdout", "a+");
+   Platform_error_log_handle = fopen("/tmp/unit_test.stderr", "a+");
+
+   uint64 heap_capacity = (1 * GiB);
+
+   // Create a heap for io, allocator, cache and splinter
+   platform_status rc = platform_heap_create(platform_get_module_id(),
+                                             heap_capacity,
+                                             &data->hh,
+                                             &data->hid);
+   platform_assert_status_ok(rc);
+}
+
+// clang-format on
+
+/*
+ * Tear down memory allocated for various sub-systems. Shutdown Splinter.
+ */
+CTEST_TEARDOWN(limitations)
+{
+   platform_heap_destroy(&data->hh);
+}
+
+/*
+ * **************************************************************************
+ * Basic test case to verify that an attempt to go through lower-level
+ * Splinter sub-system initializtion routines will correctly trap invalid
+ * page- / extent-size parameters.
+ * **************************************************************************
+ */
+CTEST2(limitations, test_io_init_invalid_page_size)
+{
+   platform_status rc;
+   uint64          num_tables = 1;
+
+   // Allocate memory for global config structures
+   data->splinter_cfg =
+      TYPED_ARRAY_MALLOC(data->hid, data->splinter_cfg, num_tables);
+
+   data->cache_cfg = TYPED_ARRAY_MALLOC(data->hid, data->cache_cfg, num_tables);
+
+   ZERO_STRUCT(data->test_exec_cfg);
+
+   rc = test_parse_args_n(data->splinter_cfg,
+                          &data->data_cfg,
+                          &data->io_cfg,
+                          &data->al_cfg,
+                          data->cache_cfg,
+                          &data->log_cfg,
+                          &data->test_exec_cfg,
+                          &data->gen,
+                          num_tables,
+                          Ctest_argc, // argc/argv globals setup by CTests
+                          (char **)Ctest_argv);
+   platform_assert_status_ok(rc);
+
+   // Allocate and initialize the IO sub-system.
+   data->io = TYPED_MALLOC(data->hid, data->io);
+   ASSERT_TRUE((data->io != NULL));
+
+   // Hard-fix the configured default page-size to an illegal value
+   uint64 page_size_configured = data->io_cfg.page_size;
+   ASSERT_EQUAL(page_size_configured, 4096);
+
+   data->io_cfg.page_size = 2048;
+
+   // This should fail.
+   rc = io_handle_init(data->io, &data->io_cfg, data->hh, data->hid);
+   ASSERT_FALSE(SUCCESS(rc));
+
+   // This should fail.
+   data->io_cfg.page_size = (page_size_configured * 2);
+   rc = io_handle_init(data->io, &data->io_cfg, data->hh, data->hid);
+   ASSERT_FALSE(SUCCESS(rc));
+
+   // Restore, and now set extent-size to invalid value
+   data->io_cfg.page_size = page_size_configured;
+
+   // This should succeed, finally!.
+   rc = io_handle_init(data->io, &data->io_cfg, data->hh, data->hid);
+   ASSERT_TRUE(SUCCESS(rc));
+
+   // Release resources acquired in this test case.
+   platform_free(data->hid, data->io->req);
+   platform_free(data->hid, data->io);
+
+   if (data->cache_cfg) {
+      platform_free(data->hid, data->cache_cfg);
+   }
+
+   if (data->splinter_cfg) {
+      platform_free(data->hid, data->splinter_cfg);
+   }
+}
+
+/*
+ * Test case to verify that we fail to initialize the IO sub-system with
+ * an invalid extent-size. Page-size is left as configured, and we diddle
+ * with extent size to verify error handling.
+ */
+CTEST2(limitations, test_io_init_invalid_extent_size)
+{
+   platform_status rc;
+   uint64          num_tables = 1;
+
+   // Allocate memory for global config structures
+   data->splinter_cfg =
+      TYPED_ARRAY_MALLOC(data->hid, data->splinter_cfg, num_tables);
+
+   data->cache_cfg = TYPED_ARRAY_MALLOC(data->hid, data->cache_cfg, num_tables);
+
+   ZERO_STRUCT(data->test_exec_cfg);
+
+   rc = test_parse_args_n(data->splinter_cfg,
+                          &data->data_cfg,
+                          &data->io_cfg,
+                          &data->al_cfg,
+                          data->cache_cfg,
+                          &data->log_cfg,
+                          &data->test_exec_cfg,
+                          &data->gen,
+                          num_tables,
+                          Ctest_argc, // argc/argv globals setup by CTests
+                          (char **)Ctest_argv);
+   platform_assert_status_ok(rc);
+
+   // Allocate and initialize the IO sub-system.
+   data->io = TYPED_MALLOC(data->hid, data->io);
+   ASSERT_TRUE((data->io != NULL));
+
+   uint64 pages_per_extent =
+      (data->io_cfg.extent_size / data->io_cfg.page_size);
+   ASSERT_EQUAL(MAX_PAGES_PER_EXTENT,
+                pages_per_extent,
+                "pages_per_extent=%lu != MAX_PAGES_PER_EXTENT=%lu ",
+                pages_per_extent,
+                MAX_PAGES_PER_EXTENT);
+
+   uint64 extent_size_configured = data->io_cfg.extent_size;
+
+   // This should fail.
+   data->io_cfg.extent_size = data->io_cfg.page_size;
+   rc = io_handle_init(data->io, &data->io_cfg, data->hh, data->hid);
+   ASSERT_FALSE(SUCCESS(rc));
+
+   // Halving the # of pages/extent. This should fail.
+   data->io_cfg.extent_size = (data->io_cfg.page_size * pages_per_extent) / 2;
+   rc = io_handle_init(data->io, &data->io_cfg, data->hh, data->hid);
+   ASSERT_FALSE(SUCCESS(rc));
+
+   // Doubling the # of pages/extent. This should fail.
+   data->io_cfg.extent_size = (data->io_cfg.page_size * pages_per_extent * 2);
+   rc = io_handle_init(data->io, &data->io_cfg, data->hh, data->hid);
+   ASSERT_FALSE(SUCCESS(rc));
+
+   data->io_cfg.extent_size = extent_size_configured;
+
+   // This should succeed, finally!.
+   rc = io_handle_init(data->io, &data->io_cfg, data->hh, data->hid);
+   ASSERT_TRUE(SUCCESS(rc));
+
+   // Release resources acquired in this test case.
+   if (data->cache_cfg) {
+      platform_free(data->hid, data->cache_cfg);
+   }
+
+   if (data->splinter_cfg) {
+      platform_free(data->hid, data->splinter_cfg);
+   }
+}
+
+/*
+ * Test splinterdb_*() interfaces with invalid page- / extent-size
+ * configurations, and verify that they fail correctly.
+ */
+CTEST2(limitations, test_splinterdb_create_invalid_page_size)
+{
+   splinterdb       *kvsb;
+   splinterdb_config cfg;
+   data_config       default_data_cfg;
+
+   default_data_config_init(TEST_MAX_KEY_SIZE, &default_data_cfg);
+   create_default_cfg(&cfg, &default_data_cfg);
+
+   uint64 page_size_configured = cfg.page_size;
+
+   // Futz around with invalid page sizes.
+   cfg.page_size = (2 * KiB);
+   int rc        = splinterdb_create(&cfg, &kvsb);
+   ASSERT_NOT_EQUAL(0, rc);
+
+   cfg.page_size = (2 * page_size_configured);
+   rc            = splinterdb_create(&cfg, &kvsb);
+   ASSERT_NOT_EQUAL(0, rc);
+}
+
+CTEST2(limitations, test_splinterdb_create_invalid_extent_size)
+{
+   splinterdb       *kvsb;
+   splinterdb_config cfg;
+   data_config       default_data_cfg;
+
+   default_data_config_init(TEST_MAX_KEY_SIZE, &default_data_cfg);
+   create_default_cfg(&cfg, &default_data_cfg);
+
+   uint64 extent_size_configured = cfg.extent_size;
+
+   // Futz around with invalid extent sizes.
+   cfg.extent_size = (extent_size_configured / 2);
+   int rc          = splinterdb_create(&cfg, &kvsb);
+   ASSERT_NOT_EQUAL(0, rc);
+
+   cfg.extent_size = (extent_size_configured * 2);
+   rc              = splinterdb_create(&cfg, &kvsb);
+   ASSERT_NOT_EQUAL(0, rc);
+}
+
+/*
+ * Test splinterdb_*() interfaces with invalid key-size to verify that
+ * we correctly fail before mounting the device. Invalid key-size during
+ * create will be caught by checks inside trunk_create(). Here, we just
+ * check that re-mounting an existing valid Splinter device when the
+ * configured key-size is changed is also trapped cleanly.
+ */
+CTEST2(limitations, test_splinterdb_mount_invalid_key_size)
+{
+   splinterdb       *kvsb;
+   splinterdb_config cfg;
+   data_config       default_data_cfg;
+
+   default_data_config_init(TEST_MAX_KEY_SIZE, &default_data_cfg);
+   create_default_cfg(&cfg, &default_data_cfg);
+
+   // This should succeed.
+   int rc = splinterdb_create(&cfg, &kvsb);
+   ASSERT_EQUAL(0, rc);
+
+   splinterdb_close(kvsb);
+
+   // We have carefully configured Splinter to use the default key-size
+   // used by tests. Force-it to be an invalid value, to check that
+   // core-Splinter trunk mount also properly generates an error message
+   cfg.data_cfg->key_size = (MAX_KEY_SIZE + 1);
+
+   // This should fail.
+   rc = splinterdb_open(&cfg, &kvsb);
+   ASSERT_NOT_EQUAL(0, rc);
+}
+
+/*
+ * Test case to verify that max key-size is correctly implemented by the
+ * trunk layer when a new SplinterDB instance is being created.
+ */
+CTEST2(limitations, test_trunk_create_invalid_key_size)
+{
+   platform_status rc = STATUS_OK;
+
+   rc = splinter_init_subsystems(data);
+   ASSERT_TRUE(SUCCESS(rc));
+
+   allocator *alp = (allocator *)&data->al;
+
+   // We have carefully configured Splinter to use the default key-size
+   // used by tests. Force-it to be an invalid value, to check that
+   // core-Splinter trunk creation properly generates an error message
+   data->splinter_cfg->data_cfg->key_size = (MAX_KEY_SIZE + 1);
+
+   trunk_handle *spl = trunk_create(data->splinter_cfg,
+                                    alp,
+                                    (cache *)data->clock_cache,
+                                    data->tasks,
+                                    test_generate_allocator_root_id(),
+                                    data->hid);
+   ASSERT_NULL(spl);
+
+   splinter_deinit_subsystems(data);
+}
+
+/*
+ * Test case to verify that max key-size is correctly implemented by the
+ * trunk layer when an existing SplinterDB instance is being mounted.
+ */
+CTEST2(limitations, test_trunk_mount_invalid_key_size)
+{
+   platform_status rc = STATUS_OK;
+
+   rc = splinter_init_subsystems(data);
+   ASSERT_TRUE(SUCCESS(rc));
+
+   allocator *alp = (allocator *)&data->al;
+
+   trunk_handle *spl = trunk_create(data->splinter_cfg,
+                                    alp,
+                                    (cache *)data->clock_cache,
+                                    data->tasks,
+                                    test_generate_allocator_root_id(),
+                                    data->hid);
+   ASSERT_NOT_NULL(spl);
+
+   trunk_destroy(spl);
+
+   // We have carefully configured Splinter to use the default key-size
+   // used by tests. Force-it to be an invalid value, to check that
+   // core-Splinter trunk creation properly generates an error message
+   data->splinter_cfg->data_cfg->key_size = (MAX_KEY_SIZE + 1);
+
+   spl = trunk_mount(data->splinter_cfg,
+                     alp,
+                     (cache *)data->clock_cache,
+                     data->tasks,
+                     test_generate_allocator_root_id(),
+                     data->hid);
+   ASSERT_NULL(spl);
+
+   splinter_deinit_subsystems(data);
+}
+
+/*
+ * Helper routine to create a valid Splinter configuration using default
+ * page- and extent-size.
+ */
+static void
+create_default_cfg(splinterdb_config *out_cfg, data_config *default_data_cfg)
+{
+   *out_cfg =
+      (splinterdb_config){.filename    = TEST_DB_NAME,
+                          .cache_size  = 64 * Mega,
+                          .disk_size   = 127 * Mega,
+                          .page_size   = TEST_CONFIG_DEFAULT_PAGE_SIZE,
+                          .extent_size = TEST_CONFIG_DEFAULT_EXTENT_SIZE,
+                          .data_cfg    = default_data_cfg};
+}
+
+/*
+ * Shared do-it-all configure and init Splinter subsystems routine.
+ */
+static platform_status
+splinter_init_subsystems(void *arg)
+{
+   // Cast void * datap to ptr-to-CTEST_DATA() struct in use.
+   struct CTEST_IMPL_DATA_SNAME(limitations) *data =
+      (struct CTEST_IMPL_DATA_SNAME(limitations) *)arg;
+
+   uint64 num_tables = 1;
+
+   // Allocate memory for global config structures
+   data->splinter_cfg =
+      TYPED_ARRAY_MALLOC(data->hid, data->splinter_cfg, num_tables);
+
+   data->cache_cfg = TYPED_ARRAY_MALLOC(data->hid, data->cache_cfg, num_tables);
+
+   ZERO_STRUCT(data->test_exec_cfg);
+
+   platform_status rc = STATUS_OK;
+
+   rc = test_parse_args_n(data->splinter_cfg,
+                          &data->data_cfg,
+                          &data->io_cfg,
+                          &data->al_cfg,
+                          data->cache_cfg,
+                          &data->log_cfg,
+                          &data->test_exec_cfg,
+                          &data->gen,
+                          num_tables,
+                          Ctest_argc, // argc/argv globals setup by CTests
+                          (char **)Ctest_argv);
+   platform_assert_status_ok(rc);
+
+   // Allocate and initialize the IO sub-system.
+   data->io = TYPED_MALLOC(data->hid, data->io);
+   ASSERT_TRUE((data->io != NULL));
+   rc = io_handle_init(data->io, &data->io_cfg, data->hh, data->hid);
+
+   // no bg threads by default.
+   for (int idx = 0; idx < NUM_TASK_TYPES; idx++) {
+      data->num_bg_threads[idx] = 0;
+   }
+
+   bool use_bg_threads = data->num_bg_threads[TASK_TYPE_NORMAL] != 0;
+
+   rc = test_init_task_system(data->hid,
+                              data->io,
+                              &data->tasks,
+                              data->splinter_cfg->use_stats,
+                              use_bg_threads,
+                              data->num_bg_threads);
+   ASSERT_TRUE(SUCCESS(rc),
+               "Failed to init splinter state: %s\n",
+               platform_status_to_string(rc));
+
+   rc_allocator_init(&data->al,
+                     &data->al_cfg,
+                     (io_handle *)data->io,
+                     data->hh,
+                     data->hid,
+                     platform_get_module_id());
+
+   int num_caches = 1;
+
+   data->clock_cache =
+      TYPED_ARRAY_MALLOC(data->hid, data->clock_cache, num_caches);
+   ASSERT_TRUE((data->clock_cache != NULL));
+
+   for (uint8 idx = 0; idx < num_caches; idx++) {
+      rc = clockcache_init(&data->clock_cache[idx],
+                           &data->cache_cfg[idx],
+                           (io_handle *)data->io,
+                           (allocator *)&data->al,
+                           "test",
+                           data->tasks,
+                           data->hh,
+                           data->hid,
+                           platform_get_module_id());
+
+      ASSERT_TRUE(SUCCESS(rc), "clockcache_init() failed for index=%d. ", idx);
+   }
+   return rc;
+}
+
+static void
+splinter_deinit_subsystems(void *arg)
+{
+   // Cast void * datap to ptr-to-CTEST_DATA() struct in use.
+   struct CTEST_IMPL_DATA_SNAME(limitations) *data =
+      (struct CTEST_IMPL_DATA_SNAME(limitations) *)arg;
+
+   clockcache_deinit(data->clock_cache);
+   platform_free(data->hid, data->clock_cache);
+
+   allocator *alp = (allocator *)&data->al;
+   allocator_assert_noleaks(alp);
+
+   rc_allocator_deinit(&data->al);
+   test_deinit_task_system(data->hid, data->tasks);
+
+   io_handle_deinit(data->io);
+   platform_free(data->hid, data->io);
+
+   if (data->cache_cfg) {
+      platform_free(data->hid, data->cache_cfg);
+   }
+
+   if (data->splinter_cfg) {
+      platform_free(data->hid, data->splinter_cfg);
+   }
+}

--- a/tests/unit/splinter_test.c
+++ b/tests/unit/splinter_test.c
@@ -215,7 +215,6 @@ CTEST_SETUP(splinter)
 
       ASSERT_TRUE(SUCCESS(rc), "clockcache_init() failed for index=%d. ", idx);
    }
-
 }
 
 // clang-format on


### PR DESCRIPTION
This commit adds checks in different places to validate that the documented page-, extent-, key-size limits are properly enforced.

Some asserts trapping these limits are converted to error messages. Add new test, limitations_test, to verify that different Splinter config / init / create interfaces fail (as expected) when used with illegal values.

----
**NOTE**: This is really _not new code-dev_, but **mainly tightening error checks** in some of the test-config interfaces, and in a few places in Splinter main code. This implements checks to verify that our supported page- / extent-size and max-key-size limits are properly enforced, with error messages, in most commonly seen interfaces. New test dev is done to verify these checks. Fixes issue #341 .

----
Here is a successful run of the limitations tests added in this PR:

```
Fusion-LocalVM:[492] $ ./bin/unit_test limitations
Running 1 CTests, suite name 'limitations', test case 'all'.
TEST 1/7 limitations:test_io_init_invalid_page_size [OK]
TEST 2/7 limitations:test_io_init_invalid_extent_size [OK]
TEST 3/7 limitations:test_splinterdb_create_invalid_page_size [OK]
TEST 4/7 limitations:test_splinterdb_create_invalid_extent_size [OK]
TEST 5/7 limitations:test_splinterdb_mount_invalid_key_size [OK]
TEST 6/7 limitations:test_trunk_create_invalid_key_size [OK]
TEST 7/7 limitations:test_trunk_mount_invalid_key_size [OK]
RESULTS: 7 tests (7 ok, 0 failed, 0 skipped) ran in 172 ms
```