### PR TITLE
Robj/message encoding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,9 +49,10 @@ CFLAGS += -D_GNU_SOURCE -ggdb3 -Wall -pthread -Wfatal-errors -Werror -Wvla
 CFLAGS += -DXXH_STATIC_LINKING_ONLY -fPIC
 CFLAGS += -DSPLINTERDB_PLATFORM_DIR=$(PLATFORM_DIR)
 
-# track git ref in the built library
+# track git ref in the built library. We don't put this into CFLAGS
+# directly because it causes false-positives in our config tracking.
 GIT_VERSION := "$(shell git describe --abbrev=8 --dirty --always --tags)"
-CFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
+GIT_VERSION_CFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
 
 cpu_arch := $(shell uname -p)
 ifeq ($(cpu_arch),x86_64)
@@ -265,7 +266,7 @@ $(BINDIR)/%/.:
 # RECIPES
 #
 
-COMPILE.c = $(CC) $(DEPFLAGS) -MT $@ -MF $(OBJDIR)/$*.d $(CFLAGS) $(INCLUDE) $(TARGET_ARCH) -c
+COMPILE.c = $(CC) $(DEPFLAGS) -MT $@ -MF $(OBJDIR)/$*.d $(CFLAGS) $(GIT_VERSION_CFLAGS) $(INCLUDE) $(TARGET_ARCH) -c
 
 $(OBJDIR)/%.o: %.c | $$(@D)/. $(CONFIG_FILE)
 	$(BRIEF_FORMATTED) "%-20s %-50s [%s]\n" Compiling $< $@
@@ -430,4 +431,4 @@ install: libs
 # to support clangd: https://clangd.llvm.org/installation.html#compile_flagstxt
 .PHONY: compile_flags.txt
 compile_flags.txt:
-	echo "$(CFLAGS) $(INCLUDE)" | tr ' ' "\n" > compile_flags.txt
+	echo "$(CFLAGS) $(GIT_VERSION_CFLAGS) $(INCLUDE)" | tr ' ' "\n" > compile_flags.txt

--- a/include/splinterdb/data.h
+++ b/include/splinterdb/data.h
@@ -33,7 +33,7 @@ typedef enum message_type {
 
 typedef struct message {
    message_type type;
-   slice data;
+   slice        data;
 } message;
 
 static inline message_type
@@ -124,12 +124,12 @@ struct data_config {
    char   max_key[MAX_KEY_SIZE];
    uint64 max_key_length;
 
-   key_compare_fn           key_compare;
-   key_hash_fn              key_hash;
-   merge_tuple_fn           merge_tuples;
-   merge_tuple_final_fn     merge_tuples_final;
-   key_to_str_fn            key_to_string;
-   message_to_str_fn        message_to_string;
+   key_compare_fn       key_compare;
+   key_hash_fn          key_hash;
+   merge_tuple_fn       merge_tuples;
+   merge_tuple_final_fn merge_tuples_final;
+   key_to_str_fn        key_to_string;
+   message_to_str_fn    message_to_string;
 };
 
 #endif // __DATA_H

--- a/include/splinterdb/public_util.h
+++ b/include/splinterdb/public_util.h
@@ -38,7 +38,7 @@ typedef struct writable_buffer writable_buffer;
 
 /* Returns 0 if wb is in the null state */
 uint64
-writable_buffer_length(writable_buffer *wb);
+writable_buffer_length(const writable_buffer *wb);
 
 /* Allocates memory as needed. Returns TRUE on success. */
 bool
@@ -46,7 +46,7 @@ writable_buffer_resize(writable_buffer *wb, uint64 newlength);
 
 /* Returns a ptr to the data region held by this writable_buffer */
 void *
-writable_buffer_data(writable_buffer *wb);
+writable_buffer_data(const writable_buffer *wb);
 
 
 /*

--- a/include/splinterdb/public_util.h
+++ b/include/splinterdb/public_util.h
@@ -7,49 +7,6 @@
 #include "splinterdb/public_platform.h"
 
 /*
- * A writable buffer is a resizable buffer whose contents can be
- * updated.
- *
- * Writable buffers can be in the following states:
- * - a special "null" state (analogous to a null pointer)
- * - non-null of length L.  Note that L may be 0, i.e. the null state
- *   is not the same as the length-0 state.
- *
- * You can query for the current length, which returns the special
- * WRITABLE_BUFFER_NULL_LENGTH when the writable_buffer is in the null
- * state.
- *
- * You can change the logical length of the buffer by calling
- * writable_buffer_resize.  Passing WRITABLE_BUFFER_NULL_LENGTH for
- * the newlength is not allowed.
- *
- * writable_buffer_data returns a pointer to the memory managed by the
- * writable_buffer.  You can then update the contents of the data as
- * you see fit.  You must not access beyond the logical length of the
- * data.
- *
- * CAUTION: Performing a resize invalidates any pointers returned by
- * prior calls to writable_buffer_data.
- *
- */
-typedef struct writable_buffer writable_buffer;
-
-#define WRITABLE_BUFFER_NULL_LENGTH UINT64_MAX
-
-/* Returns 0 if wb is in the null state */
-uint64
-writable_buffer_length(const writable_buffer *wb);
-
-/* Allocates memory as needed. Returns TRUE on success. */
-bool
-writable_buffer_resize(writable_buffer *wb, uint64 newlength);
-
-/* Returns a ptr to the data region held by this writable_buffer */
-void *
-writable_buffer_data(const writable_buffer *wb);
-
-
-/*
  * Non-disk resident descriptor for a [<length>, <value ptr>] pair
  * Used to pass-around references to keys and values of different lengths.
  *

--- a/include/splinterdb/splinterdb.h
+++ b/include/splinterdb/splinterdb.h
@@ -130,21 +130,14 @@ splinterdb_deregister_thread(splinterdb *kvs);
 int
 splinterdb_insert(const splinterdb *kvsb, slice key, slice value);
 
-// Insert a raw message at the given key.
-//
-// Custom message types can be used to encode non-overwriting
-// "blind mutations" like "increment" or "append" via the MESSAGE_TYPE_UPDATE.
-// These can be stored without doing a read of the current value.
-int
-splinterdb_insert_raw_message(const splinterdb *kvs,
-                              slice             key,
-                              slice             raw_message);
-
-
 // Delete a given key and any associated value / messages
 int
 splinterdb_delete(const splinterdb *kvsb, slice key);
 
+// Insert a key and value.
+// Relies on data_config->encode_message
+int
+splinterdb_update(const splinterdb *kvsb, slice key, slice delta);
 
 // Lookups
 

--- a/src/btree.c
+++ b/src/btree.c
@@ -105,9 +105,9 @@ index_entry_size(const slice key)
 }
 
 static inline uint64
-leaf_entry_size(const slice key, const slice message)
+leaf_entry_size(const slice key, const message msg)
 {
-   return sizeof(leaf_entry) + slice_length(key) + slice_length(message);
+   return sizeof(leaf_entry) + slice_length(key) + message_length(msg);
 }
 
 static inline uint64
@@ -176,6 +176,7 @@ btree_fill_index_entry(const btree_config *cfg,
                 <= btree_page_size(cfg));
    memcpy(entry->key, slice_data(new_pivot_key), slice_length(new_pivot_key));
    entry->key_size                            = slice_length(new_pivot_key);
+   entry->key_indirect                        = FALSE;
    entry->pivot_data.child_addr               = new_addr;
    entry->pivot_data.num_kvs_in_subtree       = kv_pairs;
    entry->pivot_data.key_bytes_in_subtree     = key_bytes;
@@ -289,16 +290,21 @@ btree_fill_leaf_entry(const btree_config *cfg,
                       btree_hdr          *hdr,
                       leaf_entry         *entry,
                       slice               key,
-                      slice               message)
+                      message             msg)
 {
-   debug_assert(pointer_byte_offset(entry, leaf_entry_size(key, message))
+   debug_assert(pointer_byte_offset(entry, leaf_entry_size(key, msg))
                 <= pointer_byte_offset(hdr, btree_page_size(cfg)));
    memcpy(entry->key_and_message, slice_data(key), slice_length(key));
    memcpy(entry->key_and_message + slice_length(key),
-          slice_data(message),
-          slice_length(message));
+          message_data(msg),
+          message_length(msg));
    entry->key_size     = slice_length(key);
-   entry->message_size = slice_length(message);
+   entry->key_indirect = FALSE;
+   entry->type         = message_class(msg);
+   /* This assertion ensures that entry->type is large enough to hold type. */
+   debug_assert(entry->type == message_class(msg));
+   entry->message_size = message_length(msg);
+   entry->message_indirect = FALSE;
 }
 
 static inline bool
@@ -306,7 +312,7 @@ btree_can_set_leaf_entry(const btree_config *cfg,
                          const btree_hdr    *hdr,
                          table_index         k,
                          slice               new_key,
-                         slice               new_message)
+                         message             new_message)
 {
    if (hdr->num_entries < k)
       return FALSE;
@@ -335,7 +341,7 @@ btree_set_leaf_entry(const btree_config *cfg,
                      btree_hdr          *hdr,
                      table_index         k,
                      slice               new_key,
-                     slice               new_message)
+                     message             new_message)
 {
    if (k < hdr->num_entries) {
       leaf_entry *old_entry = btree_get_leaf_entry(cfg, hdr, k);
@@ -379,7 +385,7 @@ btree_insert_leaf_entry(const btree_config *cfg,
                         btree_hdr          *hdr,
                         table_index         k,
                         slice               new_key,
-                        slice               new_message)
+                        message             new_message)
 {
    debug_assert(k <= hdr->num_entries);
    bool succeeded =
@@ -539,19 +545,19 @@ btree_find_tuple(const btree_config *cfg,
 static inline int
 btree_merge_tuples(const btree_config *cfg,
                    slice               key,
-                   slice               old_data,
-                   writable_buffer    *new_data)
+                   message             old_data,
+                   merge_accumulator  *new_data)
 {
    return data_merge_tuples(cfg->data_cfg, key, old_data, new_data);
 }
 
-static slice
+static message
 spec_message(const leaf_incorporate_spec *spec)
 {
    if (spec->old_entry_state == ENTRY_DID_NOT_EXIST) {
       return spec->msg.new_message;
    } else {
-      return writable_buffer_to_slice(&spec->msg.merged_message);
+      return merge_accumulator_to_message(&spec->msg.merged_message);
    }
 }
 
@@ -560,7 +566,7 @@ btree_create_leaf_incorporate_spec(const btree_config    *cfg,
                                    platform_heap_id       heap_id,
                                    btree_hdr             *hdr,
                                    slice                  key,
-                                   slice                  message,
+                                   message                msg,
                                    leaf_incorporate_spec *spec)
 {
    spec->key = key;
@@ -568,20 +574,20 @@ btree_create_leaf_incorporate_spec(const btree_config    *cfg,
    spec->idx             = btree_find_tuple(cfg, hdr, key, &found);
    spec->old_entry_state = found ? ENTRY_STILL_EXISTS : ENTRY_DID_NOT_EXIST;
    if (!found) {
-      spec->msg.new_message = message;
+      spec->msg.new_message = msg;
       spec->idx++;
       return STATUS_OK;
    } else {
       leaf_entry     *entry      = btree_get_leaf_entry(cfg, hdr, spec->idx);
-      slice           oldmessage = leaf_entry_message_slice(entry);
+      message         oldmessage = leaf_entry_message(entry);
       platform_status rc;
-      rc = writable_buffer_init_from_slice(
-         &spec->msg.merged_message, heap_id, message);
+      rc = merge_accumulator_init_from_message(
+         &spec->msg.merged_message, heap_id, msg);
       if (!SUCCESS(rc)) {
          return STATUS_NO_MEMORY;
       }
       if (btree_merge_tuples(cfg, key, oldmessage, &spec->msg.merged_message)) {
-         writable_buffer_deinit(&spec->msg.merged_message);
+         merge_accumulator_deinit(&spec->msg.merged_message);
          return STATUS_NO_MEMORY;
       } else {
          return STATUS_OK;
@@ -593,7 +599,7 @@ void
 destroy_leaf_incorporate_spec(leaf_incorporate_spec *spec)
 {
    if (spec->old_entry_state != ENTRY_DID_NOT_EXIST) {
-      writable_buffer_deinit(&spec->msg.merged_message);
+      merge_accumulator_deinit(&spec->msg.merged_message);
    }
 }
 
@@ -606,11 +612,11 @@ btree_can_perform_leaf_incorporate_spec(const btree_config          *cfg,
       return btree_can_set_leaf_entry(
          cfg, hdr, btree_num_entries(hdr), spec->key, spec->msg.new_message);
    } else if (spec->old_entry_state == ENTRY_STILL_EXISTS) {
-      slice merged = writable_buffer_to_slice(&spec->msg.merged_message);
+      message merged = merge_accumulator_to_message(&spec->msg.merged_message);
       return btree_can_set_leaf_entry(cfg, hdr, spec->idx, spec->key, merged);
    } else {
       debug_assert(spec->old_entry_state == ENTRY_HAS_BEEN_REMOVED);
-      slice merged = writable_buffer_to_slice(&spec->msg.merged_message);
+      message merged = merge_accumulator_to_message(&spec->msg.merged_message);
       return btree_can_set_leaf_entry(
          cfg, hdr, btree_num_entries(hdr), spec->key, merged);
    }
@@ -630,13 +636,15 @@ btree_try_perform_leaf_incorporate_spec(const btree_config          *cfg,
          break;
       case ENTRY_STILL_EXISTS:
       {
-         slice merged = writable_buffer_to_slice(&spec->msg.merged_message);
+         message merged =
+            merge_accumulator_to_message(&spec->msg.merged_message);
          success = btree_set_leaf_entry(cfg, hdr, spec->idx, spec->key, merged);
          break;
       }
       case ENTRY_HAS_BEEN_REMOVED:
       {
-         slice merged = writable_buffer_to_slice(&spec->msg.merged_message);
+         message merged =
+            merge_accumulator_to_message(&spec->msg.merged_message);
          success =
             btree_insert_leaf_entry(cfg, hdr, spec->idx, spec->key, merged);
          break;
@@ -685,7 +693,7 @@ btree_defragment_leaf(const btree_config    *cfg, // IN
                                  hdr,
                                  dst_idx++,
                                  leaf_entry_key_slice(entry),
-                                 leaf_entry_message_slice(entry));
+                                 leaf_entry_message(entry));
          debug_assert(success);
       }
    }
@@ -862,7 +870,7 @@ btree_split_leaf_build_right_node(const btree_config    *cfg,      // IN
                               right_hdr,
                               dst_idx,
                               leaf_entry_key_slice(entry),
-                              leaf_entry_message_slice(entry));
+                              leaf_entry_message(entry));
          dst_idx++;
       }
    }
@@ -1688,7 +1696,7 @@ btree_insert(cache              *cc,         // IN
              uint64              root_addr,  // IN
              mini_allocator     *mini,       // IN
              slice               key,        // IN
-             slice               message,    // IN
+             message             msg,        // IN
              uint64             *generation, // OUT
              bool               *was_unique)               // OUT
 {
@@ -1700,7 +1708,7 @@ btree_insert(cache              *cc,         // IN
       return STATUS_BAD_PARAM;
    }
 
-   if (MAX_INLINE_MESSAGE_SIZE < slice_length(message)) {
+   if (MAX_INLINE_MESSAGE_SIZE < message_length(msg)) {
       return STATUS_BAD_PARAM;
    }
 
@@ -1714,7 +1722,7 @@ start_over:
 
    if (btree_height(root_node.hdr) == 0) {
       rc = btree_create_leaf_incorporate_spec(
-         cfg, heap_id, root_node.hdr, key, message, &spec);
+         cfg, heap_id, root_node.hdr, key, msg, &spec);
       if (!SUCCESS(rc)) {
          btree_node_unget(cc, cfg, &root_node);
          return rc;
@@ -1904,7 +1912,7 @@ start_over:
     */
 
    rc = btree_create_leaf_incorporate_spec(
-      cfg, heap_id, child_node.hdr, key, message, &spec);
+      cfg, heap_id, child_node.hdr, key, msg, &spec);
    if (!SUCCESS(rc)) {
       btree_node_unget(cc, cfg, &parent_node);
       btree_node_unget(cc, cfg, &child_node);
@@ -1952,7 +1960,7 @@ start_over:
        * so rebuild it. */
       destroy_leaf_incorporate_spec(&spec);
       rc = btree_create_leaf_incorporate_spec(
-         cfg, heap_id, child_node.hdr, key, message, &spec);
+         cfg, heap_id, child_node.hdr, key, msg, &spec);
       if (!SUCCESS(rc)) {
          btree_node_unget(cc, cfg, &parent_node);
          btree_node_unclaim(cc, cfg, &child_node);
@@ -1991,14 +1999,15 @@ start_over:
  *-----------------------------------------------------------------------------
  */
 platform_status
-btree_lookup_node(cache        *cc,           // IN
-                  btree_config *cfg,          // IN
-                  uint64        root_addr,    // IN
-                  const slice   key,          // IN
-                  uint16      stop_at_height, // IN  search down to this height
-                  page_type   type,           // IN
-                  btree_node *out_node,       // OUT returns the node of height
-                                        // stop_at_height in which key was found
+btree_lookup_node(cache        *cc,             // IN
+                  btree_config *cfg,            // IN
+                  uint64        root_addr,      // IN
+                  const slice   key,            // IN
+                  uint16        stop_at_height, // IN
+                  page_type     type,           // IN
+                  btree_node   *out_node, // OUT returns the node of height
+                                          // stop_at_height in which
+                                          // key was found
                   uint32 *kv_rank, // ranks must be all NULL or all non-NULL
                   uint32 *key_byte_rank,
                   uint32 *message_byte_rank)
@@ -2054,52 +2063,52 @@ btree_lookup_with_ref(cache        *cc,        // IN
                       page_type     type,      // IN
                       const slice   key,       // IN
                       btree_node   *node,      // OUT
-                      slice        *data,      // OUT
+                      message      *msg,       // OUT
                       bool         *found)             // OUT
 {
    btree_lookup_node(cc, cfg, root_addr, key, 0, type, node, NULL, NULL, NULL);
    int64 idx = btree_find_tuple(cfg, node->hdr, key, found);
    if (*found) {
       leaf_entry *entry = btree_get_leaf_entry(cfg, node->hdr, idx);
-      *data             = leaf_entry_message_slice(entry);
+      *msg              = leaf_entry_message(entry);
    } else {
       btree_node_unget(cc, cfg, node);
    }
 }
 
 platform_status
-btree_lookup(cache           *cc,        // IN
-             btree_config    *cfg,       // IN
-             uint64           root_addr, // IN
-             page_type        type,      // IN
-             const slice      key,       // IN
-             writable_buffer *result)    // OUT
+btree_lookup(cache             *cc,        // IN
+             btree_config      *cfg,       // IN
+             uint64             root_addr, // IN
+             page_type          type,      // IN
+             const slice        key,       // IN
+             merge_accumulator *result)    // OUT
 {
    btree_node      node;
-   slice           data;
+   message         data;
    platform_status rc = STATUS_OK;
    bool            local_found;
 
    btree_lookup_with_ref(
       cc, cfg, root_addr, type, key, &node, &data, &local_found);
    if (local_found) {
-      rc = writable_buffer_copy_slice(result, data);
+      rc = merge_accumulator_copy_message(result, data);
       btree_node_unget(cc, cfg, &node);
    }
    return rc;
 }
 
 platform_status
-btree_lookup_and_merge(cache           *cc,        // IN
-                       btree_config    *cfg,       // IN
-                       uint64           root_addr, // IN
-                       page_type        type,      // IN
-                       const slice      key,       // IN
-                       writable_buffer *data,      // OUT
-                       bool            *local_found)          // OUT
+btree_lookup_and_merge(cache             *cc,        // IN
+                       btree_config      *cfg,       // IN
+                       uint64             root_addr, // IN
+                       page_type          type,      // IN
+                       const slice        key,       // IN
+                       merge_accumulator *data,      // OUT
+                       bool              *local_found)            // OUT
 {
    btree_node      node;
-   slice           local_data;
+   message         local_data;
    platform_status rc = STATUS_OK;
 
    log_trace_key(key, "btree_lookup");
@@ -2107,8 +2116,8 @@ btree_lookup_and_merge(cache           *cc,        // IN
    btree_lookup_with_ref(
       cc, cfg, root_addr, type, key, &node, &local_data, local_found);
    if (*local_found) {
-      if (writable_buffer_is_null(data)) {
-         rc = writable_buffer_copy_slice(data, local_data);
+      if (merge_accumulator_is_null(data)) {
+         rc = merge_accumulator_copy_message(data, local_data);
       } else if (btree_merge_tuples(cfg, key, local_data, data)) {
          rc = STATUS_NO_MEMORY;
       }
@@ -2198,7 +2207,7 @@ btree_lookup_async_with_ref(cache            *cc,        // IN
                             uint64            root_addr, // IN
                             slice             key,       // IN
                             btree_node       *node_out,  // OUT
-                            slice            *data,      // OUT
+                            message          *data,      // OUT
                             bool             *found,     // OUT
                             btree_async_ctxt *ctxt)      // IN
 {
@@ -2328,21 +2337,21 @@ btree_lookup_async_with_ref(cache            *cc,        // IN
  *-----------------------------------------------------------------------------
  */
 cache_async_result
-btree_lookup_async(cache            *cc,        // IN
-                   btree_config     *cfg,       // IN
-                   uint64            root_addr, // IN
-                   slice             key,       // IN
-                   writable_buffer  *result,    // OUT
-                   btree_async_ctxt *ctxt)      // IN
+btree_lookup_async(cache             *cc,        // IN
+                   btree_config      *cfg,       // IN
+                   uint64             root_addr, // IN
+                   slice              key,       // IN
+                   merge_accumulator *result,    // OUT
+                   btree_async_ctxt  *ctxt)       // IN
 {
    cache_async_result res;
    btree_node         node;
-   slice              data;
+   message            data;
    bool               local_found;
    res = btree_lookup_async_with_ref(
       cc, cfg, root_addr, key, &node, &data, &local_found, ctxt);
    if (res == async_success && local_found) {
-      platform_status rc = writable_buffer_copy_slice(result, data);
+      platform_status rc = merge_accumulator_copy_message(result, data);
       platform_assert_status_ok(rc); // FIXME
       btree_node_unget(cc, cfg, &node);
    }
@@ -2351,23 +2360,23 @@ btree_lookup_async(cache            *cc,        // IN
 }
 
 cache_async_result
-btree_lookup_and_merge_async(cache            *cc,          // IN
-                             btree_config     *cfg,         // IN
-                             uint64            root_addr,   // IN
-                             const slice       key,         // IN
-                             writable_buffer  *data,        // OUT
-                             bool             *local_found, // OUT
-                             btree_async_ctxt *ctxt)        // IN
+btree_lookup_and_merge_async(cache             *cc,          // IN
+                             btree_config      *cfg,         // IN
+                             uint64             root_addr,   // IN
+                             const slice        key,         // IN
+                             merge_accumulator *data,        // OUT
+                             bool              *local_found, // OUT
+                             btree_async_ctxt  *ctxt)         // IN
 {
    cache_async_result res;
    btree_node         node;
-   slice              local_data;
+   message            local_data;
 
    res = btree_lookup_async_with_ref(
       cc, cfg, root_addr, key, &node, &local_data, local_found, ctxt);
    if (res == async_success && *local_found) {
-      if (writable_buffer_is_null(data)) {
-         platform_status rc = writable_buffer_copy_slice(data, local_data);
+      if (merge_accumulator_is_null(data)) {
+         platform_status rc = merge_accumulator_copy_message(data, local_data);
          platform_assert_status_ok(rc);
       } else {
          int rc = btree_merge_tuples(cfg, key, local_data, data);
@@ -2420,7 +2429,7 @@ btree_iterator_is_at_end(btree_iterator *itor)
 }
 
 void
-btree_iterator_get_curr(iterator *base_itor, slice *key, slice *data)
+btree_iterator_get_curr(iterator *base_itor, slice *key, message *data)
 {
    debug_assert(base_itor != NULL);
    btree_iterator *itor = (btree_iterator *)base_itor;
@@ -2442,7 +2451,9 @@ btree_iterator_get_curr(iterator *base_itor, slice *key, slice *data)
       index_entry *entry =
          btree_get_index_entry(itor->cfg, itor->curr.hdr, itor->idx);
       *key  = index_entry_key_slice(entry);
-      *data = slice_create(sizeof(entry->pivot_data), &entry->pivot_data);
+      *data = message_create(
+         MESSAGE_TYPE_INVALID,
+         slice_create(sizeof(entry->pivot_data), &entry->pivot_data));
    }
 }
 
@@ -2788,10 +2799,10 @@ btree_pack_setup_finish(btree_pack_req *req, slice first_key)
 }
 
 static inline void
-btree_pack_loop(btree_pack_req *req,     // IN/OUT
-                slice           key,     // IN
-                slice           message, // IN
-                bool           *at_end)            // IN/OUT
+btree_pack_loop(btree_pack_req *req, // IN/OUT
+                slice           key, // IN
+                message         msg, // IN
+                bool           *at_end)        // IN/OUT
 {
    log_trace_key(key, "btree_pack_loop");
 
@@ -2799,7 +2810,7 @@ btree_pack_loop(btree_pack_req *req,     // IN/OUT
                              req->edge[0].hdr,
                              btree_num_entries(req->edge[0].hdr),
                              key,
-                             message))
+                             msg))
    {
       // the current leaf is full, allocate a new one and add to index
       btree_node old_edge = req->edge[0];
@@ -2817,7 +2828,7 @@ btree_pack_loop(btree_pack_req *req,     // IN/OUT
       debug_assert(cache_page_valid(req->cc, req->next_extent));
       btree_pack_node_init_hdr(req->cfg, req->edge[0].hdr, req->next_extent, 0);
       bool result =
-         btree_set_leaf_entry(req->cfg, req->edge[0].hdr, 0, key, message);
+         btree_set_leaf_entry(req->cfg, req->edge[0].hdr, 0, key, msg);
       platform_assert(result);
 
       // this loop finds the first level with a free slot
@@ -2895,7 +2906,7 @@ btree_pack_loop(btree_pack_req *req,     // IN/OUT
          req->cfg, req->edge[i].hdr, btree_num_entries(req->edge[i].hdr) - 1);
       entry->pivot_data.num_kvs_in_subtree++;
       entry->pivot_data.key_bytes_in_subtree += slice_length(key);
-      entry->pivot_data.message_bytes_in_subtree += slice_length(message);
+      entry->pivot_data.message_bytes_in_subtree += message_length(msg);
    }
 
    if (req->hash) {
@@ -2906,10 +2917,10 @@ btree_pack_loop(btree_pack_req *req,     // IN/OUT
 
    req->num_tuples++;
    req->key_bytes += slice_length(key);
-   req->message_bytes += slice_length(message);
+   req->message_bytes += message_length(msg);
 
-   iterator_advance(req->itor);
-   iterator_at_end(req->itor, at_end);
+   iterator_advance((iterator *)req->itor);
+   iterator_at_end((iterator *)req->itor, at_end);
 }
 
 
@@ -2962,11 +2973,11 @@ btree_pack_post_loop(btree_pack_req *req, slice last_key)
 }
 
 static bool
-btree_pack_can_fit_tuple(btree_pack_req *req, slice key, slice data)
+btree_pack_can_fit_tuple(btree_pack_req *req, slice key, message data)
 {
    return req->num_tuples < req->max_tuples
           && req->key_bytes + req->message_bytes + slice_length(key)
-                   + slice_length(data)
+                   + message_length(data)
                 <= req->max_kv_bytes;
 }
 
@@ -2983,13 +2994,14 @@ btree_pack(btree_pack_req *req)
 {
    btree_pack_setup_start(req);
 
-   slice key = NULL_SLICE, data;
-   bool  at_end;
+   slice   key = NULL_SLICE;
+   message data;
+   bool    at_end;
 
-   iterator_at_end(req->itor, &at_end);
+   iterator_at_end((iterator *)req->itor, &at_end);
 
    if (!at_end) {
-      iterator_get_curr(req->itor, &key, &data);
+      iterator_get_curr((iterator *)req->itor, &key, &data);
       if (btree_pack_can_fit_tuple(req, key, data)) {
          btree_pack_setup_finish(req, key);
       }
@@ -3106,7 +3118,7 @@ btree_count_in_range_by_iterator(cache        *cc,
                                  uint32       *message_bytes_rank)
 {
    btree_iterator btree_itor;
-   iterator      *itor = &btree_itor.super;
+   iterator      *itor = (iterator *)&btree_itor.super;
    btree_iterator_init(cc,
                        cfg,
                        &btree_itor,
@@ -3124,11 +3136,12 @@ btree_count_in_range_by_iterator(cache        *cc,
    bool at_end;
    iterator_at_end(itor, &at_end);
    while (!at_end) {
-      slice key, message;
-      iterator_get_curr(itor, &key, &message);
+      slice   key;
+      message msg;
+      iterator_get_curr(itor, &key, &msg);
       *kv_rank            = *kv_rank + 1;
       *key_bytes_rank     = *key_bytes_rank + slice_length(key);
-      *message_bytes_rank = *message_bytes_rank + slice_length(message);
+      *message_bytes_rank = *message_bytes_rank + message_length(msg);
       iterator_advance(itor);
       iterator_at_end(itor, &at_end);
    }
@@ -3200,11 +3213,10 @@ btree_print_locked_node(btree_config          *cfg,
       platform_log_stream("-------------------\n");
       for (uint64 i = 0; i < btree_num_entries(hdr); i++) {
          leaf_entry *entry = btree_get_leaf_entry(cfg, hdr, i);
-         platform_log_stream(
-            "%2lu:%s -- %s\n",
-            i,
-            key_string(dcfg, leaf_entry_key_slice(entry)),
-            message_string(dcfg, leaf_entry_message_slice(entry)));
+         platform_log_stream("%2lu:%s -- %s\n",
+                             i,
+                             key_string(dcfg, leaf_entry_key_slice(entry)),
+                             message_string(dcfg, leaf_entry_message(entry)));
       }
       platform_log_stream("-------------------\n");
       platform_log_stream("\n");

--- a/src/btree.c
+++ b/src/btree.c
@@ -303,7 +303,7 @@ btree_fill_leaf_entry(const btree_config *cfg,
    entry->type         = message_class(msg);
    /* This assertion ensures that entry->type is large enough to hold type. */
    debug_assert(entry->type == message_class(msg));
-   entry->message_size = message_length(msg);
+   entry->message_size     = message_length(msg);
    entry->message_indirect = FALSE;
 }
 

--- a/src/btree.h
+++ b/src/btree.h
@@ -152,13 +152,13 @@ typedef struct btree_iterator {
 
 typedef struct btree_pack_req {
    // inputs to the pack
-   cache        *cc;
-   btree_config *cfg;
-   iterator     *itor; // the itor which is being packed
-   uint64        max_tuples;
-   uint64        max_kv_bytes; // max kv_bytes for the tree
-   hash_fn       hash;         // hash function used for calculating filter_hash
-   unsigned int  seed;         // seed used for calculating filter_hash
+   cache            *cc;
+   btree_config     *cfg;
+   iterator         *itor; // the itor which is being packed
+   uint64            max_tuples;
+   uint64            max_kv_bytes; // max kv_bytes for the tree
+   hash_fn           hash; // hash function used for calculating filter_hash
+   unsigned int      seed; // seed used for calculating filter_hash
 
    // internal data
    uint64         next_extent;
@@ -211,7 +211,7 @@ btree_insert(cache              *cc,         // IN
              uint64              root_addr,  // IN
              mini_allocator     *mini,       // IN
              slice               key,        // IN
-             slice               data,       // IN
+             message             data,       // IN
              uint64             *generation, // OUT
              bool               *was_unique);              // OUT
 
@@ -274,44 +274,44 @@ btree_unblock_dec_ref(cache *cc, btree_config *cfg, uint64 root_addr);
 void
 btree_node_unget(cache *cc, const btree_config *cfg, btree_node *node);
 platform_status
-btree_lookup(cache           *cc,
-             btree_config    *cfg,
-             uint64           root_addr,
-             page_type        type,
-             slice            key,
-             writable_buffer *result);
+btree_lookup(cache             *cc,
+             btree_config      *cfg,
+             uint64             root_addr,
+             page_type          type,
+             slice              key,
+             merge_accumulator *result);
 
 static inline bool
-btree_found(writable_buffer *result)
+btree_found(merge_accumulator *result)
 {
-   return !writable_buffer_is_null(result);
+   return !merge_accumulator_is_null(result);
 }
 
 platform_status
-btree_lookup_and_merge(cache           *cc,
-                       btree_config    *cfg,
-                       uint64           root_addr,
-                       page_type        type,
-                       slice            key,
-                       writable_buffer *data,
-                       bool            *local_found);
+btree_lookup_and_merge(cache             *cc,
+                       btree_config      *cfg,
+                       uint64             root_addr,
+                       page_type          type,
+                       slice              key,
+                       merge_accumulator *data,
+                       bool              *local_found);
 
 cache_async_result
-btree_lookup_async(cache            *cc,
-                   btree_config     *cfg,
-                   uint64            root_addr,
-                   slice             key,
-                   writable_buffer  *result,
-                   btree_async_ctxt *ctxt);
+btree_lookup_async(cache             *cc,
+                   btree_config      *cfg,
+                   uint64             root_addr,
+                   slice              key,
+                   merge_accumulator *result,
+                   btree_async_ctxt  *ctxt);
 
 cache_async_result
-btree_lookup_and_merge_async(cache            *cc,          // IN
-                             btree_config     *cfg,         // IN
-                             uint64            root_addr,   // IN
-                             const slice       key,         // IN
-                             writable_buffer  *data,        // OUT
-                             bool             *local_found, // OUT
-                             btree_async_ctxt *ctxt);       // IN
+btree_lookup_and_merge_async(cache             *cc,          // IN
+                             btree_config      *cfg,         // IN
+                             uint64             root_addr,   // IN
+                             const slice        key,         // IN
+                             merge_accumulator *data,        // OUT
+                             bool              *local_found, // OUT
+                             btree_async_ctxt  *ctxt);        // IN
 
 void
 btree_iterator_init(cache          *cc,
@@ -458,7 +458,7 @@ btree_key_to_string(btree_config *cfg, slice key, char str[static 128])
 }
 
 static inline void
-btree_message_to_string(btree_config *cfg, slice data, char str[static 128])
+btree_message_to_string(btree_config *cfg, message data, char str[static 128])
 {
    return data_message_to_string(cfg->data_cfg, data, str, 128);
 }

--- a/src/btree.h
+++ b/src/btree.h
@@ -152,13 +152,13 @@ typedef struct btree_iterator {
 
 typedef struct btree_pack_req {
    // inputs to the pack
-   cache            *cc;
-   btree_config     *cfg;
-   iterator         *itor; // the itor which is being packed
-   uint64            max_tuples;
-   uint64            max_kv_bytes; // max kv_bytes for the tree
-   hash_fn           hash; // hash function used for calculating filter_hash
-   unsigned int      seed; // seed used for calculating filter_hash
+   cache        *cc;
+   btree_config *cfg;
+   iterator     *itor; // the itor which is being packed
+   uint64        max_tuples;
+   uint64        max_kv_bytes; // max kv_bytes for the tree
+   hash_fn       hash;         // hash function used for calculating filter_hash
+   unsigned int  seed;         // seed used for calculating filter_hash
 
    // internal data
    uint64         next_extent;

--- a/src/btree_private.h
+++ b/src/btree_private.h
@@ -49,9 +49,14 @@ struct ONDISK btree_hdr {
  * *************************************************************************
  */
 typedef struct ONDISK index_entry {
-   btree_pivot_data pivot_data;
-   inline_key_size  key_size;
-   char             key[];
+   // clang-format off
+   btree_pivot_data     pivot_data;
+   inline_key_size      key_size     : 8 * sizeof(inline_key_size) - 1;
+   /* Indirect keys are not currently implemented, but this field is
+      here so the on-disk format is ready when we add support. */
+   inline_key_size      key_indirect : 1;
+   char                 key[];
+   // clang-format on
 } index_entry;
 
 _Static_assert(sizeof(index_entry)
@@ -72,9 +77,18 @@ _Static_assert(offsetof(index_entry, key) == sizeof(index_entry),
  * *************************************************************************
  */
 typedef struct ONDISK leaf_entry {
-   inline_key_size     key_size;
-   inline_message_size message_size;
-   char                key_and_message[];
+   // clang-format off
+   inline_key_size      key_size         : 8 * sizeof(inline_key_size) - 1;
+   /* Indirect keys are not currently implemented, but this field is
+      here so the on-disk format is ready when we add support. */
+   inline_key_size      key_indirect     : 1;
+   inline_message_size  message_size     : 8 * sizeof(inline_message_size) - 3;
+   inline_message_size  type             : 2;
+   /* Indirect messages are not currently implemented, but this field is
+      here so the on-disk format is ready when we add support. */
+   inline_message_size  message_indirect : 1;
+   char                 key_and_message[];
+   // clang-format on
 } leaf_entry;
 
 _Static_assert(sizeof(leaf_entry)
@@ -93,8 +107,8 @@ typedef struct leaf_incorporate_spec {
    } old_entry_state;
    union {
       /* "old_entry_state" is the tag on this union. */
-      slice           new_message; /* old_entry_state == ENTRY_DID_NOT_EXIST */
-      writable_buffer merged_message; /* otherwise */
+      message           new_message; // old_entry_state == ENTRY_DID_NOT_EXIST
+      merge_accumulator merged_message; // otherwise
    } msg;
 } leaf_incorporate_spec;
 
@@ -103,7 +117,7 @@ btree_create_leaf_incorporate_spec(const btree_config    *cfg,
                                    platform_heap_id       heap_id,
                                    btree_hdr             *hdr,
                                    slice                  key,
-                                   slice                  message,
+                                   message                message,
                                    leaf_incorporate_spec *spec);
 
 bool
@@ -144,7 +158,7 @@ btree_set_leaf_entry(const btree_config *cfg,
                      btree_hdr          *hdr,
                      table_index         k,
                      slice               new_key,
-                     slice               new_message);
+                     message             new_message);
 
 void
 btree_defragment_leaf(const btree_config    *cfg, // IN
@@ -198,38 +212,57 @@ btree_init_hdr(const btree_config *cfg, btree_hdr *hdr)
 static inline uint64
 sizeof_index_entry(const index_entry *entry)
 {
+   debug_assert(entry->key_indirect == FALSE);
    return sizeof(*entry) + entry->key_size;
 }
 
 static inline uint64
 sizeof_leaf_entry(const leaf_entry *entry)
 {
+   debug_assert(entry->key_indirect == FALSE);
+   debug_assert(entry->message_indirect == FALSE);
    return sizeof(*entry) + entry->key_size + entry->message_size;
 }
 
 static inline slice
 index_entry_key_slice(const index_entry *entry)
 {
+   debug_assert(entry->key_indirect == FALSE);
    return slice_create(entry->key_size, entry->key);
 }
 
 static inline uint64
 index_entry_child_addr(const index_entry *entry)
 {
+   debug_assert(entry->key_indirect == FALSE);
    return entry->pivot_data.child_addr;
 }
 
 static inline slice
 leaf_entry_key_slice(leaf_entry *entry)
 {
+   debug_assert(entry->key_indirect == FALSE);
+   debug_assert(entry->message_indirect == FALSE);
    return slice_create(entry->key_size, entry->key_and_message);
 }
 
-static inline slice
-leaf_entry_message_slice(leaf_entry *entry)
+static inline message
+leaf_entry_message(leaf_entry *entry)
 {
-   return slice_create(entry->message_size,
-                       entry->key_and_message + entry->key_size);
+   debug_assert(entry->key_indirect == FALSE);
+   debug_assert(entry->message_indirect == FALSE);
+   return message_create(
+      entry->type,
+      slice_create(entry->message_size,
+                   entry->key_and_message + entry->key_size));
+}
+
+static inline message_type
+leaf_entry_message_type(leaf_entry *entry)
+{
+   debug_assert(entry->key_indirect == FALSE);
+   debug_assert(entry->message_indirect == FALSE);
+   return entry->type;
 }
 
 static inline leaf_entry *
@@ -247,6 +280,8 @@ btree_get_leaf_entry(const btree_config *cfg,
       (leaf_entry *)const_pointer_byte_offset(hdr, hdr->offsets[k]);
    debug_assert(hdr->offsets[k] + sizeof_leaf_entry(entry)
                 <= btree_page_size(cfg));
+   debug_assert(entry->key_indirect == FALSE);
+   debug_assert(entry->message_indirect == FALSE);
    return entry;
 }
 
@@ -258,13 +293,22 @@ btree_get_tuple_key(const btree_config *cfg,
    return leaf_entry_key_slice(btree_get_leaf_entry(cfg, hdr, k));
 }
 
-static inline slice
+static inline message
 btree_get_tuple_message(const btree_config *cfg,
                         const btree_hdr    *hdr,
                         table_index         k)
 {
-   return leaf_entry_message_slice(btree_get_leaf_entry(cfg, hdr, k));
+   return leaf_entry_message(btree_get_leaf_entry(cfg, hdr, k));
 }
+
+static inline message_type
+btree_get_tuple_message_type(const btree_config *cfg,
+                             const btree_hdr    *hdr,
+                             table_index         k)
+{
+   return leaf_entry_message_type(btree_get_leaf_entry(cfg, hdr, k));
+}
+
 
 static inline index_entry *
 btree_get_index_entry(const btree_config *cfg,
@@ -297,6 +341,7 @@ btree_get_index_entry(const btree_config *cfg,
                 hdr->offsets[k],
                 sizeof_index_entry(entry),
                 btree_page_size(cfg));
+   debug_assert(entry->key_indirect == FALSE);
    return entry;
 }
 

--- a/src/data_internal.c
+++ b/src/data_internal.c
@@ -6,3 +6,53 @@ message NULL_MESSAGE = {.type = MESSAGE_TYPE_INVALID,
 
 message DELETE_MESSAGE = {.type = MESSAGE_TYPE_DELETE,
                           .data = {.length = 0, .data = NULL}};
+
+message_type
+merge_accumulator_message_class(const merge_accumulator *ma)
+{
+   return ma->type;
+}
+
+void *
+merge_accumulator_data(const merge_accumulator *ma)
+{
+   return writable_buffer_data(&ma->data);
+}
+
+uint64
+merge_accumulator_length(const merge_accumulator *ma)
+{
+   return writable_buffer_length(&ma->data);
+}
+
+slice
+merge_accumulator_to_slice(const merge_accumulator *ma)
+{
+   return writable_buffer_to_slice(&ma->data);
+}
+
+/* Copy a message into an already-initialized merge_accumulator. */
+bool
+merge_accumulator_copy_message(merge_accumulator *ma, message msg)
+{
+   platform_status rc =
+      writable_buffer_copy_slice(&ma->data, message_slice(msg));
+   if (!SUCCESS(rc)) {
+      return FALSE;
+   }
+   ma->type = message_class(msg);
+   return TRUE;
+}
+
+bool
+merge_accumulator_resize(merge_accumulator *ma, uint64 newsize)
+{
+   platform_status rc = writable_buffer_resize(&ma->data, newsize);
+   return SUCCESS(rc);
+}
+
+void
+merge_accumulator_set_class(merge_accumulator *ma, message_type type)
+{
+   ma->type = type;
+}

--- a/src/data_internal.c
+++ b/src/data_internal.c
@@ -1,2 +1,8 @@
 
 #include "data_internal.h"
+
+message NULL_MESSAGE = {.type = MESSAGE_TYPE_INVALID,
+                        .data = {.length = 0, .data = NULL}};
+
+message DELETE_MESSAGE = {.type = MESSAGE_TYPE_DELETE,
+                          .data = {.length = 0, .data = NULL}};

--- a/src/data_internal.h
+++ b/src/data_internal.h
@@ -172,7 +172,13 @@ data_merge_tuples(const data_config *cfg,
    }
 
    // new class is UPDATE and old class is INSERT or UPDATE
-   return cfg->merge_tuples(cfg, key, old_raw_message, new_message);
+   int result = cfg->merge_tuples(cfg, key, old_raw_message, new_message);
+   if (result
+       && merge_accumulator_message_class(new_message) == MESSAGE_TYPE_DELETE)
+   {
+      merge_accumulator_resize(new_message, 0);
+   }
+   return result;
 }
 
 static inline int
@@ -183,7 +189,14 @@ data_merge_tuples_final(const data_config *cfg,
    if (merge_accumulator_is_definitive(oldest_message)) {
       return 0;
    }
-   return cfg->merge_tuples_final(cfg, key, oldest_message);
+   int result = cfg->merge_tuples_final(cfg, key, oldest_message);
+   if (result
+       && merge_accumulator_message_class(oldest_message)
+             == MESSAGE_TYPE_DELETE)
+   {
+      merge_accumulator_resize(oldest_message, 0);
+   }
+   return result;
 }
 
 static inline void

--- a/src/data_internal.h
+++ b/src/data_internal.h
@@ -13,41 +13,204 @@
 #include "splinterdb/data.h"
 #include "util.h"
 
+static inline char *
+message_type_string(message_type type)
+{
+   if (type == MESSAGE_TYPE_INSERT) {
+      return "insert";
+   } else if (type == MESSAGE_TYPE_UPDATE) {
+      return "update";
+   } else if (type == MESSAGE_TYPE_DELETE) {
+      return "delete";
+   } else {
+      debug_assert(FALSE, "Invalid message type");
+      return "invalid";
+   }
+}
+
+extern message NULL_MESSAGE;
+extern message DELETE_MESSAGE;
+
+static inline message
+message_create(message_type type, slice data)
+{
+   return (message){.type = type, .data = data};
+}
+
+static inline bool
+message_is_null(message m)
+{
+   return slice_is_null(m.data);
+}
+
 static inline int
-data_key_compare(const data_config *cfg, const slice key1, const slice key2)
+message_lex_cmp(message a, message b)
+{
+   if (a.type < b.type)
+      return -1;
+   else if (b.type < a.type)
+      return 1;
+   else
+      return slice_lex_cmp(a.data, b.data);
+}
+
+static inline const char *
+message_class_string(message msg)
+{
+   return message_type_string(msg.type);
+}
+
+struct merge_accumulator {
+   message_type    type;
+   writable_buffer data;
+};
+
+static inline void
+merge_accumulator_init(merge_accumulator *ma, platform_heap_id heap_id)
+{
+   writable_buffer_init(&ma->data, heap_id);
+   ma->type = MESSAGE_TYPE_INVALID;
+}
+
+static inline void
+merge_accumulator_init_with_buffer(merge_accumulator *ma,
+                                   platform_heap_id   heap_id,
+                                   uint64             allocation_size,
+                                   void              *data,
+                                   uint64             logical_size,
+                                   message_type       type)
+
+{
+   writable_buffer_init_with_buffer(
+      &ma->data, heap_id, allocation_size, data, logical_size);
+   ma->type = type;
+}
+
+static inline void
+merge_accumulator_deinit(merge_accumulator *ma)
+{
+   writable_buffer_deinit(&ma->data);
+   ma->type = MESSAGE_TYPE_INVALID;
+}
+
+static inline message
+merge_accumulator_to_message(const merge_accumulator *ma)
+{
+   return message_create(ma->type, writable_buffer_to_slice(&ma->data));
+}
+
+static inline slice
+merge_accumulator_to_slice(const merge_accumulator *ma)
+{
+   return writable_buffer_to_slice(&ma->data);
+}
+
+static inline slice
+merge_accumulator_to_value(const merge_accumulator *ma)
+{
+   debug_assert(ma->type == MESSAGE_TYPE_INSERT);
+   return writable_buffer_to_slice(&ma->data);
+}
+
+static inline platform_status
+merge_accumulator_copy_message(merge_accumulator *ma, message msg)
+{
+   ma->type = message_class(msg);
+   return writable_buffer_copy_slice(&ma->data, message_slice(msg));
+}
+
+static inline platform_status
+merge_accumulator_init_from_message(merge_accumulator *ma,
+                                    platform_heap_id   heap_id,
+                                    message            msg)
+{
+   merge_accumulator_init(ma, heap_id);
+   return merge_accumulator_copy_message(ma, msg);
+}
+
+static inline void
+merge_accumulator_set_to_null(merge_accumulator *ma)
+{
+   ma->type = MESSAGE_TYPE_INVALID;
+   writable_buffer_set_to_null(&ma->data);
+}
+
+static inline bool
+merge_accumulator_resize(merge_accumulator *ma, uint64 newsize)
+{
+   return writable_buffer_resize(&ma->data, newsize);
+}
+
+static inline void
+merge_accumulator_set_class(merge_accumulator *ma, message_type type)
+{
+   ma->type = type;
+}
+
+static inline message_type
+merge_accumulator_message_class(const merge_accumulator *ma)
+{
+   return ma->type;
+}
+
+static inline bool
+merge_accumulator_is_null(const merge_accumulator *ma)
+{
+   return writable_buffer_is_null(&ma->data);
+}
+
+static inline void *
+merge_accumulator_data(const merge_accumulator *ma)
+{
+   return writable_buffer_data(&ma->data);
+}
+
+static inline uint64
+merge_accumulator_length(const merge_accumulator *ma)
+{
+   return writable_buffer_length(&ma->data);
+}
+
+static inline int
+data_key_compare(const data_config *cfg, slice key1, slice key2)
 {
    return cfg->key_compare(cfg, key1, key2);
 }
 
-static inline message_type
-data_message_class(const data_config *cfg, const slice raw_message)
-{
-   return cfg->message_class(cfg, raw_message);
-}
-
 static inline int
 data_merge_tuples(const data_config *cfg,
-                  const slice        key,
-                  const slice        old_raw_message,
-                  writable_buffer   *new_message)
+                  slice              key,
+                  message            old_raw_message,
+                  merge_accumulator *new_message)
 {
+   message_type newclass = merge_accumulator_message_class(new_message);
+   if (newclass != MESSAGE_TYPE_UPDATE) {
+      return 0;
+   }
+
+   message_type oldclass = message_class(old_raw_message);
+   if (oldclass == MESSAGE_TYPE_DELETE) {
+      return cfg->merge_tuples_final(cfg, key, new_message);
+   }
+
+   // newclass is UPDATE and oldclass is INSERT or UPDATE
    return cfg->merge_tuples(cfg, key, old_raw_message, new_message);
 }
 
 static inline int
 data_merge_tuples_final(const data_config *cfg,
-                        const slice        key,
-                        writable_buffer   *oldest_message)
+                        slice              key,
+                        merge_accumulator *oldest_message)
 {
-   return cfg->merge_tuples_final(
-      cfg, slice_length(key), slice_data(key), oldest_message);
+   message_type class = merge_accumulator_message_class(oldest_message);
+   if (class != MESSAGE_TYPE_UPDATE) {
+      return 0;
+   }
+   return cfg->merge_tuples_final(cfg, key, oldest_message);
 }
 
 static inline void
-data_key_to_string(const data_config *cfg,
-                   const slice        key,
-                   char              *str,
-                   size_t             size)
+data_key_to_string(const data_config *cfg, slice key, char *str, size_t size)
 {
    cfg->key_to_string(cfg, key, str, size);
 }
@@ -63,19 +226,19 @@ data_key_to_string(const data_config *cfg,
 
 static inline void
 data_message_to_string(const data_config *cfg,
-                       const slice        message,
+                       message            msg,
                        char              *str,
                        size_t             size)
 {
-   cfg->message_to_string(cfg, message, str, size);
+   cfg->message_to_string(cfg, msg, str, size);
 }
 
-#define message_string(cfg, key)                                               \
+#define message_string(cfg, msg)                                               \
    (({                                                                         \
        struct {                                                                \
           char buffer[128];                                                    \
        } b;                                                                    \
-       data_message_to_string((cfg), (key), b.buffer, 128);                    \
+       data_message_to_string((cfg), (msg), b.buffer, 128);                    \
        b;                                                                      \
     }).buffer)
 

--- a/src/default_data_config.c
+++ b/src/default_data_config.c
@@ -30,26 +30,11 @@ key_compare(const data_config *cfg, slice key1, slice key2)
 }
 
 
-static message_type
-message_class(const data_config *cfg, slice raw_msg)
-{
-   const message_encoding *msg = slice_data(raw_msg);
-   switch (msg->type) {
-      case MESSAGE_TYPE_INSERT:
-         return MESSAGE_TYPE_INSERT;
-      case MESSAGE_TYPE_DELETE:
-         return MESSAGE_TYPE_DELETE;
-      default:
-         platform_assert(FALSE, "unknown message type: %u", msg->type);
-   }
-   return MESSAGE_TYPE_INVALID; // unreachable
-}
-
 static int
 merge_tuples(const data_config *cfg,
-             const slice        key,
-             const slice        old_raw_message,
-             writable_buffer   *new_data)
+             slice              key,
+             message            old_raw_message,
+             merge_accumulator *new_data)
 {
    // we don't implement UPDATEs, so this is a no-op:
    // new is always left intact
@@ -58,9 +43,8 @@ merge_tuples(const data_config *cfg,
 
 static int
 merge_tuples_final(const data_config *cfg,
-                   uint64             key_len,
-                   const void        *key,        // IN
-                   writable_buffer   *oldest_data // IN/OUT
+                   slice              key,
+                   merge_accumulator *oldest_data // IN/OUT
 )
 {
    // we don't implement UPDATEs, so this is a no-op:
@@ -70,55 +54,18 @@ merge_tuples_final(const data_config *cfg,
 
 
 static void
-key_or_message_to_string(const data_config *cfg,
-                         const slice        key_or_msg,
-                         char              *str,
-                         size_t             max_len)
+key_to_string(const data_config *cfg, slice key, char *str, size_t max_len)
 {
-   debug_hex_encode(
-      str, max_len, slice_data(key_or_msg), slice_length(key_or_msg));
+   debug_hex_encode(str, max_len, slice_data(key), slice_length(key));
 }
 
-
-static int
-encode_message(message_type type,
-               slice        in_value,
-               size_t       dst_msg_buffer_len,
-               void        *dst_msg_buffer,
-               size_t      *out_encoded_len)
+static void
+message_to_string(const data_config *cfg,
+                  message            msg,
+                  char              *str,
+                  size_t             max_len)
 {
-   message_encoding *msg = (message_encoding *)dst_msg_buffer;
-   msg->type             = type;
-   if (slice_length(in_value) + sizeof(message_encoding) > dst_msg_buffer_len) {
-      platform_error_log("encode_message: "
-                         "length of value %lu + encoding header %lu exceeds "
-                         "buffer size %lu bytes.",
-                         slice_length(in_value),
-                         sizeof(message_encoding),
-                         dst_msg_buffer_len);
-      return EINVAL;
-   }
-   if (slice_length(in_value) > 0) {
-      memmove(&(msg->value), slice_data(in_value), slice_length(in_value));
-   }
-   *out_encoded_len = sizeof(message_encoding) + slice_length(in_value);
-   return 0;
-}
-
-static int
-decode_message(slice in_msg, size_t *out_value_len, const char **out_value)
-{
-   if (slice_length(in_msg) < sizeof(message_encoding)) {
-      platform_error_log("decode_message: message_buffer_len=%lu must be "
-                         "at least %lu bytes.",
-                         slice_length(in_msg),
-                         sizeof(message_encoding));
-      return EINVAL;
-   }
-   const message_encoding *msg = (const message_encoding *)slice_data(in_msg);
-   *out_value_len = slice_length(in_msg) - sizeof(message_encoding);
-   *out_value     = (const void *)(msg->value);
-   return 0;
+   debug_hex_encode(str, max_len, message_data(msg), message_length(msg));
 }
 
 
@@ -141,13 +88,10 @@ default_data_config_init(const size_t max_key_size, // IN
       .max_key_length     = max_key_size,
       .key_compare        = key_compare,
       .key_hash           = platform_hash32,
-      .message_class      = message_class,
       .merge_tuples       = merge_tuples,
       .merge_tuples_final = merge_tuples_final,
-      .key_to_string      = key_or_message_to_string,
-      .message_to_string  = key_or_message_to_string,
-      .encode_message     = encode_message,
-      .decode_message     = decode_message,
+      .key_to_string      = key_to_string,
+      .message_to_string  = message_to_string,
    };
 
    memset(cfg.max_key, 0xFF, sizeof(cfg.max_key));

--- a/src/iterator.h
+++ b/src/iterator.h
@@ -4,11 +4,12 @@
 #ifndef __ITERATOR_H
 #define __ITERATOR_H
 
+#include "splinterdb/data.h"
 #include "util.h"
 
 typedef struct iterator iterator;
 
-typedef void (*iterator_get_curr_fn)(iterator *itor, slice *key, slice *data);
+typedef void (*iterator_get_curr_fn)(iterator *itor, slice *key, message *msg);
 typedef platform_status (*iterator_at_end_fn)(iterator *itor, bool *at_end);
 typedef platform_status (*iterator_advance_fn)(iterator *itor);
 typedef void (*iterator_print_fn)(iterator *itor);
@@ -27,9 +28,9 @@ struct iterator {
 };
 
 static inline void
-iterator_get_curr(iterator *itor, slice *key, slice *data)
+iterator_get_curr(iterator *itor, slice *key, message *msg)
 {
-   itor->ops->get_curr(itor, key, data);
+   itor->ops->get_curr(itor, key, msg);
 }
 
 static inline platform_status

--- a/src/log.h
+++ b/src/log.h
@@ -13,14 +13,15 @@
 #include "platform.h"
 #include "cache.h"
 #include "util.h"
+#include "splinterdb/data.h"
 
 typedef struct log_handle   log_handle;
 typedef struct log_iterator log_iterator;
 typedef struct log_config   log_config;
 
 typedef int (*log_write_fn)(log_handle *log,
-                            const slice key,
-                            const slice data,
+                            slice       key,
+                            message     data,
                             uint64      generation);
 typedef void (*log_release_fn)(log_handle *log);
 typedef uint64 (*log_addr_fn)(log_handle *log);
@@ -40,7 +41,7 @@ struct log_handle {
 };
 
 static inline int
-log_write(log_handle *log, const slice key, const slice data, uint64 generation)
+log_write(log_handle *log, slice key, message data, uint64 generation)
 {
    return log->ops->write(log, key, data, generation);
 }

--- a/src/memtable.c
+++ b/src/memtable.c
@@ -117,7 +117,7 @@ memtable_insert(memtable_context *ctxt,
                 memtable         *mt,
                 platform_heap_id  heap_id,
                 const char       *key,
-                slice             message,
+                message           msg,
                 uint64           *leaf_generation)
 {
    const threadid tid = platform_get_tid();
@@ -131,7 +131,7 @@ memtable_insert(memtable_context *ctxt,
                                      mt->root_addr,
                                      &mt->mini,
                                      key_slice,
-                                     message,
+                                     msg,
                                      leaf_generation,
                                      &was_unique);
    if (!SUCCESS(rc)) {

--- a/src/memtable.h
+++ b/src/memtable.h
@@ -148,7 +148,7 @@ memtable_insert(memtable_context *ctxt,
                 memtable         *mt,
                 platform_heap_id  heap_id,
                 const char       *key,
-                slice             message,
+                message           msg,
                 uint64           *generation);
 
 page_handle *

--- a/src/merge.c
+++ b/src/merge.c
@@ -18,7 +18,7 @@ struct merge_behavior {
 
 /* Function declarations and iterator_ops */
 void
-merge_get_curr(iterator *itor, slice *key, slice *data);
+merge_get_curr(iterator *itor, slice *key, message *data);
 
 platform_status
 merge_at_end(iterator *itor, bool *at_end);
@@ -114,7 +114,7 @@ static inline void
 debug_assert_message_type_valid(debug_only merge_iterator *merge_itor)
 {
 #if SPLINTER_DEBUG
-   message_type type = data_message_class(merge_itor->cfg, merge_itor->data);
+   message_type type = message_class(merge_itor->data);
    debug_assert(
       IMPLIES(!merge_itor->emit_deletes, type != MESSAGE_TYPE_DELETE));
    debug_assert(
@@ -152,7 +152,7 @@ advance_and_resort_min_ritor(merge_iterator *merge_itor)
 
    merge_itor->ordered_iterators[0]->next_key_equal = FALSE;
    merge_itor->ordered_iterators[0]->key            = NULL_SLICE;
-   merge_itor->ordered_iterators[0]->data           = NULL_SLICE;
+   merge_itor->ordered_iterators[0]->data           = NULL_MESSAGE;
    rc = iterator_advance(merge_itor->ordered_iterators[0]->itor);
    if (!SUCCESS(rc)) {
       return rc;
@@ -228,8 +228,8 @@ static platform_status
 merge_resolve_equal_keys(merge_iterator *merge_itor)
 {
    debug_assert(merge_itor->ordered_iterators[0]->next_key_equal);
-   debug_assert(slice_data(merge_itor->data)
-                != writable_buffer_data(&merge_itor->merge_buffer));
+   debug_assert(message_data(merge_itor->data)
+                != merge_accumulator_data(&merge_itor->merge_buffer));
    debug_assert(
       slices_equal(merge_itor->key, merge_itor->ordered_iterators[0]->key));
 
@@ -241,7 +241,8 @@ merge_resolve_equal_keys(merge_iterator *merge_itor)
 
    // there is more than one copy of the current key
    platform_status rc;
-   rc = writable_buffer_copy_slice(&merge_itor->merge_buffer, merge_itor->data);
+   rc = merge_accumulator_copy_message(&merge_itor->merge_buffer,
+                                       merge_itor->data);
    if (!SUCCESS(rc)) {
       return rc;
    }
@@ -277,7 +278,7 @@ merge_resolve_equal_keys(merge_iterator *merge_itor)
 #endif
    } while (merge_itor->ordered_iterators[0]->next_key_equal);
 
-   merge_itor->data = writable_buffer_to_slice(&merge_itor->merge_buffer);
+   merge_itor->data = merge_accumulator_to_message(&merge_itor->merge_buffer);
 
    // Dealt with all duplicates, now pointing to last copy.
    debug_assert(!merge_itor->ordered_iterators[0]->next_key_equal);
@@ -302,13 +303,13 @@ merge_finalize_updates_and_discard_deletes(merge_iterator *merge_itor,
 {
    platform_status rc;
    data_config    *cfg = merge_itor->cfg;
-   message_type class  = data_message_class(cfg, merge_itor->data);
+   message_type class  = message_class(merge_itor->data);
    if (class != MESSAGE_TYPE_INSERT && merge_itor->finalize_updates) {
-      if (slice_data(merge_itor->data)
-          != writable_buffer_data(&merge_itor->merge_buffer))
+      if (message_data(merge_itor->data)
+          != merge_accumulator_data(&merge_itor->merge_buffer))
       {
-         rc = writable_buffer_copy_slice(&merge_itor->merge_buffer,
-                                         merge_itor->data);
+         rc = merge_accumulator_copy_message(&merge_itor->merge_buffer,
+                                             merge_itor->data);
          if (!SUCCESS(rc)) {
             return rc;
          }
@@ -317,8 +318,9 @@ merge_finalize_updates_and_discard_deletes(merge_iterator *merge_itor,
              cfg, merge_itor->key, &merge_itor->merge_buffer)) {
          return STATUS_NO_MEMORY;
       }
-      merge_itor->data = writable_buffer_to_slice(&merge_itor->merge_buffer);
-      class            = data_message_class(cfg, merge_itor->data);
+      merge_itor->data =
+         merge_accumulator_to_message(&merge_itor->merge_buffer);
+      class = message_class(merge_itor->data);
    }
    if (class == MESSAGE_TYPE_DELETE && !merge_itor->emit_deletes) {
       merge_itor->discarded_deletes++;
@@ -418,7 +420,7 @@ merge_iterator_create(platform_heap_id hid,
    if (merge_itor == NULL) {
       return STATUS_NO_MEMORY;
    }
-   writable_buffer_init(&merge_itor->merge_buffer, hid);
+   merge_accumulator_init(&merge_itor->merge_buffer, hid);
 
    merge_itor->super.ops = &merge_ops;
    merge_itor->num_trees = num_trees;
@@ -438,7 +440,7 @@ merge_iterator_create(platform_heap_id hid,
          .seq            = i,
          .itor           = i == -1 ? NULL : itor_arr[i],
          .key            = NULL_SLICE,
-         .data           = NULL_SLICE,
+         .data           = NULL_MESSAGE,
          .next_key_equal = FALSE,
       };
       merge_itor->ordered_iterators[i] =
@@ -527,7 +529,7 @@ out:
 platform_status
 merge_iterator_destroy(platform_heap_id hid, merge_iterator **merge_itor)
 {
-   writable_buffer_deinit(&(*merge_itor)->merge_buffer);
+   merge_accumulator_deinit(&(*merge_itor)->merge_buffer);
    platform_free(hid, *merge_itor);
    *merge_itor = NULL;
 
@@ -573,7 +575,7 @@ merge_at_end(iterator *itor, // IN
  *-----------------------------------------------------------------------------
  */
 void
-merge_get_curr(iterator *itor, slice *key, slice *data)
+merge_get_curr(iterator *itor, slice *key, message *data)
 {
    merge_iterator *merge_itor = (merge_iterator *)itor;
    debug_assert(!merge_itor->at_end);
@@ -600,7 +602,7 @@ merge_advance(iterator *itor)
    bool retry;
    do {
       merge_itor->key  = NULL_SLICE;
-      merge_itor->data = NULL_SLICE;
+      merge_itor->data = NULL_MESSAGE;
       // Advance one iterator
       rc = advance_and_resort_min_ritor(merge_itor);
       if (!SUCCESS(rc)) {
@@ -620,7 +622,8 @@ void
 merge_iterator_print(merge_iterator *merge_itor)
 {
    uint64       i;
-   slice        key, data;
+   slice        key;
+   message      data;
    data_config *data_cfg = merge_itor->cfg;
    iterator_get_curr(&merge_itor->super, &key, &data);
 

--- a/src/merge.h
+++ b/src/merge.h
@@ -18,11 +18,11 @@
 #define MAX_MERGE_ARITY (1024)
 
 typedef struct ordered_iterator {
-   iterator *itor;
-   int       seq;
-   slice     key;
-   slice     data;
-   bool      next_key_equal;
+   iterator                 *itor;
+   int                       seq;
+   slice                     key;
+   message                   data;
+   bool                      next_key_equal;
 } ordered_iterator;
 
 /*
@@ -58,16 +58,16 @@ extern struct merge_behavior   merge_full, merge_intermediate, merge_raw;
 
 
 typedef struct merge_iterator {
-   iterator     super;     // handle for iterator.h API
-   int          num_trees; // number of trees in the forest
-   bool         merge_messages;
-   bool         finalize_updates;
-   bool         emit_deletes;
-   bool         at_end;
-   int          num_remaining; // number of ritors not at end
-   data_config *cfg;           // point message tree data config
-   slice        key;           // next key
-   slice        data;          // next data
+   iterator                  super;     // handle for iterator.h API
+   int                       num_trees; // number of trees in the forest
+   bool                      merge_messages;
+   bool                      finalize_updates;
+   bool                      emit_deletes;
+   bool                      at_end;
+   int                       num_remaining; // number of ritors not at end
+   data_config              *cfg;           // point message tree data config
+   slice                     key;           // next key
+   message                   data;          // next data
 
    // Padding so ordered_iterators[-1] is valid
    ordered_iterator ordered_iterator_stored_pad;
@@ -81,7 +81,7 @@ typedef struct merge_iterator {
    uint64 discarded_deletes;
 
    // space for merging data together
-   writable_buffer merge_buffer;
+   merge_accumulator merge_buffer;
 } merge_iterator;
 
 // Statically enforce that the padding variables act as index -1 for both arrays

--- a/src/merge.h
+++ b/src/merge.h
@@ -18,11 +18,11 @@
 #define MAX_MERGE_ARITY (1024)
 
 typedef struct ordered_iterator {
-   iterator                 *itor;
-   int                       seq;
-   slice                     key;
-   message                   data;
-   bool                      next_key_equal;
+   iterator *itor;
+   int       seq;
+   slice     key;
+   message   data;
+   bool      next_key_equal;
 } ordered_iterator;
 
 /*
@@ -58,16 +58,16 @@ extern struct merge_behavior   merge_full, merge_intermediate, merge_raw;
 
 
 typedef struct merge_iterator {
-   iterator                  super;     // handle for iterator.h API
-   int                       num_trees; // number of trees in the forest
-   bool                      merge_messages;
-   bool                      finalize_updates;
-   bool                      emit_deletes;
-   bool                      at_end;
-   int                       num_remaining; // number of ritors not at end
-   data_config              *cfg;           // point message tree data config
-   slice                     key;           // next key
-   message                   data;          // next data
+   iterator     super;     // handle for iterator.h API
+   int          num_trees; // number of trees in the forest
+   bool         merge_messages;
+   bool         finalize_updates;
+   bool         emit_deletes;
+   bool         at_end;
+   int          num_remaining; // number of ritors not at end
+   data_config *cfg;           // point message tree data config
+   slice        key;           // next key
+   message      data;          // next data
 
    // Padding so ordered_iterators[-1] is valid
    ordered_iterator ordered_iterator_stored_pad;

--- a/src/routing_filter.c
+++ b/src/routing_filter.c
@@ -1210,8 +1210,8 @@ routing_filter_verify(cache          *cc,
    iterator_at_end(itor, &at_end);
    while (!at_end) {
       slice key;
-      slice message;
-      iterator_get_curr(itor, &key, &message);
+      message msg;
+      iterator_get_curr(itor, &key, &msg);
       uint64          found_values;
       platform_status rc =
          routing_filter_lookup(cc, cfg, filter, key, &found_values);

--- a/src/routing_filter.c
+++ b/src/routing_filter.c
@@ -1209,7 +1209,7 @@ routing_filter_verify(cache          *cc,
    bool at_end;
    iterator_at_end(itor, &at_end);
    while (!at_end) {
-      slice key;
+      slice   key;
       message msg;
       iterator_get_curr(itor, &key, &msg);
       uint64          found_values;

--- a/src/shard_log.c
+++ b/src/shard_log.c
@@ -22,7 +22,7 @@
 static uint64 shard_log_magic_idx = 0;
 
 int
-shard_log_write(log_handle *log, slice key, slice data, uint64 generation);
+shard_log_write(log_handle *log, slice key, message msg, uint64 generation);
 uint64
 shard_log_addr(log_handle *log);
 uint64
@@ -38,7 +38,7 @@ static log_ops shard_log_ops = {
 };
 
 void
-shard_log_iterator_get_curr(iterator *itor, slice *key, slice *data);
+shard_log_iterator_get_curr(iterator *itor, slice *key, message *msg);
 platform_status
 shard_log_iterator_at_end(iterator *itor, bool *at_end);
 platform_status
@@ -143,6 +143,7 @@ struct ONDISK log_entry {
    uint64 generation;
    uint16 keylen;
    uint16 messagelen;
+   uint8  msg_type;
    char   contents[];
 };
 
@@ -164,16 +165,17 @@ log_entry_key(log_entry *le)
    return slice_create(le->keylen, le->contents);
 }
 
-static slice
+static message
 log_entry_message(log_entry *le)
 {
-   return slice_create(le->messagelen, le->contents + le->keylen);
+   return message_create(
+      le->msg_type, slice_create(le->messagelen, le->contents + le->keylen));
 }
 
 static uint64
-log_entry_size(const slice key, const slice message)
+log_entry_size(slice key, message msg)
 {
-   return sizeof(log_entry) + slice_length(key) + slice_length(message);
+   return sizeof(log_entry) + slice_length(key) + message_length(msg);
 }
 
 static uint64
@@ -219,10 +221,7 @@ get_new_page_for_thread(shard_log             *log,
 }
 
 int
-shard_log_write(log_handle *logh,
-                const slice key,
-                const slice message,
-                uint64      generation)
+shard_log_write(log_handle *logh, slice key, message msg, uint64 generation)
 {
    shard_log             *log = (shard_log *)logh;
    cache                 *cc  = log->cc;
@@ -246,7 +245,7 @@ shard_log_write(log_handle *logh,
 
    shard_log_hdr *hdr    = (shard_log_hdr *)page->data;
    log_entry     *cursor = (log_entry *)(page->data + thread_data->offset);
-   uint64         new_entry_size = log_entry_size(key, message);
+   uint64         new_entry_size = log_entry_size(key, msg);
    uint64 free_space = shard_log_page_size(log->cfg) - thread_data->offset;
    debug_assert(new_entry_size
                 <= shard_log_page_size(log->cfg) - sizeof(shard_log_hdr));
@@ -269,11 +268,11 @@ shard_log_write(log_handle *logh,
 
    cursor->generation = generation;
    cursor->keylen     = slice_length(key);
-   cursor->messagelen = slice_length(message);
+   cursor->messagelen = message_length(msg);
+   cursor->msg_type   = message_class(msg);
    memmove(log_entry_key_cursor(cursor), slice_data(key), slice_length(key));
-   memmove(log_entry_message_cursor(cursor),
-           slice_data(message),
-           slice_length(message));
+   memmove(
+      log_entry_message_cursor(cursor), message_data(msg), message_length(msg));
    hdr->num_entries++;
 
    thread_data->offset += new_entry_size;
@@ -430,12 +429,11 @@ shard_log_iterator_deinit(platform_heap_id hid, shard_log_iterator *itor)
 }
 
 void
-shard_log_iterator_get_curr(iterator *itorh, slice *key, slice *message)
+shard_log_iterator_get_curr(iterator *itorh, slice *key, message *msg)
 {
    shard_log_iterator *itor = (shard_log_iterator *)itorh;
    *key                     = log_entry_key(itor->entries[itor->pos]);
-   *message                 = log_entry_message(itor->entries[itor->pos]);
-   // FIXME: what about type?
+   *msg                     = log_entry_message(itor->entries[itor->pos]);
 }
 
 platform_status

--- a/src/splinterdb.c
+++ b/src/splinterdb.c
@@ -22,8 +22,6 @@
 #include "btree_private.h"
 #include "poison.h"
 
-#define MAX_ENCODED_MESSAGE_SIZE (MAX_INLINE_MESSAGE_SIZE)
-
 const char *BUILD_VERSION = "splinterdb_build_version " GIT_VERSION;
 const char *
 splinterdb_get_version()
@@ -126,7 +124,6 @@ splinterdb_validate_app_data_config(const data_config *cfg)
    platform_assert(cfg->key_hash != NULL);
    platform_assert(cfg->merge_tuples != NULL);
    platform_assert(cfg->merge_tuples_final != NULL);
-   platform_assert(cfg->message_class != NULL);
    platform_assert(cfg->key_to_string != NULL);
    platform_assert(cfg->message_to_string != NULL);
 
@@ -209,19 +206,11 @@ splinterdb_shim_key_compare(const data_config *cfg,
                                slice_create(key2->length, key2->data));
 }
 
-static message_type
-splinterdb_shim_message_class(const data_config *cfg, slice raw_message)
-{
-   shim_data_config  *shim_data_cfg = (shim_data_config *)cfg;
-   const data_config *app_cfg       = shim_data_cfg->app_data_cfg;
-   return app_cfg->message_class(app_cfg, raw_message);
-}
-
 static int
 splinterdb_shim_merge_tuple(const data_config *cfg,
-                            const slice        key_raw,
-                            const slice        old_message,
-                            writable_buffer   *new_message)
+                            slice              key_raw,
+                            message            old_message,
+                            merge_accumulator *new_message)
 {
    shim_data_config     *shim_data_cfg = (shim_data_config *)cfg;
    const data_config    *app_cfg       = shim_data_cfg->app_data_cfg;
@@ -234,22 +223,21 @@ splinterdb_shim_merge_tuple(const data_config *cfg,
 
 static int
 splinterdb_shim_merge_tuple_final(const data_config *cfg,
-                                  uint64             unused_key_len,
-                                  const void        *key_raw,
-                                  writable_buffer   *oldest_message)
+                                  slice              key_raw,
+                                  merge_accumulator *oldest_message)
 {
    shim_data_config     *shim_data_cfg = (shim_data_config *)cfg;
    const data_config    *app_cfg       = shim_data_cfg->app_data_cfg;
-   var_len_key_encoding *key           = (var_len_key_encoding *)key_raw;
+   var_len_key_encoding *key = (var_len_key_encoding *)slice_data(key_raw);
 
    platform_assert(key->length <= SPLINTERDB_MAX_KEY_SIZE);
    return app_cfg->merge_tuples_final(
-      app_cfg, key->length, key->data, oldest_message);
+      app_cfg, slice_create(key->length, key->data), oldest_message);
 }
 
 static void
 splinterdb_shim_key_to_string(const data_config *cfg,
-                              const slice        key_raw,
+                              slice              key_raw,
                               char              *str,
                               uint64             max_len)
 {
@@ -296,7 +284,6 @@ splinterdb_shim_data_config(const data_config *app_cfg,
    // it.
    shim.key_hash = app_cfg->key_hash;
 
-   shim.message_class      = splinterdb_shim_message_class;
    shim.merge_tuples       = splinterdb_shim_merge_tuple;
    shim.merge_tuples_final = splinterdb_shim_merge_tuple_final;
    shim.key_to_string      = splinterdb_shim_key_to_string;
@@ -613,7 +600,6 @@ validate_key_length(const splinterdb *kvs, uint64 key_length)
    return 0;
 }
 
-
 /*
  *-----------------------------------------------------------------------------
  * splinterdb_insert_raw_message --
@@ -627,10 +613,10 @@ validate_key_length(const splinterdb *kvs, uint64 key_length)
  *      None.
  *-----------------------------------------------------------------------------
  */
-int
-splinterdb_insert_raw_message(const splinterdb *kvs,        // IN
-                              slice             key,        // IN
-                              slice             raw_message // IN
+static int
+splinterdb_insert_message(const splinterdb *kvs, // IN
+                          slice             key, // IN
+                          message           msg  // IN
 )
 {
    platform_assert(kvs != NULL);
@@ -640,55 +626,33 @@ splinterdb_insert_raw_message(const splinterdb *kvs,        // IN
    }
 
    char key_buffer[MAX_KEY_SIZE] = {0};
-
    rc = encode_key(sizeof(key_buffer), key_buffer, key);
    if (rc != 0) {
       return rc;
    }
 
-   platform_status status = trunk_insert(kvs->spl, key_buffer, raw_message);
+   platform_status status = trunk_insert(kvs->spl, key_buffer, msg);
    return platform_status_to_int(status);
 }
 
 int
 splinterdb_insert(const splinterdb *kvsb, slice key, slice value)
 {
-   platform_assert(kvsb->shim_data_cfg.app_data_cfg->encode_message != NULL);
-
-
-   char   msg_buffer[MAX_ENCODED_MESSAGE_SIZE] = {0};
-   uint64 encoded_len;
-   int    rc =
-      kvsb->shim_data_cfg.app_data_cfg->encode_message(MESSAGE_TYPE_INSERT,
-                                                       value,
-                                                       MAX_ENCODED_MESSAGE_SIZE,
-                                                       msg_buffer,
-                                                       &encoded_len);
-   if (rc != 0) {
-      return rc;
-   }
-   return splinterdb_insert_raw_message(
-      kvsb, key, slice_create(encoded_len, msg_buffer));
+   message msg = message_create(MESSAGE_TYPE_INSERT, value);
+   return splinterdb_insert_message(kvsb, key, msg);
 }
 
 int
 splinterdb_delete(const splinterdb *kvsb, slice key)
 {
-   platform_assert(kvsb->shim_data_cfg.app_data_cfg->encode_message != NULL);
+   return splinterdb_insert_message(kvsb, key, DELETE_MESSAGE);
+}
 
-   char   msg_buffer[MAX_ENCODED_MESSAGE_SIZE] = {0};
-   uint64 encoded_len;
-   int    rc =
-      kvsb->shim_data_cfg.app_data_cfg->encode_message(MESSAGE_TYPE_DELETE,
-                                                       NULL_SLICE,
-                                                       MAX_ENCODED_MESSAGE_SIZE,
-                                                       msg_buffer,
-                                                       &encoded_len);
-   if (rc != 0) {
-      return rc;
-   }
-   return splinterdb_insert_raw_message(
-      kvsb, key, slice_create(encoded_len, msg_buffer));
+int
+splinterdb_update(const splinterdb *kvsb, slice key, slice update)
+{
+   message msg = message_create(MESSAGE_TYPE_UPDATE, update);
+   return splinterdb_insert_message(kvsb, key, msg);
 }
 
 /*
@@ -697,7 +661,7 @@ splinterdb_delete(const splinterdb *kvsb, slice key)
  *-----------------------------------------------------------------------------
  */
 typedef struct {
-   writable_buffer value;
+   merge_accumulator value;
 } _splinterdb_lookup_result;
 
 _Static_assert(sizeof(_splinterdb_lookup_result)
@@ -712,15 +676,19 @@ splinterdb_lookup_result_init(const splinterdb         *kvs,        // IN
 )
 {
    _splinterdb_lookup_result *_result = (_splinterdb_lookup_result *)result;
-   writable_buffer_init_with_buffer(
-      &_result->value, NULL, buffer_len, buffer, WRITABLE_BUFFER_NULL_LENGTH);
+   merge_accumulator_init_with_buffer(&_result->value,
+                                      NULL,
+                                      buffer_len,
+                                      buffer,
+                                      WRITABLE_BUFFER_NULL_LENGTH,
+                                      MESSAGE_TYPE_INVALID);
 }
 
 void
 splinterdb_lookup_result_deinit(splinterdb_lookup_result *result) // IN
 {
    _splinterdb_lookup_result *_result = (_splinterdb_lookup_result *)result;
-   writable_buffer_deinit(&_result->value);
+   merge_accumulator_deinit(&_result->value);
 }
 
 bool
@@ -730,43 +698,18 @@ splinterdb_lookup_found(const splinterdb_lookup_result *result) // IN
    return trunk_lookup_found(&_result->value);
 }
 
-static uint64
-splinterdb_lookup_result_size(const splinterdb_lookup_result *result) // IN
-{
-   _splinterdb_lookup_result *_result = (_splinterdb_lookup_result *)result;
-   return writable_buffer_length(&_result->value);
-}
-
-static void *
-splinterdb_lookup_result_data(const splinterdb_lookup_result *result) // IN
-{
-   _splinterdb_lookup_result *_result = (_splinterdb_lookup_result *)result;
-   return writable_buffer_data(&_result->value);
-}
-
 int
 splinterdb_lookup_result_value(const splinterdb               *kvs,
                                const splinterdb_lookup_result *result, // IN
                                slice                          *value)
 {
+   _splinterdb_lookup_result *_result = (_splinterdb_lookup_result *)result;
 
    if (!splinterdb_lookup_found(result)) {
       return EINVAL;
    }
 
-   size_t      value_size;
-   const char *value_data;
-
-   slice msg = slice_create(splinterdb_lookup_result_size(result),
-                            splinterdb_lookup_result_data(result));
-
-   int rc = kvs->shim_data_cfg.app_data_cfg->decode_message(
-      msg, &value_size, &value_data);
-   if (rc != 0) {
-      return rc;
-   }
-
-   *value = slice_create(value_size, value_data);
+   *value = merge_accumulator_to_value(&_result->value);
    return 0;
 }
 
@@ -902,23 +845,15 @@ splinterdb_iterator_get_current(splinterdb_iterator *iter, // IN
                                 slice               *value // OUT
 )
 {
-   platform_assert(iter->parent->shim_data_cfg.app_data_cfg->decode_message
-                   != NULL);
-
    slice     key_slice;
-   slice     message_slice;
+   message   msg;
    iterator *itor = &(iter->sri.super);
 
-   iterator_get_curr(itor, &key_slice, &message_slice);
+   iterator_get_curr(itor, &key_slice, &msg);
 
    var_len_key_encoding *kenc = (var_len_key_encoding *)(slice_data(key_slice));
    platform_assert(kenc->length <= SPLINTERDB_MAX_KEY_SIZE);
 
    *key = slice_create(kenc->length, kenc->data);
-
-   int rc = iter->parent->shim_data_cfg.app_data_cfg->decode_message(
-      message_slice, &(value->length), (const char **)&(value->data));
-   if (rc != 0) {
-      iter->last_rc = STATUS_BAD_PARAM;
-   }
+   *value = message_slice(msg);
 }

--- a/src/splinterdb.c
+++ b/src/splinterdb.c
@@ -854,6 +854,6 @@ splinterdb_iterator_get_current(splinterdb_iterator *iter, // IN
    var_len_key_encoding *kenc = (var_len_key_encoding *)(slice_data(key_slice));
    platform_assert(kenc->length <= SPLINTERDB_MAX_KEY_SIZE);
 
-   *key = slice_create(kenc->length, kenc->data);
+   *key   = slice_create(kenc->length, kenc->data);
    *value = message_slice(msg);
 }

--- a/src/trunk.c
+++ b/src/trunk.c
@@ -8364,7 +8364,7 @@ trunk_print_lookup(trunk_handle *spl, const char *key)
          char message_str[128];
          trunk_key_to_string(spl, key, key_str);
          message msg = merge_accumulator_to_message(&data);
-         trunk_message_to_string(spl, message, message_str);
+         trunk_message_to_string(spl, msg, message_str);
          platform_log_stream("Key %s found in node %lu pivot %u with data %s\n",
                              key_str,
                              node->disk_addr,
@@ -8387,7 +8387,7 @@ trunk_print_lookup(trunk_handle *spl, const char *key)
                char message_str[128];
                trunk_key_to_string(spl, key, key_str);
                message msg = merge_accumulator_to_message(&data);
-               trunk_message_to_string(spl, message, message_str);
+               trunk_message_to_string(spl, msg, message_str);
                platform_log_stream(
                   "!! Key %s found in branch %u of node %lu pivot %u "
                   "with data %s\n",
@@ -8414,7 +8414,7 @@ trunk_print_lookup(trunk_handle *spl, const char *key)
       char message_str[128];
       trunk_key_to_string(spl, key, key_str);
       message msg = merge_accumulator_to_message(&data);
-      trunk_message_to_string(spl, message, message_str);
+      trunk_message_to_string(spl, msg, message_str);
       platform_log_stream("Key %s found in node %lu pivot %u with data %s\n",
                           key_str,
                           node->disk_addr,
@@ -8437,7 +8437,7 @@ trunk_print_lookup(trunk_handle *spl, const char *key)
             char message_str[128];
             trunk_key_to_string(spl, key, key_str);
             message msg = merge_accumulator_to_message(&data);
-            trunk_message_to_string(spl, message, message_str);
+            trunk_message_to_string(spl, msg, message_str);
             platform_log_stream(
                "!! Key %s found in branch %u of node %lu pivot %u "
                "with data %s\n",

--- a/src/trunk.c
+++ b/src/trunk.c
@@ -3017,8 +3017,8 @@ trunk_memtable_compact_and_build_filter(trunk_handle  *spl,
 
    uint64         memtable_root_addr = mt->root_addr;
    btree_iterator btree_itor;
-   iterator         *itor    = &btree_itor.super;
-   const char       *min_key = spl->cfg.data_cfg->min_key;
+   iterator      *itor    = &btree_itor.super;
+   const char    *min_key = spl->cfg.data_cfg->min_key;
 
    trunk_memtable_iterator_init(
       spl, &btree_itor, memtable_root_addr, min_key, NULL, FALSE, FALSE);
@@ -5905,7 +5905,7 @@ trunk_insert(trunk_handle *spl, char *key, message data)
    timestamp                            ts;
    __attribute((unused)) const threadid tid = platform_get_tid();
    if (spl->cfg.use_stats) {
-      ts       = platform_get_timestamp();
+      ts = platform_get_timestamp();
    }
 
    platform_status rc = trunk_memtable_insert(spl, key, data);
@@ -8155,8 +8155,8 @@ trunk_print_lookup(trunk_handle *spl, const char *key)
                         &data);
       platform_assert_status_ok(rc);
       if (!merge_accumulator_is_null(&data)) {
-         char  key_str[128];
-         char  message_str[128];
+         char    key_str[128];
+         char    message_str[128];
          message msg = merge_accumulator_to_message(&data);
          trunk_key_to_string(spl, key, key_str);
          trunk_message_to_string(spl, msg, message_str);

--- a/src/trunk.c
+++ b/src/trunk.c
@@ -5989,6 +5989,10 @@ trunk_insert(trunk_handle *spl, char *key, message data)
       ts = platform_get_timestamp();
    }
 
+   if (message_class(data) == MESSAGE_TYPE_DELETE) {
+      data = DELETE_MESSAGE;
+   }
+
    platform_status rc = trunk_memtable_insert(spl, key, data);
    if (!SUCCESS(rc)) {
       goto out;

--- a/src/trunk.h
+++ b/src/trunk.h
@@ -327,22 +327,22 @@ typedef struct {
  */
 
 platform_status
-trunk_insert(trunk_handle *spl, char *key, slice data);
+trunk_insert(trunk_handle *spl, char *key, message data);
 
 platform_status
-trunk_lookup(trunk_handle *spl, char *key, writable_buffer *result);
+trunk_lookup(trunk_handle *spl, char *key, merge_accumulator *result);
 
 static inline bool
-trunk_lookup_found(writable_buffer *result)
+trunk_lookup_found(merge_accumulator *result)
 {
-   return !writable_buffer_is_null(result);
+   return !merge_accumulator_is_null(result);
 }
 
 cache_async_result
-trunk_lookup_async(trunk_handle     *spl,
-                   char             *key,
-                   writable_buffer  *data,
-                   trunk_async_ctxt *ctxt);
+trunk_lookup_async(trunk_handle      *spl,
+                   char              *key,
+                   merge_accumulator *data,
+                   trunk_async_ctxt  *ctxt);
 platform_status
 trunk_range_iterator_init(trunk_handle         *spl,
                           trunk_range_iterator *range_itor,
@@ -352,7 +352,7 @@ trunk_range_iterator_init(trunk_handle         *spl,
 void
 trunk_range_iterator_deinit(trunk_range_iterator *range_itor);
 
-typedef void (*tuple_function)(slice key, slice value, void *arg);
+typedef void (*tuple_function)(slice key, message value, void *arg);
 platform_status
 trunk_range(trunk_handle  *spl,
             const char    *start_key,
@@ -436,9 +436,9 @@ trunk_key_to_string(trunk_handle *spl, const char *key, char str[static 128])
 }
 
 static inline void
-trunk_message_to_string(trunk_handle *spl, slice message, char str[static 128])
+trunk_message_to_string(trunk_handle *spl, message msg, char str[static 128])
 {
-   btree_message_to_string(&spl->cfg.btree_cfg, message, str);
+   btree_message_to_string(&spl->cfg.btree_cfg, msg, str);
 }
 
 static inline void

--- a/src/util.c
+++ b/src/util.c
@@ -36,36 +36,16 @@ writable_buffer_ensure_space(writable_buffer *wb, uint64 minspace)
    return STATUS_OK;
 }
 
-uint64
-writable_buffer_length(const writable_buffer *wb)
-{
-   if (wb->length == WRITABLE_BUFFER_NULL_LENGTH) {
-      return 0;
-   }
-   return wb->length;
-}
-
-/* May allocate memory */
-bool
+platform_status
 writable_buffer_resize(writable_buffer *wb, uint64 newlength)
 {
    platform_assert(newlength != WRITABLE_BUFFER_NULL_LENGTH);
    platform_status rc = writable_buffer_ensure_space(wb, newlength);
    if (!SUCCESS(rc)) {
-      return FALSE;
+      return rc;
    }
    wb->length = newlength;
-   return TRUE;
-}
-
-void *
-writable_buffer_data(const writable_buffer *wb)
-{
-   if (wb->length == WRITABLE_BUFFER_NULL_LENGTH) {
-      return NULL;
-   } else {
-      return wb->buffer;
-   }
+   return rc;
 }
 
 /*

--- a/src/util.c
+++ b/src/util.c
@@ -37,7 +37,7 @@ writable_buffer_ensure_space(writable_buffer *wb, uint64 minspace)
 }
 
 uint64
-writable_buffer_length(writable_buffer *wb)
+writable_buffer_length(const writable_buffer *wb)
 {
    if (wb->length == WRITABLE_BUFFER_NULL_LENGTH) {
       return 0;
@@ -59,7 +59,7 @@ writable_buffer_resize(writable_buffer *wb, uint64 newlength)
 }
 
 void *
-writable_buffer_data(writable_buffer *wb)
+writable_buffer_data(const writable_buffer *wb)
 {
    if (wb->length == WRITABLE_BUFFER_NULL_LENGTH) {
       return NULL;

--- a/tests/functional/btree_test.c
+++ b/tests/functional/btree_test.c
@@ -112,9 +112,9 @@ test_btree_lookup(cache        *cc,
                   slice         key,
                   message       expected_data)
 {
-   platform_status rc;
+   platform_status   rc;
    merge_accumulator result;
-   bool            ret;
+   bool              ret;
 
    merge_accumulator_init(&result, NULL);
 
@@ -185,8 +185,8 @@ test_btree_insert_thread(void *arg)
    uint64                    thread_id   = params->thread_id;
    uint64                    num_inserts = params->num_ops;
 
-   uint64          start_time = platform_get_timestamp();
-   writable_buffer key;
+   uint64            start_time = platform_get_timestamp();
+   writable_buffer   key;
    merge_accumulator data;
 
    writable_buffer_init(&key, NULL);
@@ -308,10 +308,10 @@ destroy_btrees:
 
 // A single async context
 typedef struct {
-   btree_async_ctxt ctxt;
-   cache_async_ctxt cache_ctxt;
-   bool             ready;
-   writable_buffer  key;
+   btree_async_ctxt  ctxt;
+   cache_async_ctxt  cache_ctxt;
+   bool              ready;
+   writable_buffer   key;
    merge_accumulator result;
 } btree_test_async_ctxt;
 
@@ -549,8 +549,8 @@ test_btree_basic(cache             *cc,
 
    btree_test_async_ctxt_init(async_lookup);
 
-   uint64          start_time = platform_get_timestamp();
-   writable_buffer key;
+   uint64            start_time = platform_get_timestamp();
+   writable_buffer   key;
    merge_accumulator expected_data;
    writable_buffer_init(&key, NULL);
    merge_accumulator_init(&expected_data, NULL);
@@ -799,7 +799,7 @@ test_btree_create_packed_trees(cache             *cc,
       test_memtable_context_create(cc, cfg, num_trees, hid);
 
    // fill the memtables
-   writable_buffer key;
+   writable_buffer   key;
    merge_accumulator data;
    writable_buffer_init(&key, NULL);
    merge_accumulator_init(&data, NULL);
@@ -1259,7 +1259,7 @@ test_btree_rough_iterator(cache             *cc,
       if (SUCCESS(iterator_at_end(&rough_btree_itor[tree_no].super, &at_end))
           && !at_end)
       {
-         slice key;
+         slice   key;
          message msg;
          iterator_get_curr(&rough_btree_itor[tree_no].super, &key, &msg);
          platform_log("key size: %lu\n", slice_length(key));

--- a/tests/functional/log_test.c
+++ b/tests/functional/log_test.c
@@ -89,7 +89,7 @@ test_log_crash(clockcache             *cc,
    for (i = 0; i < num_entries && !at_end; i++) {
       test_key(keybuffer, TEST_RANDOM, i, 0, 0, cfg->data_cfg->key_size, 0);
       generate_test_message(gen, i, &msg);
-      slice skey = slice_create(1 + (i % cfg->data_cfg->key_size), keybuffer);
+      slice   skey = slice_create(1 + (i % cfg->data_cfg->key_size), keybuffer);
       message mmessage = merge_accumulator_to_message(&msg);
       iterator_get_curr(itorh, &returned_key, &returned_message);
       if (slice_lex_cmp(skey, returned_key)

--- a/tests/functional/splinter_test.c
+++ b/tests/functional/splinter_test.c
@@ -113,7 +113,7 @@ test_trunk_insert_thread(void *arg)
    uint64    num_inserts     = 0;
    timestamp next_check_time = platform_get_timestamp();
    // divide the per second insert rate into periods of 10 milli seconds.
-   uint64          insert_rate = params->insert_rate / 100;
+   uint64            insert_rate = params->insert_rate / 100;
    merge_accumulator msg;
    merge_accumulator_init(&msg, NULL);
 

--- a/tests/functional/splinter_test.c
+++ b/tests/functional/splinter_test.c
@@ -114,8 +114,8 @@ test_trunk_insert_thread(void *arg)
    timestamp next_check_time = platform_get_timestamp();
    // divide the per second insert rate into periods of 10 milli seconds.
    uint64          insert_rate = params->insert_rate / 100;
-   writable_buffer msg;
-   writable_buffer_init(&msg, NULL);
+   merge_accumulator msg;
+   merge_accumulator_init(&msg, NULL);
 
    while (1) {
       for (uint8 spl_idx = 0; spl_idx < num_tables; spl_idx++) {
@@ -158,7 +158,7 @@ test_trunk_insert_thread(void *arg)
                      test_cfg[spl_idx].period);
             generate_test_message(test_cfg->gen, insert_num, &msg);
             platform_status rc =
-               trunk_insert(spl, key, writable_buffer_to_slice(&msg));
+               trunk_insert(spl, key, merge_accumulator_to_message(&msg));
             platform_assert_status_ok(rc);
             if (spl->cfg.use_stats) {
                ts = platform_timestamp_elapsed(ts);
@@ -185,7 +185,7 @@ test_trunk_insert_thread(void *arg)
       }
    }
 out:
-   writable_buffer_deinit(&msg);
+   merge_accumulator_deinit(&msg);
    params->rc = STATUS_OK;
    platform_free(platform_get_heap_id(), insert_base);
    for (uint64 i = 0; i < num_tables; i++) {
@@ -215,8 +215,8 @@ test_trunk_lookup_thread(void *arg)
       TYPED_ARRAY_ZALLOC(platform_get_heap_id(), lookup_base, num_tables);
    uint8 done = 0;
 
-   writable_buffer data;
-   writable_buffer_init(&data, NULL);
+   merge_accumulator data;
+   merge_accumulator_init(&data, NULL);
 
 
    while (1) {
@@ -268,7 +268,7 @@ test_trunk_lookup_thread(void *arg)
                             test_cfg->gen,
                             lookup_num,
                             key,
-                            writable_buffer_to_slice(&data),
+                            merge_accumulator_to_message(&data),
                             expected_found);
             } else {
                ctxt = test_async_ctxt_get(spl, async_lookup, &vtarg);
@@ -299,13 +299,13 @@ test_trunk_lookup_thread(void *arg)
       }
    }
 out:
-   writable_buffer_deinit(&data);
+   merge_accumulator_deinit(&data);
    params->rc = STATUS_OK;
    platform_free(platform_get_heap_id(), lookup_base);
 }
 
 static void
-nop_tuple_func(slice key, slice value, void *arg)
+nop_tuple_func(slice key, message value, void *arg)
 {}
 
 void
@@ -489,8 +489,8 @@ do_operation(test_splinter_thread_params *params,
    uint8              num_tables     = params->num_tables;
    verify_tuple_arg   vtarg          = {.stats_only = TRUE,
                                         .stats      = &params->lookup_stats[ASYNC_LU]};
-   writable_buffer    msg;
-   writable_buffer_init(&msg, NULL);
+   merge_accumulator  msg;
+   merge_accumulator_init(&msg, NULL);
 
    for (uint64 op_idx = op_offset; op_idx != op_offset + num_ops; op_idx++) {
       if (op_idx >= op_granularity) {
@@ -517,7 +517,7 @@ do_operation(test_splinter_thread_params *params,
             generate_test_message(test_cfg->gen, op_num, &msg);
             ts = platform_get_timestamp();
             platform_status rc =
-               trunk_insert(spl, key, writable_buffer_to_slice(&msg));
+               trunk_insert(spl, key, merge_accumulator_to_message(&msg));
             platform_assert_status_ok(rc);
             ts = platform_timestamp_elapsed(ts);
             params->insert_stats.duration += ts;
@@ -574,7 +574,7 @@ do_operation(test_splinter_thread_params *params,
       }
    }
 
-   writable_buffer_deinit(&msg);
+   merge_accumulator_deinit(&msg);
 }
 
 /*

--- a/tests/functional/test.h
+++ b/tests/functional/test.h
@@ -157,7 +157,7 @@ typedef struct test_message_generator {
 static inline void
 generate_test_message(const test_message_generator *generator,
                       uint64                        idx,
-                      writable_buffer              *msg)
+                      merge_accumulator            *msg)
 {
    debug_assert(generator->min_payload_size <= generator->max_payload_size,
                 "generator min_payload_size=%lu should be less than generator "
@@ -173,8 +173,9 @@ generate_test_message(const test_message_generator *generator,
       generator->min_payload_size
       + (idx % (generator->max_payload_size - generator->min_payload_size + 1));
    uint64 total_size = sizeof(data_handle) + payload_size;
-   writable_buffer_resize(msg, total_size);
-   data_handle *raw_data = writable_buffer_data(msg);
+   merge_accumulator_set_class(msg, generator->type);
+   merge_accumulator_resize(msg, total_size);
+   data_handle *raw_data = merge_accumulator_data(msg);
    memset(raw_data, idx, total_size);
    raw_data->message_type = generator->type;
    raw_data->ref_count    = 1;

--- a/tests/functional/test.h
+++ b/tests/functional/test.h
@@ -177,8 +177,7 @@ generate_test_message(const test_message_generator *generator,
    merge_accumulator_resize(msg, total_size);
    data_handle *raw_data = merge_accumulator_data(msg);
    memset(raw_data, idx, total_size);
-   raw_data->message_type = generator->type;
-   raw_data->ref_count    = 1;
+   raw_data->ref_count = 1;
    memcpy(raw_data->data, &idx, sizeof(idx));
 }
 

--- a/tests/functional/test_async.c
+++ b/tests/functional/test_async.c
@@ -81,7 +81,7 @@ async_ctxt_init(platform_heap_id    hid,                // IN
    async_lookup->ready_q = pcq_alloc(hid, max_async_inflight);
    platform_assert(async_lookup->ready_q);
    for (uint64 i = 0; i < max_async_inflight; i++) {
-      writable_buffer_init(&async_lookup->ctxt[i].data, NULL);
+      merge_accumulator_init(&async_lookup->ctxt[i].data, NULL);
       async_lookup->ctxt[i].ready_q = async_lookup->ready_q;
       // All ctxts start out as available
       pcq_enqueue(async_lookup->avail_q, &async_lookup->ctxt[i]);
@@ -100,7 +100,7 @@ async_ctxt_deinit(platform_heap_id hid, test_async_lookup *async_lookup)
    platform_assert(pcq_is_empty(async_lookup->ready_q));
    pcq_free(hid, async_lookup->ready_q);
    for (uint64 i = 0; i < async_lookup->max_async_inflight; i++) {
-      writable_buffer_deinit(&async_lookup->ctxt[i].data);
+      merge_accumulator_deinit(&async_lookup->ctxt[i].data);
    }
    platform_free(hid, async_lookup);
 }

--- a/tests/functional/test_async.h
+++ b/tests/functional/test_async.h
@@ -27,7 +27,7 @@ typedef struct {
       int8   refcount;   // Used by functionality test
       uint64 lookup_num; // Used by rest
    };
-   char            key[MAX_KEY_SIZE];
+   char              key[MAX_KEY_SIZE];
    merge_accumulator data;
 } test_async_ctxt;
 

--- a/tests/functional/test_async.h
+++ b/tests/functional/test_async.h
@@ -28,7 +28,7 @@ typedef struct {
       uint64 lookup_num; // Used by rest
    };
    char            key[MAX_KEY_SIZE];
-   writable_buffer data;
+   merge_accumulator data;
 } test_async_ctxt;
 
 /*

--- a/tests/functional/test_functionality.c
+++ b/tests/functional/test_functionality.c
@@ -38,7 +38,7 @@ search_for_key_via_iterator(trunk_handle *spl, slice target)
    uint64 count = 0;
    while (SUCCESS(iterator_at_end((iterator *)&iter, &at_end)) && !at_end) {
       slice key;
-      slice value;
+      message value;
       iterator_get_curr((iterator *)&iter, &key, &value);
       if (slice_lex_cmp(target, key) == 0) {
          platform_log("Found missing key %s\n",
@@ -54,17 +54,17 @@ search_for_key_via_iterator(trunk_handle *spl, slice target)
 static void
 verify_tuple(trunk_handle    *spl,
              const char      *keybuf,
-             slice            message,
+             message          mmsg,
              int8             refcount,
              platform_status *result)
 {
-   const data_handle *msg   = slice_data(message);
+   const data_handle *msg   = message_data(mmsg);
    bool               found = msg != NULL;
    uint64             key   = be64toh(*(uint64 *)keybuf);
 
-   if (msg && slice_length(message) < sizeof(data_handle)) {
+   if (msg && message_length(mmsg) < sizeof(data_handle)) {
       platform_error_log("ERROR: Short message of length %ld, key = 0x%08lx, ",
-                         slice_length(message),
+                         message_length(mmsg),
                          key);
       platform_assert(0);
    }
@@ -95,13 +95,13 @@ verify_tuple(trunk_handle    *spl,
       trunk_print_lookup(spl, keybuf);
       platform_assert(0);
    } else if (refcount && found) {
-      writable_buffer expected_message;
-      writable_buffer_init(&expected_message, NULL);
+      merge_accumulator expected_message;
+      merge_accumulator_init(&expected_message, NULL);
       test_data_generate_message(
          spl->cfg.data_cfg, MESSAGE_TYPE_INSERT, refcount, &expected_message);
-      slice expected_msg = writable_buffer_to_slice(&expected_message);
-      platform_assert(!slice_is_null(message));
-      platform_assert(slice_lex_cmp(message, expected_msg) == 0,
+      message expected_msg = merge_accumulator_to_message(&expected_message);
+      platform_assert(!message_is_null(mmsg));
+      platform_assert(message_lex_cmp(mmsg, expected_msg) == 0,
                       "ERROR: message does not match expected message.  "
                       "key = 0x%08lx "
                       "shadow ref: %4d "
@@ -111,9 +111,9 @@ verify_tuple(trunk_handle    *spl,
                       key,
                       refcount,
                       msg->ref_count,
-                      slice_length(expected_msg),
-                      slice_length(message));
-      writable_buffer_deinit(&expected_message);
+                      message_length(expected_msg),
+                      message_length(mmsg));
+      merge_accumulator_deinit(&expected_message);
    } else {
       /* !refcount && !found.  We're good. */
    }
@@ -127,7 +127,7 @@ verify_tuple_callback(trunk_handle *spl, test_async_ctxt *ctxt, void *arg)
 
    verify_tuple(spl,
                 ctxt->key,
-                writable_buffer_to_slice(&ctxt->data),
+                merge_accumulator_to_message(&ctxt->data),
                 ctxt->refcount,
                 result);
 }
@@ -161,8 +161,8 @@ verify_against_shadow(trunk_handle               *spl,
    platform_status rc, result = STATUS_OK;
 
    uint64          i;
-   writable_buffer message;
-   writable_buffer_init(&message, spl->heap_id);
+   merge_accumulator msgacc;
+   merge_accumulator_init(&msgacc, spl->heap_id);
 
    for (i = 0; i < sharr->nkeys; i++) {
       uint64           key      = sharr->keys[i];
@@ -177,19 +177,19 @@ verify_against_shadow(trunk_handle               *spl,
       if (ctxt == NULL) {
          test_int_to_key(keybuf, key, key_size);
 
-         rc = trunk_lookup(spl, keybuf, &message);
+         rc = trunk_lookup(spl, keybuf, &msgacc);
          if (!SUCCESS(rc)) {
             return rc;
          }
-         slice message_slice = writable_buffer_to_slice(&message);
-         verify_tuple(spl, keybuf, message_slice, refcount, &result);
+         message msg = merge_accumulator_to_message(&msgacc);
+         verify_tuple(spl, keybuf, msg, refcount, &result);
       } else {
          test_int_to_key(ctxt->key, key, key_size);
          ctxt->refcount = refcount;
          async_ctxt_process_one(
             spl, async_lookup, ctxt, NULL, verify_tuple_callback, &result);
       }
-      writable_buffer_set_to_null(&message);
+      merge_accumulator_set_to_null(&msgacc);
    }
 
    if (async_lookup) {
@@ -204,7 +204,7 @@ verify_against_shadow(trunk_handle               *spl,
       }
    }
 
-   writable_buffer_deinit(&message);
+   merge_accumulator_deinit(&msgacc);
 
    return result;
 }
@@ -224,7 +224,7 @@ verify_range_against_shadow(trunk_handle               *spl,
 {
    platform_status    status;
    slice              splinter_keybuf;
-   slice              splinter_message;
+   message            splinter_message;
    const data_handle *splinter_data_handle;
    uint64             splinter_key;
    uint64             i;
@@ -266,7 +266,7 @@ verify_range_against_shadow(trunk_handle               *spl,
       iterator_get_curr(
          (iterator *)range_itor, &splinter_keybuf, &splinter_message);
       splinter_key         = be64toh(*(uint64 *)slice_data(splinter_keybuf));
-      splinter_data_handle = slice_data(splinter_message);
+      splinter_data_handle = message_data(splinter_message);
 
       // platform_log("Range test %d: Shadow: 0x%08lx, Tree: 0x%08lx\n",
       //   i,
@@ -566,8 +566,8 @@ insert_random_messages(trunk_handle              *spl,
    int             i;
    platform_status rc = STATUS_OK;
    uint64          key;
-   writable_buffer msg;
-   writable_buffer_init(&msg, NULL);
+   merge_accumulator msg;
+   merge_accumulator_init(&msg, NULL);
 
    key = minkey;
    for (i = 0; i < num_messages; i++) {
@@ -584,10 +584,13 @@ insert_random_messages(trunk_handle              *spl,
       int8 ref_count = 0;
       if (op != MESSAGE_TYPE_DELETE) {
          ref_count = ((int)(random_next_uint64(prg) % 256)) - 127;
+         if (ref_count == 0) {
+            ref_count = 1;
+         }
       }
       test_data_generate_message(spl->cfg.data_cfg, op, ref_count, &msg);
 
-      rc = trunk_insert(spl, keybuf, writable_buffer_to_slice(&msg));
+      rc = trunk_insert(spl, keybuf, merge_accumulator_to_message(&msg));
       if (!SUCCESS(rc)) {
          goto cleanup;
       }
@@ -610,7 +613,7 @@ insert_random_messages(trunk_handle              *spl,
    }
 
 cleanup:
-   writable_buffer_deinit(&msg);
+   merge_accumulator_deinit(&msg);
    return rc;
 }
 

--- a/tests/functional/test_functionality.c
+++ b/tests/functional/test_functionality.c
@@ -37,7 +37,7 @@ search_for_key_via_iterator(trunk_handle *spl, slice target)
    trunk_range_iterator_init(spl, &iter, NULL, NULL, UINT64_MAX);
    uint64 count = 0;
    while (SUCCESS(iterator_at_end((iterator *)&iter, &at_end)) && !at_end) {
-      slice key;
+      slice   key;
       message value;
       iterator_get_curr((iterator *)&iter, &key, &value);
       if (slice_lex_cmp(target, key) == 0) {
@@ -160,7 +160,7 @@ verify_against_shadow(trunk_handle               *spl,
 
    platform_status rc, result = STATUS_OK;
 
-   uint64          i;
+   uint64            i;
    merge_accumulator msgacc;
    merge_accumulator_init(&msgacc, spl->heap_id);
 
@@ -563,9 +563,9 @@ insert_random_messages(trunk_handle              *spl,
    platform_assert(key_size >= sizeof(uint64));
    platform_assert(sizeof(data_handle) <= sizeof(void *));
 
-   int             i;
-   platform_status rc = STATUS_OK;
-   uint64          key;
+   int               i;
+   platform_status   rc = STATUS_OK;
+   uint64            key;
    merge_accumulator msg;
    merge_accumulator_init(&msg, NULL);
 

--- a/tests/functional/test_functionality.c
+++ b/tests/functional/test_functionality.c
@@ -86,10 +86,8 @@ verify_tuple(trunk_handle    *spl,
       platform_error_log(
          "ERROR: A key found in the Splinter has refcount 0 in shadow tree. "
          "key = 0x%08lx, "
-         "splinter flags = %d, "
          "splinter refcount = 0x%08x\n",
          key,
-         msg->message_type,
          msg->ref_count);
       *result = STATUS_INVALID_STATE;
       trunk_print_lookup(spl, keybuf);
@@ -278,12 +276,11 @@ verify_range_against_shadow(trunk_handle               *spl,
       } else {
          platform_error_log("ERROR: Key mismatch: "
                             "Shadow Key: 0x%08lx, Shadow Refcount: %3d, "
-                            "Tree Key: 0x%08lx, Tree Msg Type: 0x%02x, "
+                            "Tree Key: 0x%08lx, "
                             "Tree Refcount: %3d\n",
                             shadow_key,
                             shadow_refcount,
                             splinter_key,
-                            splinter_data_handle->message_type,
                             splinter_data_handle->ref_count);
          platform_assert(0);
          status = STATUS_INVALID_STATE;
@@ -310,9 +307,8 @@ verify_range_against_shadow(trunk_handle               *spl,
       splinter_key = be64toh(*(uint64 *)slice_data(splinter_keybuf));
 
       platform_log("Range iterator EXTRA KEY: %08lx \n"
-                   "Tree Msg Type: 0x%02x, Tree Refcount %3d\n",
+                   "Tree Refcount %3d\n",
                    splinter_key,
-                   splinter_data_handle->message_type,
                    splinter_data_handle->ref_count);
       if (!SUCCESS(iterator_advance((iterator *)range_itor))) {
          goto destroy;

--- a/tests/functional/ycsb_test.c
+++ b/tests/functional/ycsb_test.c
@@ -304,7 +304,7 @@ typedef struct ycsb_phase {
 } ycsb_phase;
 
 static void
-nop_tuple_func(slice key, slice value, void *arg)
+nop_tuple_func(slice key, message value, void *arg)
 {}
 
 static void
@@ -317,8 +317,8 @@ ycsb_thread(void *arg)
    uint64           num_ops    = params->total_ops;
    uint64           batch_size = params->batch_size;
    uint64           my_batch;
-   writable_buffer  value;
-   writable_buffer_init(&value, NULL);
+   merge_accumulator value;
+   merge_accumulator_init(&value, NULL);
 
    uint64_t start_time = platform_get_timestamp();
    __sync_val_compare_and_swap(
@@ -353,8 +353,10 @@ ycsb_thread(void *arg)
             case 'i':
             case 'u':
             {
-               slice value_slice = slice_create(YCSB_DATA_SIZE, ops->value);
-               rc                = trunk_insert(spl, ops->key, value_slice);
+               message val =
+                  message_create(MESSAGE_TYPE_INSERT,
+                                 slice_create(YCSB_DATA_SIZE, ops->value));
+               rc = trunk_insert(spl, ops->key, val);
                platform_assert_status_ok(rc);
                break;
             }
@@ -402,7 +404,7 @@ ycsb_thread(void *arg)
       SEC_TO_NSEC(end_thread_cputime.tv_sec) + end_thread_cputime.tv_nsec
       - SEC_TO_NSEC(start_thread_cputime.tv_sec) - start_thread_cputime.tv_nsec;
    __sync_fetch_and_add(&params->times.sum_of_cpu_times, thread_cputime);
-   writable_buffer_deinit(&value);
+   merge_accumulator_deinit(&value);
 }
 
 static int

--- a/tests/functional/ycsb_test.c
+++ b/tests/functional/ycsb_test.c
@@ -310,13 +310,13 @@ nop_tuple_func(slice key, message value, void *arg)
 static void
 ycsb_thread(void *arg)
 {
-   platform_status  rc;
-   uint64           i;
-   ycsb_log_params *params     = (ycsb_log_params *)arg;
-   trunk_handle    *spl        = params->spl;
-   uint64           num_ops    = params->total_ops;
-   uint64           batch_size = params->batch_size;
-   uint64           my_batch;
+   platform_status   rc;
+   uint64            i;
+   ycsb_log_params  *params     = (ycsb_log_params *)arg;
+   trunk_handle     *spl        = params->spl;
+   uint64            num_ops    = params->total_ops;
+   uint64            batch_size = params->batch_size;
+   uint64            my_batch;
    merge_accumulator value;
    merge_accumulator_init(&value, NULL);
 

--- a/tests/functional/ycsb_test.c
+++ b/tests/functional/ycsb_test.c
@@ -582,15 +582,12 @@ parse_ycsb_log_file(void *arg)
          platform_assert(ret == 2);
       } else if (result[i].cmd == 'd') {
          platform_assert(ret == 2);
-         test_data_set_delete_flag(dh);
       } else if (result[i].cmd == 'u') {
          platform_assert(ret == 2);
          random_bytes(&rs, (char *)dh->data, YCSB_DATA_SIZE - 2);
-         test_data_set_insert_flag(dh);
       } else if (result[i].cmd == 'i') {
          platform_assert(ret == 2);
          random_bytes(&rs, (char *)dh->data, YCSB_DATA_SIZE - 2);
-         test_data_set_insert_flag(dh);
       } else if (result[i].cmd == 's') {
          ret = sscanf(buffer,
                       "%c %64s %lu\n",

--- a/tests/test_common.c
+++ b/tests/test_common.c
@@ -25,10 +25,10 @@ verify_tuple(trunk_handle           *spl,
              test_message_generator *gen,
              uint64                  lookup_num,
              char                   *key,
-             slice                   data,
+             message                 data,
              bool                    expected_found)
 {
-   if (slice_is_null(data) != !expected_found) {
+   if (message_is_null(data) != !expected_found) {
       char key_str[128];
       trunk_key_to_string(spl, key, key_str);
       platform_handle_log(stderr,
@@ -36,22 +36,23 @@ verify_tuple(trunk_handle           *spl,
                           platform_get_tid(),
                           lookup_num,
                           key_str,
-                          !slice_is_null(data),
+                          !message_is_null(data),
                           expected_found);
       trunk_print_lookup(spl, key);
       platform_assert(FALSE);
    }
 
-   if (!slice_is_null(data) && expected_found) {
-      writable_buffer expected_msg;
-      writable_buffer_init(&expected_msg, NULL);
+   if (!message_is_null(data) && expected_found) {
+      merge_accumulator expected_msg;
+      merge_accumulator_init(&expected_msg, NULL);
       char data_str[128];
       generate_test_message(gen, lookup_num, &expected_msg);
-      if (slice_lex_cmp(writable_buffer_to_slice(&expected_msg), data) != 0) {
+      if (message_lex_cmp(merge_accumulator_to_message(&expected_msg), data)
+          != 0) {
          trunk_message_to_string(spl, data, data_str);
          platform_handle_log(stderr, "key found with data: %s\n", data_str);
          trunk_message_to_string(
-            spl, writable_buffer_to_slice(&expected_msg), data_str);
+            spl, merge_accumulator_to_message(&expected_msg), data_str);
          platform_handle_log(stderr, "expected data: %s\n", data_str);
          platform_assert(FALSE);
       }

--- a/tests/test_common.h
+++ b/tests/test_common.h
@@ -32,7 +32,7 @@ verify_tuple(trunk_handle           *spl,
              test_message_generator *gen,
              uint64                  lookup_num,
              char                   *key,
-             slice                   data,
+             message                 data,
              bool                    expected_found);
 
 void

--- a/tests/test_data.c
+++ b/tests/test_data.c
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "test_data.h"
+#include "data_internal.h"
 
 typedef struct data_test_config {
    data_config super;
@@ -18,7 +19,7 @@ void
 test_data_generate_message(const data_config *cfg,
                            message_type       type,
                            uint8              ref_count,
-                           writable_buffer   *msg)
+                           merge_accumulator *msg)
 {
    uint64 payload_size = 0;
    if (type == MESSAGE_TYPE_INSERT) {
@@ -27,8 +28,9 @@ test_data_generate_message(const data_config *cfg,
       payload_size = (253456363ULL + (uint64)ref_count * 750599937895091ULL)
                      % tdcfg->payload_size_limit;
    }
-   writable_buffer_resize(msg, sizeof(data_handle) + payload_size);
-   data_handle *dh  = writable_buffer_data(msg);
+   merge_accumulator_set_class(msg, type);
+   merge_accumulator_resize(msg, sizeof(data_handle) + payload_size);
+   data_handle *dh  = merge_accumulator_data(msg);
    dh->message_type = type;
    dh->ref_count    = ref_count;
    memset(dh->data, ref_count, payload_size);
@@ -44,69 +46,31 @@ test_data_generate_message(const data_config *cfg,
  */
 static int
 test_data_merge_tuples(const data_config *cfg,
-                       const slice        key,
-                       const slice        old_raw_message,
-                       writable_buffer   *new_raw_message)
+                       slice              key,
+                       message            old_raw_message,
+                       merge_accumulator *new_raw_message)
 {
-   assert(sizeof(data_handle) <= slice_length(old_raw_message));
-   assert(sizeof(data_handle) <= writable_buffer_length(new_raw_message));
+   platform_assert(sizeof(data_handle) <= message_length(old_raw_message));
+   platform_assert(sizeof(data_handle)
+                   <= merge_accumulator_length(new_raw_message));
+   platform_assert(merge_accumulator_message_class(new_raw_message)
+                   == MESSAGE_TYPE_UPDATE);
+   platform_assert(message_class(old_raw_message) != MESSAGE_TYPE_DELETE);
 
-   const data_handle *old_data = slice_data(old_raw_message);
-   data_handle       *new_data = writable_buffer_data(new_raw_message);
+   const data_handle *old_data = message_data(old_raw_message);
+   data_handle       *new_data = merge_accumulator_data(new_raw_message);
    debug_assert(old_data != NULL);
    debug_assert(new_data != NULL);
-   // platform_log("data_merge_tuples: op=%d old_op=%d key=0x%08lx old=%d
-   // new=%d\n",
-   //         new_data->message_type, old_data->message_type, htobe64(*(uint64
-   //         *)key), old_data->ref_count, new_data->ref_count);
 
-   switch (new_data->message_type) {
-      case MESSAGE_TYPE_INSERT:
-      case MESSAGE_TYPE_DELETE:
-         break;
-      case MESSAGE_TYPE_UPDATE:
-         switch (old_data->message_type) {
-            case MESSAGE_TYPE_INSERT:
-               new_data->message_type = MESSAGE_TYPE_INSERT;
-               new_data->ref_count += old_data->ref_count;
-               break;
-            case MESSAGE_TYPE_UPDATE:
-               new_data->ref_count += old_data->ref_count;
-               break;
-            case MESSAGE_TYPE_DELETE:
-               if (new_data->ref_count == 0) {
-                  new_data->message_type = MESSAGE_TYPE_DELETE;
-               } else {
-                  new_data->message_type = MESSAGE_TYPE_INSERT;
-               }
-               break;
-            default:
-               platform_assert(0);
-         }
-         test_data_generate_message(
-            cfg, new_data->message_type, new_data->ref_count, new_raw_message);
-         break;
-      default:
-         platform_assert(0);
+   int8         result_ref_count = old_data->ref_count + new_data->ref_count;
+   message_type result_type      = message_class(old_raw_message);
+   if (result_ref_count == 0 && result_type == MESSAGE_TYPE_INSERT) {
+      result_type = MESSAGE_TYPE_DELETE;
    }
+   test_data_generate_message(
+      cfg, result_type, result_ref_count, new_raw_message);
 
    return 0;
-   // if (new_data->message_type == MESSAGE_TYPE_INSERT) {
-   //   ;
-   //} else if (new_data->message_type == MESSAGE_TYPE_DELETE) {
-   //   ;
-   //} else if (old_data == NULL || old_data->message_type ==
-   // MESSAGE_TYPE_DELETE) {
-   //   if (new_data->ref_count == 0)
-   //      new_data->message_type = MESSAGE_TYPE_DELETE;
-   //   else
-   //      new_data->message_type = MESSAGE_TYPE_INSERT;
-   //} else if (old_data->message_type == MESSAGE_TYPE_INSERT) {
-   //   new_data->message_type = MESSAGE_TYPE_INSERT;
-   //   new_data->ref_count += old_data->ref_count;
-   //} else {
-   //   new_data->ref_count += old_data->ref_count;
-   //}
 }
 
 /*
@@ -121,59 +85,27 @@ test_data_merge_tuples(const data_config *cfg,
  */
 static int
 test_data_merge_tuples_final(const data_config *cfg,
-                             uint64             key_len,
-                             const void        *key,           // IN
-                             writable_buffer   *oldest_raw_data) // IN/OUT
+                             slice              key,
+                             merge_accumulator *oldest_raw_data) // IN/OUT
 {
-   assert(sizeof(data_handle) <= writable_buffer_length(oldest_raw_data));
+   platform_assert(merge_accumulator_message_class(oldest_raw_data)
+                   == MESSAGE_TYPE_UPDATE);
+   assert(sizeof(data_handle) <= merge_accumulator_length(oldest_raw_data));
 
-   data_handle *old_data = writable_buffer_data(oldest_raw_data);
+   data_handle *old_data = merge_accumulator_data(oldest_raw_data);
    debug_assert(old_data != NULL);
 
-   if (old_data->message_type == MESSAGE_TYPE_UPDATE) {
-      test_data_generate_message(
-         cfg,
-         (old_data->ref_count == 0) ? MESSAGE_TYPE_DELETE : MESSAGE_TYPE_INSERT,
-         old_data->ref_count,
-         oldest_raw_data);
-   }
+   test_data_generate_message(cfg,
+                              (old_data->ref_count == 0) ? MESSAGE_TYPE_DELETE
+                                                         : MESSAGE_TYPE_INSERT,
+                              old_data->ref_count,
+                              oldest_raw_data);
    return 0;
-}
-
-/*
- *-----------------------------------------------------------------------------
- * data_class --
- *
- *      Given a data message, returns its message class.
- *-----------------------------------------------------------------------------
- */
-static message_type
-test_data_message_class(const data_config *cfg, slice raw_data)
-{
-   platform_assert((sizeof(data_handle) <= slice_length(raw_data)),
-                   "sizeof(data_handle)=%lu, raw_data_len=%lu",
-                   sizeof(data_handle),
-                   slice_length(raw_data));
-
-   const data_handle *data = slice_data(raw_data);
-   switch (data->message_type) {
-      case MESSAGE_TYPE_INSERT:
-         return data->ref_count == 0 ? MESSAGE_TYPE_DELETE
-                                     : MESSAGE_TYPE_INSERT;
-      case MESSAGE_TYPE_DELETE:
-         return MESSAGE_TYPE_DELETE;
-      case MESSAGE_TYPE_UPDATE:
-         return MESSAGE_TYPE_UPDATE;
-      default:
-         platform_error_log("data class error: %d\n", data->message_type);
-         platform_assert(0);
-   }
-   return MESSAGE_TYPE_INVALID;
 }
 
 static void
 test_data_key_to_string(const data_config *cfg,
-                        const slice        key,
+                        slice              key,
                         char              *str,
                         size_t             len)
 {
@@ -182,53 +114,11 @@ test_data_key_to_string(const data_config *cfg,
 
 static void
 test_data_message_to_string(const data_config *cfg,
-                            const slice        message,
+                            message            message,
                             char              *str,
                             size_t             len)
 {
-   debug_hex_encode(str, len, slice_data(message), slice_length(message));
-}
-
-static int
-test_encode_message(message_type type,
-                    slice        in_value,
-                    size_t       dst_msg_buffer_len,
-                    void        *dst_msg_buffer,
-                    size_t      *out_encoded_len)
-{
-   data_handle *msg  = (data_handle *)dst_msg_buffer;
-   msg->message_type = type;
-   msg->ref_count    = 1;
-   if (slice_length(in_value) + sizeof(data_handle) > dst_msg_buffer_len) {
-      platform_error_log(
-         "encode_message: "
-         "value_len %lu + encoding header %lu exceeds buffer size %lu bytes.",
-         slice_length(in_value),
-         sizeof(data_handle),
-         dst_msg_buffer_len);
-      return EINVAL;
-   }
-   if (slice_length(in_value) > 0) {
-      memmove(msg->data, slice_data(in_value), slice_length(in_value));
-   }
-   *out_encoded_len = sizeof(data_handle) + slice_length(in_value);
-   return 0;
-}
-
-static int
-test_decode_message(slice in_msg, size_t *out_value_len, const char **out_value)
-{
-   if (slice_length(in_msg) < sizeof(data_handle)) {
-      platform_error_log("decode_message: message_buffer_len=%lu must be "
-                         "at least %lu bytes.",
-                         slice_length(in_msg),
-                         sizeof(data_handle));
-      return EINVAL;
-   }
-   const data_handle *msg = (const data_handle *)slice_data(in_msg);
-   *out_value_len         = slice_length(in_msg) - sizeof(data_handle);
-   *out_value             = (const void *)(msg->data);
-   return 0;
+   debug_hex_encode(str, len, message_data(message), message_length(message));
 }
 
 static data_test_config data_test_config_internal = {
@@ -247,9 +137,6 @@ static data_test_config data_test_config_internal = {
          .message_to_string  = test_data_message_to_string,
          .merge_tuples       = test_data_merge_tuples,
          .merge_tuples_final = test_data_merge_tuples_final,
-         .message_class      = test_data_message_class,
-         .encode_message     = test_encode_message,
-         .decode_message     = test_decode_message,
       },
    .payload_size_limit = 24};
 

--- a/tests/test_data.c
+++ b/tests/test_data.c
@@ -30,8 +30,8 @@ test_data_generate_message(const data_config *cfg,
    }
    merge_accumulator_set_class(msg, type);
    merge_accumulator_resize(msg, sizeof(data_handle) + payload_size);
-   data_handle *dh  = merge_accumulator_data(msg);
-   dh->ref_count    = ref_count;
+   data_handle *dh = merge_accumulator_data(msg);
+   dh->ref_count   = ref_count;
    memset(dh->data, ref_count, payload_size);
 }
 

--- a/tests/test_data.c
+++ b/tests/test_data.c
@@ -31,7 +31,6 @@ test_data_generate_message(const data_config *cfg,
    merge_accumulator_set_class(msg, type);
    merge_accumulator_resize(msg, sizeof(data_handle) + payload_size);
    data_handle *dh  = merge_accumulator_data(msg);
-   dh->message_type = type;
    dh->ref_count    = ref_count;
    memset(dh->data, ref_count, payload_size);
 }

--- a/tests/test_data.h
+++ b/tests/test_data.h
@@ -19,7 +19,7 @@ void
 test_data_generate_message(const data_config *cfg,
                            message_type       type,
                            uint8              ref_count,
-                           writable_buffer   *msg);
+                           merge_accumulator *msg);
 
 static inline void
 test_data_set_insert_flag(void *raw_data)

--- a/tests/test_data.h
+++ b/tests/test_data.h
@@ -10,7 +10,6 @@
 extern data_config *test_data_config;
 
 typedef struct PACKED data_handle {
-   uint8 message_type;
    int8  ref_count;
    uint8 data[0];
 } data_handle;
@@ -20,33 +19,6 @@ test_data_generate_message(const data_config *cfg,
                            message_type       type,
                            uint8              ref_count,
                            merge_accumulator *msg);
-
-static inline void
-test_data_set_insert_flag(void *raw_data)
-{
-   data_handle *data  = (data_handle *)raw_data;
-   data->message_type = MESSAGE_TYPE_INSERT;
-}
-
-static inline void
-test_data_set_delete_flag(void *raw_data)
-{
-   data_handle *data  = (data_handle *)raw_data;
-   data->message_type = MESSAGE_TYPE_DELETE;
-}
-
-static inline void
-test_data_set_insert(void  *raw_data,
-                     int8   ref_count,
-                     char  *val,
-                     uint64 data_size)
-{
-   memset(raw_data, 0, data_size);
-   data_handle *data = (data_handle *)raw_data;
-   test_data_set_insert_flag(data);
-   data->ref_count = ref_count;
-   memmove(data->data, val, data_size - 2);
-}
 
 static inline void
 test_data_print_key(const void *key)

--- a/tests/unit/btree_stress_test.c
+++ b/tests/unit/btree_stress_test.c
@@ -362,8 +362,7 @@ gen_msg(btree_config *cfg, uint64 i, uint8 *buffer, size_t length)
    uint64       datalen = sizeof(i) + (i % (btree_page_size(cfg) / 3));
 
    platform_assert(datalen + sizeof(i) <= length);
-   dh->message_type = MESSAGE_TYPE_INSERT;
-   dh->ref_count    = 1;
+   dh->ref_count = 1;
    memset(dh->data, 0, datalen);
    memcpy(dh->data, &i, sizeof(i));
    return message_create(MESSAGE_TYPE_INSERT,

--- a/tests/unit/btree_stress_test.c
+++ b/tests/unit/btree_stress_test.c
@@ -81,7 +81,7 @@ gen_key(btree_config *cfg, uint64 i, uint8 *buffer, size_t length);
 static uint64
 ungen_key(slice key);
 
-static slice
+static message
 gen_msg(btree_config *cfg, uint64 i, uint8 *buffer, size_t length);
 
 /*
@@ -355,7 +355,7 @@ ungen_key(slice key)
    return (k - 99382474567ULL) * 14122572041603317147ULL;
 }
 
-static slice
+static message
 gen_msg(btree_config *cfg, uint64 i, uint8 *buffer, size_t length)
 {
    data_handle *dh      = (data_handle *)buffer;
@@ -366,7 +366,8 @@ gen_msg(btree_config *cfg, uint64 i, uint8 *buffer, size_t length)
    dh->ref_count    = 1;
    memset(dh->data, 0, datalen);
    memcpy(dh->data, &i, sizeof(i));
-   return slice_create(sizeof(data_handle) + datalen, buffer);
+   return message_create(MESSAGE_TYPE_INSERT,
+                         slice_create(sizeof(data_handle) + datalen, buffer));
 }
 
 static int
@@ -381,8 +382,8 @@ query_tests(cache           *cc,
    uint8 *msgbuf = TYPED_MALLOC_MANUAL(hid, msgbuf, btree_page_size(cfg));
    memset(msgbuf, 0, btree_page_size(cfg));
 
-   writable_buffer result;
-   writable_buffer_init(&result, hid);
+   merge_accumulator result;
+   merge_accumulator_init(&result, hid);
 
    for (uint64 i = 0; i < nkvs; i++) {
       btree_lookup(cc,
@@ -392,14 +393,14 @@ query_tests(cache           *cc,
                    gen_key(cfg, i, keybuf, btree_page_size(cfg)),
                    &result);
       if (!btree_found(&result)
-          || slice_lex_cmp(writable_buffer_to_slice(&result),
-                           gen_msg(cfg, i, msgbuf, btree_page_size(cfg))))
+          || message_lex_cmp(merge_accumulator_to_message(&result),
+                             gen_msg(cfg, i, msgbuf, btree_page_size(cfg))))
       {
          ASSERT_TRUE(FALSE, "Failure on lookup %lu\n", i);
       }
    }
 
-   writable_buffer_deinit(&result);
+   merge_accumulator_deinit(&result);
    platform_free(hid, keybuf);
    platform_free(hid, msgbuf);
    return 1;
@@ -434,7 +435,8 @@ iterator_tests(cache           *cc,
    uint8 *msgbuf  = TYPED_MALLOC_MANUAL(hid, msgbuf, btree_page_size(cfg));
 
    while (SUCCESS(iterator_at_end(iter, &at_end)) && !at_end) {
-      slice key, msg;
+      slice   key;
+      message msg;
 
       iterator_get_curr(iter, &key, &msg);
       uint64 k = ungen_key(key);
@@ -444,7 +446,7 @@ iterator_tests(cache           *cc,
       rc = slice_lex_cmp(key, gen_key(cfg, k, keybuf, btree_page_size(cfg)));
       ASSERT_EQUAL(0, rc);
 
-      rc = slice_lex_cmp(msg, gen_msg(cfg, k, msgbuf, btree_page_size(cfg)));
+      rc = message_lex_cmp(msg, gen_msg(cfg, k, msgbuf, btree_page_size(cfg)));
       ASSERT_EQUAL(0, rc);
 
       ASSERT_TRUE(slice_is_null(prev) || slice_lex_cmp(prev, key) < 0);

--- a/tests/unit/btree_test.c
+++ b/tests/unit/btree_test.c
@@ -180,9 +180,9 @@ leaf_hdr_tests(btree_config *cfg, btree_scratch *scratch, platform_heap_id hid)
 
    int cmp_rv = 0;
    for (uint32 i = 0; i < nkvs; i++) {
-      slice key     = btree_get_tuple_key(cfg, hdr, i);
-      message msg     = btree_get_tuple_message(cfg, hdr, i);
-      cmp_rv        = slice_lex_cmp(slice_create(i % sizeof(i), &i), key);
+      slice   key = btree_get_tuple_key(cfg, hdr, i);
+      message msg = btree_get_tuple_message(cfg, hdr, i);
+      cmp_rv      = slice_lex_cmp(slice_create(i % sizeof(i), &i), key);
       ASSERT_EQUAL(0, cmp_rv, "Bad 4-byte key %d\n", i);
 
       cmp_rv = message_lex_cmp(
@@ -204,9 +204,9 @@ leaf_hdr_tests(btree_config *cfg, btree_scratch *scratch, platform_heap_id hid)
 
    cmp_rv = 0;
    for (uint64 i = 0; i < nkvs; i++) {
-      slice key     = btree_get_tuple_key(cfg, hdr, i);
-      message msg     = btree_get_tuple_message(cfg, hdr, i);
-      cmp_rv        = slice_lex_cmp(slice_create(i % sizeof(i), &i), key);
+      slice   key = btree_get_tuple_key(cfg, hdr, i);
+      message msg = btree_get_tuple_message(cfg, hdr, i);
+      cmp_rv      = slice_lex_cmp(slice_create(i % sizeof(i), &i), key);
       ASSERT_EQUAL(0, cmp_rv, "Bad 4-byte key %d\n", i);
 
       cmp_rv = message_lex_cmp(
@@ -219,9 +219,9 @@ leaf_hdr_tests(btree_config *cfg, btree_scratch *scratch, platform_heap_id hid)
    btree_defragment_leaf(cfg, scratch, hdr, &spec);
 
    for (uint64 i = 0; i < nkvs; i++) {
-      slice key     = btree_get_tuple_key(cfg, hdr, i);
-      message msg     = btree_get_tuple_message(cfg, hdr, i);
-      cmp_rv        = slice_lex_cmp(slice_create(i % sizeof(i), &i), key);
+      slice   key = btree_get_tuple_key(cfg, hdr, i);
+      message msg = btree_get_tuple_message(cfg, hdr, i);
+      cmp_rv      = slice_lex_cmp(slice_create(i % sizeof(i), &i), key);
       ASSERT_EQUAL(0, cmp_rv, "Bad 4-byte key %d\n", i);
 
       cmp_rv = message_lex_cmp(
@@ -251,7 +251,7 @@ leaf_hdr_search_tests(btree_config *cfg, platform_heap_id hid)
       keybuf[0]     = 17 * i;
       messagebuf[0] = i;
 
-      slice key     = slice_create(1, &keybuf);
+      slice   key = slice_create(1, &keybuf);
       message msg =
          message_create(MESSAGE_TYPE_INSERT, slice_create(i % 8, messagebuf));
 
@@ -385,7 +385,7 @@ leaf_split_tests(btree_config    *cfg,
 
    btree_init_hdr(cfg, hdr);
 
-   int   msgsize = btree_page_size(cfg) / (nkvs + 1);
+   int     msgsize = btree_page_size(cfg) / (nkvs + 1);
    message msg =
       message_create(MESSAGE_TYPE_INSERT, slice_create(msgsize, msg_buffer));
    message bigger_msg = message_create(

--- a/tests/unit/splinter_test.c
+++ b/tests/unit/splinter_test.c
@@ -306,16 +306,17 @@ trunk_shadow_reinit(trunk_shadow *shadow)
  * rows will be used later during lookup-validation using range searches.
  */
 static void
-trunk_shadow_append(trunk_shadow *shadow, slice key, slice value)
+trunk_shadow_append(trunk_shadow *shadow, slice key, message value)
 {
+   platform_assert(message_class(value) == MESSAGE_TYPE_INSERT);
    uint64 key_offset =
       writable_buffer_append(&shadow->data, slice_length(key), slice_data(key));
    writable_buffer_append(
-      &shadow->data, slice_length(value), slice_data(value));
+      &shadow->data, message_length(value), message_data(value));
 
    shadow_entry new_entry = {.key_offset   = key_offset,
                              .key_length   = slice_length(key),
-                             .value_length = slice_length(value)};
+                             .value_length = message_length(value)};
    writable_buffer_append(&shadow->entries, sizeof(new_entry), &new_entry);
    shadow->sorted = FALSE;
 }
@@ -326,11 +327,13 @@ shadow_entry_key(const shadow_entry *entry, char *data)
    return slice_create(entry->key_length, data + entry->key_offset);
 }
 
-static slice
+static message
 shadow_entry_value(const shadow_entry *entry, char *data)
 {
-   return slice_create(entry->value_length,
-                       data + entry->key_offset + entry->key_length);
+   return message_create(
+      MESSAGE_TYPE_INSERT,
+      slice_create(entry->value_length,
+                   data + entry->key_offset + entry->key_length));
 }
 
 static int
@@ -361,7 +364,7 @@ trunk_shadow_sort(trunk_shadow *shadow)
 }
 
 static void
-trunk_shadow_get(trunk_shadow *shadow, uint64 i, slice *key, slice *value)
+trunk_shadow_get(trunk_shadow *shadow, uint64 i, slice *key, message *value)
 {
 
    if (!shadow->sorted) {
@@ -387,7 +390,7 @@ test_splinter_bsearch(trunk_shadow *shadow, slice key)
       // invariant: forall i | i < lo  :: s[i] < key
       // invariant: forall i | hi <= i :: key <= s[i]
       slice  ckey;
-      slice  cvalue;
+      message cvalue;
       uint64 mid = (lo + hi) / 2;
       trunk_shadow_get(shadow, mid, &ckey, &cvalue);
       int cmp = slice_lex_cmp(key, ckey);
@@ -435,8 +438,8 @@ CTEST2(splinter, test_lookups)
                     "Expected to have inserted non-zero rows, num_inserts=%lu.",
                     num_inserts);
 
-   writable_buffer qdata;
-   writable_buffer_init(&qdata, NULL);
+   merge_accumulator qdata;
+   merge_accumulator_init(&qdata, NULL);
    char         key[MAX_KEY_SIZE];
    const size_t key_size = trunk_key_size(spl);
 
@@ -456,7 +459,7 @@ CTEST2(splinter, test_lookups)
          insert_num, num_inserts, "Verify positive lookups %3lu%% complete");
 
       test_key(key, TEST_RANDOM, insert_num, 0, 0, key_size, 0);
-      writable_buffer_set_to_null(&qdata);
+      merge_accumulator_set_to_null(&qdata);
 
       rc = trunk_lookup(spl, key, &qdata);
       ASSERT_TRUE(SUCCESS(rc),
@@ -468,7 +471,7 @@ CTEST2(splinter, test_lookups)
                    &data->gen,
                    insert_num,
                    key,
-                   writable_buffer_to_slice(&qdata),
+                   merge_accumulator_to_message(&qdata),
                    TRUE);
    }
 
@@ -505,7 +508,7 @@ CTEST2(splinter, test_lookups)
                    &data->gen,
                    insert_num,
                    key,
-                   writable_buffer_to_slice(&qdata),
+                   merge_accumulator_to_message(&qdata),
                    FALSE);
    }
 
@@ -683,8 +686,8 @@ splinter_do_inserts(void         *datap,
    platform_default_log("trunk_insert() test with %d inserts %s ...\n",
                         num_inserts,
                         (verify ? "and verify" : ""));
-   writable_buffer msg;
-   writable_buffer_init(&msg, NULL);
+   merge_accumulator msg;
+   merge_accumulator_init(&msg, NULL);
    for (insert_num = 0; insert_num < num_inserts; insert_num++) {
 
       // Show progress message in %age-completed to stdout
@@ -699,7 +702,7 @@ splinter_do_inserts(void         *datap,
       }
       test_key(key, TEST_RANDOM, insert_num, 0, 0, key_size, 0);
       generate_test_message(&data->gen, insert_num, &msg);
-      rc = trunk_insert(spl, key, writable_buffer_to_slice(&msg));
+      rc = trunk_insert(spl, key, merge_accumulator_to_message(&msg));
       ASSERT_TRUE(SUCCESS(rc),
                   "trunk_insert() FAILURE: %s\n",
                   platform_status_to_string(rc));
@@ -707,8 +710,9 @@ splinter_do_inserts(void         *datap,
       // Caller is interested in using a copy of the rows inserted for
       // verification; e.g. by range-search lookups.
       if (shadow) {
-         trunk_shadow_append(
-            shadow, trunk_key_slice(spl, key), writable_buffer_to_slice(&msg));
+         trunk_shadow_append(shadow,
+                             trunk_key_slice(spl, key),
+                             merge_accumulator_to_message(&msg));
       }
    }
 
@@ -729,7 +733,7 @@ splinter_do_inserts(void         *datap,
    cache_assert_free((cache *)data->clock_cache);
 
    // Cleanup memory allocated in this test case
-   writable_buffer_deinit(&msg);
+   merge_accumulator_deinit(&msg);
    return num_inserts;
 }
 
@@ -741,14 +745,14 @@ typedef struct shadow_check_tuple_arg {
 } shadow_check_tuple_arg;
 
 static void
-shadow_check_tuple_func(slice key, slice value, void *varg)
+shadow_check_tuple_func(slice key, message value, void *varg)
 {
    shadow_check_tuple_arg *arg = varg;
 
    slice shadow_key;
-   slice shadow_value;
+   message shadow_value;
    trunk_shadow_get(arg->shadow, arg->pos, &shadow_key, &shadow_value);
-   if (slice_lex_cmp(key, shadow_key) || slice_lex_cmp(value, shadow_value)) {
+   if (slice_lex_cmp(key, shadow_key) || message_lex_cmp(value, shadow_value)) {
       char expected_key[128];
       char actual_key[128];
       char expected_value[128];

--- a/tests/unit/splinter_test.c
+++ b/tests/unit/splinter_test.c
@@ -389,9 +389,9 @@ test_splinter_bsearch(trunk_shadow *shadow, slice key)
    while (lo < hi) {
       // invariant: forall i | i < lo  :: s[i] < key
       // invariant: forall i | hi <= i :: key <= s[i]
-      slice  ckey;
+      slice   ckey;
       message cvalue;
-      uint64 mid = (lo + hi) / 2;
+      uint64  mid = (lo + hi) / 2;
       trunk_shadow_get(shadow, mid, &ckey, &cvalue);
       int cmp = slice_lex_cmp(key, ckey);
       if (cmp <= 0) {
@@ -749,7 +749,7 @@ shadow_check_tuple_func(slice key, message value, void *varg)
 {
    shadow_check_tuple_arg *arg = varg;
 
-   slice shadow_key;
+   slice   shadow_key;
    message shadow_value;
    trunk_shadow_get(arg->shadow, arg->pos, &shadow_key, &shadow_value);
    if (slice_lex_cmp(key, shadow_key) || message_lex_cmp(value, shadow_value)) {

--- a/tests/unit/splinterdb_quick_test.c
+++ b/tests/unit/splinterdb_quick_test.c
@@ -725,7 +725,7 @@ CTEST2(splinterdb_quick, test_custom_data_config)
    // insert a message that adds to the refcount
    msg.message_type = MESSAGE_TYPE_UPDATE;
    msg.ref_count    = 5;
-   rc = splinterdb_update(data->kvsb, key, msg_slice);
+   rc               = splinterdb_update(data->kvsb, key, msg_slice);
    ASSERT_EQUAL(0, rc);
 
    // check still found
@@ -734,9 +734,9 @@ CTEST2(splinterdb_quick, test_custom_data_config)
    ASSERT_TRUE(splinterdb_lookup_found(&result));
 
    // insert a message that drops the refcount to zero
-   msg.message_type  = MESSAGE_TYPE_UPDATE;
-   msg.ref_count     = -6;
-   rc                = splinterdb_update(data->kvsb, key, msg_slice);
+   msg.message_type = MESSAGE_TYPE_UPDATE;
+   msg.ref_count    = -6;
+   rc               = splinterdb_update(data->kvsb, key, msg_slice);
    ASSERT_EQUAL(0, rc);
 
    // on lookup, merge will decide the tuple is deleted

--- a/tests/unit/splinterdb_quick_test.c
+++ b/tests/unit/splinterdb_quick_test.c
@@ -701,9 +701,9 @@ CTEST2(splinterdb_quick, test_custom_data_config)
    int rc = splinterdb_create(&data->cfg, &data->kvsb);
    ASSERT_EQUAL(0, rc);
 
-   const size_t key_len  = 3;
-   const char  *key_data = "foo";
-   slice        key      = slice_create(key_len, key_data);
+   const size_t key_len   = 3;
+   const char  *key_data  = "foo";
+   slice        key       = slice_create(key_len, key_data);
    data_handle  msg       = {.ref_count = 1};
    slice        msg_slice = slice_create(sizeof(msg), &msg);
 
@@ -723,8 +723,8 @@ CTEST2(splinterdb_quick, test_custom_data_config)
    ASSERT_EQUAL(0, slice_lex_cmp(value, msg_slice));
 
    // insert a message that adds to the refcount
-   msg.ref_count    = 5;
-   rc               = splinterdb_update(data->kvsb, key, msg_slice);
+   msg.ref_count = 5;
+   rc            = splinterdb_update(data->kvsb, key, msg_slice);
    ASSERT_EQUAL(0, rc);
 
    // check still found
@@ -733,8 +733,8 @@ CTEST2(splinterdb_quick, test_custom_data_config)
    ASSERT_TRUE(splinterdb_lookup_found(&result));
 
    // insert a message that drops the refcount to zero
-   msg.ref_count    = -6;
-   rc               = splinterdb_update(data->kvsb, key, msg_slice);
+   msg.ref_count = -6;
+   rc            = splinterdb_update(data->kvsb, key, msg_slice);
    ASSERT_EQUAL(0, rc);
 
    // on lookup, merge will decide the tuple is deleted
@@ -743,8 +743,8 @@ CTEST2(splinterdb_quick, test_custom_data_config)
    ASSERT_FALSE(splinterdb_lookup_found(&result));
 
    // add it back as a value
-   msg.ref_count    = 12;
-   rc               = splinterdb_insert(data->kvsb, key, msg_slice);
+   msg.ref_count = 12;
+   rc            = splinterdb_insert(data->kvsb, key, msg_slice);
    ASSERT_EQUAL(0, rc);
 
    // delete it using a raw message

--- a/tests/unit/splinterdb_quick_test.c
+++ b/tests/unit/splinterdb_quick_test.c
@@ -704,7 +704,7 @@ CTEST2(splinterdb_quick, test_custom_data_config)
    const size_t key_len  = 3;
    const char  *key_data = "foo";
    slice        key      = slice_create(key_len, key_data);
-   data_handle  msg = {.message_type = MESSAGE_TYPE_INSERT, .ref_count = 1};
+   data_handle  msg       = {.ref_count = 1};
    slice        msg_slice = slice_create(sizeof(msg), &msg);
 
    ASSERT_EQUAL(0, rc);
@@ -723,7 +723,6 @@ CTEST2(splinterdb_quick, test_custom_data_config)
    ASSERT_EQUAL(0, slice_lex_cmp(value, msg_slice));
 
    // insert a message that adds to the refcount
-   msg.message_type = MESSAGE_TYPE_UPDATE;
    msg.ref_count    = 5;
    rc               = splinterdb_update(data->kvsb, key, msg_slice);
    ASSERT_EQUAL(0, rc);
@@ -734,7 +733,6 @@ CTEST2(splinterdb_quick, test_custom_data_config)
    ASSERT_TRUE(splinterdb_lookup_found(&result));
 
    // insert a message that drops the refcount to zero
-   msg.message_type = MESSAGE_TYPE_UPDATE;
    msg.ref_count    = -6;
    rc               = splinterdb_update(data->kvsb, key, msg_slice);
    ASSERT_EQUAL(0, rc);
@@ -745,7 +743,6 @@ CTEST2(splinterdb_quick, test_custom_data_config)
    ASSERT_FALSE(splinterdb_lookup_found(&result));
 
    // add it back as a value
-   msg.message_type = MESSAGE_TYPE_INSERT;
    msg.ref_count    = 12;
    rc               = splinterdb_insert(data->kvsb, key, msg_slice);
    ASSERT_EQUAL(0, rc);

--- a/tests/unit/splinterdb_quick_test.c
+++ b/tests/unit/splinterdb_quick_test.c
@@ -389,12 +389,6 @@ CTEST2(splinterdb_quick, test_variable_length_values)
    ASSERT_EQUAL(TEST_MAX_VALUE_SIZE, slice_length(value));
    ASSERT_STREQN(max_length_string, slice_data(value), slice_length(value));
 
-   // our buffer is untouched
-   ASSERT_DATA(saved_big_buffer,
-               sizeof(saved_big_buffer),
-               big_buffer,
-               sizeof(big_buffer));
-
    // we can deinit the result, and it doesn't try to free the stack space we
    // originally gave it
    splinterdb_lookup_result_deinit(&result);
@@ -710,8 +704,11 @@ CTEST2(splinterdb_quick, test_custom_data_config)
    const size_t key_len  = 3;
    const char  *key_data = "foo";
    slice        key      = slice_create(key_len, key_data);
+   data_handle  msg = {.message_type = MESSAGE_TYPE_INSERT, .ref_count = 1};
+   slice        msg_slice = slice_create(sizeof(msg), &msg);
+
    ASSERT_EQUAL(0, rc);
-   rc = splinterdb_insert(data->kvsb, key, slice_create(3, "bar"));
+   rc = splinterdb_insert(data->kvsb, key, msg_slice);
 
    // confirm its there
    splinterdb_lookup_result result;
@@ -723,16 +720,12 @@ CTEST2(splinterdb_quick, test_custom_data_config)
    slice value;
    rc = splinterdb_lookup_result_value(data->kvsb, &result, &value);
    ASSERT_EQUAL(0, rc);
-   ASSERT_EQUAL(3, slice_length(value));
-   ASSERT_EQUAL(0, memcmp(slice_data(value), "bar", 3));
+   ASSERT_EQUAL(0, slice_lex_cmp(value, msg_slice));
 
    // insert a message that adds to the refcount
-   char         msg_buffer[sizeof(data_handle)] = {0};
-   data_handle *msg                             = (data_handle *)msg_buffer;
-   msg->message_type                            = MESSAGE_TYPE_UPDATE;
-   msg->ref_count                               = 5;
-   rc                                           = splinterdb_insert_raw_message(
-      data->kvsb, key, slice_create(sizeof(msg_buffer), msg_buffer));
+   msg.message_type = MESSAGE_TYPE_UPDATE;
+   msg.ref_count    = 5;
+   rc = splinterdb_update(data->kvsb, key, msg_slice);
    ASSERT_EQUAL(0, rc);
 
    // check still found
@@ -741,10 +734,9 @@ CTEST2(splinterdb_quick, test_custom_data_config)
    ASSERT_TRUE(splinterdb_lookup_found(&result));
 
    // insert a message that drops the refcount to zero
-   msg->message_type = MESSAGE_TYPE_UPDATE;
-   msg->ref_count    = -6;
-   rc                = splinterdb_insert_raw_message(
-      data->kvsb, key, slice_create(sizeof(msg_buffer), msg_buffer));
+   msg.message_type  = MESSAGE_TYPE_UPDATE;
+   msg.ref_count     = -6;
+   rc                = splinterdb_update(data->kvsb, key, msg_slice);
    ASSERT_EQUAL(0, rc);
 
    // on lookup, merge will decide the tuple is deleted
@@ -753,13 +745,13 @@ CTEST2(splinterdb_quick, test_custom_data_config)
    ASSERT_FALSE(splinterdb_lookup_found(&result));
 
    // add it back as a value
-   rc = splinterdb_insert(data->kvsb, key, slice_create(3, "bar"));
+   msg.message_type = MESSAGE_TYPE_INSERT;
+   msg.ref_count    = 12;
+   rc               = splinterdb_insert(data->kvsb, key, msg_slice);
    ASSERT_EQUAL(0, rc);
 
    // delete it using a raw message
-   msg->message_type = MESSAGE_TYPE_DELETE;
-   rc                = splinterdb_insert_raw_message(
-      data->kvsb, key, slice_create(sizeof(msg_buffer), msg_buffer));
+   rc = splinterdb_delete(data->kvsb, key);
    ASSERT_EQUAL(0, rc);
 
    // on lookup, it should not be found


### PR DESCRIPTION
This PR eliminates the message encoding stuff in splinterdb.c.

Instead, message types are encoded in the metadata in the btree.

This eliminates a copy on inserts.

This also makes the interface for performing inserts much simpler:
`splinterdb_update(spl, key, msg);`

And it eliminates some limitations imposed by the splinterdb.c implementation (e.g. `MAX_ENCODED_MESSAGE_SIZE`) that, although not currently important, could become a hassle down the road.

It also introduces a new `message` type for passing around messages along with their types.  This will also be useful down the road for storing other metadata we will need for indirect messages.

Analogously, it introduces a `merge_accumulator` for performing merges.

These types are very analogous to `slice`s and `writable_buffer`s when they are used for messages, so the code changes are largely mechanical.

These types are used internally and in the `data.h` apis, but don't show up in query or insert apis.

This PR also adds an indirect bit for keys and values in the btree.  This bit is currently unused, but putting it in place will enable us to add indirect keys/values to the btree w/o changing the on-disk format.

