### PR TITLE
set extents_per_memtable to 2 * memtable_capacity

### DIFF
--- a/src/memtable.c
+++ b/src/memtable.c
@@ -345,5 +345,5 @@ memtable_config_init(memtable_config *cfg,
    cfg->btree_cfg     = btree_cfg;
    cfg->max_memtables = max_memtables;
    cfg->max_extents_per_memtable =
-      memtable_capacity / cache_config_extent_size(btree_cfg->cache_cfg);
+      2 * memtable_capacity / cache_config_extent_size(btree_cfg->cache_cfg);
 }

--- a/src/memtable.c
+++ b/src/memtable.c
@@ -345,5 +345,6 @@ memtable_config_init(memtable_config *cfg,
    cfg->btree_cfg     = btree_cfg;
    cfg->max_memtables = max_memtables;
    cfg->max_extents_per_memtable =
-      2 * memtable_capacity / cache_config_extent_size(btree_cfg->cache_cfg);
+      MEMTABLE_SPACE_OVERHEAD_FACTOR * memtable_capacity
+      / cache_config_extent_size(btree_cfg->cache_cfg);
 }

--- a/src/memtable.h
+++ b/src/memtable.h
@@ -15,6 +15,8 @@
 #include "cache.h"
 #include "btree.h"
 
+#define MEMTABLE_SPACE_OVERHEAD_FACTOR (2)
+
 typedef enum memtable_state {
    MEMTABLE_STATE_READY, // if it's the correct one, go ahead and insert
    MEMTABLE_STATE_FINALIZED,

--- a/src/splinterdb.c
+++ b/src/splinterdb.c
@@ -20,6 +20,7 @@
 #include "rc_allocator.h"
 #include "trunk.h"
 #include "btree_private.h"
+#include "shard_log.h"
 #include "poison.h"
 
 #define MAX_ENCODED_MESSAGE_SIZE (MAX_INLINE_MESSAGE_SIZE)
@@ -51,6 +52,7 @@ typedef struct splinterdb {
    rc_allocator         allocator_handle;
    clockcache_config    cache_cfg;
    clockcache           cache_handle;
+   shard_log_config     log_cfg;
    allocator_root_id    trunk_id;
    trunk_config         trunk_cfg;
    trunk_handle        *spl;
@@ -364,10 +366,13 @@ splinterdb_init_config(const splinterdb_config *kvs_cfg, // IN
                           cfg.cache_logfile,
                           cfg.use_stats);
 
+   shard_log_config_init(
+      &kvs->log_cfg, &kvs->cache_cfg.super, &kvs->shim_data_cfg.super);
+
    trunk_config_init(&kvs->trunk_cfg,
                      &kvs->cache_cfg.super,
                      &kvs->shim_data_cfg.super,
-                     NULL,
+                     (log_config *)&kvs->log_cfg,
                      cfg.memtable_capacity,
                      cfg.fanout,
                      cfg.max_branches_per_node,

--- a/src/trunk.c
+++ b/src/trunk.c
@@ -8687,7 +8687,7 @@ trunk_config_init(trunk_config *trunk_cfg,
    // Has to be set after btree_config_init is called
    trunk_cfg->max_kv_bytes_per_node =
       trunk_cfg->fanout * trunk_cfg->mt_cfg.max_extents_per_memtable
-      * cache_config_extent_size(cache_cfg);
+      * cache_config_extent_size(cache_cfg) / MEMTABLE_SPACE_OVERHEAD_FACTOR;
    trunk_cfg->target_leaf_kv_bytes = trunk_cfg->max_kv_bytes_per_node / 2;
    trunk_cfg->max_tuples_per_node  = trunk_cfg->max_kv_bytes_per_node / 32;
 


### PR DESCRIPTION
Addresses #389.

Another way to address 389 would be to double the default memtable size.  I think that is probably the better way, since it gives users more accurate control over how much cache the memtable can consume.
