### PR TITLE
(#370) Add 'help' to Makefile, report minimal usage msg.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,9 @@
 PLATFORM = linux
 PLATFORM_DIR = platform_$(PLATFORM)
 
+help::
+	@echo 'Usage: make [debug]'
+
 #*************************************************************#
 # DIRECTORIES, SRC, OBJ, ETC
 #


### PR DESCRIPTION
Pre-stage support for 'help' target to Makefile, so that associated
changes to CI-build scripts can be pre-staged (to address issue #371).
All this is needed to smooth the integration of larger Makefile
rework coming up under PR #332 .