### PR TITLE
(#378) Minor re-indentation of run_with_timing() calls

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -160,9 +160,9 @@ function nightly_functionality_stress_tests() {
     echo "$Me: Run ${test_name} with ${n_mills} million rows, on ${ntables} tables, with ${cache_size} GiB cache"
     run_with_timing "Functionality Stress test ${test_descr}" \
             "$BINDIR"/driver_test splinter_test --functionality  ${num_rows} 1000 \
-                                          --num-tables ${ntables} \
-                                          --cache-capacity-gib ${cache_size} \
-                                          --db-location ${dbname}
+                                                --num-tables ${ntables} \
+                                                --cache-capacity-gib ${cache_size} \
+                                                --db-location ${dbname}
 
     # ----
     ntables=2
@@ -171,9 +171,9 @@ function nightly_functionality_stress_tests() {
     echo "$Me: Run ${test_name} with ${n_mills} million rows, on ${ntables} tables, with ${cache_size} GiB cache"
     run_with_timing "Functionality Stress test ${test_descr}" \
             "$BINDIR"/driver_test splinter_test --functionality  ${num_rows} 1000 \
-                                          --num-tables ${ntables} \
-                                          --cache-capacity-gib ${cache_size} \
-                                          --db-location ${dbname}
+                                                --num-tables ${ntables} \
+                                                --cache-capacity-gib ${cache_size} \
+                                                --db-location ${dbname}
 
     # ----
     cache_size=1        # GiB
@@ -187,9 +187,9 @@ function nightly_functionality_stress_tests() {
     echo "$Me: Run with ${n_mills} million rows, on ${ntables} tables, with default ${cache_size} GiB cache"
     run_with_timing "Functionality Stress test ${test_descr}" \
             "$BINDIR"/driver_test splinter_test --functionality ${num_rows} 1000 \
-                                          --num-tables ${ntables} \
-                                          --cache-capacity-gib ${cache_size} \
-                                          --db-location ${dbname}
+                                                --num-tables ${ntables} \
+                                                --cache-capacity-gib ${cache_size} \
+                                                --db-location ${dbname}
 
     # ----
     ntables=4
@@ -198,9 +198,9 @@ function nightly_functionality_stress_tests() {
     echo "$Me: Run with ${n_mills} million rows, on ${ntables} tables, with default ${cache_size} GiB cache"
     run_with_timing "Functionality Stress test ${test_descr}" \
             "$BINDIR"/driver_test splinter_test --functionality ${num_rows} 1000 \
-                                          --num-tables ${ntables} \
-                                          --cache-capacity-gib ${cache_size} \
-                                          --db-location ${dbname}
+                                                --num-tables ${ntables} \
+                                                --cache-capacity-gib ${cache_size} \
+                                                --db-location ${dbname}
     # ----
     cache_size=512      # MiB
     test_descr="${nrows_h} rows, ${ntables} tables, ${cache_size} MiB cache"
@@ -208,9 +208,9 @@ function nightly_functionality_stress_tests() {
     # Commented out, because we run into issue # 322.
     # run_with_timing "Functionality Stress test ${test_descr}" \
     #       "$BINDIR"/driver_test splinter_test --functionality ${num_rows} 1000 \
-                                        # --num-tables ${ntables} \
-                                        # --cache-capacity-mib ${cache_size} \
-                                        # --db-location ${dbname}
+                                        #       --num-tables ${ntables} \
+                                        #       --cache-capacity-mib ${cache_size} \
+                                        #       --db-location ${dbname}
     rm ${dbname}
 }
 
@@ -245,13 +245,13 @@ function nightly_sync_perf_tests() {
     # --num-range-lookup-threads 0
     # run_with_timing "Performance (sync) test ${test_descr}" \
     #       "$BINDIR"/driver_test splinter_test --perf \
-    #                                     --max-async-inflight 0 \
-    #                                     --num-insert-threads ${nins_t} \
-    #                                     --num-lookup-threads ${nlookup_t} \
-    #                                     --num-range-lookup-threads ${nrange_lookup_t} \
-    #                                     --lookup-positive-percent 10 \
-    #                                     --db-capacity-gib 60 \
-    #                                     --db-location ${dbname}
+    #                                           --max-async-inflight 0 \
+    #                                           --num-insert-threads ${nins_t} \
+    #                                           --num-lookup-threads ${nlookup_t} \
+    #                                           --num-range-lookup-threads ${nrange_lookup_t} \
+    #                                           --lookup-positive-percent 10 \
+    #                                           --db-capacity-gib 60 \
+    #                                           --db-location ${dbname}
     # rm ${dbname}
 
     local npthreads=8
@@ -261,12 +261,12 @@ function nightly_sync_perf_tests() {
 
     run_with_timing "Parallel Performance (sync) test ${test_descr}" \
             "$BINDIR"/driver_test splinter_test --parallel-perf \
-                                          --max-async-inflight 0 \
-                                          --num-pthreads ${npthreads} \
-                                          --lookup-positive-percent 10 \
-                                          --tree-size-gib ${tree_size} \
-                                          --db-capacity-gib 60 \
-                                          --db-location ${dbname}
+                                                --max-async-inflight 0 \
+                                                --num-pthreads ${npthreads} \
+                                                --lookup-positive-percent 10 \
+                                                --tree-size-gib ${tree_size} \
+                                                --db-capacity-gib 60 \
+                                                --db-location ${dbname}
     rm ${dbname}
 }
 
@@ -278,15 +278,15 @@ function nightly_cache_perf_tests() {
     local test_descr="default cache size"
     run_with_timing "Cache Performance test, ${test_descr}" \
             "$BINDIR"/driver_test cache_test --perf \
-                                       --db-location ${dbname}
+                                             --db-location ${dbname}
 
     cache_size=6  # GiB
     test_descr="${cache_size} GiB cache"
     run_with_timing "Cache Performance test, ${test_descr}" \
             "$BINDIR"/driver_test cache_test --perf \
-                                       --db-location ${dbname} \
-                                       --cache-capacity-gib ${cache_size} \
-                                       --db-capacity-gib 60
+                                             --db-location ${dbname} \
+                                             --cache-capacity-gib ${cache_size} \
+                                             --db-capacity-gib 60
     rm ${dbname}
 }
 
@@ -303,11 +303,11 @@ function nightly_async_perf_tests() {
     local dbname="splinter_test.perf.db"
     run_with_timing "Parallel Async Performance test ${test_descr}" \
             "$BINDIR"/driver_test splinter_test --parallel-perf \
-                                          --num-bg-threads ${nbgthreads} \
-                                          --max-async-inflight ${nasync} \
-                                          --num-pthreads ${npthreads} \
-                                          --db-capacity-gib 60 \
-                                          --db-location ${dbname}
+                                                --num-bg-threads ${nbgthreads} \
+                                                --max-async-inflight ${nasync} \
+                                                --num-pthreads ${npthreads} \
+                                                --db-capacity-gib 60 \
+                                                --db-location ${dbname}
     rm ${dbname}
 }
 
@@ -406,7 +406,8 @@ run_with_timing "Fast unit tests" "$BINDIR"/unit_test
 run_with_timing "Splinter inserts test" "$BINDIR"/unit/splinter_test test_inserts
 
 # Use fewer rows for this case, to keep elapsed times of MSAN runs reasonable.
-run_with_timing "Splinter lookups test" "$BINDIR"/unit/splinter_test --num-inserts 2000000 test_lookups
+run_with_timing "Splinter lookups test" \
+        "$BINDIR"/unit/splinter_test --num-inserts 2000000 test_lookups
 
 UNIT_TESTS_DB_DEV="unit_tests_db"
 if [ -f ${UNIT_TESTS_DB_DEV} ]; then
@@ -414,30 +415,53 @@ if [ -f ${UNIT_TESTS_DB_DEV} ]; then
 fi
 
 key_size=8
-run_with_timing "Functionality test, key size=${key_size} bytes" "$BINDIR"/driver_test splinter_test --functionality 1000000 100 --key-size ${key_size} --seed "$SEED"
+run_with_timing "Functionality test, key size=${key_size} bytes" \
+        "$BINDIR"/driver_test splinter_test --functionality 1000000 100 \
+                                            --key-size ${key_size} --seed "$SEED"
 
-run_with_timing "Functionality test, with default key size" "$BINDIR"/driver_test splinter_test --functionality 1000000 100 --seed "$SEED"
+run_with_timing "Functionality test, with default key size" \
+        "$BINDIR"/driver_test splinter_test --functionality 1000000 100 \
+                                            --seed "$SEED"
 
 max_key_size=105
-run_with_timing "Functionality test, key size=maximum (${max_key_size} bytes)" "$BINDIR"/driver_test splinter_test --functionality 1000000 100 --key-size ${max_key_size} --seed "$SEED"
+run_with_timing "Functionality test, key size=maximum (${max_key_size} bytes)" \
+        "$BINDIR"/driver_test splinter_test --functionality 1000000 100 \
+                                            --key-size ${max_key_size} --seed "$SEED"
 
-run_with_timing "Performance test" "$BINDIR"/driver_test splinter_test --perf --max-async-inflight 0 --num-insert-threads 4 --num-lookup-threads 4 --num-range-lookup-threads 0 --tree-size-gib 2 --cache-capacity-mib 512
+run_with_timing "Performance test" \
+        "$BINDIR"/driver_test splinter_test --perf \
+                                            --max-async-inflight 0 \
+                                            --num-insert-threads 4 \
+                                            --num-lookup-threads 4 \
+                                            --num-range-lookup-threads 0 \
+                                            --tree-size-gib 2 \
+                                            --cache-capacity-mib 512
 
-run_with_timing "Cache test" "$BINDIR"/driver_test cache_test --seed "$SEED"
+run_with_timing "Cache test" \
+        "$BINDIR"/driver_test cache_test --seed "$SEED"
 
 key_size=8
-run_with_timing "BTree test, key size=${key_size} bytes" "$BINDIR"/driver_test btree_test --key-size ${key_size} --seed "$SEED"
+run_with_timing "BTree test, key size=${key_size} bytes" \
+        "$BINDIR"/driver_test btree_test --key-size ${key_size} \
+                                         --seed "$SEED"
 
-run_with_timing "BTree test, with default key size" "$BINDIR"/driver_test btree_test --seed "$SEED"
+run_with_timing "BTree test, with default key size" \
+        "$BINDIR"/driver_test btree_test --seed "$SEED"
 
 key_size=100
-run_with_timing "BTree test, key size=${key_size} bytes" "$BINDIR"/driver_test btree_test --key-size ${key_size} --seed "$SEED"
+run_with_timing "BTree test, key size=${key_size} bytes" \
+        "$BINDIR"/driver_test btree_test --key-size ${key_size} --seed "$SEED"
 
-run_with_timing "BTree Perf test" "$BINDIR"/driver_test btree_test --perf --cache-capacity-gib 4 --seed "$SEED"
+run_with_timing "BTree Perf test"
+        "$BINDIR"/driver_test btree_test --perf \
+                                         --cache-capacity-gib 4 \
+                                         --seed "$SEED"
 
-run_with_timing "Log test" "$BINDIR"/driver_test log_test --seed "$SEED"
+run_with_timing "Log test" \
+        "$BINDIR"/driver_test log_test --seed "$SEED"
 
-run_with_timing "Filter test" "$BINDIR"/driver_test filter_test --seed "$SEED"
+run_with_timing "Filter test" \
+        "$BINDIR"/driver_test filter_test --seed "$SEED"
 
 record_elapsed_time ${testRunStartSeconds} "All Tests"
 echo ALL PASSED


### PR DESCRIPTION
Re-indent long-lines to invove tests via run_with_timing() to
properly align multiple parameters. Improve readability and
consistency in test.sh .

---

While re-formatting lines to align parameters, also re-indented set of single-line calls to `run_with_timing()` to indent the calls as multi-line statement. This way, all calls to this function are consistent in the entire file.