### PR TITLE
(#365) Restrict --key-size to be >= 8 while parsing test-config options

### DIFF
--- a/tests/config.c
+++ b/tests/config.c
@@ -34,6 +34,9 @@ _Static_assert(TEST_CONFIG_DEFAULT_PAGES_PER_EXTENT <= MAX_PAGES_PER_EXTENT,
 #define TEST_CONFIG_DEFAULT_MAX_BRANCHES_PER_NODE 24
 
 // Deal with reasonable key / message sizes for tests
+// There are open issues in some tests for smaller key-sizes.
+// For now, restrict tests to use this minimum key-size.
+#define TEST_CONFIG_MIN_KEY_SIZE         ((int)sizeof(uint64))
 #define TEST_CONFIG_DEFAULT_KEY_SIZE     24
 #define TEST_CONFIG_DEFAULT_MESSAGE_SIZE 100
 
@@ -252,6 +255,14 @@ config_parse(master_config *cfg, const uint8 num_config, int argc, char *argv[])
                                cfg[cfg_idx].extent_size
                                   / cfg[cfg_idx].page_size,
                                MAX_PAGES_PER_EXTENT);
+            return STATUS_BAD_PARAM;
+         }
+         if (cfg[cfg_idx].key_size < TEST_CONFIG_MIN_KEY_SIZE) {
+            platform_error_log("Configured key-size, %lu, should be at least "
+                               "%d bytes. Support for smaller key-sizes is "
+                               "experimental.\n",
+                               cfg[cfg_idx].key_size,
+                               TEST_CONFIG_MIN_KEY_SIZE);
             return STATUS_BAD_PARAM;
          }
          if (cfg[cfg_idx].key_size > MAX_KEY_SIZE) {


### PR DESCRIPTION
Execution of tests using stand-alone binaries, such as splinter_test,
btree_test, can run into unreliable behaviour with smaller key-size values.
Temporarily, restrict the min-key-size to be >= 8 bytes through these
interfaces.

----

Companion test-code fixes for doc-updates under issue #364.


**NOTE**: There is another open PR #361, which implements some other forms of these hard-checks.
In that work, there are ways to add calls to `test.sh` with invalid arguments; e.g. here `--key-size 3`, to verify that we are correctly raising an error.

I don't plan to add any test-cases to this PR, and will extend that PR's testing footprint to include this case, too, when that PR clears review.