### PR TITLE
(#396) NULL-out input handle(s) after close(). Rename dismount -> unmount(), where applicable.

### DIFF
--- a/include/splinterdb/splinterdb.h
+++ b/include/splinterdb/splinterdb.h
@@ -99,7 +99,7 @@ splinterdb_open(const splinterdb_config *cfg, splinterdb **kvs);
 //
 // This will flush all data to disk and release all resources
 void
-splinterdb_close(splinterdb *kvs);
+splinterdb_close(splinterdb **kvs);
 
 // Register the current thread so that it can be used with splinterdb.
 // This causes scratch space to be allocated for the thread.

--- a/src/rc_allocator.c
+++ b/src/rc_allocator.c
@@ -323,7 +323,7 @@ rc_allocator_deinit(rc_allocator *al)
 
 /*
  *----------------------------------------------------------------------
- * rc_allocator_[dis]mount --
+ * rc_allocator_{mount,unmount} --
  *
  *      Loads the file system from disk
  *      Write the file system to disk
@@ -404,15 +404,15 @@ rc_allocator_mount(rc_allocator        *al,
 
 
 void
-rc_allocator_dismount(rc_allocator *al)
+rc_allocator_unmount(rc_allocator *al)
 {
    platform_status status;
 
    platform_default_log(
-      "Allocated at dismount: %lu MiB\n",
+      "Allocated at unmount: %lu MiB\n",
       B_TO_MiB(al->stats.curr_allocated * al->cfg->io_cfg->extent_size));
 
-   // persist the ref counts upon dismount.
+   // persist the ref counts upon unmount.
    uint32 io_size =
       ROUNDUP(al->cfg->extent_capacity, al->cfg->io_cfg->page_size);
    status =

--- a/src/rc_allocator.h
+++ b/src/rc_allocator.h
@@ -113,6 +113,6 @@ rc_allocator_mount(rc_allocator        *al,
                    platform_module_id   mid);
 
 void
-rc_allocator_dismount(rc_allocator *al);
+rc_allocator_unmount(rc_allocator *al);
 
 #endif /* __RC_ALLOCATOR_H */

--- a/src/splinterdb.c
+++ b/src/splinterdb.c
@@ -510,9 +510,9 @@ splinterdb_create_or_open(const splinterdb_config *kvs_cfg,      // IN
 deinit_cache:
    clockcache_deinit(&kvs->cache_handle);
 deinit_allocator:
-   rc_allocator_dismount(&kvs->allocator_handle);
+   rc_allocator_unmount(&kvs->allocator_handle);
 deinit_system:
-   task_system_destroy(kvs->heap_id, kvs->task_sys);
+   task_system_destroy(kvs->heap_id, &kvs->task_sys);
 deinit_iohandle:
    io_handle_deinit(&kvs->io_handle);
 deinit_kvhandle:
@@ -552,17 +552,19 @@ splinterdb_open(const splinterdb_config *cfg, // IN
  *-----------------------------------------------------------------------------
  */
 void
-splinterdb_close(splinterdb *kvs) // IN
+splinterdb_close(splinterdb **kvs_in) // IN
 {
+   splinterdb *kvs = *kvs_in;
    platform_assert(kvs != NULL);
 
-   trunk_dismount(kvs->spl);
+   trunk_unmount(&kvs->spl);
    clockcache_deinit(&kvs->cache_handle);
-   rc_allocator_dismount(&kvs->allocator_handle);
+   rc_allocator_unmount(&kvs->allocator_handle);
    io_handle_deinit(&kvs->io_handle);
-   task_system_destroy(kvs->heap_id, kvs->task_sys);
+   task_system_destroy(kvs->heap_id, &kvs->task_sys);
 
    platform_free(kvs->heap_id, kvs);
+   *kvs_in = (splinterdb *)NULL;
 }
 
 

--- a/src/task.c
+++ b/src/task.c
@@ -649,12 +649,14 @@ task_system_io_register_thread(task_system *ts)
 }
 
 void
-task_system_destroy(platform_heap_id hid, task_system *ts)
+task_system_destroy(platform_heap_id hid, task_system **ts_in)
 {
+   task_system *ts = *ts_in;
    for (task_type type = 0; type != NUM_TASK_TYPES; type++) {
       task_group_deinit(&ts->group[type]);
    }
    platform_free(hid, ts);
+   *ts_in = (task_system *)NULL;
 }
 
 uint64 *

--- a/src/task.h
+++ b/src/task.h
@@ -144,7 +144,7 @@ task_system_create(platform_heap_id    hid,
                    uint64              scratch_size);
 
 void
-task_system_destroy(platform_heap_id hid, task_system *ts);
+task_system_destroy(platform_heap_id hid, task_system **ts);
 
 
 void *

--- a/src/trunk.h
+++ b/src/trunk.h
@@ -380,7 +380,7 @@ trunk_mount(trunk_config     *cfg,
             allocator_root_id id,
             platform_heap_id  hid);
 void
-trunk_dismount(trunk_handle *spl);
+trunk_unmount(trunk_handle **spl);
 
 void
 trunk_perform_tasks(trunk_handle *spl);

--- a/tests/functional/btree_test.c
+++ b/tests/functional/btree_test.c
@@ -1664,7 +1664,7 @@ btree_test(int argc, char *argv[])
    clockcache_deinit(cc);
    platform_free(hid, cc);
    rc_allocator_deinit(&al);
-   test_deinit_task_system(hid, ts);
+   test_deinit_task_system(hid, &ts);
    rc = STATUS_OK;
 deinit_iohandle:
    io_handle_deinit(io);

--- a/tests/functional/cache_test.c
+++ b/tests/functional/cache_test.c
@@ -1125,7 +1125,7 @@ cache_test(int argc, char *argv[])
    clockcache_deinit(cc);
    platform_free(hid, cc);
    rc_allocator_deinit(&al);
-   test_deinit_task_system(hid, ts);
+   test_deinit_task_system(hid, &ts);
    rc = STATUS_OK;
 deinit_iohandle:
    io_handle_deinit(io);

--- a/tests/functional/filter_test.c
+++ b/tests/functional/filter_test.c
@@ -416,7 +416,7 @@ filter_test(int argc, char *argv[])
    clockcache_deinit(cc);
    platform_free(hid, cc);
    rc_allocator_deinit(&al);
-   test_deinit_task_system(hid, ts);
+   test_deinit_task_system(hid, &ts);
 deinit_iohandle:
    io_handle_deinit(io);
 free_iohandle:

--- a/tests/functional/log_test.c
+++ b/tests/functional/log_test.c
@@ -366,7 +366,7 @@ log_test(int argc, char *argv[])
    platform_free(hid, log);
    platform_free(hid, cc);
    rc_allocator_deinit(&al);
-   test_deinit_task_system(hid, ts);
+   test_deinit_task_system(hid, &ts);
 deinit_iohandle:
    io_handle_deinit(io);
 free_iohandle:

--- a/tests/functional/splinter_test.c
+++ b/tests/functional/splinter_test.c
@@ -2850,7 +2850,7 @@ splinter_test(int argc, char *argv[])
    platform_free(hid, cc);
    allocator_assert_noleaks(alp);
    rc_allocator_deinit(&al);
-   test_deinit_task_system(hid, ts);
+   test_deinit_task_system(hid, &ts);
 handle_deinit:
    io_handle_deinit(io);
 io_free:

--- a/tests/functional/test.h
+++ b/tests/functional/test.h
@@ -72,7 +72,7 @@ test_init_task_system(platform_heap_id    hid,
 }
 
 static inline void
-test_deinit_task_system(platform_heap_id hid, task_system *ts)
+test_deinit_task_system(platform_heap_id hid, task_system **ts)
 {
    task_system_destroy(hid, ts);
 }

--- a/tests/functional/ycsb_test.c
+++ b/tests/functional/ycsb_test.c
@@ -1336,11 +1336,11 @@ ycsb_test(int argc, char *argv[])
 
    run_all_ycsb_phases(spl, phases, nphases, ts, hid);
 
-   trunk_dismount(spl);
+   trunk_unmount(&spl);
    clockcache_deinit(cc);
    platform_free(hid, cc);
-   rc_allocator_dismount(&al);
-   test_deinit_task_system(hid, ts);
+   rc_allocator_unmount(&al);
+   test_deinit_task_system(hid, &ts);
    rc = STATUS_OK;
 
    // struct rusage usage;

--- a/tests/unit/limitations_test.c
+++ b/tests/unit/limitations_test.c
@@ -310,7 +310,7 @@ CTEST2(limitations, test_splinterdb_mount_invalid_key_size)
    int rc = splinterdb_create(&cfg, &kvsb);
    ASSERT_EQUAL(0, rc);
 
-   splinterdb_close(kvsb);
+   splinterdb_close(&kvsb);
 
    // We have carefully configured Splinter to use the default key-size
    // used by tests. Force-it to be an invalid value, to check that
@@ -506,7 +506,7 @@ splinter_deinit_subsystems(void *arg)
    allocator_assert_noleaks(alp);
 
    rc_allocator_deinit(&data->al);
-   test_deinit_task_system(data->hid, data->tasks);
+   test_deinit_task_system(data->hid, &data->tasks);
 
    io_handle_deinit(data->io);
    platform_free(data->hid, data->io);

--- a/tests/unit/splinter_test.c
+++ b/tests/unit/splinter_test.c
@@ -228,7 +228,7 @@ CTEST_TEARDOWN(splinter)
    allocator_assert_noleaks(alp);
 
    rc_allocator_deinit(&data->al);
-   test_deinit_task_system(data->hid, data->tasks);
+   test_deinit_task_system(data->hid, &data->tasks);
 
    io_handle_deinit(data->io);
    platform_free(data->hid, data->io);

--- a/tests/unit/splinterdb_quick_test.c
+++ b/tests/unit/splinterdb_quick_test.c
@@ -112,7 +112,7 @@ CTEST_SETUP(splinterdb_quick)
 // Optional teardown function for suite, called after every test in suite
 CTEST_TEARDOWN(splinterdb_quick)
 {
-   splinterdb_close(data->kvsb);
+   splinterdb_close(&data->kvsb);
 }
 
 /*
@@ -641,7 +641,7 @@ CTEST2(splinterdb_quick, test_close_and_reopen)
    ASSERT_EQUAL(0, rc);
 
    // Close and re-open the database
-   splinterdb_close(data->kvsb);
+   splinterdb_close(&data->kvsb);
    rc = splinterdb_open(&data->cfg, &data->kvsb);
    ASSERT_EQUAL(0, rc);
 
@@ -683,7 +683,7 @@ CTEST2(splinterdb_quick, test_repeated_insert_close_reopen)
          data->kvsb, slice_create(key_len, key), slice_create(val_len, val));
       ASSERT_EQUAL(0, rc, "Insert is expected to pass, iter=%d.", i);
 
-      splinterdb_close(data->kvsb);
+      splinterdb_close(&data->kvsb);
 
       rc = splinterdb_open(&data->cfg, &data->kvsb);
       ASSERT_EQUAL(0, rc);
@@ -696,7 +696,7 @@ CTEST2(splinterdb_quick, test_custom_data_config)
 {
    // We need to reconfigure Splinter with user-specified data_config
    // Tear down default instance, and create a new one.
-   splinterdb_close(data->kvsb);
+   splinterdb_close(&data->kvsb);
    data->cfg.data_cfg                 = test_data_config;
    data->cfg.data_cfg->key_size       = 20;
    data->cfg.data_cfg->max_key_length = 20;
@@ -765,7 +765,7 @@ CTEST2(splinterdb_quick, test_iterator_custom_comparator)
 {
    // We need to reconfigure Splinter with user-specified key comparator fn.
    // Tear down default instance, and create a new one.
-   splinterdb_close(data->kvsb);
+   splinterdb_close(&data->kvsb);
 
    data->default_data_cfg.super.key_compare = custom_key_comparator;
    data->default_data_cfg.num_comparisons   = 0;

--- a/tests/unit/splinterdb_stress_test.c
+++ b/tests/unit/splinterdb_stress_test.c
@@ -65,7 +65,7 @@ CTEST_SETUP(splinterdb_stress)
 // Optional teardown function for suite, called after every test in suite
 CTEST_TEARDOWN(splinterdb_stress)
 {
-   splinterdb_close(data->kvsb);
+   splinterdb_close(&data->kvsb);
 }
 
 // Do random inserts across multiple threads


### PR DESCRIPTION
Minor rework to tighten the interfaces which close / deinit sub-system handles:

- Rename "dismount" to "unmount"; as in 'trunk_unmount()'
- splinterdb_close(), trunk_unmount(), test_deinit_task_system(),
  task_system_destroy() now receive an addr-of-ptr to handle, and NULL-out
  the handle upon a successful close / unmount / deinit. This will cause
  a seg-fault if caller tries to access said handle after it has been closed.


-----

While developing C-example programs, I ran into some bad code (my own) while calling `splinterdb_close()`. 
I corrected the interface in my private branch, and then recollected that I had proposed to do this cleanup some weeks ago.
Peeling off this cleanup item as its own PR so that this rework can be done independently. 

It will help write out the C-example programs with a neat code-construct, calling `splinterdb_close(&splinter_handle)`, so as to inculcate proper form in application programs.