### PR TITLE
(#419) Fix bug in splinterdb_iterator_init() when min_key is configured.

### DIFF
--- a/include/splinterdb/splinterdb.h
+++ b/include/splinterdb/splinterdb.h
@@ -292,4 +292,7 @@ splinterdb_iterator_get_current(splinterdb_iterator *iter, // IN
 int
 splinterdb_iterator_status(const splinterdb_iterator *iter);
 
+bool
+splinterdb_validate_key_in_range(const splinterdb *kvs, slice key);
+
 #endif // _SPLINTERDB_H_

--- a/include/splinterdb/splinterdb.h
+++ b/include/splinterdb/splinterdb.h
@@ -292,7 +292,4 @@ splinterdb_iterator_get_current(splinterdb_iterator *iter, // IN
 int
 splinterdb_iterator_status(const splinterdb_iterator *iter);
 
-bool
-splinterdb_validate_key_in_range(const splinterdb *kvs, slice key);
-
 #endif // _SPLINTERDB_H_

--- a/src/splinterdb.c
+++ b/src/splinterdb.c
@@ -17,6 +17,7 @@
 
 #include "clockcache.h"
 #include "splinterdb/splinterdb.h"
+#include "splinterdb_private.h"
 #include "rc_allocator.h"
 #include "trunk.h"
 #include "btree_private.h"

--- a/src/splinterdb.c
+++ b/src/splinterdb.c
@@ -635,7 +635,7 @@ validate_key_length(const splinterdb *kvs, uint64 key_length)
  * Validate that a key being inserted is within [min, max]-key range.
  */
 bool
-splinterdb_validate_key_in_range(const splinterdb *kvs, slice key)
+validate_key_in_range(const splinterdb *kvs, slice key)
 {
    const data_config *cfg = kvs->shim_data_cfg.app_data_cfg;
 
@@ -645,11 +645,10 @@ splinterdb_validate_key_in_range(const splinterdb *kvs, slice key)
    cmp_rv = cfg->key_compare(
       cfg, slice_create(cfg->min_key_length, cfg->min_key), key);
    if (cmp_rv > 0) {
-      platform_error_log("Key '%.*s' is less than configured min-key '%.*s'.\n",
-                         (int)slice_length(key),
-                         (char *)slice_data(key),
-                         (int)cfg->min_key_length,
-                         cfg->min_key);
+      platform_error_log(
+         "Key '%s' is less than configured min-key '%s'.\n",
+         key_string(cfg, key),
+         key_string(cfg, slice_create(cfg->min_key_length, cfg->min_key)));
       return FALSE;
    }
 
@@ -658,11 +657,9 @@ splinterdb_validate_key_in_range(const splinterdb *kvs, slice key)
       cfg, key, slice_create(cfg->max_key_length, cfg->max_key));
    if (cmp_rv > 0) {
       platform_error_log(
-         "Key '%.*s' is greater than configured max-key '%.*s'.\n",
-         (int)slice_length(key),
-         (char *)slice_data(key),
-         (int)cfg->max_key_length,
-         cfg->max_key);
+         "Key '%s' is greater than configured max-key '%s'.\n",
+         key_string(cfg, key),
+         key_string(cfg, slice_create(cfg->max_key_length, cfg->max_key)));
       return FALSE;
    }
    return TRUE;
@@ -693,7 +690,7 @@ splinterdb_insert_message(const splinterdb *kvs, // IN
       return rc;
    }
 
-   debug_assert(splinterdb_validate_key_in_range(kvs, key),
+   debug_assert(validate_key_in_range(kvs, key),
                 "Attempt to insert key outside configured min/max key-range");
 
    char key_buffer[MAX_KEY_SIZE] = {0};

--- a/src/splinterdb.c
+++ b/src/splinterdb.c
@@ -16,7 +16,6 @@
 #include "platform.h"
 
 #include "clockcache.h"
-#include "splinterdb/splinterdb.h"
 #include "splinterdb_private.h"
 #include "rc_allocator.h"
 #include "trunk.h"

--- a/src/splinterdb_private.h
+++ b/src/splinterdb_private.h
@@ -11,6 +11,8 @@
 #ifndef __SPLINTERDB_PRIVATE_H__
 #define __SPLINTERDB_PRIVATE_H__
 
+#include "splinterdb/splinterdb.h"
+
 bool
 validate_key_in_range(const splinterdb *kvs, slice key);
 

--- a/src/splinterdb_private.h
+++ b/src/splinterdb_private.h
@@ -1,0 +1,17 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+ * splinterdb_private.h --
+ *
+ * This file contains the private interfaces implemented in splinterdb.c.
+ * These definitions are provided here so that they can be shared by the
+ * source and test modules.
+ */
+#ifndef __SPLINTERDB_PRIVATE_H__
+#define __SPLINTERDB_PRIVATE_H__
+
+bool
+validate_key_in_range(const splinterdb *kvs, slice key);
+
+#endif // __SPLINTERDB_PRIVATE_H__

--- a/tests/unit/splinterdb_quick_test.c
+++ b/tests/unit/splinterdb_quick_test.c
@@ -31,7 +31,6 @@
 #include "splinterdb/data.h"
 #include "splinterdb/public_platform.h"
 #include "splinterdb/default_data_config.h"
-#include "splinterdb/splinterdb.h"
 #include "splinterdb_private.h"
 #include "unit_tests.h"
 #include "util.h"

--- a/tests/unit/splinterdb_quick_test.c
+++ b/tests/unit/splinterdb_quick_test.c
@@ -32,6 +32,7 @@
 #include "splinterdb/public_platform.h"
 #include "splinterdb/default_data_config.h"
 #include "splinterdb/splinterdb.h"
+#include "splinterdb_private.h"
 #include "unit_tests.h"
 #include "util.h"
 #include "test_data.h"
@@ -66,10 +67,6 @@ check_current_tuple(splinterdb_iterator *it, const int expected_i);
 
 static int
 custom_key_comparator(const data_config *cfg, slice key1, slice key2);
-
-// Extern prototype defined in the library.
-bool
-validate_key_in_range(const splinterdb *kvs, slice key);
 
 typedef struct {
    data_config super;

--- a/tests/unit/splinterdb_quick_test.c
+++ b/tests/unit/splinterdb_quick_test.c
@@ -67,6 +67,10 @@ check_current_tuple(splinterdb_iterator *it, const int expected_i);
 static int
 custom_key_comparator(const data_config *cfg, slice key1, slice key2);
 
+// Extern prototype defined in the library.
+bool
+validate_key_in_range(const splinterdb *kvs, slice key);
+
 typedef struct {
    data_config super;
    uint64      num_comparisons;
@@ -836,26 +840,26 @@ CTEST2(splinterdb_quick, test_validate_key_in_range)
    bool  is_valid = FALSE;
    char *test_key = "jkey-000"; // Invalid; key < min-key
 
-   is_valid = splinterdb_validate_key_in_range(
-      data->kvsb, slice_create(strlen(test_key), test_key));
+   is_valid = validate_key_in_range(data->kvsb,
+                                    slice_create(strlen(test_key), test_key));
    ASSERT_FALSE(is_valid);
 
    test_key = "key-000"; // Valid key
 
-   is_valid = splinterdb_validate_key_in_range(
-      data->kvsb, slice_create(strlen(test_key), test_key));
+   is_valid = validate_key_in_range(data->kvsb,
+                                    slice_create(strlen(test_key), test_key));
    ASSERT_TRUE(is_valid);
 
    test_key = "key-9999999"; // Invalid; key > max-key
 
-   is_valid = splinterdb_validate_key_in_range(
-      data->kvsb, slice_create(strlen(test_key), test_key));
+   is_valid = validate_key_in_range(data->kvsb,
+                                    slice_create(strlen(test_key), test_key));
    ASSERT_FALSE(is_valid);
 
    test_key = "lkey-000"; // Invalid; key > max-key
 
-   is_valid = splinterdb_validate_key_in_range(
-      data->kvsb, slice_create(strlen(test_key), test_key));
+   is_valid = validate_key_in_range(data->kvsb,
+                                    slice_create(strlen(test_key), test_key));
    ASSERT_FALSE(is_valid);
 }
 

--- a/tests/unit/splinterdb_quick_test.c
+++ b/tests/unit/splinterdb_quick_test.c
@@ -437,6 +437,8 @@ CTEST2(splinterdb_quick, test_basic_iterator)
       ASSERT_EQUAL(0, rc);
       i++;
    }
+   ASSERT_EQUAL(num_inserts, i);
+
    rc = splinterdb_iterator_status(it);
    ASSERT_EQUAL(0, rc);
 
@@ -805,6 +807,108 @@ CTEST2(splinterdb_quick, test_iterator_custom_comparator)
    if (it) {
       splinterdb_iterator_deinit(it);
    }
+}
+
+/*
+ * Exercise the utility function which validates that the key being inserted
+ * is within [min, max] range. That check was added upon discovering that
+ * we would allow invalid keys to be inserted which lead to downstream
+ * errors while exercising the iteration interfaces.
+ */
+CTEST2(splinterdb_quick, test_validate_key_in_range)
+{
+   // We need to reconfigure Splinter with user-specified data_config
+   // Tear down default instance, and create a new one.
+   splinterdb_close(&data->kvsb);
+   data->cfg.data_cfg = test_data_config;
+
+   data->cfg.data_cfg->key_size = 11;
+
+   sprintf(data->cfg.data_cfg->min_key, "%s", "key-0");
+   data->cfg.data_cfg->min_key_length = strlen(data->cfg.data_cfg->min_key);
+
+   sprintf(data->cfg.data_cfg->max_key, "%s", "key-999999");
+   data->cfg.data_cfg->max_key_length = strlen(data->cfg.data_cfg->max_key);
+
+   int rc = splinterdb_create(&data->cfg, &data->kvsb);
+   ASSERT_EQUAL(0, rc);
+
+   bool  is_valid = FALSE;
+   char *test_key = "jkey-000"; // Invalid; key < min-key
+
+   is_valid = splinterdb_validate_key_in_range(
+      data->kvsb, slice_create(strlen(test_key), test_key));
+   ASSERT_FALSE(is_valid);
+
+   test_key = "key-000"; // Valid key
+
+   is_valid = splinterdb_validate_key_in_range(
+      data->kvsb, slice_create(strlen(test_key), test_key));
+   ASSERT_TRUE(is_valid);
+
+   test_key = "key-9999999"; // Invalid; key > max-key
+
+   is_valid = splinterdb_validate_key_in_range(
+      data->kvsb, slice_create(strlen(test_key), test_key));
+   ASSERT_FALSE(is_valid);
+
+   test_key = "lkey-000"; // Invalid; key > max-key
+
+   is_valid = splinterdb_validate_key_in_range(
+      data->kvsb, slice_create(strlen(test_key), test_key));
+   ASSERT_FALSE(is_valid);
+}
+
+/*
+ * Test case to verify that iterator interfaces work correctly.
+ * Prior to fix for issue #419, this test case would fail with an assertion
+ * (that is activated only) in debug mode runs.
+ */
+CTEST2(splinterdb_quick, test_iterator_init_bug)
+{
+   // We need to reconfigure Splinter with user-specified data_config
+   // Tear down default instance, and create a new one.
+   splinterdb_close(&data->kvsb);
+   data->cfg.data_cfg = test_data_config;
+
+   // The triggering check was the use of min-key while configuring
+   // the database. (Without this line, this test case will pass.)
+   sprintf(data->cfg.data_cfg->min_key, "%s", "key-0");
+
+   data->cfg.data_cfg->min_key_length = strlen(data->cfg.data_cfg->min_key);
+
+   int rc = splinterdb_create(&data->cfg, &data->kvsb);
+   ASSERT_EQUAL(0, rc);
+
+   // Iterator init should find nothing when no keys were inserted, yet.
+   splinterdb_iterator *it = NULL;
+   rc = splinterdb_iterator_init(data->kvsb, &it, NULL_SLICE);
+   ASSERT_EQUAL(0, rc);
+
+   bool iter_valid = splinterdb_iterator_valid(it);
+   ASSERT_FALSE(iter_valid);
+
+   splinterdb_iterator_deinit(it);
+
+   // Insert some kv-pairs, so iterator is initialized to something valid
+   const int num_inserts = 5;
+   rc                    = insert_some_keys(num_inserts, data->kvsb);
+   ASSERT_EQUAL(0, rc);
+
+   it = NULL;
+   rc = splinterdb_iterator_init(data->kvsb, &it, NULL_SLICE);
+   ASSERT_EQUAL(0, rc);
+
+   iter_valid = splinterdb_iterator_valid(it);
+   ASSERT_TRUE(iter_valid);
+
+   int i = 0;
+   for (; splinterdb_iterator_valid(it); splinterdb_iterator_next(it)) {
+      i++;
+   }
+   ASSERT_EQUAL(num_inserts, i);
+
+   splinterdb_iterator_deinit(it);
 }
 
 /*


### PR DESCRIPTION
This commit fixes a latent bug in splinterdb_iterator_init() which might
cause splinterdb_iterator_valid() to incorrectly return FALSE when
min_key is configured. Add a test case to demonstrate the problem,
albeit one that only fails in debug-mode.

As a defensive check against test/user-code attempting to add invalid
keys, add debug assertion checks in insert code-flow to validate that
keys are within the valid [min,max] key-range.

(This issue and the consequent bug-fix is rather temporary and may all
be dismantled once min/max key configuration is undone.)