### PR TITLE
(#120) Handle invalid user-type messages in 'btree_insert' and 'btree_pack'

### DIFF
--- a/src/data_internal.h
+++ b/src/data_internal.h
@@ -55,6 +55,13 @@ message_is_definitive(message msg)
    return msg.type == MESSAGE_TYPE_INSERT || msg.type == MESSAGE_TYPE_DELETE;
 }
 
+static inline bool
+message_is_invalid_user_type(message msg)
+{
+   return msg.type == MESSAGE_TYPE_INVALID
+          || msg.type > MESSAGE_TYPE_MAX_VALID_USER_TYPE;
+}
+
 /* Define an arbitrary ordering on messages.  In practice, all we care
  * about is equality, but this is written to follow the same
  * comparison interface as for ordered types. */

--- a/src/trunk.c
+++ b/src/trunk.c
@@ -3186,7 +3186,12 @@ trunk_memtable_compact_and_build_filter(trunk_handle  *spl,
       spl->stats[tid].root_compactions++;
       pack_start = platform_get_timestamp();
    }
-   btree_pack(&req);
+
+   platform_status pack_status = btree_pack(&req);
+   platform_assert(SUCCESS(pack_status),
+                   "platform_status of btree_pack: %d\n",
+                   pack_status.r);
+
    platform_assert(req.num_tuples <= spl->cfg.max_tuples_per_node);
    if (spl->cfg.use_stats) {
       spl->stats[tid].root_compaction_pack_time_ns +=
@@ -4835,7 +4840,12 @@ trunk_compact_bundle(void *arg, void *scratch_buf)
    if (spl->cfg.use_stats) {
       pack_start = platform_get_timestamp();
    }
-   btree_pack(&pack_req);
+
+   platform_status pack_status = btree_pack(&pack_req);
+   platform_assert(SUCCESS(pack_status),
+                   "platform_status of btree_pack: %d\n",
+                   pack_status.r);
+
    if (spl->cfg.use_stats) {
       spl->stats[tid].compaction_pack_time_ns[height] +=
          platform_timestamp_elapsed(pack_start);


### PR DESCRIPTION
In `btree_insert` and `btree_pack`, invalid user-type messages are not
handled properly. This change makes those functions return an error
when they receive invalid user-type messages. An error that
`btree_insert` returns is forwarded to an application. On the other
hand, when `btree_pack` returns an error, the program will be
asserted.