### PR TITLE
git ignore build dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,9 @@ bin/
 obj/
 lib/
 db
+splinterdb_*_db
 cache-log
 tags
 unit_tests_db
 compile_flags.txt
+build


### PR DESCRIPTION
on a fresh checkout, a `make` dirties the working directory.  this keep it clean.