### PR TITLE
Fixes applied on top of Rob's Makefile rework to get CI tests to run.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,6 @@
 #
 # To build the image from a local source checkout:
 # $ docker build -t splinterdb .
-# To then run the splinterdb-cli within the build image:
-# $ docker run --rm splinterdb bin/splinterdb-cli --help
 # or to run tests:
 # $ docker run --rm splinterdb ./test.sh
 
@@ -42,10 +40,14 @@ COPY --from=build /splinterdb-install/lib/ /usr/local/lib/
 COPY --from=build /splinterdb-install/include/splinterdb/ /usr/local/include/splinterdb/
 
 # Copy over the test binaries under bin/ (recursively) and the test script
-COPY --from=build /splinterdb-src/bin/ /splinterdb/bin/
+# (Default BUILD_DIR is 'build'.)
+COPY --from=build /splinterdb-src/build/bin/ /splinterdb/build/bin/
 COPY --from=build /splinterdb-src/test.sh /splinterdb/test.sh
+
 # TODO: Currently driver_test dynamically links against the relative path lib/libsplinterdb.so
 # Instead we should link driver_test statically against libsplinterdb.a so that this hack isn't necessary
-RUN mkdir /splinterdb/lib && ln -s /usr/local/lib/libsplinterdb.so /splinterdb/lib/libsplinterdb.so
+# As all test binaries are linked against the libraries produced during the build,
+# adjust the lib-paths to drive off of default $BUILD_DIR dir; i.e. 'build'.
+RUN mkdir -p /splinterdb/build/lib && ln -s /usr/local/lib/libsplinterdb.so /splinterdb/build/lib/libsplinterdb.so
 
 WORKDIR "/splinterdb"

--- a/Makefile
+++ b/Makefile
@@ -68,12 +68,12 @@ DEPFLAGS  = -MMD -MP
 #
 
 help::
-	$(SUMMARY) Environment variables controlling the build
-	$(SUMMARY) '  BUILD_SUFFIX: Base suffix for build output.'
-	$(SUMMARY) '    Objects go into obj-$$(BUILD_SUFFIX)'
-	$(SUMMARY) '    Libraries go into lib-$$(BUILD_SUFFIX)'
-	$(SUMMARY) '    Executables go into bin-$$(BUILD_SUFFIX)'
-	$(SUMMARY) '    Note: setting DEBUGMODE and other flags may further modify the suffix'
+	@echo Environment variables controlling the build
+	@echo '  BUILD_SUFFIX: Base suffix for build output.'
+	@echo '    Objects go into obj-$$(BUILD_SUFFIX)'
+	@echo '    Libraries go into lib-$$(BUILD_SUFFIX)'
+	@echo '    Executables go into bin-$$(BUILD_SUFFIX)'
+	@echo '    Note: setting DEBUGMODE and other flags may further modify the suffix'
 
 #
 # Debug mode
@@ -94,7 +94,7 @@ $(error Unknown DEBUGMODE "$(DEBUGMODE)".  Valid options are "debug" and "releas
 endif
 
 help::
-	$(SUMMARY) '  DEBUGMODE: "release" or "debug" (Default: "release")'
+	@echo '  DEBUGMODE: "release" or "debug" (Default: "release")'
 
 #
 # address sanitizer
@@ -113,7 +113,7 @@ $(error Unknown ASAN mode "$(ASAN)".  Valid values are "0" or "1". Default is "0
 endif
 
 help::
-	$(SUMMARY) '  ASAN={0,1}: Disable/enable address-sanitizer (Default: disabled)'
+	@echo '  ASAN={0,1}: Disable/enable address-sanitizer (Default: disabled)'
 
 #
 # memory sanitizer
@@ -132,7 +132,7 @@ $(error Unknown MSAN mode "$(MSAN)".  Valid values are "0" or "1". Default is "0
 endif
 
 help::
-	$(SUMMARY) '  MSAN={0,1}: Disable/enable memory-sanitizer (Default: disabled)'
+	@echo '  MSAN={0,1}: Disable/enable memory-sanitizer (Default: disabled)'
 
 #
 # Verbosity
@@ -158,7 +158,7 @@ $(error Unknown VERBOSE mode "$(VERBOSE)".  Valid values are "0" or "1". Default
 endif
 
 help::
-	$(SUMMARY) '  VERBOSE={0,1}: Disable/enable verbose output (Default: disabled)'
+	@echo '  VERBOSE={0,1}: Disable/enable verbose output (Default: disabled)'
 
 
 ###################################################################

--- a/Makefile
+++ b/Makefile
@@ -69,11 +69,16 @@ DEPFLAGS  = -MMD -MP
 
 help::
 	@echo Environment variables controlling the build
-	@echo '  BUILD_SUFFIX: Base suffix for build output.'
-	@echo '    Objects go into obj-$$(BUILD_SUFFIX)'
-	@echo '    Libraries go into lib-$$(BUILD_SUFFIX)'
-	@echo '    Executables go into bin-$$(BUILD_SUFFIX)'
-	@echo '    Note: setting DEBUGMODE and other flags may further modify the suffix'
+	@echo '  BUILD_DIR: Base name for build output (Default: "build").'
+	@echo '    $$(BUILD_DIR)/obj: object files'
+	@echo '    $$(BUILD_DIR)/lib: libraries'
+	@echo '    $$(BUILD_DIR)/bin: executables'
+	@echo '  Note: setting BUILD_MODE and other flags may further modify BUILD_DIR'
+	@echo
+
+ifndef BUILD_DIR
+BUILD_DIR := build
+endif
 
 #
 # Debug mode
@@ -99,66 +104,66 @@ help::
 #
 # address sanitizer
 #
-ifndef ASAN
-ASAN=0
+ifndef BUILD_ASAN
+BUILD_ASAN=0
 endif
 
-ifeq "$(ASAN)" "1"
+ifeq "$(BUILD_ASAN)" "1"
 CFLAGS  += -fsanitize=address
 LDFLAGS += -fsanitize=address
-BUILD_SUFFIX:=$(BUILD_SUFFIX)-asan
-else ifeq "$(ASAN)" "0"
+BUILD_DIR:=$(BUILD_DIR)-asan
+else ifeq "$(BUILD_ASAN)" "0"
 else
-$(error Unknown ASAN mode "$(ASAN)".  Valid values are "0" or "1". Default is "0")
+$(error Unknown BUILD_ASAN mode "$(BUILD_ASAN)".  Valid values are "0" or "1". Default is "0")
 endif
 
 help::
-	@echo '  ASAN={0,1}: Disable/enable address-sanitizer (Default: disabled)'
+	@echo '  BUILD_ASAN={0,1}: Disable/enable address-sanitizer (Default: disabled)'
 
 #
 # memory sanitizer
 #
-ifndef MSAN
-MSAN=0
+ifndef BUILD_MSAN
+BUILD_MSAN=0
 endif
 
-ifeq "$(MSAN)" "1"
+ifeq "$(BUILD_MSAN)" "1"
 CFLAGS  += -fsanitize=memory
 LDFLAGS += -fsanitize=memory
-BUILD_SUFFIX:=$(BUILD_SUFFIX)-msan
-else ifeq "$(MSAN)" "0"
+BUILD_DIR:=$(BUILD_DIR)-msan
+else ifeq "$(BUILD_MSAN)" "0"
 else
-$(error Unknown MSAN mode "$(MSAN)".  Valid values are "0" or "1". Default is "0")
+$(error Unknown BUILD_MSAN mode "$(BUILD_MSAN)".  Valid values are "0" or "1". Default is "0")
 endif
 
 help::
-	@echo '  MSAN={0,1}: Disable/enable memory-sanitizer (Default: disabled)'
+	@echo '  BUILD_MSAN={0,1}: Disable/enable memory-sanitizer (Default: disabled)'
 
 #
 # Verbosity
 #
-ifndef VERBOSE
-VERBOSE=0
+ifndef BUILD_VERBOSE
+BUILD_VERBOSE=0
 endif
 
-ifeq "$(VERBOSE)" "1"
+ifeq "$(BUILD_VERBOSE)" "1"
 COMMAND=
 PROLIX=@echo
 BRIEF=@ >/dev/null echo
 BRIEF_FORMATTED=@ >/dev/null echo
 BRIEF_PARTIAL=@ >/dev/null echo
-else ifeq "$(VERBOSE)" "0"
+else ifeq "$(BUILD_VERBOSE)" "0"
 COMMAND=@
 PROLIX=@ >/dev/null echo
 BRIEF=@echo
 BRIEF_FORMATTED=@printf
 BRIEF_PARTIAL=@echo -n
 else
-$(error Unknown VERBOSE mode "$(VERBOSE)".  Valid values are "0" or "1". Default is "0")
+$(error Unknown BUILD_VERBOSE mode "$(BUILD_VERBOSE)".  Valid values are "0" or "1". Default is "0")
 endif
 
 help::
-	@echo '  VERBOSE={0,1}: Disable/enable verbose output (Default: disabled)'
+	@echo '  BUILD_VERBOSE={0,1}: Disable/enable verbose output (Default: disabled)'
 
 
 ###################################################################
@@ -198,6 +203,12 @@ UNIT_TESTBINS=$(UNIT_TESTBIN_SRC:$(TESTS_DIR)/%_test.c=$(BINDIR)/%_test)
 all: libs tests $(EXTRA_TARGETS)
 libs: $(LIBDIR)/libsplinterdb.so $(LIBDIR)/libsplinterdb.a
 tests: $(BINDIR)/driver_test $(BINDIR)/unit_test $(UNIT_TESTBINS)
+
+
+# This is for backwards compatibility with old CI.  Once we update CI,
+# we can delete this target
+debug: all
+
 
 #######################################################################
 # CONFIGURATION CHECKING
@@ -400,17 +411,16 @@ tags:
 
 .PHONY: install
 
-run-tests: $(BINDIR)/driver_test $(BINDIR)/unit_test
+run-tests: all-tests
 	BINDIR=$(BINDIR) ./test.sh
 
-test-results: $(BINDIR)/driver_test $(BINDIR)/unit_test
-	(BINDIR=$(BINDIR) ./test.sh > ./test-results.out 2>&1 &) && echo "tail -f ./test-results.out "
+test-results: all-tests
+	(INCLUDE_SLOW_TESTS=true BINDIR=$(BINDIR) ./test.sh > ./test-results.out 2>&1 &) && echo "tail -f ./test-results.out "
 
 INSTALL_PATH ?= /usr/local
 
-install: $(LIBDIR)/libsplinterdb.so
+install: libs
 	mkdir -p $(INSTALL_PATH)/include/splinterdb $(INSTALL_PATH)/lib
-
 	# -p retains the timestamp of the file being copied over
 	cp -p $(LIBDIR)/libsplinterdb.so $(LIBDIR)/libsplinterdb.a $(INSTALL_PATH)/lib
 	cp -p -r $(INCDIR)/splinterdb/ $(INSTALL_PATH)/include/

--- a/test.sh
+++ b/test.sh
@@ -6,6 +6,9 @@
 Me=$(basename "$0")
 set -euo pipefail
 
+# location of binaries
+BINDIR="${BINDIR:-bin}"
+
 # Top-level env-vars controlling test execution logic. CI sets these, too.
 INCLUDE_SLOW_TESTS="${INCLUDE_SLOW_TESTS:-false}"
 RUN_NIGHTLY_TESTS="${RUN_NIGHTLY_TESTS:-false}"
@@ -127,7 +130,7 @@ function nightly_functionality_stress_tests() {
     local dbname="splinter_test.functionality.db"
     echo "$Me: Run ${test_name} with ${n_mills} million rows, on ${ntables} tables, with ${cache_size} GiB cache"
     run_with_timing "Functionality Stress test ${test_descr}" \
-            bin/driver_test splinter_test --functionality  ${num_rows} 1000 \
+            $BINDIR/driver_test splinter_test --functionality  ${num_rows} 1000 \
                                           --num-tables ${ntables} \
                                           --cache-capacity-gib ${cache_size} \
                                           --db-location ${dbname}
@@ -138,7 +141,7 @@ function nightly_functionality_stress_tests() {
     local dbname="splinter_test.functionality.db"
     echo "$Me: Run ${test_name} with ${n_mills} million rows, on ${ntables} tables, with ${cache_size} GiB cache"
     run_with_timing "Functionality Stress test ${test_descr}" \
-            bin/driver_test splinter_test --functionality  ${num_rows} 1000 \
+            $BINDIR/driver_test splinter_test --functionality  ${num_rows} 1000 \
                                           --num-tables ${ntables} \
                                           --cache-capacity-gib ${cache_size} \
                                           --db-location ${dbname}
@@ -154,7 +157,7 @@ function nightly_functionality_stress_tests() {
     test_descr="${nrows_h} rows, ${ntables} tables, ${cache_size} MiB cache"
     echo "$Me: Run with ${n_mills} million rows, on ${ntables} tables, with default ${cache_size} GiB cache"
     run_with_timing "Functionality Stress test ${test_descr}" \
-            bin/driver_test splinter_test --functionality ${num_rows} 1000 \
+            $BINDIR/driver_test splinter_test --functionality ${num_rows} 1000 \
                                           --num-tables ${ntables} \
                                           --cache-capacity-gib ${cache_size} \
                                           --db-location ${dbname}
@@ -165,7 +168,7 @@ function nightly_functionality_stress_tests() {
     test_descr="${nrows_h} rows, ${ntables} tables, ${cache_size} MiB cache"
     echo "$Me: Run with ${n_mills} million rows, on ${ntables} tables, with default ${cache_size} GiB cache"
     run_with_timing "Functionality Stress test ${test_descr}" \
-            bin/driver_test splinter_test --functionality ${num_rows} 1000 \
+            $BINDIR/driver_test splinter_test --functionality ${num_rows} 1000 \
                                           --num-tables ${ntables} \
                                           --cache-capacity-gib ${cache_size} \
                                           --db-location ${dbname}
@@ -175,7 +178,7 @@ function nightly_functionality_stress_tests() {
     # echo "$Me: Run with ${n_mills} million rows, on ${ntables} tables, with small ${cache_size} MiB cache"
     # Commented out, because we run into issue # 322.
     # run_with_timing "Functionality Stress test ${test_descr}" \
-    #       bin/driver_test splinter_test --functionality ${num_rows} 1000 \
+    #       $BINDIR/driver_test splinter_test --functionality ${num_rows} 1000 \
                                         # --num-tables ${ntables} \
                                         # --cache-capacity-mib ${cache_size} \
                                         # --db-location ${dbname}
@@ -207,6 +210,7 @@ function nightly_sync_perf_tests() {
     local nrange_lookup_t=8
     local test_descr="${nins_t} insert, ${nlookup_t} lookup, ${nrange_lookup_t} range lookup threads"
 
+<<<<<<< HEAD
     # ----
     # (#325) Commented this out till slow-performance of this test is resolved.
     # splinter_test --perf is included in CI-runs, but just with
@@ -225,10 +229,23 @@ function nightly_sync_perf_tests() {
     local npthreads=8
     local tree_size=8 # GiB
     test_descr="tree-size ${tree_size} GiB, ${npthreads} pthreads"
+=======
+    run_with_timing "Performance (sync) test ${test_descr}" \
+            $BINDIR/driver_test splinter_test --perf \
+                                          --max-async-inflight 0 \
+                                          --num-insert-threads ${nins_t} \
+                                          --num-lookup-threads ${nlookup_t} \
+                                          --num-range-lookup-threads ${nrange_lookup_t} \
+                                          --lookup-positive-percent 10 \
+                                          --db-capacity-gib 60 \
+                                          --db-location ${dbname}
+    rm ${dbname}
+
+>>>>>>> respond to all comments and feature requests
     dbname="splinter_test.pll_perf.db"
 
     run_with_timing "Parallel Performance (sync) test ${test_descr}" \
-            bin/driver_test splinter_test --parallel-perf \
+            $BINDIR/driver_test splinter_test --parallel-perf \
                                           --max-async-inflight 0 \
                                           --num-pthreads ${npthreads} \
                                           --lookup-positive-percent 10 \
@@ -243,6 +260,7 @@ function nightly_sync_perf_tests() {
 function nightly_cache_perf_tests() {
 
     local dbname="cache_test.perf.db"
+<<<<<<< HEAD
     local test_descr="default cache size"
     run_with_timing "Cache Performance test, ${test_descr}" \
             bin/driver_test cache_test --perf \
@@ -252,6 +270,17 @@ function nightly_cache_perf_tests() {
     test_descr="${cache_size} GiB cache"
     run_with_timing "Cache Performance test, ${test_descr}" \
             bin/driver_test cache_test --perf \
+=======
+    local test_descr=", default cache size"
+    run_with_timing "Cache Performance test ${test_descr}" \
+            $BINDIR/driver_test cache_test --perf \
+                                       --db-location ${dbname}
+
+    cache_size=6  # GiB
+    test_descr=", ${cache_size} GiB cache"
+    run_with_timing "Cache Performance test ${test_descr}" \
+            $BINDIR/driver_test cache_test --perf \
+>>>>>>> respond to all comments and feature requests
                                        --db-location ${dbname} \
                                        --cache-capacity-gib ${cache_size} \
                                        --db-capacity-gib 60
@@ -270,7 +299,7 @@ function nightly_async_perf_tests() {
     local test_descr="${npthreads} pthreads,bgt=${nbgthreads},async=${nasync}"
     local dbname="splinter_test.perf.db"
     run_with_timing "Parallel Async Performance test ${test_descr}" \
-            bin/driver_test splinter_test --parallel-perf \
+            $BINDIR/driver_test splinter_test --parallel-perf \
                                           --num-bg-threads ${nbgthreads} \
                                           --max-async-inflight ${nasync} \
                                           --num-pthreads ${npthreads} \
@@ -336,11 +365,11 @@ if [ "$INCLUDE_SLOW_TESTS" != "true" ]; then
 
    # For some coverage, exercise --help, --list args for unit test binaries
    set -x
-   bin/unit_test --help
-   bin/unit_test --list
-   bin/unit_test --list splinterdb_quick
-   bin/unit/btree_test --help
-   bin/unit/splinterdb_quick_test --list
+   $BINDIR/unit_test --help
+   $BINDIR/unit_test --list
+   $BINDIR/unit_test --list splinterdb_quick
+   $BINDIR/unit/btree_test --help
+   $BINDIR/unit/splinterdb_quick_test --list
    set +x
 
    echo
@@ -350,10 +379,10 @@ if [ "$INCLUDE_SLOW_TESTS" != "true" ]; then
    start_seconds=$SECONDS
 
    set -x
-   bin/unit/splinterdb_quick_test
-   bin/unit/btree_test
-   bin/unit/util_test
-   bin/unit/misc_test
+   $BINDIR/unit/splinterdb_quick_test
+   $BINDIR/unit/btree_test
+   $BINDIR/unit/util_test
+   $BINDIR/unit/misc_test
    set +x
 
    echo "Fast tests passed"
@@ -365,22 +394,23 @@ fi
 # ---- Rest of the coverage runs included in CI test runs ----
 
 # Run all the unit-tests first, to get basic coverage
-run_with_timing "Fast unit tests" bin/unit_test
+run_with_timing "Fast unit tests" $BINDIR/unit_test
 
 # ------------------------------------------------------------------------
 # Explicitly run individual cases from specific slow running unit-tests,
 # where appropriate with a different test-configuration that has been found to
 # provide the required coverage.
-run_with_timing "Splinter inserts test" bin/unit/splinter_test test_inserts
+run_with_timing "Splinter inserts test" $BINDIR/unit/splinter_test test_inserts
 
 # Use fewer rows for this case, to keep elapsed times of MSAN runs reasonable.
-run_with_timing "Splinter lookups test" bin/unit/splinter_test --num-inserts 2000000 test_lookups
+run_with_timing "Splinter lookups test" $BINDIR/unit/splinter_test --num-inserts 2000000 test_lookups
 
 UNIT_TESTS_DB_DEV="unit_tests_db"
 if [ -f ${UNIT_TESTS_DB_DEV} ]; then
     rm ${UNIT_TESTS_DB_DEV}
 fi
 
+<<<<<<< HEAD
 key_size=8
 run_with_timing "Functionality test, key size=${key_size} bytes" bin/driver_test splinter_test --functionality 1000000 100 --key-size ${key_size} --seed "$SEED"
 
@@ -388,11 +418,15 @@ run_with_timing "Functionality test, with default key size" bin/driver_test spli
 
 max_key_size=105
 run_with_timing "Functionality test, key size=maximum (${max_key_size} bytes)" bin/driver_test splinter_test --functionality 1000000 100 --key-size ${max_key_size} --seed "$SEED"
+=======
+run_with_timing "Functionality test" $BINDIR/driver_test splinter_test --functionality 1000000 100 --seed "$SEED"
+>>>>>>> respond to all comments and feature requests
 
-run_with_timing "Performance test" bin/driver_test splinter_test --perf --max-async-inflight 0 --num-insert-threads 4 --num-lookup-threads 4 --num-range-lookup-threads 0 --tree-size-gib 2 --cache-capacity-mib 512
+run_with_timing "Performance test" $BINDIR/driver_test splinter_test --perf --max-async-inflight 0 --num-insert-threads 4 --num-lookup-threads 4 --num-range-lookup-threads 0 --tree-size-gib 2 --cache-capacity-mib 512
 
-run_with_timing "Cache test" bin/driver_test cache_test --seed "$SEED"
+run_with_timing "Cache test" $BINDIR/driver_test cache_test --seed "$SEED"
 
+<<<<<<< HEAD
 key_size=8
 run_with_timing "BTree test, key size=${key_size} bytes" bin/driver_test btree_test --key-size ${key_size} --seed "$SEED"
 
@@ -400,12 +434,15 @@ run_with_timing "BTree test, with default key size" bin/driver_test btree_test -
 
 key_size=100
 run_with_timing "BTree test, key size=${key_size} bytes" bin/driver_test btree_test --key-size ${key_size} --seed "$SEED"
+=======
+run_with_timing "BTree test" $BINDIR/driver_test btree_test --seed "$SEED"
+>>>>>>> respond to all comments and feature requests
 
-run_with_timing "BTree Perf test" bin/driver_test btree_test --perf --cache-capacity-gib 4 --seed "$SEED"
+run_with_timing "BTree Perf test" $BINDIR/driver_test btree_test --perf --cache-capacity-gib 4 --seed "$SEED"
 
-run_with_timing "Log test" bin/driver_test log_test --seed "$SEED"
+run_with_timing "Log test" $BINDIR/driver_test log_test --seed "$SEED"
 
-run_with_timing "Filter test" bin/driver_test filter_test --seed "$SEED"
+run_with_timing "Filter test" $BINDIR/driver_test filter_test --seed "$SEED"
 
 record_elapsed_time ${testRunStartSeconds} "All Tests"
 echo ALL PASSED

--- a/test.sh
+++ b/test.sh
@@ -6,8 +6,37 @@
 Me=$(basename "$0")
 set -euo pipefail
 
-# location of binaries
-BINDIR="${BINDIR:-bin}"
+# location of binaries, which live under $BUILD_DIR, if set.
+build_dir="${BUILD_DIR:-build}"
+BINDIR="${BINDIR:-${build_dir}/bin}"
+
+# Location of binaries, which live under $BUILD_DIR, if BINDIR is not set.
+# If BINDIR -was- set in the user's env, we need to drive off of that.
+# To avoid raising a script error by referencing this variable if it was
+# -not-set- we just initialized it above to this value. Thus, if the
+# following is true, it means the env-var BINDIR was -not- set already.
+if [ "${BINDIR}" == "${build_dir}/bin" ]; then
+
+   # If BUILD_MODE is -set-, fix build-dir path.
+   build_mode="${BUILD_MODE:-0}"
+   if [ "${build_mode}" != "0" ]; then
+      build_dir="${build_dir}-${build_mode}"
+   fi
+
+   # If either one of Asan / Msan build options is -set-, fix build-dir path.
+   build_asan="${BUILD_ASAN:-0}"
+   build_msan="${BUILD_MSAN:-0}"
+   if [ "${build_asan}" == "1" ]; then
+      build_dir="${build_dir}-asan"
+   elif [ "${build_msan}" == "1" ]; then
+      build_dir="${build_dir}-msan"
+   fi
+
+   # Establish bin/ dir-path, to account for the other build parameters
+   BINDIR="${build_dir}/bin"
+fi
+
+echo "$Me: build_dir='${build_dir}', BINDIR='${BINDIR}'"
 
 # Top-level env-vars controlling test execution logic. CI sets these, too.
 INCLUDE_SLOW_TESTS="${INCLUDE_SLOW_TESTS:-false}"
@@ -130,7 +159,7 @@ function nightly_functionality_stress_tests() {
     local dbname="splinter_test.functionality.db"
     echo "$Me: Run ${test_name} with ${n_mills} million rows, on ${ntables} tables, with ${cache_size} GiB cache"
     run_with_timing "Functionality Stress test ${test_descr}" \
-            $BINDIR/driver_test splinter_test --functionality  ${num_rows} 1000 \
+            "$BINDIR"/driver_test splinter_test --functionality  ${num_rows} 1000 \
                                           --num-tables ${ntables} \
                                           --cache-capacity-gib ${cache_size} \
                                           --db-location ${dbname}
@@ -141,7 +170,7 @@ function nightly_functionality_stress_tests() {
     local dbname="splinter_test.functionality.db"
     echo "$Me: Run ${test_name} with ${n_mills} million rows, on ${ntables} tables, with ${cache_size} GiB cache"
     run_with_timing "Functionality Stress test ${test_descr}" \
-            $BINDIR/driver_test splinter_test --functionality  ${num_rows} 1000 \
+            "$BINDIR"/driver_test splinter_test --functionality  ${num_rows} 1000 \
                                           --num-tables ${ntables} \
                                           --cache-capacity-gib ${cache_size} \
                                           --db-location ${dbname}
@@ -157,7 +186,7 @@ function nightly_functionality_stress_tests() {
     test_descr="${nrows_h} rows, ${ntables} tables, ${cache_size} MiB cache"
     echo "$Me: Run with ${n_mills} million rows, on ${ntables} tables, with default ${cache_size} GiB cache"
     run_with_timing "Functionality Stress test ${test_descr}" \
-            $BINDIR/driver_test splinter_test --functionality ${num_rows} 1000 \
+            "$BINDIR"/driver_test splinter_test --functionality ${num_rows} 1000 \
                                           --num-tables ${ntables} \
                                           --cache-capacity-gib ${cache_size} \
                                           --db-location ${dbname}
@@ -168,7 +197,7 @@ function nightly_functionality_stress_tests() {
     test_descr="${nrows_h} rows, ${ntables} tables, ${cache_size} MiB cache"
     echo "$Me: Run with ${n_mills} million rows, on ${ntables} tables, with default ${cache_size} GiB cache"
     run_with_timing "Functionality Stress test ${test_descr}" \
-            $BINDIR/driver_test splinter_test --functionality ${num_rows} 1000 \
+            "$BINDIR"/driver_test splinter_test --functionality ${num_rows} 1000 \
                                           --num-tables ${ntables} \
                                           --cache-capacity-gib ${cache_size} \
                                           --db-location ${dbname}
@@ -178,7 +207,7 @@ function nightly_functionality_stress_tests() {
     # echo "$Me: Run with ${n_mills} million rows, on ${ntables} tables, with small ${cache_size} MiB cache"
     # Commented out, because we run into issue # 322.
     # run_with_timing "Functionality Stress test ${test_descr}" \
-    #       $BINDIR/driver_test splinter_test --functionality ${num_rows} 1000 \
+    #       "$BINDIR"/driver_test splinter_test --functionality ${num_rows} 1000 \
                                         # --num-tables ${ntables} \
                                         # --cache-capacity-mib ${cache_size} \
                                         # --db-location ${dbname}
@@ -210,13 +239,12 @@ function nightly_sync_perf_tests() {
     local nrange_lookup_t=8
     local test_descr="${nins_t} insert, ${nlookup_t} lookup, ${nrange_lookup_t} range lookup threads"
 
-<<<<<<< HEAD
     # ----
     # (#325) Commented this out till slow-performance of this test is resolved.
     # splinter_test --perf is included in CI-runs, but just with
     # --num-range-lookup-threads 0
     # run_with_timing "Performance (sync) test ${test_descr}" \
-    #       bin/driver_test splinter_test --perf \
+    #       "$BINDIR"/driver_test splinter_test --perf \
     #                                     --max-async-inflight 0 \
     #                                     --num-insert-threads ${nins_t} \
     #                                     --num-lookup-threads ${nlookup_t} \
@@ -229,23 +257,10 @@ function nightly_sync_perf_tests() {
     local npthreads=8
     local tree_size=8 # GiB
     test_descr="tree-size ${tree_size} GiB, ${npthreads} pthreads"
-=======
-    run_with_timing "Performance (sync) test ${test_descr}" \
-            $BINDIR/driver_test splinter_test --perf \
-                                          --max-async-inflight 0 \
-                                          --num-insert-threads ${nins_t} \
-                                          --num-lookup-threads ${nlookup_t} \
-                                          --num-range-lookup-threads ${nrange_lookup_t} \
-                                          --lookup-positive-percent 10 \
-                                          --db-capacity-gib 60 \
-                                          --db-location ${dbname}
-    rm ${dbname}
-
->>>>>>> respond to all comments and feature requests
     dbname="splinter_test.pll_perf.db"
 
     run_with_timing "Parallel Performance (sync) test ${test_descr}" \
-            $BINDIR/driver_test splinter_test --parallel-perf \
+            "$BINDIR"/driver_test splinter_test --parallel-perf \
                                           --max-async-inflight 0 \
                                           --num-pthreads ${npthreads} \
                                           --lookup-positive-percent 10 \
@@ -260,27 +275,15 @@ function nightly_sync_perf_tests() {
 function nightly_cache_perf_tests() {
 
     local dbname="cache_test.perf.db"
-<<<<<<< HEAD
     local test_descr="default cache size"
     run_with_timing "Cache Performance test, ${test_descr}" \
-            bin/driver_test cache_test --perf \
+            "$BINDIR"/driver_test cache_test --perf \
                                        --db-location ${dbname}
 
     cache_size=6  # GiB
     test_descr="${cache_size} GiB cache"
     run_with_timing "Cache Performance test, ${test_descr}" \
-            bin/driver_test cache_test --perf \
-=======
-    local test_descr=", default cache size"
-    run_with_timing "Cache Performance test ${test_descr}" \
-            $BINDIR/driver_test cache_test --perf \
-                                       --db-location ${dbname}
-
-    cache_size=6  # GiB
-    test_descr=", ${cache_size} GiB cache"
-    run_with_timing "Cache Performance test ${test_descr}" \
-            $BINDIR/driver_test cache_test --perf \
->>>>>>> respond to all comments and feature requests
+            "$BINDIR"/driver_test cache_test --perf \
                                        --db-location ${dbname} \
                                        --cache-capacity-gib ${cache_size} \
                                        --db-capacity-gib 60
@@ -299,7 +302,7 @@ function nightly_async_perf_tests() {
     local test_descr="${npthreads} pthreads,bgt=${nbgthreads},async=${nasync}"
     local dbname="splinter_test.perf.db"
     run_with_timing "Parallel Async Performance test ${test_descr}" \
-            $BINDIR/driver_test splinter_test --parallel-perf \
+            "$BINDIR"/driver_test splinter_test --parallel-perf \
                                           --num-bg-threads ${nbgthreads} \
                                           --max-async-inflight ${nasync} \
                                           --num-pthreads ${npthreads} \
@@ -365,11 +368,11 @@ if [ "$INCLUDE_SLOW_TESTS" != "true" ]; then
 
    # For some coverage, exercise --help, --list args for unit test binaries
    set -x
-   $BINDIR/unit_test --help
-   $BINDIR/unit_test --list
-   $BINDIR/unit_test --list splinterdb_quick
-   $BINDIR/unit/btree_test --help
-   $BINDIR/unit/splinterdb_quick_test --list
+   "$BINDIR"/unit_test --help
+   "$BINDIR"/unit_test --list
+   "$BINDIR"/unit_test --list splinterdb_quick
+   "$BINDIR"/unit/btree_test --help
+   "$BINDIR"/unit/splinterdb_quick_test --list
    set +x
 
    echo
@@ -379,10 +382,10 @@ if [ "$INCLUDE_SLOW_TESTS" != "true" ]; then
    start_seconds=$SECONDS
 
    set -x
-   $BINDIR/unit/splinterdb_quick_test
-   $BINDIR/unit/btree_test
-   $BINDIR/unit/util_test
-   $BINDIR/unit/misc_test
+   "$BINDIR"/unit/splinterdb_quick_test
+   "$BINDIR"/unit/btree_test
+   "$BINDIR"/unit/util_test
+   "$BINDIR"/unit/misc_test
    set +x
 
    echo "Fast tests passed"
@@ -394,55 +397,47 @@ fi
 # ---- Rest of the coverage runs included in CI test runs ----
 
 # Run all the unit-tests first, to get basic coverage
-run_with_timing "Fast unit tests" $BINDIR/unit_test
+run_with_timing "Fast unit tests" "$BINDIR"/unit_test
 
 # ------------------------------------------------------------------------
 # Explicitly run individual cases from specific slow running unit-tests,
 # where appropriate with a different test-configuration that has been found to
 # provide the required coverage.
-run_with_timing "Splinter inserts test" $BINDIR/unit/splinter_test test_inserts
+run_with_timing "Splinter inserts test" "$BINDIR"/unit/splinter_test test_inserts
 
 # Use fewer rows for this case, to keep elapsed times of MSAN runs reasonable.
-run_with_timing "Splinter lookups test" $BINDIR/unit/splinter_test --num-inserts 2000000 test_lookups
+run_with_timing "Splinter lookups test" "$BINDIR"/unit/splinter_test --num-inserts 2000000 test_lookups
 
 UNIT_TESTS_DB_DEV="unit_tests_db"
 if [ -f ${UNIT_TESTS_DB_DEV} ]; then
     rm ${UNIT_TESTS_DB_DEV}
 fi
 
-<<<<<<< HEAD
 key_size=8
-run_with_timing "Functionality test, key size=${key_size} bytes" bin/driver_test splinter_test --functionality 1000000 100 --key-size ${key_size} --seed "$SEED"
+run_with_timing "Functionality test, key size=${key_size} bytes" "$BINDIR"/driver_test splinter_test --functionality 1000000 100 --key-size ${key_size} --seed "$SEED"
 
-run_with_timing "Functionality test, with default key size" bin/driver_test splinter_test --functionality 1000000 100 --seed "$SEED"
+run_with_timing "Functionality test, with default key size" "$BINDIR"/driver_test splinter_test --functionality 1000000 100 --seed "$SEED"
 
 max_key_size=105
-run_with_timing "Functionality test, key size=maximum (${max_key_size} bytes)" bin/driver_test splinter_test --functionality 1000000 100 --key-size ${max_key_size} --seed "$SEED"
-=======
-run_with_timing "Functionality test" $BINDIR/driver_test splinter_test --functionality 1000000 100 --seed "$SEED"
->>>>>>> respond to all comments and feature requests
+run_with_timing "Functionality test, key size=maximum (${max_key_size} bytes)" "$BINDIR"/driver_test splinter_test --functionality 1000000 100 --key-size ${max_key_size} --seed "$SEED"
 
-run_with_timing "Performance test" $BINDIR/driver_test splinter_test --perf --max-async-inflight 0 --num-insert-threads 4 --num-lookup-threads 4 --num-range-lookup-threads 0 --tree-size-gib 2 --cache-capacity-mib 512
+run_with_timing "Performance test" "$BINDIR"/driver_test splinter_test --perf --max-async-inflight 0 --num-insert-threads 4 --num-lookup-threads 4 --num-range-lookup-threads 0 --tree-size-gib 2 --cache-capacity-mib 512
 
-run_with_timing "Cache test" $BINDIR/driver_test cache_test --seed "$SEED"
+run_with_timing "Cache test" "$BINDIR"/driver_test cache_test --seed "$SEED"
 
-<<<<<<< HEAD
 key_size=8
-run_with_timing "BTree test, key size=${key_size} bytes" bin/driver_test btree_test --key-size ${key_size} --seed "$SEED"
+run_with_timing "BTree test, key size=${key_size} bytes" "$BINDIR"/driver_test btree_test --key-size ${key_size} --seed "$SEED"
 
-run_with_timing "BTree test, with default key size" bin/driver_test btree_test --seed "$SEED"
+run_with_timing "BTree test, with default key size" "$BINDIR"/driver_test btree_test --seed "$SEED"
 
 key_size=100
-run_with_timing "BTree test, key size=${key_size} bytes" bin/driver_test btree_test --key-size ${key_size} --seed "$SEED"
-=======
-run_with_timing "BTree test" $BINDIR/driver_test btree_test --seed "$SEED"
->>>>>>> respond to all comments and feature requests
+run_with_timing "BTree test, key size=${key_size} bytes" "$BINDIR"/driver_test btree_test --key-size ${key_size} --seed "$SEED"
 
-run_with_timing "BTree Perf test" $BINDIR/driver_test btree_test --perf --cache-capacity-gib 4 --seed "$SEED"
+run_with_timing "BTree Perf test" "$BINDIR"/driver_test btree_test --perf --cache-capacity-gib 4 --seed "$SEED"
 
-run_with_timing "Log test" $BINDIR/driver_test log_test --seed "$SEED"
+run_with_timing "Log test" "$BINDIR"/driver_test log_test --seed "$SEED"
 
-run_with_timing "Filter test" $BINDIR/driver_test filter_test --seed "$SEED"
+run_with_timing "Filter test" "$BINDIR"/driver_test filter_test --seed "$SEED"
 
 record_elapsed_time ${testRunStartSeconds} "All Tests"
 echo ALL PASSED


### PR DESCRIPTION
These are edits on top of Rob's` Makefile` work. ... to run thru CI-jobs, and see whether they run to completion.

With this one single commit, we are now able to run thru CI successfully.

Rob: Here is what I suggest you can do:

1. Review this single commit, and confirm that the diffs are acceptable to you.
2. Cherry-pick this commit to your dev-branch, and move the code to merge to /main. (I am fairly confident that they will go thru CI.)

Peeled-off following issues, which can be done in /main after your main PR #332 integrates.

1. (rob) https://github.com/vmware/splinterdb/issues/379 - make install fails
2. (gapisback) https://github.com/vmware/splinterdb/issues/378 - Code cleanup of indentation in `test.sh` script
3. (gapisback) https://github.com/vmware/splinterdb/issues/377 - Code cleanup of CI-scripts' use of `debug` flags