### PR TITLE
(#305) Add instrumentation to track assertion in clockcache_get_internal()

### DIFF
--- a/src/allocator.h
+++ b/src/allocator.h
@@ -90,7 +90,6 @@ typedef platform_status (*alloc_super_addr_fn)(allocator        *al,
                                                uint64           *addr);
 typedef void (*remove_super_addr_fn)(allocator *al, allocator_root_id spl_id);
 typedef uint64 (*get_size_fn)(allocator *al);
-typedef uint64 (*get_num_fn)(allocator *al, uint64 addr);
 
 typedef void (*print_fn)(allocator *al);
 typedef void (*assert_fn)(allocator *al);
@@ -113,8 +112,6 @@ typedef struct allocator_ops {
    get_size_fn in_use;
 
    get_size_fn get_capacity;
-
-   get_num_fn get_extent_num;
 
    assert_fn assert_noleaks;
 
@@ -182,12 +179,6 @@ static inline uint64
 allocator_get_capacity(allocator *al)
 {
    return al->ops->get_capacity(al);
-}
-
-static inline uint64
-allocator_get_extent_num(allocator *al, uint64 page_addr)
-{
-   return al->ops->get_extent_num(al, page_addr);
 }
 
 static inline void

--- a/src/allocator.h
+++ b/src/allocator.h
@@ -90,6 +90,7 @@ typedef platform_status (*alloc_super_addr_fn)(allocator        *al,
                                                uint64           *addr);
 typedef void (*remove_super_addr_fn)(allocator *al, allocator_root_id spl_id);
 typedef uint64 (*get_size_fn)(allocator *al);
+typedef uint64 (*get_num_fn)(allocator *al, uint64 addr);
 
 typedef void (*print_fn)(allocator *al);
 typedef void (*assert_fn)(allocator *al);
@@ -113,10 +114,12 @@ typedef struct allocator_ops {
 
    get_size_fn get_capacity;
 
+   get_num_fn get_extent_num;
+
    assert_fn assert_noleaks;
 
    print_fn print_stats;
-   print_fn debug_print;
+   print_fn print_allocated;
 } allocator_ops;
 
 // To sub-class cache, make a cache your first field;
@@ -181,6 +184,12 @@ allocator_get_capacity(allocator *al)
    return al->ops->get_capacity(al);
 }
 
+static inline uint64
+allocator_get_extent_num(allocator *al, uint64 page_addr)
+{
+   return al->ops->get_extent_num(al, page_addr);
+}
+
 static inline void
 allocator_assert_noleaks(allocator *al)
 {
@@ -194,9 +203,9 @@ allocator_print_stats(allocator *al)
 }
 
 static inline void
-allocator_debug_print(allocator *al)
+allocator_print_allocated(allocator *al)
 {
-   return al->ops->debug_print(al);
+   return al->ops->print_allocated(al);
 }
 
 #endif // __ALLOCATOR_H

--- a/src/clockcache.c
+++ b/src/clockcache.c
@@ -2128,7 +2128,25 @@ clockcache_get_internal(clockcache   *cc,       // IN
    platform_status   status;
    uint64            start, elapsed;
 
-   debug_assert(allocator_get_ref(cc->al, base_addr) > 1);
+#if SPLINTER_DEBUG
+   uint8 extent_ref_count = allocator_get_ref(cc->al, base_addr);
+
+   // Dump allocated extents info for deeper debugging.
+   if (extent_ref_count <= 1) {
+      allocator_print_allocated(cc->al);
+   }
+   debug_assert((extent_ref_count > 1),
+                "Attempt to get a buffer for page addr=%lu"
+                ", page type=%d ('%s'),"
+                " from extent addr=%lu, (extent number=%lu)"
+                ", which is an unallocated extent, extent_ref_count=%u.",
+                addr,
+                type,
+                page_type_str[type],
+                base_addr,
+                allocator_get_extent_num(cc->al, base_addr),
+                extent_ref_count);
+#endif // SPLINTER_DEBUG
 
    // We expect entry_number to be valid, but it's still validated below
    // in case some arithmetic goes wrong.

--- a/src/clockcache.c
+++ b/src/clockcache.c
@@ -2144,7 +2144,7 @@ clockcache_get_internal(clockcache   *cc,       // IN
                 type,
                 page_type_str[type],
                 base_addr,
-                allocator_get_extent_num(cc->al, base_addr),
+                (base_addr / clockcache_extent_size(cc)),
                 extent_ref_count);
 #endif // SPLINTER_DEBUG
 

--- a/src/rc_allocator.c
+++ b/src/rc_allocator.c
@@ -190,7 +190,7 @@ const static allocator_ops rc_allocator_ops = {
  * Is page address 'base_addr' a valid extent address? I.e. it is the address
  * of the 1st page in an extent.
  */
-static inline bool
+__attribute__((unused)) static inline bool
 rc_allocator_valid_extent_addr(rc_allocator *al, uint64 base_addr)
 {
    return ((base_addr % al->cfg->io_cfg->extent_size) == 0);
@@ -510,7 +510,7 @@ rc_allocator_unmount(rc_allocator *al)
 uint8
 rc_allocator_inc_ref(rc_allocator *al, uint64 addr)
 {
-   debug_assert(addr % al->cfg->io_cfg->extent_size == 0);
+   debug_assert(rc_allocator_valid_extent_addr(al, addr));
 
    uint64 extent_no = addr / al->cfg->io_cfg->extent_size;
    debug_assert(extent_no < al->cfg->extent_capacity);
@@ -529,7 +529,7 @@ rc_allocator_inc_ref(rc_allocator *al, uint64 addr)
 uint8
 rc_allocator_dec_ref(rc_allocator *al, uint64 addr, page_type type)
 {
-   debug_assert(addr % al->cfg->io_cfg->extent_size == 0);
+   debug_assert(rc_allocator_valid_extent_addr(al, addr));
 
    uint64 extent_no = addr / al->cfg->io_cfg->extent_size;
    debug_assert(extent_no < al->cfg->extent_capacity);

--- a/src/rc_allocator.c
+++ b/src/rc_allocator.c
@@ -139,16 +139,6 @@ rc_allocator_get_capacity_virtual(allocator *a)
    return rc_allocator_get_capacity(al);
 }
 
-uint64
-rc_allocator_get_extent_num(rc_allocator *al, uint64 page_addr);
-
-uint64
-rc_allocator_get_extent_num_virtual(allocator *a, uint64 page_addr)
-{
-   rc_allocator *al = (rc_allocator *)a;
-   return rc_allocator_get_extent_num(al, page_addr);
-}
-
 void
 rc_allocator_assert_noleaks(rc_allocator *al);
 
@@ -188,7 +178,6 @@ const static allocator_ops rc_allocator_ops = {
    .alloc_super_addr  = rc_allocator_alloc_super_addr_virtual,
    .remove_super_addr = rc_allocator_remove_super_addr_virtual,
    .get_capacity      = rc_allocator_get_capacity_virtual,
-   .get_extent_num    = rc_allocator_get_extent_num_virtual,
    .assert_noleaks    = rc_allocator_assert_noleaks_virtual,
    .print_stats       = rc_allocator_print_stats_virtual,
    .print_allocated   = rc_allocator_print_allocated_virtual,
@@ -559,17 +548,6 @@ rc_allocator_get_capacity(rc_allocator *al)
 {
    return al->cfg->capacity;
 }
-
-/*
- * Given a page-address, compute and return the holding extent's number (i.e.
- * index into the allocated extents reference count array.
- */
-uint64
-rc_allocator_get_extent_num(rc_allocator *al, uint64 page_addr)
-{
-   return rc_allocator_extent_num(al, page_addr);
-}
-
 
 platform_status
 rc_allocator_get_super_addr(rc_allocator     *al,

--- a/src/rc_allocator.c
+++ b/src/rc_allocator.c
@@ -34,7 +34,6 @@
  */
 #define SHOULD_TRACE(addr) (0) // Do not trace anything
 
-
 /*
  *------------------------------------------------------------------------------
  * Function declarations
@@ -140,6 +139,16 @@ rc_allocator_get_capacity_virtual(allocator *a)
    return rc_allocator_get_capacity(al);
 }
 
+uint64
+rc_allocator_get_extent_num(rc_allocator *al, uint64 page_addr);
+
+uint64
+rc_allocator_get_extent_num_virtual(allocator *a, uint64 page_addr)
+{
+   rc_allocator *al = (rc_allocator *)a;
+   return rc_allocator_get_extent_num(al, page_addr);
+}
+
 void
 rc_allocator_assert_noleaks(rc_allocator *al);
 
@@ -179,9 +188,10 @@ const static allocator_ops rc_allocator_ops = {
    .alloc_super_addr  = rc_allocator_alloc_super_addr_virtual,
    .remove_super_addr = rc_allocator_remove_super_addr_virtual,
    .get_capacity      = rc_allocator_get_capacity_virtual,
+   .get_extent_num    = rc_allocator_get_extent_num_virtual,
    .assert_noleaks    = rc_allocator_assert_noleaks_virtual,
    .print_stats       = rc_allocator_print_stats_virtual,
-   .debug_print       = rc_allocator_print_allocated_virtual,
+   .print_allocated   = rc_allocator_print_allocated_virtual,
 };
 
 static platform_status
@@ -530,8 +540,8 @@ rc_allocator_get_ref(rc_allocator *al, uint64 addr)
 {
    uint64 extent_no;
 
-   debug_assert(addr % al->cfg->io_cfg->extent_size == 0);
-   extent_no = addr / al->cfg->io_cfg->extent_size;
+   debug_assert(rc_allocator_valid_extent_addr(al, addr));
+   extent_no = rc_allocator_extent_num(al, addr);
    debug_assert(extent_no < al->cfg->extent_capacity);
    return al->ref_count[extent_no];
 }
@@ -548,6 +558,16 @@ uint64
 rc_allocator_get_capacity(rc_allocator *al)
 {
    return al->cfg->capacity;
+}
+
+/*
+ * Given a page-address, compute and return the holding extent's number (i.e.
+ * index into the allocated extents reference count array.
+ */
+uint64
+rc_allocator_get_extent_num(rc_allocator *al, uint64 page_addr)
+{
+   return rc_allocator_extent_num(al, page_addr);
 }
 
 
@@ -673,7 +693,7 @@ rc_allocator_alloc(rc_allocator *al,   // IN
    if (!extent_is_free) {
       platform_default_log(
          "Out of Space, while allocating an extent of type=%d (%s):"
-         " allocated %lu out of %lu addrs.\n",
+         " allocated %lu out of %lu extents.\n",
          type,
          page_type_str[type],
          al->stats.curr_allocated,

--- a/src/rc_allocator.c
+++ b/src/rc_allocator.c
@@ -183,6 +183,32 @@ const static allocator_ops rc_allocator_ops = {
    .print_allocated   = rc_allocator_print_allocated_virtual,
 };
 
+/*
+ * Helper methods
+ */
+/*
+ * Is page address 'base_addr' a valid extent address? I.e. it is the address
+ * of the 1st page in an extent.
+ */
+static inline bool
+rc_allocator_valid_extent_addr(rc_allocator *al, uint64 base_addr)
+{
+   return ((base_addr % al->cfg->io_cfg->extent_size) == 0);
+}
+
+/*
+ * Convert page-address to the extent number of extent containing this page.
+ * Returns the index into the allocated extents reference count array.
+ * This function can be used on any page-address to map it to the holding
+ * extent's number. 'addr' need not be just the base_addr; i.e. the address
+ * of the 1st page in an extent.
+ */
+static inline uint64
+rc_allocator_extent_number(rc_allocator *al, uint64 addr)
+{
+   return (addr / al->cfg->io_cfg->extent_size);
+}
+
 static platform_status
 rc_allocator_init_meta_page(rc_allocator *al)
 {
@@ -530,7 +556,7 @@ rc_allocator_get_ref(rc_allocator *al, uint64 addr)
    uint64 extent_no;
 
    debug_assert(rc_allocator_valid_extent_addr(al, addr));
-   extent_no = rc_allocator_extent_num(al, addr);
+   extent_no = rc_allocator_extent_number(al, addr);
    debug_assert(extent_no < al->cfg->extent_capacity);
    return al->ref_count[extent_no];
 }

--- a/src/rc_allocator.h
+++ b/src/rc_allocator.h
@@ -88,6 +88,20 @@ typedef struct rc_allocator {
 } rc_allocator;
 
 
+/* Is page address 'addr' is a valid extent address */
+static inline bool
+rc_allocator_valid_extent_addr(rc_allocator *al, uint64 addr)
+{
+   return (addr % al->cfg->io_cfg->extent_size == 0);
+}
+
+/* Convert page-address to the extent number of extent containing this page */
+static inline uint64
+rc_allocator_extent_num(rc_allocator *al, uint64 addr)
+{
+   return (addr / al->cfg->io_cfg->extent_size);
+}
+
 void
 rc_allocator_config_init(rc_allocator_config *allocator_cfg,
                          io_config           *io_cfg,

--- a/src/rc_allocator.h
+++ b/src/rc_allocator.h
@@ -88,14 +88,17 @@ typedef struct rc_allocator {
 } rc_allocator;
 
 
-/* Is page address 'addr' is a valid extent address */
+/* Is page address 'addr' a valid extent address? */
 static inline bool
 rc_allocator_valid_extent_addr(rc_allocator *al, uint64 addr)
 {
-   return (addr % al->cfg->io_cfg->extent_size == 0);
+   return ((addr % al->cfg->io_cfg->extent_size) == 0);
 }
 
-/* Convert page-address to the extent number of extent containing this page */
+/*
+ * Convert page-address to the extent number of extent containing this page.
+ * Returns the index into the allocated extents reference count array.
+ */
 static inline uint64
 rc_allocator_extent_num(rc_allocator *al, uint64 addr)
 {

--- a/src/rc_allocator.h
+++ b/src/rc_allocator.h
@@ -87,24 +87,6 @@ typedef struct rc_allocator {
    rc_allocator_stats stats;
 } rc_allocator;
 
-
-/* Is page address 'addr' a valid extent address? */
-static inline bool
-rc_allocator_valid_extent_addr(rc_allocator *al, uint64 addr)
-{
-   return ((addr % al->cfg->io_cfg->extent_size) == 0);
-}
-
-/*
- * Convert page-address to the extent number of extent containing this page.
- * Returns the index into the allocated extents reference count array.
- */
-static inline uint64
-rc_allocator_extent_num(rc_allocator *al, uint64 addr)
-{
-   return (addr / al->cfg->io_cfg->extent_size);
-}
-
 void
 rc_allocator_config_init(rc_allocator_config *allocator_cfg,
                          io_config           *io_cfg,

--- a/tests/unit/splinter_test.c
+++ b/tests/unit/splinter_test.c
@@ -661,7 +661,7 @@ CTEST2(splinter, test_splinter_print_diags)
 
    platform_default_log("\n** Allocator stats **\n");
    allocator_print_stats(alp);
-   allocator_debug_print(alp);
+   allocator_print_allocated(alp);
 
    trunk_destroy(spl);
 }


### PR DESCRIPTION
Test splinter_test --perf, and some other tests, are randomly tripping up a
debug assertion in clockcache_get_internal(), which reports that we
are trying to cache a page from an unallocated extent. This problem is
not reproducible. This commit improves the assertion message to report
addresses involved, and also calls-out to a print method to dump out
allocated extents bitmap. (This should only occur very rarely, if at all.)

----

This arises from the triaging of the assertion failure reported in issue #305. Several attempts have been made to try to repro it, but no avail.

Rather than closing out the issue as "not reproducible", I am adding some instrumentation, that will only trip in debug builds, to report more data when the assertion trips. This may give us some more clues for further troubleshooting.

A request was made by @ajhconway to may be print the call-stack. The work to generate a human-readable stack, mapping addresses to fn-names is a possibility, but will take longer than we have at this time. Building that stack trace facility is a separate dev-item, which is not on the priority radar right now. For now, this minimalistic instrumentation should suffice.