### PR TITLE
Add ownership to `platform_mutex`, fix/cleanup bundle accounting

### DIFF
--- a/src/platform_linux/platform.h
+++ b/src/platform_linux/platform.h
@@ -64,7 +64,15 @@
 /* Evaluates to sizeof() a field, f, in a C-structure, s */
 #define FSIZEOF(s, f) sizeof(((typeof(s) *)NULL)->f)
 
+/*
+ * MAX_THREADS is used primarily for convenience, where allocations made on a
+ * per-thread basis create an array with MAX_THREADS items, e.g. the
+ * trunk_stats field in trunk_handle. The task subsystem also uses a 64-bit
+ * bit-array to track thread IDs in use. This could be changed relatively
+ * easily if needed.
+ */
 #define MAX_THREADS (64)
+#define INVALID_TID (MAX_THREADS)
 
 #define HASH_SEED         (42)
 #define UNUSED_FUNCTION() __attribute__((__unused__))

--- a/src/platform_linux/platform_types.h
+++ b/src/platform_linux/platform_types.h
@@ -104,8 +104,11 @@ platform_assert_msg(platform_stream_handle stream,
 
 typedef pthread_t platform_thread;
 
-// Mutex
-typedef pthread_mutex_t platform_mutex;
+// Thread-specific mutex, with ownership tracking.
+typedef struct {
+   pthread_mutex_t mutex;
+   threadid        owner;
+} platform_mutex;
 
 // Spin lock
 typedef pthread_spinlock_t platform_spinlock;

--- a/src/task.c
+++ b/src/task.c
@@ -26,8 +26,6 @@ void
 task_system_io_register_thread(task_system *ts);
 // end forward declarations
 
-#define INVALID_TID (MAX_THREADS)
-
 void
 task_init_tid_bitmask(uint64 *tid_bitmask)
 {
@@ -342,6 +340,7 @@ task_group_deinit(task_group *group)
    if (task_system_use_bg_threads(group->ts)) {
       platform_condvar_destroy(&group->bg.cv);
    } else {
+      platform_mutex_unlock(&group->fg.mutex);
       platform_mutex_destroy(&group->fg.mutex);
    }
 }


### PR DESCRIPTION
Adds an `owner` field to `platform_mutex`, which is used for asserting that threads are correctly locking and unlocking the mutex.

Fixes a bug where `trunk_bundle_live` and `trunk_bundle_live_for_pivot` would answer incorrectly. This is because they used the bundle start branch to determine liveness, but accessing the start branch of a dead bundle results in undefined behavior.

Partially fixes the convoluted logic in `trunk_flush_fullest`, where the return value would frequently be FALSE, despite a successful flush.