### PR TITLE
(#391) Fix memory leaks found in ASAN-test runs of quick unit-tests.

### DIFF
--- a/tests/unit/splinterdb_quick_test.c
+++ b/tests/unit/splinterdb_quick_test.c
@@ -227,6 +227,8 @@ CTEST2(splinterdb_quick, test_apis_for_max_key_length)
    rc = splinterdb_lookup(data->kvsb, large_key, &result);
    ASSERT_EQUAL(0, rc);
    ASSERT_FALSE(splinterdb_lookup_found(&result));
+
+   splinterdb_lookup_result_deinit(&result);
 }
 
 /*
@@ -755,6 +757,8 @@ CTEST2(splinterdb_quick, test_custom_data_config)
    rc = splinterdb_lookup(data->kvsb, key, &result);
    ASSERT_EQUAL(0, rc);
    ASSERT_FALSE(splinterdb_lookup_found(&result));
+
+   splinterdb_lookup_result_deinit(&result);
 }
 
 CTEST2(splinterdb_quick, test_iterator_custom_comparator)


### PR DESCRIPTION
Couple of test cases in splinterdb_quick_test.c were missing a call
to splinterdb_lookup_result_deinit() before exiting the test case.
This causes memory leaks, detected on ASAN-test-runs. This commit
fixes those problems.