### PR TITLE
Set of example C-programs, to demonstrate use of SplinterDB APIs.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ INCDIR               = include
 FUNCTIONAL_TESTSDIR  = $(TESTS_DIR)/functional
 UNITDIR              = unit
 UNIT_TESTSDIR        = $(TESTS_DIR)/$(UNITDIR)
+EXAMPLES_DIR         = examples
 
 SRC := $(shell find $(SRCDIR) -name "*.c")
 
@@ -39,6 +40,8 @@ TESTSRC := $(COMMON_TESTSRC) $(FUNCTIONAL_TESTSRC) $(UNIT_TESTSRC)
 #  - Skip tests that are to be invoked with specialized command-line arguments.
 # These skipped tests which will have to be run stand-alone.
 FAST_UNIT_TESTSRC := $(shell find $(UNIT_TESTSDIR) -name "*.c" | egrep -v -e"splinter_test|config_parse_test")
+
+EXAMPLES_SRC := $(shell find $(EXAMPLES_DIR) -name "*.c")
 
 #*************************************************************#
 # CFLAGS, LDFLAGS, ETC
@@ -226,12 +229,18 @@ FAST_UNIT_TESTOBJS= $(FAST_UNIT_TESTSRC:%.c=$(OBJDIR)/%.o)
 UNIT_TESTBIN_SRC=$(filter %_test.c, $(UNIT_TESTSRC))
 UNIT_TESTBINS=$(UNIT_TESTBIN_SRC:$(TESTS_DIR)/%_test.c=$(BINDIR)/%_test)
 
+# ---- Symbols to build example sample programs
+EXAMPLES_OBJ= $(EXAMPLES_SRC:%.c=$(OBJDIR)/%.o)
+EXAMPLES_BIN_SRC=$(filter %_example.c, $(EXAMPLES_SRC))
+EXAMPLES_BINS=$(EXAMPLES_BIN_SRC:$(EXAMPLES_DIR)/%_example.c=$(BINDIR)/$(EXAMPLES_DIR)/%_example)
+
 ####################################################################
 # The main targets
 #
-all: libs all-tests $(EXTRA_TARGETS)
+all: libs all-tests all-examples $(EXTRA_TARGETS)
 libs: $(LIBDIR)/libsplinterdb.so $(LIBDIR)/libsplinterdb.a
 all-tests: $(BINDIR)/driver_test $(BINDIR)/unit_test $(UNIT_TESTBINS)
+all-examples: $(EXAMPLES_BINS)
 
 #######################################################################
 # CONFIGURATION CHECKING
@@ -331,6 +340,7 @@ $(BINDIR)/unit_test: $(FAST_UNIT_TESTOBJS) $(COMMON_TESTOBJ) $(LIBDIR)/libsplint
 # all the mini unit tests depend on these files
 $(UNIT_TESTBINS): $(OBJDIR)/$(UNIT_TESTSDIR)/main.o
 
+# -----------------------------------------------------------------------------
 # Every unit test of the form bin/unit/<test> depends on obj/tests/unit/<test>.o
 #
 # We can't use pattern rules to state this dependency pattern because
@@ -414,7 +424,7 @@ $(BINDIR)/$(UNITDIR)/config_parse_test: $(UTIL_SYS)                             
                                         $(LIBDIR)/libsplinterdb.so
 
 ########################################
-# Convenience targets
+# Convenience mini unit-test targets
 unit/util_test:                    $(BINDIR)/$(UNITDIR)/util_test
 unit/misc_test:                    $(BINDIR)/$(UNITDIR)/misc_test
 unit/btree_test:                   $(BINDIR)/$(UNITDIR)/btree_test
@@ -424,6 +434,25 @@ unit/splinterdb_quick_test:        $(BINDIR)/$(UNITDIR)/splinterdb_quick_test
 unit/splinterdb_stress_test:       $(BINDIR)/$(UNITDIR)/splinterdb_stress_test
 unit/writable_buffer_test:         $(BINDIR)/$(UNITDIR)/writable_buffer_test
 unit_test:                         $(BINDIR)/unit_test
+
+# -----------------------------------------------------------------------------
+# Every example program of the form bin/examples/<eg-prog> depends on
+# obj/examples/<eg-prog>.o
+
+#################################################################
+# The dependencies of each example program
+
+$(BINDIR)/$(EXAMPLES_DIR)/splinterdb_intro_example: $(OBJDIR)/$(EXAMPLES_DIR)/splinterdb_intro_example.o \
+                                                    $(LIBDIR)/libsplinterdb.so
+
+$(BINDIR)/$(EXAMPLES_DIR)/splinterdb_wide_values_example: $(OBJDIR)/$(EXAMPLES_DIR)/splinterdb_wide_values_example.o \
+                                                   $(LIBDIR)/libsplinterdb.so
+
+$(BINDIR)/$(EXAMPLES_DIR)/splinterdb_iterators_example: $(OBJDIR)/$(EXAMPLES_DIR)/splinterdb_iterators_example.o \
+                                                        $(LIBDIR)/libsplinterdb.so
+
+$(BINDIR)/$(EXAMPLES_DIR)/splinterdb_custom_ipv4_addr_sortcmp_example: $(OBJDIR)/$(EXAMPLES_DIR)/splinterdb_custom_ipv4_addr_sortcmp_example.o \
+                                                                       $(LIBDIR)/libsplinterdb.so
 
 #*************************************************************#
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,8 @@
 
 [Diagnostics](./diagnostics.md)
 
+[Example C-programs](../examples/README.md)
+
 [Contributing](../CONTRIBUTING.md)
 
 [Code of Conduct](../CODE-OF-CONDUCT.md)

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,33 @@
+# SplinterDB Example Programs
+
+The following example C-programs are useful to understand SplinterDB interfaces
+and the key-value APIs. The programs are laid out with slightly increasing
+complexity of the usages and program construction.
+
+> Try to work through these example programs by running them, in this order,
+  and review the output messages.
+
+[SplinterDB, Hello World! ](./splinterdb_intro_example.c)
+An introductory program that show how to configure and start a SplinterDB instance.
+And how to insert key-value pairs, do a lookup given a key, and to iterate through
+all key-value pairs in the database. Many of the commonly used interfaces can be
+seen in this program.
+
+[Handling wide values](./splinterdb_wide_values_example.c)
+Program shows how to work with wide-values and how to work with client-provided
+output buffers when retrieving data. Lookups of wide-values may trigger memory
+allocation if caller-provided output buffer is not wide enough.
+
+[Using Lookup Iterators](./splinterdb_iterators_example.c)
+Program demonstrates use of the iterator interfaces, using real-life data
+involving URLs mapped to inet-addresses, and other hard-coded 'ping' metrics.
+This program demonstrates the default storage order of keys, which is in
+lexicographic sort order.
+
+[Using Custom Key-Comparison](./splinterdb_custom_ipv4_addr_sortcmp_example.c)
+This program demonstrates the use of user-specified key-comparison routines. Here,
+the key is a 4-part IP4 ip-address (stored as a string; e.g. "33.24.128.22"). The
+key is mapped to a payload consisting of the www-URL, and some hard-coded 'ping'
+metrics. A custom key-comparison function is provided while configuring
+SplinterDB to generate numerically sorted ordering for the constituent parts of
+the IP-address.

--- a/examples/splinterdb_custom_ipv4_addr_sortcmp_example.c
+++ b/examples/splinterdb_custom_ipv4_addr_sortcmp_example.c
@@ -1,0 +1,390 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+ * ----------------------------------------------------------------------------
+ * SplinterDB Advanced Iterators Example Program with custom sort-comparison.
+ *
+ * What's new beyond previous splinterdb_iterators_example.c?
+ *
+ * In this program, we show the application of user-specified custom
+ * key-comparison routines. The 'key' here is the 4-part IP-address, which
+ * is stored as the string seen from 'ping'; i.e. "208.80.154.232" .
+ * To illustrate the use of user-defined keys, we then provide a
+ * sort-comparison routine, which splits up the IP-address to its
+ * constituent parts, and does a numeric comparison of each 1-byte value.
+ *
+ * See:
+ * - The definition of custom splinter_data_cfg.key_compare to the
+ *   user-provided comparison function, custom_key_compare()
+ * - The ip4_ipaddr_keycmp() and ip4_split() functions that show how one
+ *   can deal with application-specific key formats.
+ * ----------------------------------------------------------------------------
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <string.h>
+
+#include "splinterdb/default_data_config.h"
+#include "splinterdb/splinterdb.h"
+
+/*
+ * App-specific 'defaults' that can be parameterized, eventually.
+ */
+#define DB_FILE_NAME    "splinterdb_custom_ipv4_sortcmp_example_db"
+#define DB_FILE_SIZE_MB 1024 // Size of SplinterDB device; Fixed when created
+#define CACHE_SIZE_MB   64   // Size of cache; can be changed across boots
+
+// Describe the layout of fields in an IP4-address
+#define IPV4_NUM_FIELDS 4
+#define IPV4_NUM_DOTS   (IPV4_NUM_FIELDS - 1)
+
+#define IP4_MIN_KEY_SIZE ((1 * IPV4_NUM_FIELDS) + IPV4_NUM_DOTS)
+
+// Application declares the limit of key-sizes it intends to use
+#define IP4_MAX_KEY_SIZE ((3 * IPV4_NUM_FIELDS) + IPV4_NUM_DOTS)
+
+// Max # of chars in a well-formed IP4 address, including null-terminator byte
+#define IPV4_MAX_KEY_BUF_SIZE (IP4_MAX_KEY_SIZE + 1)
+
+// Key is a 4-part inet-address string, whose value is a description of
+// the IP-address: its www-name, and some ping metrics.
+typedef struct www_ping_metrics {
+   uint32     ttl_ms; // Time-to-live
+   uint32     rtt_ms; // Round trip time
+   const char www_name[30];
+} www_ping_metrics;
+
+#define WWW_PING_SIZE(p)                                                       \
+   (size_t)(offsetof(www_ping_metrics, www_name) + strlen((p)->www_name))
+
+typedef struct kv_pair {
+   char            *kv_key;
+   www_ping_metrics kv_val;
+} kv_pair;
+
+// clang-format off
+// Define a hard-coded array of key-value pairs to load
+// Mapping from inet-IP address to www.address etc.
+kv_pair inet_addr_info[] =
+{
+    //   ip-address             ttl  rtt   www-address
+      { "5.79.89.114"       , {  47, 171, "www.acm.org" } }
+    , { "208.80.154.232"    , {  52,  99, "www.wikidpedia.org" } }
+    , { "151.101.188.81"    , {  57,  28, "www.bbc.com" } }
+    , { "99.84.238.130"     , { 240,  46, "www.worldbank.org" } }
+    , { "10.113.78.20"      , {  57,  32, "www.vmware.com" } }
+    , { "34.102.136.180"    , {  116, 33, "www.eiffeltower.com" } }
+    , { "184.26.53.176"     , {  56,  33, "www.rediff.com" } }
+    , { "151.101.190.154"   , {  58,  37, "www.cnet.com" } }
+    , { "104.244.42.129"    , {  52,  74, "www.twitter.com" } }
+    , { "104.143.9.110"     , {  49,  91, "www.hongkongair.com" } }
+};
+
+int num_inet_addrs = (sizeof(inet_addr_info) / sizeof(*inet_addr_info));
+
+// clang-format on
+
+// Define min/max key values for user-defined IP4-addr keys
+#define IP4ADDR_MIN_KEY "0.0.0.0"
+#define IP4ADDR_MAX_KEY "255.255.255.255"
+
+// Function Prototypes
+static void
+configure_splinter_instance(splinterdb_config *splinterdb_cfg,
+                            data_config       *splinter_data_cfg,
+                            const char        *filename,
+                            uint64             dev_size,
+                            uint64             cache_size);
+
+int
+custom_key_compare(const data_config *cfg, slice key1, slice key2);
+
+int
+ip4_ipaddr_keycmp(const char  *key1,
+                  const size_t key1_len,
+                  const char  *key2,
+                  const size_t key2_len);
+
+int
+ip4_split(int *key_fields, const char *key, const size_t key_len);
+
+static void
+do_inserts(splinterdb *spl_handle, kv_pair *kv_pairs, int num_kv_pairs);
+
+static int
+do_iterate_from(splinterdb *spl_handle, const char *from_key);
+
+static void
+print_ping_metrics(int kctr, slice key, slice value);
+
+/*
+ * -----------------------------------------------------------------------------
+ * main() Driver for SplinterDB program for iterators interfaces.
+ * -----------------------------------------------------------------------------
+ */
+int
+main()
+{
+   printf("     **** SplinterDB Iterators example program: "
+          "Custom sort comparison  ****\n\n");
+
+   // Initialize data configuration, describing your key-value properties
+   data_config splinter_data_cfg;
+   default_data_config_init(IP4_MAX_KEY_SIZE, &splinter_data_cfg);
+
+   // -- ACTION IS HERE --
+   // Customize key-comparison with our implementation for IP4 addresses
+   // **** NOTE **** Custom key-comparision function needs to be provided
+   // up-front. Every insert will invoke this method to insert the new key
+   // in custom-sorted order.
+   sprintf(splinter_data_cfg.min_key, "%s", IP4ADDR_MIN_KEY);
+   sprintf(splinter_data_cfg.max_key, "%s", IP4ADDR_MAX_KEY);
+
+   splinter_data_cfg.min_key_length = strlen(splinter_data_cfg.min_key);
+   splinter_data_cfg.max_key_length = strlen(splinter_data_cfg.max_key);
+   splinter_data_cfg.key_compare    = custom_key_compare;
+
+   // Basic configuration of a SplinterDB instance
+   splinterdb_config splinterdb_cfg;
+   configure_splinter_instance(&splinterdb_cfg,
+                               &splinter_data_cfg,
+                               DB_FILE_NAME,
+                               (DB_FILE_SIZE_MB * 1024 * 1024),
+                               (CACHE_SIZE_MB * 1024 * 1024));
+
+   splinterdb *spl_handle = NULL; // To a running SplinterDB instance
+
+   int rc = splinterdb_create(&splinterdb_cfg, &spl_handle);
+   if (rc) {
+      printf("SplinterDB creation failed. (rc=%d)\n", rc);
+      return rc;
+   }
+
+   printf("Insert and iterate through %d {ipaddr} -> {www-url, metrics} "
+          "mapping table:\n",
+          num_inet_addrs);
+   do_inserts(spl_handle, inet_addr_info, num_inet_addrs);
+
+   // NULL start_key => Iterate through all key-value pairs
+   do_iterate_from(spl_handle, NULL);
+
+   const char *start_key = "99.84.238.130";
+   do_iterate_from(spl_handle, start_key);
+
+   // Specify a non-existent start key; Scan should return from 104.143.9.110
+   start_key = "100.101.102.103";
+   do_iterate_from(spl_handle, start_key);
+
+   splinterdb_close(&spl_handle);
+   printf("Shutdown SplinterDB instance, dbname '%s'.\n\n", DB_FILE_NAME);
+
+   return rc;
+}
+
+/*
+ * -----------------------------------------------------------------------------
+ * configure_splinter_instance()
+ *
+ * Basic configuration of a SplinterDB instance, specifying min parameters such
+ * as the device's name, device and cache sizes.
+ * -----------------------------------------------------------------------------
+ */
+static void
+configure_splinter_instance(splinterdb_config *splinterdb_cfg,
+                            data_config       *splinter_data_cfg,
+                            const char        *filename,
+                            uint64             dev_size, // in bytes
+                            uint64             cache_size)           // in bytes
+{
+   memset(splinterdb_cfg, 0, sizeof(*splinterdb_cfg));
+   splinterdb_cfg->filename   = filename;
+   splinterdb_cfg->disk_size  = dev_size;
+   splinterdb_cfg->cache_size = cache_size;
+   splinterdb_cfg->data_cfg   = splinter_data_cfg;
+   return;
+}
+
+/*
+ * -----------------------------------------------------------------------------
+ * custom_key_compare() - Implement custom key-comparison function
+ * -----------------------------------------------------------------------------
+ */
+int
+custom_key_compare(const data_config *cfg, slice key1, slice key2)
+{
+   return ip4_ipaddr_keycmp((const char *)slice_data(key1),
+                            slice_length(key1),
+                            (const char *)slice_data(key2),
+                            slice_length(key2));
+}
+
+/*
+ * -----------------------------------------------------------------------------
+ * ipaddr_keycmp() - Custom IPV4 IP-address key-comparison routine.
+ *
+ * -- ACTION IS HERE --
+ * 'key1' and 'key2' are expected to be well-formed IP4 addresses.
+ * - Extract each of the 4 parts of the IP-address
+ * - Implement comparison by numerical sort-order of each part.
+ *
+ * Returns: See below:
+ * -----------------------------------------------------------------------------
+ */
+/* Return value expected from key comparison routine */
+#define KEYCMP_RV_KEY1_LT_KEY2 ((int)-1)
+#define KEYCMP_RV_KEY1_EQ_KEY2 ((int)0)
+#define KEYCMP_RV_KEY1_GT_KEY2 ((int)1)
+
+int
+ip4_ipaddr_keycmp(const char  *key1,
+                  const size_t key1_len,
+                  const char  *key2,
+                  const size_t key2_len)
+{
+   int key1_fields[IPV4_NUM_FIELDS];
+   int key2_fields[IPV4_NUM_FIELDS];
+
+   ip4_split(key1_fields, key1, key1_len);
+   ip4_split(key2_fields, key2, key2_len);
+
+   // Do a field-by-field comparison to return in sorted order.
+   int *key1p = key1_fields;
+   int *key2p = key2_fields;
+
+   // When we exit loop below, both keys are known to match.
+   int rv   = KEYCMP_RV_KEY1_EQ_KEY2;
+   int fctr = 0;
+   do {
+      if (*key1p < *key2p) {
+         return KEYCMP_RV_KEY1_LT_KEY2;
+      } else if (*key1p == *key2p) {
+         // Advance to next field in address for both keys
+         key1p++;
+         key2p++;
+         fctr++;
+      } else {
+         return KEYCMP_RV_KEY1_GT_KEY2;
+      }
+   } while (fctr < IPV4_NUM_FIELDS);
+
+   return rv;
+}
+
+/*
+ * -----------------------------------------------------------------------------
+ * ip4_split() - Split a well-formed IPV4-address into its constituent parts.
+ *
+ * Returns: Output array key_fields[], populated with each piece of IP-address.
+ * -----------------------------------------------------------------------------
+ */
+int
+ip4_split(int *key_fields, const char *key, const size_t key_len)
+{
+   assert(key_len < IPV4_MAX_KEY_BUF_SIZE);
+
+   // Process on-stack copy of key, so as to not trash user's data
+   char keybuf[IPV4_MAX_KEY_BUF_SIZE];
+   snprintf(keybuf, sizeof(keybuf), "%.*s", (int)key_len, key);
+
+   char *cp   = (char *)keybuf;
+   char *dot  = NULL;
+   int   fctr = 0;
+
+   // Split each ip-address into its constituent parts
+   while ((dot = strchr(cp, '.')) != NULL) {
+      *dot             = '\n';
+      key_fields[fctr] = atoi(cp);
+      fctr++;
+      cp = (dot + 1);
+   }
+   key_fields[fctr] = atoi(cp);
+   fctr++;
+
+   return fctr;
+}
+
+/*
+ * -----------------------------------------------------------------------------
+ * do_inserts()
+ *
+ * Insert a small number of key-value pairs.
+ * -----------------------------------------------------------------------------
+ */
+static void
+do_inserts(splinterdb *spl_handle, kv_pair *kv_pairs, int num_kv_pairs)
+{
+   int ictr = 0;
+   for (; ictr < num_kv_pairs; ictr++) {
+      slice key =
+         slice_create(strlen(kv_pairs[ictr].kv_key), kv_pairs[ictr].kv_key);
+      slice value = slice_create(WWW_PING_SIZE(&kv_pairs[ictr].kv_val),
+                                 (const char *)&kv_pairs[ictr].kv_val);
+      int   rc    = splinterdb_insert(spl_handle, key, value);
+      if (rc) {
+         printf(
+            "Insert of key '%s' failed; rc=%d\n", kv_pairs[ictr].kv_key, rc);
+         return;
+      }
+   }
+   printf("Inserted %d key-value pairs for inet-addr ping times.\n\n", ictr);
+}
+
+/*
+ * ---------------------------------------------------------------------------
+ * do_iterate_from()
+ *
+ * Implement basic iterator interfaces to scan through all key-value pairs,
+ * starting from an initial search key.
+ * ----------------------------------------------------------------------------
+ */
+static int
+do_iterate_from(splinterdb *spl_handle, const char *from_key)
+{
+   printf("Iterate through all the keys starting from '%s':\n", from_key);
+
+   splinterdb_iterator *it = NULL;
+
+   // Initialize start key if initial search key was provided.
+   slice start_key =
+      (from_key ? slice_create(strlen(from_key), from_key) : NULL_SLICE);
+   int rc = splinterdb_iterator_init(spl_handle, &it, start_key);
+
+   int i = 0;
+
+   for (; splinterdb_iterator_valid(it); splinterdb_iterator_next(it)) {
+      slice key, value;
+      splinterdb_iterator_get_current(it, &key, &value);
+      print_ping_metrics(i, key, value);
+      i++;
+   }
+   rc = splinterdb_iterator_status(it);
+   splinterdb_iterator_deinit(it);
+
+   printf("Found %d key-value pairs\n\n", i);
+   return rc;
+}
+
+/*
+ * ---------------------------------------------------------------------------
+ * print_ping_metrics()
+ *
+ * Decode a key/value pair and print ping-metrics.
+ * ----------------------------------------------------------------------------
+ */
+static void
+print_ping_metrics(int kctr, slice key, slice value)
+{
+   www_ping_metrics *ping_value;
+   ping_value = ((www_ping_metrics *)slice_data(value));
+   printf("[%d] key='%.*s', value=[ttl=%u, time=%u, name='%.*s']\n",
+          kctr,
+          (int)slice_length(key),
+          (char *)slice_data(key),
+          ping_value->ttl_ms,
+          ping_value->rtt_ms,
+          (int)(slice_length(value) - 8),
+          ping_value->www_name);
+}

--- a/examples/splinterdb_intro_example.c
+++ b/examples/splinterdb_intro_example.c
@@ -1,0 +1,137 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+/*
+ * SplinterDB "Hello World" example program. Demonstrate use of:
+ *  - Basic SplinterDB configuration and create() interface
+ *  - Insert, lookup and iterator interfaces
+ *  - Close and reopen a SplinterDB db (instance)
+ */
+#include <stdio.h>
+#include <string.h>
+
+#include "splinterdb/default_data_config.h"
+#include "splinterdb/splinterdb.h"
+
+#define DB_FILE_NAME    "splinterdb_intro_db"
+#define DB_FILE_SIZE_MB 1024 // Size of SplinterDB device; Fixed when created
+#define CACHE_SIZE_MB   64   // Size of cache; can be changed across boots
+
+/* Application declares the limit of key-sizes it intends to use */
+#define USER_MAX_KEY_SIZE ((int)100)
+
+/*
+ * -------------------------------------------------------------------------------
+ * We, intentionally, do not check for errors or show error handling, as this is
+ * mostly a sample program to illustrate how-to use the APIs.
+ * -------------------------------------------------------------------------------
+ */
+int
+main()
+{
+   printf("     **** SplinterDB Basic example program ****\n\n");
+
+   // Initialize data configuration, using default key-comparison handling.
+   data_config splinter_data_cfg;
+   default_data_config_init(USER_MAX_KEY_SIZE, &splinter_data_cfg);
+
+   // Basic configuration of a SplinterDB instance
+   splinterdb_config splinterdb_cfg;
+   memset(&splinterdb_cfg, 0, sizeof(splinterdb_cfg));
+   splinterdb_cfg.filename   = DB_FILE_NAME;
+   splinterdb_cfg.disk_size  = (DB_FILE_SIZE_MB * 1024 * 1024);
+   splinterdb_cfg.cache_size = (CACHE_SIZE_MB * 1024 * 1024);
+   splinterdb_cfg.data_cfg   = &splinter_data_cfg;
+
+   splinterdb *spl_handle = NULL; // To a running SplinterDB instance
+
+   int rc = splinterdb_create(&splinterdb_cfg, &spl_handle);
+   printf("Created SplinterDB instance, dbname '%s'.\n\n", DB_FILE_NAME);
+
+   // Insert a few kv-pairs, describing properties of fruits.
+   const char *fruit = "apple";
+   const char *descr = "An apple a day keeps the doctor away!";
+   slice       key   = slice_create((size_t)strlen(fruit), fruit);
+   slice       value = slice_create((size_t)strlen(descr), descr);
+
+   rc = splinterdb_insert(spl_handle, key, value);
+   printf("Inserted key '%s'\n", fruit);
+
+   fruit = "Orange";
+   descr = "Is a good source of vitamin-C.";
+   key   = slice_create((size_t)strlen(fruit), fruit);
+   value = slice_create((size_t)strlen(descr), descr);
+   rc    = splinterdb_insert(spl_handle, key, value);
+   printf("Inserted key '%s'\n", fruit);
+
+   fruit = "Mango";
+   descr = "Mango is the king of fruits.";
+   key   = slice_create((size_t)strlen(fruit), fruit);
+   value = slice_create((size_t)strlen(descr), descr);
+   rc    = splinterdb_insert(spl_handle, key, value);
+   printf("Inserted key '%s'\n", fruit);
+
+   // Retrieve a key-value pair.
+   splinterdb_lookup_result result;
+   splinterdb_lookup_result_init(spl_handle, &result, 0, NULL);
+
+   fruit = "Orange";
+   key   = slice_create((size_t)strlen(fruit), fruit);
+   rc    = splinterdb_lookup(spl_handle, key, &result);
+   rc    = splinterdb_lookup_result_value(spl_handle, &result, &value);
+   if (!rc) {
+      printf("Found key: '%s', value: '%.*s'\n",
+             fruit,
+             (int)slice_length(value),
+             (char *)slice_data(value));
+   }
+
+   // Handling non-existent keys
+   fruit = "Banana";
+   key   = slice_create((size_t)strlen(fruit), fruit);
+   rc    = splinterdb_lookup(spl_handle, key, &result);
+   rc    = splinterdb_lookup_result_value(spl_handle, &result, &value);
+   if (rc) {
+      printf("Key: '%s' not found. (rc=%d)\n", fruit, rc);
+   }
+   printf("\n");
+
+   printf("Shutdown and reopen SplinterDB instance ...\n");
+   splinterdb_close(&spl_handle);
+
+   rc = splinterdb_open(&splinterdb_cfg, &spl_handle);
+   if (rc) {
+      printf("Error re-opening SplinterDB instance, dbname '%s' (rc=%d).\n",
+             DB_FILE_NAME,
+             rc);
+      return (rc);
+   }
+
+   // Retrieve all the key-value pairs from the database
+   printf("Iterate through all the key-value pairs"
+          " returning keys in lexicographic sort order:\n");
+
+   splinterdb_iterator *it = NULL;
+   rc = splinterdb_iterator_init(spl_handle, &it, NULL_SLICE);
+
+   int i = 0;
+   for (; splinterdb_iterator_valid(it); splinterdb_iterator_next(it)) {
+      slice key, value;
+      splinterdb_iterator_get_current(it, &key, &value);
+      printf("  [%d] key='%.*s', value='%.*s'\n",
+             i,
+             (int)slice_length(key),
+             (char *)slice_data(key),
+             (int)slice_length(value),
+             (char *)slice_data(value));
+      i++;
+   }
+   rc = splinterdb_iterator_status(it);
+   splinterdb_iterator_deinit(it);
+
+   printf("Found %d key-value pairs\n\n", i);
+
+   splinterdb_close(&spl_handle);
+   printf("Shutdown SplinterDB instance, dbname '%s'.\n\n", DB_FILE_NAME);
+
+   return rc;
+}

--- a/examples/splinterdb_iterators_example.c
+++ b/examples/splinterdb_iterators_example.c
@@ -1,0 +1,168 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+ * SplinterDB Iterators example program, using start-key for scan.
+ */
+#include <stdio.h>
+#include <string.h>
+
+#include "splinterdb/default_data_config.h"
+#include "splinterdb/splinterdb.h"
+
+#define DB_FILE_NAME    "splinterdb_iterators_example_db"
+#define DB_FILE_SIZE_MB 1024 // Size of SplinterDB device; Fixed when created
+#define CACHE_SIZE_MB   64   // Size of cache; can be changed across boots
+
+/* Application declares the limit of key-sizes it intends to use */
+#define USER_MAX_KEY_SIZE ((int)100)
+
+// Declare a struct to build a key/value pair
+typedef struct kv_pair {
+   char *kv_key;
+   char *kv_val;
+} kv_pair;
+
+// clang-format off
+// Define an array of key-value pairs to load
+// Mapping from www.address to inet-IP address etc.
+kv_pair www_inet_info[] =
+{
+      { "www.acm.org"         , "5.79.89.114, ttl=47 time=171.147 ms" }
+    , { "www.wikidpedia.org"  , "208.80.154.232, ttl=52 time=99.427 ms" }
+    , { "www.bbc.com"         , "151.101.188.81, ttl=57 time=28.620 ms" }
+    , { "www.worldbank.org"   , "99.84.238.130, ttl=240 time=46.452 ms" }
+    , { "www.vmware.com"      , "10.113.78.20, ttl=57 time=31.888 ms" }
+    , { "www.eiffeltower.com" , "34.102.136.180, ttl=116 time=33.266 ms" }
+    , { "www.rediff.com"      , "184.26.53.176, ttl=56 time=33.587 ms" }
+    , { "www.cnet.com"        , "151.101.190.154, ttl=58 time=37.691 ms" }
+    , { "www.hongkongair.com" , "104.143.9.110, ttl=49 time=91.059 ms" }
+};
+
+int num_www_addrs = (sizeof(www_inet_info) / sizeof(*www_inet_info));
+
+// clang-format on
+
+// Function Prototypes
+static void
+do_inserts(splinterdb *spl_handle, kv_pair *kv_pairs, int num_kv_pairs);
+
+static int
+do_iterate_from(splinterdb *spl_handle, const char *from_key);
+
+/*
+ * -----------------------------------------------------------------------------
+ * main() Driver for SplinterDB program for iterators interfaces.
+ * -----------------------------------------------------------------------------
+ */
+int
+main()
+{
+   printf("     **** SplinterDB Iterators example program: "
+          "Lexicographic sort comparison  ****\n\n");
+
+   // Initialize data configuration, using default key-comparison handling.
+   data_config splinter_data_cfg;
+   default_data_config_init(USER_MAX_KEY_SIZE, &splinter_data_cfg);
+
+   // Basic configuration of a SplinterDB instance
+   splinterdb_config splinterdb_cfg;
+   memset(&splinterdb_cfg, 0, sizeof(splinterdb_cfg));
+   splinterdb_cfg.filename   = DB_FILE_NAME;
+   splinterdb_cfg.disk_size  = (DB_FILE_SIZE_MB * 1024 * 1024);
+   splinterdb_cfg.cache_size = (CACHE_SIZE_MB * 1024 * 1024);
+   splinterdb_cfg.data_cfg   = &splinter_data_cfg;
+
+   splinterdb *spl_handle = NULL; // To a running SplinterDB instance
+
+   int rc = splinterdb_create(&splinterdb_cfg, &spl_handle);
+   printf("Created SplinterDB instance, dbname '%s'.\n\n", DB_FILE_NAME);
+
+   printf("Insert and iterate through %d {www-url} -> {ipaddr, metrics} "
+          "mapping table:\n",
+          num_www_addrs);
+   do_inserts(spl_handle, www_inet_info, num_www_addrs);
+
+   // Iterate through all key-value pairs, w/o specifying start-key
+   do_iterate_from(spl_handle, NULL);
+
+   const char *start_key = "www.eiffeltower.com";
+   do_iterate_from(spl_handle, start_key);
+
+   // Iteration should start from key past the non-existent start-key
+   start_key = "www.twitter.com";
+   do_iterate_from(spl_handle, start_key);
+
+   splinterdb_close(&spl_handle);
+   printf("Shutdown SplinterDB instance, dbname '%s'.\n\n", DB_FILE_NAME);
+
+   return rc;
+}
+
+/*
+ * -----------------------------------------------------------------------------
+ * do_inserts()
+ *
+ * Insert a small number of key-value pairs.
+ * -----------------------------------------------------------------------------
+ */
+static void
+do_inserts(splinterdb *spl_handle, kv_pair *kv_pairs, int num_kv_pairs)
+{
+   int ictr = 0;
+   for (; ictr < num_kv_pairs; ictr++) {
+      slice key =
+         slice_create(strlen(kv_pairs[ictr].kv_key), kv_pairs[ictr].kv_key);
+      slice value =
+         slice_create(strlen(kv_pairs[ictr].kv_val), kv_pairs[ictr].kv_val);
+      int rc = splinterdb_insert(spl_handle, key, value);
+      if (rc) {
+         printf(
+            "Insert for key='%s' failed, rc=%d\n", kv_pairs[ictr].kv_key, rc);
+         return;
+      }
+   }
+   printf("Inserted %d unordered key-value pairs for inet-addr ping times.\n\n",
+          ictr);
+}
+
+/*
+ * ---------------------------------------------------------------------------
+ * do_iterate_from()
+ *
+ * Implement basic iterator interfaces to scan through all key-value pairs,
+ * starting from an initial search key. If start key is NULL, return all pairs.
+ * ----------------------------------------------------------------------------
+ */
+static int
+do_iterate_from(splinterdb *spl_handle, const char *from_key)
+{
+   printf("Iterate through all the keys starting from '%s':\n", from_key);
+
+   splinterdb_iterator *it = NULL;
+
+   // -- ACTION IS HERE --
+   // Initialize start key if initial search key was provided.
+   slice start_key =
+      (from_key ? slice_create(strlen(from_key), from_key) : NULL_SLICE);
+   int rc = splinterdb_iterator_init(spl_handle, &it, start_key);
+
+   int i = 0;
+
+   for (; splinterdb_iterator_valid(it); splinterdb_iterator_next(it)) {
+      slice key, value;
+      splinterdb_iterator_get_current(it, &key, &value);
+      printf("[%d] key='%.*s', value='%.*s'\n",
+             i,
+             (int)slice_length(key),
+             (char *)slice_data(key),
+             (int)slice_length(value),
+             (char *)slice_data(value));
+      i++;
+   }
+   rc = splinterdb_iterator_status(it);
+   splinterdb_iterator_deinit(it);
+
+   printf("Found %d key-value pairs\n\n", i);
+   return rc;
+}

--- a/examples/splinterdb_wide_values_example.c
+++ b/examples/splinterdb_wide_values_example.c
@@ -1,0 +1,115 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+ * SplinterDB Wide values APIs example program.
+ */
+#include <stdio.h>
+#include <string.h>
+
+#include "splinterdb/default_data_config.h"
+#include "splinterdb/splinterdb.h"
+
+#define DB_FILE_NAME    "splinterdb_wide_values_example_db"
+#define DB_FILE_SIZE_MB 1024 // Size of SplinterDB device; Fixed when created
+#define CACHE_SIZE_MB   64   // Size of cache; can be changed across boots
+
+/* Application declares the limit of key-sizes it intends to use */
+#define USER_MAX_KEY_SIZE ((int)100)
+
+/* Avg value size and max value sizes we expect to deal with in this program */
+#define USER_AVG_VALUE_SIZE ((int)128)
+#define USER_MAX_VALUE_SIZE ((int)1024)
+
+/*
+ * -------------------------------------------------------------------------------
+ * main() for SplinterDB program handling inserts & lookups of wide values.
+ * -------------------------------------------------------------------------------
+ */
+int
+main()
+{
+   printf("     **** SplinterDB Wide Values APIs example program ****\n\n");
+
+   // Initialize data configuration, using default key-comparison handling.
+   data_config splinter_data_cfg;
+   default_data_config_init(USER_MAX_KEY_SIZE, &splinter_data_cfg);
+
+   // Basic configuration of a SplinterDB instance
+   splinterdb_config splinterdb_cfg;
+   memset(&splinterdb_cfg, 0, sizeof(splinterdb_cfg));
+   splinterdb_cfg.filename   = DB_FILE_NAME;
+   splinterdb_cfg.disk_size  = (DB_FILE_SIZE_MB * 1024 * 1024);
+   splinterdb_cfg.cache_size = (CACHE_SIZE_MB * 1024 * 1024);
+   splinterdb_cfg.data_cfg   = &splinter_data_cfg;
+
+   splinterdb *spl_handle = NULL; // To a running SplinterDB instance
+
+   int rc = splinterdb_create(&splinterdb_cfg, &spl_handle);
+   printf("Created SplinterDB instance, dbname '%s'.\n\n", DB_FILE_NAME);
+
+   // -- ACTION IS HERE --
+   char key_buf[USER_MAX_KEY_SIZE];
+   char val_buf[USER_MAX_VALUE_SIZE];
+
+   int nrows = 0;
+   // Insert few values doubling value-size for each new key inserted
+   for (int val_len = 16; val_len <= USER_MAX_VALUE_SIZE;
+        val_len <<= 1, nrows++) {
+      snprintf(key_buf, sizeof(key_buf), "Key with val_len=%d", val_len);
+      memset(val_buf, 'z', val_len);
+
+      slice key   = slice_create(strlen(key_buf), key_buf);
+      slice value = slice_create(val_len, val_buf);
+      rc          = splinterdb_insert(spl_handle, key, value);
+      if (rc) {
+         break;
+      }
+   }
+   printf("Inserted %d rows with wide-values\n", nrows);
+
+   nrows = 0;
+
+   // Initialize a result struct, providing an output buffer for use
+   char outbuf[USER_AVG_VALUE_SIZE];
+
+   splinterdb_lookup_result result;
+   splinterdb_lookup_result_init(spl_handle, &result, sizeof(outbuf), outbuf);
+
+   printf("Retrieve values of different lengths using output buffer of"
+          " fixed size=%lu bytes:\n",
+          sizeof(outbuf));
+
+   // Lookup keys which have increasingly wider-values, using a small fixed size
+   // output buffer. When necessary, memory will be allocated for wider values.
+   for (int val_len = 16; val_len <= USER_MAX_VALUE_SIZE;
+        val_len <<= 1, nrows++) {
+
+      char key_buf[USER_MAX_KEY_SIZE];
+      snprintf(key_buf, sizeof(key_buf), "Key with val_len=%d", val_len);
+      size_t key_len = strlen(key_buf);
+
+      slice key = slice_create(key_len, key_buf);
+      rc        = splinterdb_lookup(spl_handle, key, &result);
+
+      slice value;
+      rc = splinterdb_lookup_result_value(spl_handle, &result, &value);
+      if (!rc) {
+         printf(
+            "  [%d] Found key (key_len=%d): '%.*s', value length found = %lu\n",
+            nrows,
+            (int)key_len,
+            (int)key_len,
+            key_buf,
+            slice_length(value));
+      } else {
+         printf("Did not find key '%.*s'.\n", (int)key_len, key_buf);
+      }
+   }
+   splinterdb_lookup_result_deinit(&result);
+
+   splinterdb_close(&spl_handle);
+   printf("Shutdown SplinterDB instance, dbname '%s'.\n\n", DB_FILE_NAME);
+
+   return rc;
+}

--- a/src/trunk.c
+++ b/src/trunk.c
@@ -1372,7 +1372,13 @@ trunk_find_pivot(trunk_handle *spl,
             debug_assert(cmp < 0);
             return 0;
          case less_than_or_equal:
-            debug_assert(cmp <= 0);
+            debug_assert(cmp <= 0,
+                         "cmp=%d, key='%.*s' ['%.*s']",
+                         cmp,
+                         (int)trunk_key_size(spl),
+                         key,
+                         (int)*key,
+                         (key + 1));
             return 0;
          case greater_than:
             return cmp > 0 ? 0 : 1;
@@ -1496,7 +1502,8 @@ trunk_add_pivot_new_root(trunk_handle *spl,
 {
    const char *pivot_key                       = trunk_get_pivot(spl, child, 0);
    __attribute__((unused)) const char *min_key = spl->cfg.data_cfg->min_key;
-   debug_assert(trunk_key_compare(spl, pivot_key, min_key) == 0);
+   debug_only const int key_cmp_rv = trunk_key_compare(spl, pivot_key, min_key);
+   debug_assert((key_cmp_rv == 0), "key_cmp_rv=%d\n", key_cmp_rv);
 
    const char *max_key = spl->cfg.data_cfg->max_key;
    trunk_set_initial_pivots(spl, parent, pivot_key, max_key);

--- a/test.sh
+++ b/test.sh
@@ -500,6 +500,17 @@ function test_make_run_tests() {
 }
 
 # ##################################################################
+# Exercise example programs, to ensure that they don't fail.
+# ##################################################################
+function test_example_programs() {
+
+    "$BINDIR"/examples/splinterdb_intro_example
+    "$BINDIR"/examples/splinterdb_wide_values_example
+    "$BINDIR"/examples/splinterdb_iterators_example
+    "$BINDIR"/examples/splinterdb_custom_ipv4_addr_sortcmp_example
+}
+
+# ##################################################################
 # main() begins here
 # ##################################################################
 
@@ -587,6 +598,8 @@ if [ "$INCLUDE_SLOW_TESTS" != "true" ]; then
    echo "Fast tests passed"
 
    record_elapsed_time ${start_seconds} "Fast unit tests"
+
+   run_with_timing "Test example programs" test_example_programs
 
    if [ "$RUN_MAKE_TESTS" == "true" ]; then
       run_with_timing "Basic build-and-test tests" test_make_run_tests


### PR DESCRIPTION
This commit adds a small number of C-sample programs, to demonstrate use of SplinterDB core APIs.
Associated changes to build this set of stand-alone programs applied to `Makefile`. A small new "test-case" is added to
`test.sh` to always execute these programs as part of default testing set.
Associated docs files are also updated to direct the user to these programs.