### PR TITLE
Clarify in limitations that min-key size should be 8 bytes.

### DIFF
--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -8,7 +8,8 @@ Thus, SplinterDB is provided *as-is* given the following limitations and missing
 * Public API is not yet stable. Users should expect breaking changes in future versions.
 * SplinterDB on-disk format is not versioned (Data may not survive software upgrades.)
 * Single 4KiB page size, with fixed extent size of 32 pages/extent.
-* Key and value size need to be less than the page size. Key size is limited to 105 bytes.
+* Key and value size need to be less than the page size. Key size must be
+  between 8 to 105 bytes. Support for smaller key-sizes is experimental.
 * The application must specify the minimum and maximum of the key range.
 * SplinterDB on-disk size is fixed at compile time.
 * SplinterDB does not expose an API to force the latest write to be durable (e.g., fsync/commit.)


### PR DESCRIPTION
Minor doc update in `limitations.md` to document the min-key-size we will support. (Some tests fail if you use smaller key-sizes.)