### PR TITLE
(#395) Redefine start-value of various enum-types to be something other than 0. (0 usually means uninitialized value.)

### DIFF
--- a/include/splinterdb/data.h
+++ b/include/splinterdb/data.h
@@ -24,11 +24,17 @@
 #include "splinterdb/public_platform.h"
 #include "splinterdb/public_util.h"
 
+/*
+ * Message type up to MESSAGE_TYPE_MAX_VALID_USER_TYPE is a
+ * disk-resident value (not including MESSAGE_TYPE_INVALID).
+ */
 typedef enum message_type {
+   MESSAGE_TYPE_INVALID = 0,
    MESSAGE_TYPE_INSERT,
    MESSAGE_TYPE_UPDATE,
    MESSAGE_TYPE_DELETE,
-   MESSAGE_TYPE_INVALID,
+   MESSAGE_TYPE_MAX_VALID_USER_TYPE = MESSAGE_TYPE_DELETE,
+   MESSAGE_TYPE_PIVOT_DATA          = 1000
 } message_type;
 
 /*

--- a/src/allocator.h
+++ b/src/allocator.h
@@ -46,8 +46,9 @@ typedef uint64 allocator_root_id;
  * ----------------------------------------------------------------------------
  */
 typedef enum page_type {
-   PAGE_TYPE_FIRST = 0,
-   PAGE_TYPE_TRUNK = PAGE_TYPE_FIRST,
+   PAGE_TYPE_INVALID = 0,
+   PAGE_TYPE_FIRST   = 1,
+   PAGE_TYPE_TRUNK   = PAGE_TYPE_FIRST,
    PAGE_TYPE_BRANCH,
    PAGE_TYPE_MEMTABLE,
    PAGE_TYPE_FILTER,
@@ -56,10 +57,10 @@ typedef enum page_type {
    PAGE_TYPE_MISC, // Used mainly as a testing hook, for cache access testing.
    PAGE_TYPE_LOCK_NO_DATA,
    NUM_PAGE_TYPES,
-   PAGE_TYPE_INVALID,
 } page_type;
 
-static const char *const page_type_str[] = {"trunk",
+static const char *const page_type_str[] = {"invalid",
+                                            "trunk",
                                             "branch",
                                             "memtable",
                                             "filter",

--- a/src/btree.c
+++ b/src/btree.c
@@ -2453,7 +2453,7 @@ btree_iterator_get_curr(iterator *base_itor, slice *key, message *data)
          btree_get_index_entry(itor->cfg, itor->curr.hdr, itor->idx);
       *key  = index_entry_key_slice(entry);
       *data = message_create(
-         MESSAGE_TYPE_INVALID,
+         MESSAGE_TYPE_PIVOT_DATA,
          slice_create(sizeof(entry->pivot_data), &entry->pivot_data));
    }
 }

--- a/src/btree.h
+++ b/src/btree.h
@@ -176,6 +176,7 @@ typedef void (*btree_async_cb)(struct btree_async_ctxt *ctxt);
 
 // States for the btree async lookup.
 typedef enum {
+   btree_async_state_invalid = 0,
    btree_async_state_start,
    btree_async_state_get_node, // re-entrant state
    btree_async_state_get_index_complete,

--- a/src/btree_private.h
+++ b/src/btree_private.h
@@ -80,7 +80,7 @@ _Static_assert(offsetof(index_entry, key) == sizeof(index_entry),
  * *************************************************************************
  */
 #define MESSAGE_TYPE_BITS (2)
-_Static_assert(MESSAGE_TYPE_INVALID < (1ULL << MESSAGE_TYPE_BITS),
+_Static_assert(MESSAGE_TYPE_MAX_VALID_USER_TYPE < (1ULL << MESSAGE_TYPE_BITS),
                "MESSAGE_TYPE_BITS is too small");
 
 typedef struct ONDISK leaf_entry {

--- a/src/clockcache.c
+++ b/src/clockcache.c
@@ -970,7 +970,7 @@ clockcache_assert_clean(clockcache *cc)
  */
 
 typedef enum {
-   GET_RC_SUCCESS,
+   GET_RC_SUCCESS = 0,
    GET_RC_CONFLICT,
    GET_RC_EVICTED,
    GET_RC_FLUSHING,

--- a/src/data_internal.h
+++ b/src/data_internal.h
@@ -23,8 +23,11 @@ message_type_string(message_type type)
          return "update";
       case MESSAGE_TYPE_DELETE:
          return "delete";
+      case MESSAGE_TYPE_PIVOT_DATA:
+         return "pivot_data";
+      case MESSAGE_TYPE_INVALID:
       default:
-         debug_assert(FALSE, "Invalid message type");
+         debug_assert(FALSE, "Invalid message type=%d", type);
          return "invalid";
    }
 }

--- a/src/memtable.h
+++ b/src/memtable.h
@@ -18,6 +18,7 @@
 #define MEMTABLE_SPACE_OVERHEAD_FACTOR (2)
 
 typedef enum memtable_state {
+   MEMTABLE_STATE_INVALID = 0,
    MEMTABLE_STATE_READY, // if it's the correct one, go ahead and insert
    MEMTABLE_STATE_FINALIZED,
    MEMTABLE_STATE_COMPACTED,

--- a/src/routing_filter.h
+++ b/src/routing_filter.h
@@ -60,6 +60,7 @@ typedef void (*routing_async_cb)(struct routing_async_ctxt *ctxt);
 
 // States for the filter async lookup.
 typedef enum {
+   routing_async_state_invalid = 0,
    routing_async_state_start,
    routing_async_state_get_index,  // re-entrant state
    routing_async_state_get_filter, // re-entrant state

--- a/src/task.c
+++ b/src/task.c
@@ -482,7 +482,7 @@ task_perform_all(task_system *ts)
 
    } else {
       // wait for bg threads to finish running all the queued up tasks.
-      for (task_type type = 0; type != NUM_TASK_TYPES; type++) {
+      for (task_type type = TASK_TYPE_FIRST; type != NUM_TASK_TYPES; type++) {
          task_group *group = &ts->group[type];
          while (group->current_outstanding_tasks != 0) {
             platform_sleep(USEC_TO_NSEC(100000)); // 100 msec.
@@ -571,7 +571,7 @@ task_perform_one(task_system *ts)
 {
    platform_assert(!ts->use_bg_threads);
    platform_status rc = STATUS_OK;
-   for (task_type type = 0; type != NUM_TASK_TYPES; type++) {
+   for (task_type type = TASK_TYPE_FIRST; type != NUM_TASK_TYPES; type++) {
       rc = task_group_perform_one(&ts->group[type]);
       if (STATUS_IS_NE(rc, STATUS_TIMEDOUT)) {
          return rc;
@@ -614,7 +614,7 @@ task_system_create(platform_heap_id    hid,
    ts->scratch_size   = scratch_size;
    ts->init_tid       = INVALID_TID;
 
-   for (task_type type = 0; type != NUM_TASK_TYPES; type++) {
+   for (task_type type = TASK_TYPE_FIRST; type != NUM_TASK_TYPES; type++) {
       platform_status rc = task_group_init(&ts->group[type],
                                            ts,
                                            use_stats,
@@ -652,7 +652,7 @@ void
 task_system_destroy(platform_heap_id hid, task_system **ts_in)
 {
    task_system *ts = *ts_in;
-   for (task_type type = 0; type != NUM_TASK_TYPES; type++) {
+   for (task_type type = TASK_TYPE_FIRST; type != NUM_TASK_TYPES; type++) {
       task_group_deinit(&ts->group[type]);
    }
    platform_free(hid, ts);
@@ -680,7 +680,7 @@ task_system_get_thread_scratch(task_system *ts, const threadid tid)
 void
 task_wait_for_completion(task_system *ts)
 {
-   for (task_type type = 0; type != NUM_TASK_TYPES; type++) {
+   for (task_type type = TASK_TYPE_FIRST; type != NUM_TASK_TYPES; type++) {
       task_group *group             = &ts->group[type];
       uint64      outstanding_tasks = 0;
       while (group->current_outstanding_tasks != 0) {
@@ -747,7 +747,7 @@ task_group_print_stats(task_group *group, task_type type)
 void
 task_print_stats(task_system *ts)
 {
-   for (task_type type = 0; type != NUM_TASK_TYPES; type++) {
+   for (task_type type = TASK_TYPE_FIRST; type != NUM_TASK_TYPES; type++) {
       task_group_print_stats(&ts->group[type], type);
    }
 }

--- a/src/task.h
+++ b/src/task.h
@@ -71,10 +71,11 @@ typedef struct task_group {
 } task_group;
 
 typedef enum task_type {
-   TASK_TYPE_FIRST    = 0,
-   TASK_TYPE_MEMTABLE = TASK_TYPE_FIRST,
+   TASK_TYPE_INVALID = 0,
+   TASK_TYPE_MEMTABLE,
    TASK_TYPE_NORMAL,
    NUM_TASK_TYPES,
+   TASK_TYPE_FIRST = TASK_TYPE_MEMTABLE
 } task_type;
 
 /*

--- a/src/trunk.c
+++ b/src/trunk.c
@@ -460,7 +460,8 @@ typedef struct ONDISK trunk_super_block {
  */
 typedef uint16 trunk_subbundle_state_t;
 typedef enum trunk_subbundle_state {
-   SB_STATE_UNCOMPACTED_INDEX = 0,
+   SB_STATE_INVALID = 0,
+   SB_STATE_UNCOMPACTED_INDEX,
    SB_STATE_UNCOMPACTED_LEAF,
    SB_STATE_COMPACTED, // compacted subbundles are always index
 } trunk_subbundle_state;
@@ -610,6 +611,7 @@ typedef struct trunk_btree_skiperator {
 
 // for find_pivot
 typedef enum lookup_type {
+   invalid = 0,
    less_than,
    less_than_or_equal,
    greater_than,
@@ -1376,6 +1378,8 @@ trunk_find_pivot(trunk_handle *spl,
             return cmp > 0 ? 0 : 1;
          case greater_than_or_equal:
             return cmp >= 0 ? 0 : 1;
+         default:
+            platform_assert(0);
       }
    }
 
@@ -6803,6 +6807,10 @@ trunk_lookup_async(trunk_handle      *spl,    // IN
                   }
                   branch_no = ctxt->sb->start_branch;
                   break;
+               default:
+                  platform_error_log("Invalid async_lookup_state=%d\n",
+                                     ctxt->lookup_state);
+                  platform_assert(0);
             }
             ctxt->branch = trunk_get_branch(spl, node, branch_no);
             btree_ctxt_init(&ctxt->btree_ctxt,
@@ -6896,6 +6904,10 @@ trunk_lookup_async(trunk_handle      *spl,    // IN
                   }
                   trunk_async_set_state(ctxt, async_state_subbundle_lookup);
                   continue;
+               default:
+                  platform_error_log("Invalid async_lookup_state=%d\n",
+                                     ctxt->lookup_state);
+                  platform_assert(0);
             }
             break;
          }
@@ -8070,8 +8082,11 @@ trunk_print_branches_and_bundles(platform_log_handle *log_handle,
       {
          trunk_subbundle *sb = trunk_get_subbundle(spl, node, sb_no);
          // Generate marker line if curr branch is a sub-bundle's start branch
+         platform_assert(sb->state != SB_STATE_INVALID);
+
          if (branch_no == sb->start_branch) {
             uint16 filter_count = trunk_subbundle_filter_count(spl, node, sb);
+
             // clang-format off
             platform_log(log_handle,
                "|     |  -- %2scomp subbundle %2u --  | %12lu | %12lu | %12lu | %14s |\n",

--- a/src/trunk.h
+++ b/src/trunk.h
@@ -244,6 +244,7 @@ typedef struct trunk_range_iterator {
 
 
 typedef enum {
+   async_state_invalid = 0,
    async_state_start,
    async_state_lookup_memtable,
    async_state_get_root_reentrant,
@@ -263,6 +264,7 @@ typedef enum {
 } trunk_async_state;
 
 typedef enum {
+   async_lookup_state_invalid = 0,
    async_lookup_state_pivot,
    async_lookup_state_subbundle,
    async_lookup_state_compacted_subbundle


### PR DESCRIPTION
This commit is for code clean-up, not a bug-fix. A collection of enum types are
changed to have start values with something other than 0. This avoids risk of
interpreting uninitialized value (0) as a valid enum value. There is no
functional changes with this commit.

---

Changed enum types:
- message_type
- page_type
- btree_async_state
- GET_RC (Set GET_RC_SUCCESS to 0 explicitly)
- memtable_state
- routing_async_state
- task_type
- trunk_subbundle_state
- lookup_type
- async_state
- async_lookup_state