### PR TITLE
remove dependency on malloc.h

### DIFF
--- a/src/platform_linux/platform_types.h
+++ b/src/platform_linux/platform_types.h
@@ -8,7 +8,6 @@
 #include <ctype.h> // for isspace,isascii,isdigit,isalpha,isupper
 #include <errno.h>
 #include <fcntl.h>
-#include <malloc.h>
 #include <pthread.h>
 #include <semaphore.h>
 #include <stdlib.h>


### PR DESCRIPTION
It's non-standard and not actually used.

Signed-off-by: Eric Lagergren <eric@ericlagergren.com>