### PR TITLE
Data Recovery: Remove Sibling Pointers from Trunk

### DIFF
--- a/src/trunk.c
+++ b/src/trunk.c
@@ -476,7 +476,6 @@ typedef struct ONDISK trunk_bundle {
 typedef struct ONDISK trunk_hdr {
    uint16 num_pivot_keys;   // number of used pivot keys (== num_children + 1)
    uint16 height;           // height of the node
-   uint64 next_addr;        // PBN of the node's successor (0 if no successor)
    uint64 generation;       // counter incremented on a node split
    uint64 pivot_generation; // counter incremented when new pivots are added
 
@@ -536,11 +535,11 @@ typedef enum trunk_compaction_type {
 // arguments to a compact_bundle job
 struct trunk_compact_bundle_req {
    trunk_handle         *spl;
-   uint64                addr;
+   char                  start_key[MAX_KEY_SIZE];
+   char                  end_key[MAX_KEY_SIZE];
    uint16                height;
    uint16                bundle_no;
    trunk_compaction_type type;
-   uint64                generation;
    uint64                pivot_generation[TRUNK_MAX_PIVOTS];
    uint64                max_pivot_generation;
    uint64                input_pivot_tuple_count[TRUNK_MAX_PIVOTS];
@@ -605,7 +604,6 @@ typedef union {
 
 // clang-format off
 static inline bool                 trunk_is_leaf                   (trunk_handle *spl, page_handle *node);
-static inline uint64               trunk_next_addr                 (trunk_handle *spl, page_handle *node);
 static inline int                  trunk_key_compare               (trunk_handle *spl, const char *key1, const char *key2);
 static inline page_handle *        trunk_node_get                  (trunk_handle *spl, uint64 addr);
 static inline void                 trunk_node_unget                (trunk_handle *spl, page_handle **node);
@@ -622,6 +620,7 @@ static inline uint16               trunk_num_children              (trunk_handle
 static inline uint16               trunk_num_pivot_keys            (trunk_handle *spl, page_handle *node);
 static inline void                 trunk_inc_num_pivot_keys        (trunk_handle *spl, page_handle *node);
 static inline char *               trunk_max_key                   (trunk_handle *spl, page_handle *node);
+static inline char *               trunk_min_key                   (trunk_handle *spl, page_handle *node);
 static inline uint64               trunk_pivot_num_tuples          (trunk_handle *spl, page_handle *node, uint16 pivot_no);
 static inline uint64               trunk_pivot_kv_bytes            (trunk_handle *spl, page_handle *node, uint16 pivot_no);
 static inline void                 trunk_pivot_branch_tuple_counts (trunk_handle *spl, page_handle  *node, uint16 pivot_no, uint16 branch_no, uint64 *num_tuples, uint64 *num_kv_bytes);
@@ -861,18 +860,27 @@ trunk_node_is_full(trunk_handle *spl, page_handle *node)
    return num_kv_bytes > spl->cfg.max_kv_bytes_per_node;
 }
 
-static inline uint64
-trunk_next_addr(trunk_handle *spl, page_handle *node)
+bool
+trunk_for_each_subtree(trunk_handle *spl, uint64 addr, node_fn func, void *arg)
 {
-   trunk_hdr *hdr = (trunk_hdr *)node->data;
-   return hdr->next_addr;
-}
+   // func may be deallocation, so first apply to subtree
+   page_handle *node = trunk_node_get(spl, addr);
+   if (!trunk_is_leaf(spl, node)) {
+      uint16 num_children = trunk_num_children(spl, node);
+      for (uint16 pivot_no = 0; pivot_no < num_children; pivot_no++) {
+         trunk_pivot_data *pdata = trunk_get_pivot_data(spl, node, pivot_no);
+         bool succeeded_on_subtree = trunk_for_each_subtree(spl, pdata->addr, func, arg);
+         if (!succeeded_on_subtree) {
+            goto failed_on_subtree;
+         }
+      }
+   }
+   trunk_node_unget(spl, &node);
+   return func(spl, addr, arg);
 
-static inline void
-trunk_set_next_addr(trunk_handle *spl, page_handle *node, uint64 addr)
-{
-   trunk_hdr *hdr = (trunk_hdr *)node->data;
-   hdr->next_addr = addr;
+failed_on_subtree:
+   trunk_node_unget(spl, &node);
+   return FALSE;
 }
 
 /*
@@ -885,29 +893,7 @@ trunk_set_next_addr(trunk_handle *spl, page_handle *node, uint64 addr)
 bool
 trunk_for_each_node(trunk_handle *spl, node_fn func, void *arg)
 {
-   page_handle *root   = trunk_node_get(spl, spl->root_addr);
-   uint16       height = trunk_height(spl, root);
-   trunk_node_unget(spl, &root);
-   uint64 next_level_addr = spl->root_addr;
-   for (uint64 i = 0; i <= height; i++) {
-      page_handle *node = trunk_node_get(spl, next_level_addr);
-      uint64       addr = next_level_addr;
-      next_level_addr   = trunk_get_pivot_data(spl, node, 0)->addr;
-      trunk_node_unget(spl, &node);
-      while (addr != 0) {
-         // first get the next_addr, then apply func, in case func
-         // deletes the node for example
-         node             = trunk_node_get(spl, addr);
-         uint64 next_addr = trunk_next_addr(spl, node);
-         trunk_node_unget(spl, &node);
-         bool rc = func(spl, addr, arg);
-         if (rc != TRUE) {
-            return rc;
-         }
-         addr = next_addr;
-      }
-   }
-   return TRUE;
+   return trunk_for_each_subtree(spl, spl->root_addr, func, arg);
 }
 
 static inline btree_config *
@@ -985,6 +971,51 @@ trunk_alloc(trunk_handle *spl, uint64 height)
    uint64 addr = mini_alloc(&spl->mini, height, NULL_SLICE, NULL);
    return cache_alloc(spl->cc, addr, PAGE_TYPE_TRUNK);
 }
+
+/*
+ *-----------------------------------------------------------------------------
+ * Fetch Trunk Nodes By Key and Height
+ *
+ * Returns the node whose key range contains key at height height. Returns an
+ * error if no such node exists, which should only happen when height >
+ * height(root);
+ *-----------------------------------------------------------------------------
+ */
+
+platform_status
+trunk_node_get_by_key_and_height(trunk_handle *spl,      // IN
+                                 const char *  key,      // IN
+                                 uint16        height,   // IN
+                                 page_handle **out_node) // OUT
+{
+   page_handle *node = trunk_node_get(spl, spl->root_addr);
+   uint16 root_height = trunk_height(spl, node);
+   if (height > root_height) {
+      goto error;
+   }
+
+   for (uint16 h = root_height; h > height; h--) {
+      debug_assert(trunk_height(spl, node) == h);
+      uint16 pivot_no = trunk_find_pivot(spl, node, key, less_than_or_equal);
+      debug_assert(pivot_no < trunk_num_children(spl, node));
+      trunk_pivot_data *pdata = trunk_get_pivot_data(spl, node, pivot_no);
+      page_handle *child = trunk_node_get(spl, pdata->addr);
+      trunk_node_unget(spl, &node);
+      node = child;
+   }
+
+   debug_assert(trunk_height(spl, node) == height);
+   debug_assert(trunk_key_compare(spl, trunk_min_key(spl, node), key) <= 0);
+   debug_assert(trunk_key_compare(spl, key, trunk_max_key(spl, node)) < 0);
+
+   *out_node = node;
+   return STATUS_OK;
+
+error:
+   trunk_node_unget(spl, &node);
+   return STATUS_BAD_PARAM;
+}
+
 
 /*
  *-----------------------------------------------------------------------------
@@ -1131,7 +1162,6 @@ trunk_set_initial_pivots(trunk_handle *spl,
    memmove(dst_pivot_key, max_key, trunk_key_size(spl));
 }
 
-UNUSED_FUNCTION()
 static inline char *
 trunk_min_key(trunk_handle *spl, page_handle *node)
 {
@@ -1221,13 +1251,6 @@ trunk_pivot_start_branch(trunk_handle *spl, page_handle *node, uint16 pivot_no)
 {
    trunk_pivot_data *pdata = trunk_get_pivot_data(spl, node, pivot_no);
    return pdata->start_branch;
-}
-
-static inline uint64
-trunk_generation(trunk_handle *spl, page_handle *node)
-{
-   trunk_hdr *hdr = (trunk_hdr *)node->data;
-   return hdr->generation;
 }
 
 static inline void
@@ -3272,10 +3295,10 @@ trunk_memtable_incorporate(trunk_handle  *spl,
    routing_filter *filter        = trunk_subbundle_filter(spl, root, sb, 0);
    *filter                       = cmt->filter;
    req->spl                      = spl;
-   req->addr                     = spl->root_addr;
    req->height                   = trunk_height(spl, root);
-   req->generation               = trunk_generation(spl, root);
    req->max_pivot_generation     = trunk_pivot_generation(spl, root);
+   trunk_key_copy(spl, req->start_key, trunk_min_key(spl, root));
+   trunk_key_copy(spl, req->end_key, trunk_max_key(spl, root));
    trunk_tuples_in_bundle(spl,
                           root,
                           bundle,
@@ -3303,7 +3326,11 @@ trunk_memtable_incorporate(trunk_handle  *spl,
    }
    debug_assert(trunk_subbundle_branch_count(spl, root, sb) != 0);
    trunk_log_stream(
-      "enqueuing build filter %lu-%u\n", req->addr, req->bundle_no);
+      "enqueuing build filter: range %s-%s, height %u, bundle %u\n",
+      key_string(trunk_data_config(spl), slice_create(trunk_key_size(spl), req->start_key)),
+      key_string(trunk_data_config(spl), slice_create(trunk_key_size(spl), req->end_key)),
+      req->height,
+      req->bundle_no);
    task_enqueue(
       spl->ts, TASK_TYPE_NORMAL, trunk_bundle_build_filters, req, TRUE);
 
@@ -3532,43 +3559,38 @@ trunk_filter_req_init(trunk_compact_bundle_req *compact_req,
    ZERO_CONTENTS(filter_req);
    filter_req->fp_arr = compact_req->fp_arr;
 }
-
-static inline page_handle *
-trunk_node_get_maybe_descend(trunk_handle *spl, trunk_compact_bundle_req *req)
+static inline bool
+trunk_compact_bundle_node_has_split(trunk_handle             *spl,
+                                    trunk_compact_bundle_req *req,
+                                    page_handle              *node)
 {
-   page_handle *node = trunk_node_get(spl, req->addr);
-   while (trunk_height(spl, node) != req->height) {
-      debug_assert(trunk_height(spl, node) > req->height);
-      debug_assert(req->height != 0);
-      trunk_pivot_data *pdata = trunk_get_pivot_data(spl, node, 0);
-      req->addr               = pdata->addr;
-      trunk_open_log_stream();
-      trunk_log_stream("build_filter descending from root\n");
-      trunk_log_stream(
-         "enqueuing build filter %lu-%u\n", req->addr, req->bundle_no);
-      trunk_log_node(spl, node);
-      trunk_node_unget(spl, &node);
-      node = trunk_node_get(spl, req->addr);
-   }
-   return node;
+   return !trunk_key_equal(spl, req->end_key, trunk_max_key(spl, node));
 }
 
-static inline page_handle *
-trunk_node_get_claim_maybe_descend(trunk_handle             *spl,
-                                   trunk_compact_bundle_req *req)
+static inline platform_status
+trunk_compact_bundle_node_get(trunk_handle             *spl,
+                              trunk_compact_bundle_req *req,
+                              page_handle             **node)
 {
-   page_handle *node;
-   uint64       wait = 1;
-   while (1) {
-      node = trunk_node_get_maybe_descend(spl, req);
-      if (cache_claim(spl->cc, node)) {
-         break;
-      }
-      trunk_node_unget(spl, &node);
-      platform_sleep(wait);
-      wait = wait > 2048 ? wait : 2 * wait;
+   return trunk_node_get_by_key_and_height(spl, req->start_key, req->height, node);
+}
+
+static inline platform_status
+trunk_compact_bundle_node_get_and_claim(trunk_handle             *spl,
+                                        trunk_compact_bundle_req *req,
+                                        page_handle             **node)
+{
+   platform_status rc = trunk_node_get_by_key_and_height(spl, req->start_key, req->height, node);
+   if (!SUCCESS(rc)) {
+      return rc;
    }
-   return node;
+   trunk_node_claim(spl, node);
+   if (trunk_height(spl, *node) != req->height) {
+      trunk_node_unclaim(spl, *node);
+      trunk_node_unget(spl, node);
+      return trunk_compact_bundle_node_get_and_claim(spl, req, node);
+   }
+   return rc;
 }
 
 static inline bool
@@ -3576,12 +3598,14 @@ trunk_build_filter_should_abort(trunk_compact_bundle_req *req,
                                 page_handle              *node)
 {
    trunk_handle *spl    = req->spl;
-   uint16        height = trunk_height(spl, node);
-   if (height == 0 && req->generation < trunk_generation(spl, node)) {
+   if (trunk_is_leaf(spl, node) && trunk_compact_bundle_node_has_split(spl, req, node)) {
       trunk_open_log_stream();
       trunk_log_stream(
-         "build_filter leaf abort %lu-%u\n", req->addr, req->bundle_no);
-      trunk_log_node(spl, node);
+         "build_filter leaf abort: range %s-%s, height %u, bundle %u\n",
+         key_string(trunk_data_config(spl), slice_create(trunk_key_size(spl), req->start_key)),
+         key_string(trunk_data_config(spl), slice_create(trunk_key_size(spl), req->end_key)),
+         req->height,
+         req->bundle_no);
       trunk_close_log_stream();
       return TRUE;
    }
@@ -3594,10 +3618,12 @@ trunk_build_filter_should_skip(trunk_compact_bundle_req *req, page_handle *node)
    trunk_handle *spl = req->spl;
    if (!trunk_bundle_live(spl, node, req->bundle_no)) {
       trunk_open_log_stream();
-      trunk_log_stream("build_filter flush abort %lu-%u (%u)\n",
-                       req->addr,
-                       req->bundle_no,
-                       req->height);
+      trunk_log_stream(
+         "build_filter flush abort: range %s-%s, height %u, bundle %u\n",
+         key_string(trunk_data_config(spl), slice_create(trunk_key_size(spl), req->start_key)),
+         key_string(trunk_data_config(spl), slice_create(trunk_key_size(spl), req->end_key)),
+         req->height,
+         req->bundle_no);
       trunk_log_node(spl, node);
       trunk_close_log_stream();
       return TRUE;
@@ -3613,10 +3639,12 @@ trunk_build_filter_should_reenqueue(trunk_compact_bundle_req *req,
    if (req->bundle_no != trunk_start_bundle(spl, node)) {
       trunk_open_log_stream();
       trunk_log_stream(
-         "build filter for %lu bundle %u\n", req->addr, req->bundle_no);
+         "build_filter reenqueuing: range %s-%s, height %u, bundle %u\n",
+         key_string(trunk_data_config(spl), slice_create(trunk_key_size(spl), req->start_key)),
+         key_string(trunk_data_config(spl), slice_create(trunk_key_size(spl), req->end_key)),
+         req->height,
+         req->bundle_no);
       trunk_log_node(spl, node);
-      trunk_log_stream(
-         "reenqueuing build filter %lu-%u\n", req->addr, req->bundle_no);
       trunk_close_log_stream();
       return TRUE;
    }
@@ -3794,16 +3822,20 @@ trunk_bundle_build_filters(void *arg, void *scratch)
    trunk_compact_bundle_req *compact_req = (trunk_compact_bundle_req *)arg;
    trunk_handle             *spl         = compact_req->spl;
 
-   uint64 generation;
-   do {
-      page_handle *node = trunk_node_get_maybe_descend(spl, compact_req);
+   bool should_continue_build_filters = TRUE;
+   while (should_continue_build_filters) {
+      page_handle *node = NULL;
+      platform_status rc = trunk_compact_bundle_node_get(spl, compact_req, &node);
+      platform_assert_status_ok(rc);
       platform_assert(node != NULL);
 
       trunk_open_log_stream();
-      trunk_log_stream("build filter for %lu bundle %u pivot_gen %lu\n",
-                       compact_req->addr,
-                       compact_req->bundle_no,
-                       compact_req->max_pivot_generation);
+      trunk_log_stream(
+         "build_filter: range %s-%s, height %u, bundle %u\n",
+         key_string(trunk_data_config(spl), slice_create(trunk_key_size(spl), compact_req->start_key)),
+         key_string(trunk_data_config(spl), slice_create(trunk_key_size(spl), compact_req->end_key)),
+         compact_req->height,
+         compact_req->bundle_no);
       trunk_log_node(spl, node);
       if (trunk_build_filter_should_abort(compact_req, node)) {
          trunk_log_stream("leaf split, aborting\n");
@@ -3830,18 +3862,20 @@ trunk_bundle_build_filters(void *arg, void *scratch)
       debug_assert(trunk_verify_node(spl, node));
       trunk_filter_req filter_req = {0};
       trunk_prepare_build_filter(spl, compact_req, &filter_req, node);
-      uint64 filter_generation = trunk_generation(spl, node);
       trunk_node_unget(spl, &node);
 
       trunk_build_filters(spl, compact_req, &filter_req);
 
-      trunk_log_stream("----------------------------------------\n");
+      trunk_log_stream("Filters built\n");
 
-      do {
-         node = trunk_node_get_claim_maybe_descend(spl, compact_req);
+      bool should_continue_replacing_filters = TRUE;
+      while (should_continue_replacing_filters)
+      {
+         rc = trunk_compact_bundle_node_get_and_claim(spl, compact_req, &node);
+         platform_assert_status_ok(rc);
+         debug_assert(trunk_height(spl, node) == compact_req->height);
          if (trunk_build_filter_should_abort(compact_req, node)) {
-            trunk_log_stream("replace_filter abort leaf split (%lu)\n",
-                             compact_req->addr);
+            trunk_log_stream("replace_filter abort leaf split\n");
             trunk_node_unclaim(spl, node);
             trunk_node_unget(spl, &node);
             for (uint64 pos = 0; pos < TRUNK_MAX_PIVOTS; pos++) {
@@ -3856,38 +3890,55 @@ trunk_bundle_build_filters(void *arg, void *scratch)
          }
          trunk_node_unlock(spl, node);
          trunk_node_unclaim(spl, node);
-         compact_req->addr = trunk_next_addr(spl, node);
-         generation        = trunk_generation(spl, node);
          debug_assert(trunk_verify_node(spl, node));
-         if (generation != filter_generation) {
-            trunk_log_stream("replace_filter split to %lu\n",
-                             compact_req->addr);
-            debug_assert(compact_req->height != 0);
-            debug_assert(compact_req->addr != 0);
-            trunk_node_unget(spl, &node);
+
+         trunk_log_node(spl, node);
+         trunk_log_stream("Filters replaced in node:\n");
+         trunk_log_stream("addr: %lu, height: %u\n", node->disk_addr, trunk_height(spl, node));
+         trunk_log_stream("range: %s-%s\n",
+                          key_string(trunk_data_config(spl),
+                                     slice_create(trunk_key_size(spl),
+                                                  compact_req->start_key)),
+                          key_string(trunk_data_config(spl),
+                                     slice_create(trunk_key_size(spl),
+                                                  compact_req->end_key)));
+
+         trunk_key_copy(spl, compact_req->start_key, trunk_max_key(spl, node));
+         should_continue_replacing_filters =
+            !trunk_key_equal(spl, compact_req->start_key, compact_req->end_key);
+         if (should_continue_replacing_filters) {
+            trunk_log_stream(
+               "replace_filter split: range %s-%s, height %u, bundle %u\n",
+               key_string(trunk_data_config(spl), slice_create(trunk_key_size(spl), compact_req->start_key)),
+               key_string(trunk_data_config(spl), slice_create(trunk_key_size(spl), compact_req->end_key)),
+               compact_req->height,
+               compact_req->bundle_no);
+               debug_assert(compact_req->height != 0);
+               trunk_node_unget(spl, &node);
          }
-      } while (generation != filter_generation);
+      }
 
       for (uint64 pos = 0; pos < TRUNK_MAX_PIVOTS; pos++) {
          trunk_dec_filter(spl, &filter_req.filter[pos]);
       }
 
-      trunk_log_node(spl, node);
-      trunk_log_stream("----------------------------------------\n");
-      trunk_log_stream("\n");
-
    next_node:
-      compact_req->addr = trunk_next_addr(spl, node);
-      generation        = trunk_generation(spl, node);
       debug_assert(trunk_verify_node(spl, node));
+      trunk_key_copy(spl, compact_req->start_key, trunk_max_key(spl, node));
       trunk_node_unget(spl, &node);
-      if (compact_req->generation != generation) {
-         trunk_log_stream("build_filter split to %lu\n", compact_req->addr);
+      should_continue_build_filters =
+         !trunk_key_equal(spl, compact_req->start_key, compact_req->end_key);
+      if (should_continue_build_filters) {
+         trunk_log_stream(
+            "build_filter split: range %s-%s, height %u, bundle %u\n",
+            key_string(trunk_data_config(spl), slice_create(trunk_key_size(spl), compact_req->start_key)),
+            key_string(trunk_data_config(spl), slice_create(trunk_key_size(spl), compact_req->end_key)),
+            compact_req->height,
+            compact_req->bundle_no);
          debug_assert(compact_req->height != 0);
-         debug_assert(compact_req->addr != 0);
       }
       trunk_close_log_stream();
-   } while (compact_req->generation != generation);
+   } while (should_continue_build_filters);
 
 out:
    platform_free(spl->heap_id, compact_req->fp_arr);
@@ -3937,12 +3988,12 @@ trunk_flush_into_bundle(trunk_handle             *spl,    // IN
    trunk_log_stream("----------------------------------------\n");
 
    req->spl    = spl;
-   req->addr   = child->disk_addr;
    req->height = trunk_height(spl, child);
-   debug_assert(req->addr != 0);
    req->bundle_no            = trunk_get_new_bundle(spl, child);
-   req->generation           = trunk_generation(spl, child);
    req->max_pivot_generation = trunk_pivot_generation(spl, child);
+
+   trunk_key_copy(spl, req->start_key, trunk_min_key(spl, child));
+   trunk_key_copy(spl, req->end_key, trunk_max_key(spl, child));
 
    uint16 num_children = trunk_num_children(spl, child);
    for (uint16 pivot_no = 0; pivot_no < num_children; pivot_no++) {
@@ -4136,7 +4187,6 @@ trunk_flush(trunk_handle     *spl,
                                        req->input_pivot_tuple_count,
                                        req->input_pivot_kv_byte_count);
    trunk_bundle_inc_pivot_rc(spl, child, bundle);
-   debug_assert(cache_page_valid(spl->cc, req->addr));
    req->type = is_space_rec ? TRUNK_COMPACTION_TYPE_FLUSH
                             : TRUNK_COMPACTION_TYPE_SPACE_REC;
 
@@ -4160,7 +4210,11 @@ trunk_flush(trunk_handle     *spl,
    trunk_node_unget(spl, &child);
 
    trunk_default_log(
-      "enqueuing compact_bundle %lu-%u\n", req->addr, req->bundle_no);
+      "compact_bundle enqueue: range %s-%s, height %u, bundle %u\n",
+      key_string(trunk_data_config(spl), slice_create(trunk_key_size(spl), req->start_key)),
+      key_string(trunk_data_config(spl), slice_create(trunk_key_size(spl), req->end_key)),
+      req->height,
+      req->bundle_no);
    rc =
       task_enqueue(spl->ts, TASK_TYPE_NORMAL, trunk_compact_bundle, req, FALSE);
    platform_assert_status_ok(rc);
@@ -4518,7 +4572,9 @@ trunk_compact_bundle(void *arg, void *scratch_buf)
    /*
     * 1. Acquire node read lock
     */
-   page_handle *node = trunk_node_get(spl, req->addr);
+   page_handle *node;
+   rc = trunk_compact_bundle_node_get(spl, req, &node);
+   platform_assert_status_ok(rc);
 
    /*
     * 2. Flush if node is full (acquires write lock)
@@ -4548,20 +4604,20 @@ trunk_compact_bundle(void *arg, void *scratch_buf)
     *    bundle was copied to the new sibling[s], so issue compact_bundles for
     *    those nodes
     */
-   if (req->generation < trunk_generation(spl, node)) {
+   if (trunk_compact_bundle_node_has_split(spl, req, node)) {
       if (height != 0) {
-         debug_assert(trunk_next_addr(spl, node) != 0);
          trunk_compact_bundle_req *next_req =
             TYPED_MALLOC(spl->heap_id, next_req);
          memmove(next_req, req, sizeof(trunk_compact_bundle_req));
-         next_req->addr = trunk_next_addr(spl, node);
-         debug_assert(next_req->addr != 0);
+         trunk_key_copy(spl, next_req->start_key, trunk_max_key(spl, node));
+         trunk_key_copy(spl, req->end_key, trunk_max_key(spl, node));
 
-         req->generation = trunk_generation(spl, node);
-
-         trunk_default_log("compact_bundle split from %lu to %lu\n",
-                           req->addr,
-                           next_req->addr);
+         trunk_default_log(
+            "compact_bundle split to: range %s-%s, height %u, bundle %u\n",
+            key_string(trunk_data_config(spl), slice_create(trunk_key_size(spl), req->start_key)),
+            key_string(trunk_data_config(spl), slice_create(trunk_key_size(spl), req->end_key)),
+            next_req->height,
+            next_req->bundle_no);
          rc = task_enqueue(
             spl->ts, TASK_TYPE_NORMAL, trunk_compact_bundle, next_req, FALSE);
          platform_assert_status_ok(rc);
@@ -4570,7 +4626,12 @@ trunk_compact_bundle(void *arg, void *scratch_buf)
           * 4. Abort if node is a splitting leaf (interaction 6)
           */
          trunk_node_unget(spl, &node);
-         trunk_default_log("compact_bundle abort leaf split %lu\n", req->addr);
+         trunk_default_log(
+            "compact_bundle abort leaf split: range %s-%s, height %u, bundle %u\n",
+            key_string(trunk_data_config(spl), slice_create(trunk_key_size(spl), req->start_key)),
+            key_string(trunk_data_config(spl), slice_create(trunk_key_size(spl), req->end_key)),
+            req->height,
+            req->bundle_no);
          platform_free(spl->heap_id, req);
          if (spl->cfg.use_stats) {
             spl->stats[tid].compactions_aborted_leaf_split[height]++;
@@ -4581,9 +4642,6 @@ trunk_compact_bundle(void *arg, void *scratch_buf)
       }
    }
 
-   // store the generation of the node so we can detect splits after compaction
-   uint64 start_generation = trunk_generation(spl, node);
-
    /*
     * 5. The bundle may have been completely flushed by 2., if so abort
     *       -- note this cannot happen in leaves (if the bundle isn't live, the
@@ -4593,7 +4651,12 @@ trunk_compact_bundle(void *arg, void *scratch_buf)
    if (!trunk_bundle_live(spl, node, req->bundle_no)) {
       debug_assert(height != 0);
       trunk_node_unget(spl, &node);
-      trunk_default_log("compact_bundle abort flushed %lu\n", req->addr);
+      trunk_default_log(
+         "compact_bundle abort flushed: range %s-%s, height %u, bundle %u\n",
+         key_string(trunk_data_config(spl), slice_create(trunk_key_size(spl), req->start_key)),
+         key_string(trunk_data_config(spl), slice_create(trunk_key_size(spl), req->end_key)),
+         req->height,
+         req->bundle_no);
       platform_free(spl->heap_id, req);
       if (spl->cfg.use_stats) {
          spl->stats[tid].compactions_aborted_flushed[height]++;
@@ -4624,7 +4687,12 @@ trunk_compact_bundle(void *arg, void *scratch_buf)
 
    trunk_open_log_stream();
    trunk_log_stream(
-      "compact_bundle addr %lu bundle %hu\n", req->addr, req->bundle_no);
+      "compact_bundle starting: addr %lu, range %s-%s, height %u, bundle %u\n",
+      node->disk_addr,
+      key_string(trunk_data_config(spl), slice_create(trunk_key_size(spl), req->start_key)),
+      key_string(trunk_data_config(spl), slice_create(trunk_key_size(spl), req->end_key)),
+      req->height,
+      req->bundle_no);
 
    /*
     * 6. Build iterators
@@ -4685,7 +4753,7 @@ trunk_compact_bundle(void *arg, void *scratch_buf)
 
    req->fp_arr = pack_req.fingerprint_arr;
 
-   trunk_log_stream("output: %lu\n", req->addr);
+   trunk_log_stream("output: %lu\n", new_branch.root_addr);
    if (spl->cfg.use_stats) {
       if (pack_req.num_tuples == 0) {
          spl->stats[tid].compactions_empty[height]++;
@@ -4710,16 +4778,15 @@ trunk_compact_bundle(void *arg, void *scratch_buf)
    /*
     * 11. Reacquire read lock
     */
-   node = trunk_node_get(spl, req->addr);
-   platform_assert(node != NULL);
+   rc = trunk_compact_bundle_node_get(spl, req, &node);
+   platform_assert_status_ok(rc);
 
    /*
     * 12. For each newly split sibling replace bundle with new branch
     */
-   uint64 addr             = req->addr;
    uint64 num_replacements = 0;
-   uint64 generation;
-   do {
+   bool should_continue = TRUE;
+   while (should_continue) {
       platform_assert(node != NULL);
       trunk_node_claim(spl, &node);
       trunk_node_lock(spl, node);
@@ -4734,8 +4801,15 @@ trunk_compact_bundle(void *arg, void *scratch_buf)
        *      need to look for the bundle in the split siblings, so simply
        *      exit.
        */
-      if (height == 0 && req->generation < trunk_generation(spl, node)) {
-         trunk_log_stream("compact_bundle discard split %lu\n", req->addr);
+      if (trunk_is_leaf(spl, node)
+          && trunk_compact_bundle_node_has_split(spl, req, node))
+      {
+         trunk_default_log(
+            "compact_bundle discard split: range %s-%s, height %u, bundle %u\n",
+            key_string(trunk_data_config(spl), slice_create(trunk_key_size(spl), req->start_key)),
+            key_string(trunk_data_config(spl), slice_create(trunk_key_size(spl), req->end_key)),
+            req->height,
+            req->bundle_no);
          if (spl->cfg.use_stats) {
             spl->stats[tid].compactions_discarded_leaf_split[height]++;
             spl->stats[tid].compaction_time_wasted_ns[height] +=
@@ -4758,41 +4832,41 @@ trunk_compact_bundle(void *arg, void *scratch_buf)
             trunk_replace_bundle_branches(spl, node, &new_branch, req);
             num_replacements++;
             trunk_log_stream(
-               "inserted %lu into %lu\n", new_branch.root_addr, addr);
+               "inserted %lu into %lu\n", new_branch.root_addr, node->disk_addr);
          } else {
             trunk_replace_bundle_branches(spl, node, NULL, req);
-            trunk_log_stream("compact_bundle empty %lu\n", addr);
+            trunk_log_stream("compact_bundle empty %lu\n", node->disk_addr);
          }
       } else {
          /*
           * 12b. ...unless node is internal and bundle has been flushed
           */
          platform_assert(height != 0);
-         trunk_log_stream("compact_bundle discarded flushed %lu\n", addr);
+         trunk_log_stream("compact_bundle discarded flushed %lu\n", node->disk_addr);
       }
 
-      addr       = trunk_next_addr(spl, node);
-      generation = trunk_generation(spl, node);
       trunk_log_node(spl, node);
       debug_assert(trunk_verify_node(spl, node));
 
-      if (num_replacements != 0 && pack_req.num_tuples != 0
-          && start_generation == generation)
-      {
+      should_continue = trunk_compact_bundle_node_has_split(spl, req, node);
+      if (!should_continue && num_replacements != 0 && pack_req.num_tuples != 0) {
          const char *max_key = trunk_max_key(spl, node);
          trunk_zap_branch_range(
             spl, &new_branch, max_key, NULL, PAGE_TYPE_BRANCH);
       }
 
+      if (should_continue) {
+         debug_assert(height != 0);
+         trunk_key_copy(spl, req->start_key, trunk_max_key(spl, node));
+      }
       trunk_node_unlock(spl, node);
       trunk_node_unclaim(spl, node);
       trunk_node_unget(spl, &node);
-      if (start_generation != generation) {
-         debug_assert(height != 0);
-         debug_assert(addr != 0);
-         node = trunk_node_get(spl, addr);
+      if (should_continue) {
+         rc = trunk_compact_bundle_node_get(spl, req, &node);
+         platform_assert_status_ok(rc);
       }
-   } while (start_generation != generation);
+   }
 
    if (spl->cfg.use_stats) {
       if (req->type == TRUNK_COMPACTION_TYPE_SPACE_REC) {
@@ -4825,8 +4899,12 @@ trunk_compact_bundle(void *arg, void *scratch_buf)
             spl->stats[tid].compaction_time_max_ns[height] = compaction_start;
          }
       }
-      trunk_log_stream(
-         "enqueuing build filter %lu-%u\n", req->addr, req->bundle_no);
+      trunk_default_log(
+         "build_filter enqueue: range %s-%s, height %u, bundle %u\n",
+         key_string(trunk_data_config(spl), slice_create(trunk_key_size(spl), req->start_key)),
+         key_string(trunk_data_config(spl), slice_create(trunk_key_size(spl), req->end_key)),
+         req->height,
+         req->bundle_no);
       task_enqueue(
          spl->ts, TASK_TYPE_NORMAL, trunk_bundle_build_filters, req, TRUE);
    }
@@ -4965,9 +5043,6 @@ trunk_split_index(trunk_handle *spl,
 
    right_hdr->num_pivot_keys = left_hdr->num_pivot_keys - target_num_children;
    left_hdr->num_pivot_keys  = target_num_children + 1;
-
-   right_hdr->next_addr = left_hdr->next_addr;
-   left_hdr->next_addr  = right_addr;
 
    left_hdr->generation++;
    trunk_reset_start_branch(spl, right_node);
@@ -5282,7 +5357,6 @@ trunk_split_leaf(trunk_handle *spl,
    uint16 bundle_no = trunk_leaf_rebundle_all_branches(
       spl, leaf, leaf0_num_tuples, leaf0_kv_bytes, FALSE);
    trunk_inc_generation(spl, leaf);
-   uint64 last_next_addr = trunk_next_addr(spl, leaf);
 
    for (uint16 leaf_no = 0; leaf_no < num_leaves; leaf_no++) {
       /*
@@ -5331,9 +5405,6 @@ trunk_split_leaf(trunk_handle *spl,
          spl, new_leaf, 0, new_leaf_num_tuples[0], new_leaf_kv_bytes[0]);
 
       if (leaf_no != 0) {
-         // set next_addr of leaf
-         trunk_set_next_addr(spl, leaf, new_leaf->disk_addr);
-
          // inc the refs of all the branches
          for (uint16 branch_no = trunk_start_branch(spl, new_leaf);
               branch_no != trunk_end_branch(spl, new_leaf);
@@ -5368,17 +5439,21 @@ trunk_split_leaf(trunk_handle *spl,
           */
          trunk_compact_bundle_req *req = TYPED_ZALLOC(spl->heap_id, req);
          req->spl                      = spl;
-         req->addr                     = leaf->disk_addr;
          req->type                     = comp_type;
          req->bundle_no                = bundle_no;
-         req->generation               = trunk_generation(spl, leaf);
          req->max_pivot_generation     = trunk_pivot_generation(spl, leaf);
          req->pivot_generation[0]      = trunk_pivot_generation(spl, leaf) - 1;
          req->input_pivot_tuple_count[0] = trunk_pivot_num_tuples(spl, leaf, 0);
          req->input_pivot_kv_byte_count[0] = trunk_pivot_kv_bytes(spl, leaf, 0);
+         trunk_key_copy(spl, req->start_key, trunk_min_key(spl, leaf));
+         trunk_key_copy(spl, req->end_key, trunk_max_key(spl, leaf));
 
          trunk_default_log(
-            "enqueuing compact_bundle %lu-%u\n", req->addr, req->bundle_no);
+            "compact_bundle enqueue: range %s-%s, height %u, bundle %u\n",
+            key_string(trunk_data_config(spl), slice_create(trunk_key_size(spl), req->start_key)),
+            key_string(trunk_data_config(spl), slice_create(trunk_key_size(spl), req->end_key)),
+            req->height,
+            req->bundle_no);
          rc = task_enqueue(
             spl->ts, TASK_TYPE_NORMAL, trunk_compact_bundle, req, FALSE);
          platform_assert(SUCCESS(rc));
@@ -5395,22 +5470,25 @@ trunk_split_leaf(trunk_handle *spl,
    }
 
    // set next_addr of leaf (from last iteration)
-   trunk_set_next_addr(spl, leaf, last_next_addr);
    trunk_compact_bundle_req *req = TYPED_ZALLOC(spl->heap_id, req);
    req->spl                      = spl;
-   req->addr                     = leaf->disk_addr;
    // req->height already 0
    req->bundle_no                    = bundle_no;
-   req->generation                   = trunk_generation(spl, leaf);
    req->max_pivot_generation         = trunk_pivot_generation(spl, leaf);
    req->pivot_generation[0]          = trunk_pivot_generation(spl, leaf) - 1;
    req->input_pivot_tuple_count[0]   = trunk_pivot_num_tuples(spl, leaf, 0);
    req->input_pivot_kv_byte_count[0] = trunk_pivot_kv_bytes(spl, leaf, 0);
    req->type                         = comp_type;
+   trunk_key_copy(spl, req->start_key, trunk_min_key(spl, leaf));
+   trunk_key_copy(spl, req->end_key, trunk_max_key(spl, leaf));
 
    // issue compact_bundle for leaf and release
    trunk_default_log(
-      "enqueuing compact_bundle %lu-%u\n", req->addr, req->bundle_no);
+      "compact_bundle enqueue: range %s-%s, height %u, bundle %u\n",
+      key_string(trunk_data_config(spl), slice_create(trunk_key_size(spl), req->start_key)),
+      key_string(trunk_data_config(spl), slice_create(trunk_key_size(spl), req->end_key)),
+      req->height,
+      req->bundle_no);
    platform_status rc =
       task_enqueue(spl->ts, TASK_TYPE_NORMAL, trunk_compact_bundle, req, FALSE);
    platform_assert(SUCCESS(rc));
@@ -5454,7 +5532,6 @@ trunk_split_root(trunk_handle *spl, page_handle *root)
    memmove(child_hdr, root_hdr, trunk_page_size(&spl->cfg));
    // num_pivot_keys is changed by add_pivot_new_root below
    root_hdr->height++;
-   debug_assert(root_hdr->next_addr == 0);
    // leave generation and pivot_generation
    root_hdr->start_branch      = 0;
    root_hdr->start_frac_branch = 0;
@@ -5846,18 +5923,22 @@ trunk_compact_leaf(trunk_handle *spl, page_handle *leaf)
    // Issue compact_bundle for leaf and release
    trunk_compact_bundle_req *req = TYPED_ZALLOC(spl->heap_id, req);
    req->spl                      = spl;
-   req->addr                     = leaf->disk_addr;
    // req->height already 0
    req->bundle_no                    = bundle_no;
-   req->generation                   = trunk_generation(spl, leaf);
    req->max_pivot_generation         = trunk_pivot_generation(spl, leaf);
    req->pivot_generation[0]          = trunk_pivot_generation(spl, leaf) - 1;
    req->input_pivot_tuple_count[0]   = trunk_pivot_num_tuples(spl, leaf, 0);
    req->input_pivot_kv_byte_count[0] = trunk_pivot_kv_bytes(spl, leaf, 0);
    req->type                         = TRUNK_COMPACTION_TYPE_SPACE_REC;
+   trunk_key_copy(spl, req->start_key, trunk_min_key(spl, leaf));
+   trunk_key_copy(spl, req->end_key, trunk_max_key(spl, leaf));
 
    trunk_default_log(
-      "enqueuing compact_bundle %lu-%u\n", req->addr, req->bundle_no);
+      "compact_bundle enqueue: range %s-%s, height %u, bundle %u\n",
+      key_string(trunk_data_config(spl), slice_create(trunk_key_size(spl), req->start_key)),
+      key_string(trunk_data_config(spl), slice_create(trunk_key_size(spl), req->end_key)),
+      req->height,
+      req->bundle_no);
    platform_status rc =
       task_enqueue(spl->ts, TASK_TYPE_NORMAL, trunk_compact_bundle, req, FALSE);
    platform_assert(SUCCESS(rc));
@@ -7033,10 +7114,6 @@ trunk_mount(trunk_config     *cfg,
    }
    uint64 meta_head = spl->root_addr + trunk_page_size(&spl->cfg);
 
-   // get a free node for the root
-   // we don't use the next_addr arr for this, since the root doesn't
-   // maintain constant height
-
    memtable_config *mt_cfg = &spl->cfg.mt_cfg;
    spl->mt_ctxt            = memtable_context_create(
       spl->heap_id, cc, mt_cfg, trunk_memtable_flush_virtual, spl);
@@ -7555,34 +7632,42 @@ out:
    return is_valid;
 }
 
+
+/*
+ * Scratch space used with trunk_verify_node_with_neighbors to verify that
+ * pivots are coherent across neighboring nodes
+ */
+typedef struct trunk_verify_scratch {
+   char last_key_seen[TRUNK_MAX_HEIGHT][MAX_KEY_SIZE];
+} trunk_verify_scratch;
+
 /*
  * verify_node_with_neighbors checks that the node has:
  * 1. coherent max key with successor's min key
  * 2. coherent pivots with children's min/max keys
  */
 bool
-trunk_verify_node_with_neighbors(trunk_handle *spl, page_handle *node)
+trunk_verify_node_with_neighbors(trunk_handle         *spl,
+                                 page_handle          *node,
+                                 trunk_verify_scratch *scratch)
 {
    bool   is_valid = FALSE;
    uint64 addr     = node->disk_addr;
 
-   // check node and successor have coherent pivots
-   uint64 succ_addr = trunk_next_addr(spl, node);
-   if (succ_addr != 0) {
-      page_handle *succ     = trunk_node_get(spl, succ_addr);
-      const char  *ube      = trunk_max_key(spl, node);
-      const char  *succ_lbi = trunk_min_key(spl, succ);
-      if (trunk_key_compare(spl, ube, succ_lbi) != 0) {
-         platform_log("trunk_verify_node_with_neighbors: "
-                      "mismatched pivots with successor\n");
-         platform_log("addr: %lu\n", addr);
-         trunk_node_unget(spl, &succ);
-         goto out;
-      }
-      trunk_node_unget(spl, &succ);
+   uint16 height   = trunk_height(spl, node);
+   // check node and predescessor have coherent pivots
+   if (!trunk_key_equal(spl, scratch->last_key_seen[height], trunk_min_key(spl, node))) {
+      platform_log("trunk_verify_node_with_neighbors: mismatched pivots with predescessor\n");
+      platform_log(
+         "predescessor max key: %s\n",
+         key_string(trunk_data_config(spl), slice_create(trunk_key_size(spl), scratch->last_key_seen[height])));
+      goto out;
    }
+   // set last key seen in scratch
+   trunk_key_copy(spl, scratch->last_key_seen[height], trunk_max_key(spl, node));
 
-   if (trunk_height(spl, node) == 0) {
+   // don't need to verify coherence with children if node is a leaf
+   if (trunk_is_leaf(spl, node)) {
       is_valid = TRUE;
       goto out;
    }
@@ -7647,7 +7732,8 @@ trunk_verify_node_and_neighbors(trunk_handle *spl, uint64 addr, void *arg)
    if (!is_valid) {
       goto out;
    }
-   is_valid = trunk_verify_node_with_neighbors(spl, node);
+   trunk_verify_scratch *scratch = (trunk_verify_scratch *)arg;
+   is_valid = trunk_verify_node_with_neighbors(spl, node, scratch);
 
 out:
    trunk_node_unget(spl, &node);
@@ -7660,7 +7746,11 @@ out:
 bool
 trunk_verify_tree(trunk_handle *spl)
 {
-   return trunk_for_each_node(spl, trunk_verify_node_and_neighbors, NULL);
+   trunk_verify_scratch scratch = { 0 };
+   for (uint64 h = 0; h < TRUNK_MAX_HEIGHT; h++) {
+      trunk_key_copy(spl, scratch.last_key_seen[h], trunk_data_config(spl)->min_key);
+   }
+   return trunk_for_each_node(spl, trunk_verify_node_and_neighbors, &scratch);
 }
 
 /*
@@ -7725,6 +7815,7 @@ trunk_print_space_use(trunk_handle *spl)
    platform_log("\n");
 }
 
+// clang-format off
 void
 trunk_print_locked_node(trunk_handle          *spl,
                         page_handle           *node,
@@ -7732,14 +7823,13 @@ trunk_print_locked_node(trunk_handle          *spl,
 {
    uint16 height = trunk_height(spl, node);
    // clang-format off
-   platform_log_stream("---------------------------------------------------------------------------------------------------\n");
-   platform_log_stream("|          |     addr     |   next addr  | height |   gen   | pvt gen |                           |\n");
-   platform_log_stream("|  HEADER  |--------------|--------------|--------|---------|---------|---------------------------|\n");
-   platform_log_stream("|          | %12lu | %12lu | %6u | %7lu | %7lu |                           |\n",
+   platform_log_stream("---------------------------------------------------------------------------------------\n");
+   platform_log_stream("|          |     addr      | height | pvt gen |                                       |\n");
+   platform_log_stream("|  HEADER  |---------------|--------|---------|---------|-----------------------------|\n");
+   platform_log_stream(
+      "|          | %12lu^ | %6u | %7lu |                                       |\n",
       node->disk_addr,
-      trunk_next_addr(spl, node),
       height,
-      trunk_generation(spl, node),
       trunk_pivot_generation(spl, node));
    platform_log_stream("|-------------------------------------------------------------------------------------------------|\n");
    platform_log_stream("|                                       PIVOTS                                                    |\n");
@@ -7845,6 +7935,7 @@ trunk_print_locked_node(trunk_handle          *spl,
    // clang-format on
    platform_log_stream("\n");
 }
+// clang-format on
 
 void
 trunk_print_node(trunk_handle *spl, uint64 addr, platform_stream_handle stream)

--- a/src/trunk.h
+++ b/src/trunk.h
@@ -427,6 +427,24 @@ trunk_key_compare(trunk_handle *spl, const char *key1, const char *key2)
    return btree_key_compare(&spl->cfg.btree_cfg, key1_slice, key2_slice);
 }
 
+static inline bool
+trunk_key_equal(trunk_handle *spl, const char *key1, const char *key2)
+{
+   return trunk_key_compare(spl, key1, key2) == 0;
+}
+
+static inline void
+trunk_key_copy(trunk_handle *spl, char *dst, const char *src)
+{
+   memmove(dst, src, spl->cfg.data_cfg->key_size);
+}
+
+static inline data_config *
+trunk_data_config(trunk_handle *spl)
+{
+   return spl->cfg.data_cfg;
+}
+
 static inline void
 trunk_key_to_string(trunk_handle *spl, const char *key, char str[static 128])
 {


### PR DESCRIPTION
Removes sibling pointers from trunk nodes.

Changes compaction and filter-build tasks to reference their target
node[s] by key range and height through new functions
trunk_node_get_by_key_and_height and trunk_compact_bundle_node_get.

Change trunk_for_each_node to perform a DFS. It used to perform a BFS
using sibling pointers.

Changes trunk_verify_node_with_neighbors to take a new scratch struct
which stores the last key seen at each height. This allows
trunk_verify_node_with_neighbors to verify that the current node's min
key matches its predescessor's max key.

Removes hdr->generation and req->filter_generation

These generation numbers used to be used to determine when nodes split,
but this is now done via start_key and end_key in compaction and filter
build tasks.