### PR TITLE
Fix invocation of test binaries with $BINDIR path prefix.

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -343,27 +343,27 @@ function nightly_test_limitations() {
 
     # All these invocations are expected to raise an error. If they
     # sneak-through that's a test failure.
-    run_check_rc bin/driver_test splinter_test --page-size 1024
-    run_check_rc bin/driver_test splinter_test --page-size 2000
-    run_check_rc bin/driver_test splinter_test --page-size 2048
-    run_check_rc bin/driver_test splinter_test --page-size 8192
+    run_check_rc "${BINDIR}"/driver_test splinter_test --page-size 1024
+    run_check_rc "${BINDIR}"/driver_test splinter_test --page-size 2000
+    run_check_rc "${BINDIR}"/driver_test splinter_test --page-size 2048
+    run_check_rc "${BINDIR}"/driver_test splinter_test --page-size 8192
 
     # Only --extent-size 131072 (i.e. 32 pages/extent) is valid.
-    run_check_rc bin/driver_test splinter_test --extent-size 2048
-    run_check_rc bin/driver_test splinter_test --extent-size 4096
-    run_check_rc bin/driver_test splinter_test --extent-size 40960
-    run_check_rc bin/driver_test splinter_test --extent-size 8192
-    run_check_rc bin/driver_test splinter_test --extent-size 135168
-    run_check_rc bin/driver_test splinter_test --extent-size 262144
+    run_check_rc "${BINDIR}"/driver_test splinter_test --extent-size 2048
+    run_check_rc "${BINDIR}"/driver_test splinter_test --extent-size 4096
+    run_check_rc "${BINDIR}"/driver_test splinter_test --extent-size 40960
+    run_check_rc "${BINDIR}"/driver_test splinter_test --extent-size 8192
+    run_check_rc "${BINDIR}"/driver_test splinter_test --extent-size 135168
+    run_check_rc "${BINDIR}"/driver_test splinter_test --extent-size 262144
 
     # Validate that test-configs honor min / max key-sizes
-    run_check_rc bin/driver_test splinter_test --key-size 0
-    run_check_rc bin/driver_test splinter_test --key-size 7
-    run_check_rc bin/driver_test splinter_test --key-size 122
-    run_check_rc bin/driver_test splinter_test --key-size 200
+    run_check_rc "${BINDIR}"/driver_test splinter_test --key-size 0
+    run_check_rc "${BINDIR}"/driver_test splinter_test --key-size 7
+    run_check_rc "${BINDIR}"/driver_test splinter_test --key-size 122
+    run_check_rc "${BINDIR}"/driver_test splinter_test --key-size 200
 
     # Invoke help usage; to confirm that it still works.
-    bin/driver_test splinter_test --help
+    "${BINDIR}"/driver_test splinter_test --help
 }
 
 # ##################################################################


### PR DESCRIPTION
Nightly tests executed under nightly_test_limitations() were broken
as the test binaries were being executed from bin/ dir. This has been
reworked to live under build/bin. Regression crept in from #341
@SHA f5de8cf. Fix is to consistently use $BINDIR handle to locate test
binaries.