### PR TITLE
(#377) Purge 'debug' as make target. Fix CI-build scripts.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,8 @@ PLATFORM = linux
 PLATFORM_DIR = platform_$(PLATFORM)
 
 help::
-	@echo 'Usage: make [debug]'
+	@echo 'Usage: make [<target>]'
+	@echo 'Supported targets: clean all libs all-tests run-tests test-results install'
 
 #*************************************************************#
 # SOURCE DIRECTORIES AND FILES
@@ -206,16 +207,9 @@ UNIT_TESTBINS=$(UNIT_TESTBIN_SRC:$(TESTS_DIR)/%_test.c=$(BINDIR)/%_test)
 ####################################################################
 # The main targets
 #
-
 all: libs all-tests $(EXTRA_TARGETS)
 libs: $(LIBDIR)/libsplinterdb.so $(LIBDIR)/libsplinterdb.a
 all-tests: $(BINDIR)/driver_test $(BINDIR)/unit_test $(UNIT_TESTBINS)
-
-
-# This is for backwards compatibility with old CI.  Once we update CI,
-# we can delete this target
-debug: all
-
 
 #######################################################################
 # CONFIGURATION CHECKING

--- a/ci/steps.lib.yml
+++ b/ci/steps.lib.yml
@@ -118,14 +118,10 @@ config:
     #@ end
 
     #@ if sanitize == "asan":
-    DEFAULT_CFLAGS: "-fsanitize=address"
-    DEFAULT_LDFLAGS: "-fsanitize=address"
     BUILD_ASAN: "1"
     #! work around issue "LeakSanitizer has encountered a fatal error", may be kernel-dependent
     ASAN_OPTIONS: "detect_leaks=0"
     #@ elif sanitize == "msan":
-    DEFAULT_CFLAGS: "-fsanitize=memory"
-    DEFAULT_LDFLAGS: "-fsanitize=memory"
     BUILD_MSAN: "1"
     #@ end
 
@@ -134,11 +130,7 @@ config:
     dir: #@ input_name
     args:
     - "-c"
-    #@ if is_debug:
-    - "make $MAKE_HELP debug all run-tests"
-    #@ else:
     - "make $MAKE_HELP all run-tests"
-    #@ end
 #@ end
 
 ---


### PR DESCRIPTION
This commit cleans-up CI-scripts of 'make debug' which is no
longer needed. CI jobs drive 'make' using BUILD_ env-vars to
control release v/s debug builds. Makefile no longer needs to
support 'debug' target. Update the 'help' message to list
supported targets.

----

Updated `make help` looks like follows:

```
Fusion-LocalVM:[43] $ make help
Usage: make [<target>]
Supported targets: clean all libs all-tests run-tests test-results install
Environment variables controlling the build:
[... rest of the output is unchanged ...]
```

NOTE: This change has to go in conjunction with `ci/apply-pipeline.sh` to update the CI-scripts in the CI machinery.
For now, I have applied this manually, just to make sure that this PR's CI-jobs succeed. Once they pass, I will revert the CI-scripts to those in /main. And when review passes, will re-apply then. Manual jugglery.