### PR TITLE
CI updates: extend timeouts, sanitizer jobs only run nightly

### DIFF
--- a/ci/jobs.lib.yml
+++ b/ci/jobs.lib.yml
@@ -67,8 +67,8 @@ plan:
 
 
 #! Build, test and publish container images
-#@ def job_main_build_test_push(compiler, also_latest=False):
-name: #@ "main-build-test-" + compiler
+#@ def job_main_push(compiler, also_latest=False):
+name: #@ "main-push-" + compiler
 public: true
 on_success: #@ step_set_commit_status("success", compiler)
 on_failure: #@ step_set_commit_status("failure", compiler)
@@ -109,23 +109,42 @@ plan:
 
 ---
 
+#@ def friendly_name(compiler, debug, sanitize, nightly_test):
+#@   ret = ""
+#@   if debug:
+#@     ret += "debug-"
+#@   end
+#@   if sanitize:
+#@     ret += sanitize + "-"
+#@   end
+#@   if nightly_test:
+#@     ret += "nightly-test-"
+#@   end
+#@   return ret + compiler
+#@ end
+
+
 #! Debug build and test
-#@ def job_debug_main_build_test(compiler):
-name: #@ "main-debug-build-test-" + compiler
+#@ def job_main(compiler, sanitize="", trigger="main", is_debug=False, test_nightly=False):
+#@   name = friendly_name(compiler, is_debug, sanitize, test_nightly)
+name: #@ "main-" + name
 public: true
-on_success: #@ step_set_commit_status("success", compiler + "-debug")
-on_failure: #@ step_set_commit_status("failure", compiler + "-debug")
-on_error: #@ step_set_commit_status("error", compiler + "-debug")
+on_success: #@ step_set_commit_status("success", name)
+on_failure: #@ step_set_commit_status("failure", name)
+on_error: #@ step_set_commit_status("error", name)
 plan:
 - in_parallel:
   - get: branch-main
-    trigger: true
+    trigger: #@ (trigger == "main")
   - get: build-env-image-latest
     passed: [ recreate-build-env ]
     trigger: true
-- #@ step_set_commit_status("pending", compiler + "-debug")
-- #@ step_build_test(compiler, "branch-main", is_debug=True)
-
+#@ if trigger == "nightly":
+  - get: nightly-timer
+    trigger: true
+#@ end
+- #@ step_set_commit_status("pending", name)
+- #@ step_build_test(compiler, "branch-main", is_debug=is_debug, sanitize=sanitize, test_nightly=test_nightly)
 #@ end
 
 ---
@@ -150,27 +169,3 @@ plan:
 - #@ step_set_pr_status(job_name, "pending", description)
 - #@ template.replace(sequence)
 #@ end
-
----
-
-#! Release build and test run nightly, for extended testing
-#@ def job_nightly_main_build_test(compiler="gcc"):
-name: #@ "main-nightly-build-test-" + compiler
-public: true
-on_success: #@ step_set_commit_status("success", compiler + "-nightly")
-on_failure: #@ step_set_commit_status("failure", compiler + "-nightly")
-on_error: #@ step_set_commit_status("error", compiler + "-nightly")
-plan:
-- in_parallel:
-  - get: branch-main
-    trigger: false  #! Do not trigger on every push / commit
-  - get: build-env-image-latest
-    passed: [ recreate-build-env ]
-    trigger: false  #! Do not trigger on every change of the build-env
-  - get: nightly-timer
-    trigger: true  #! -Do- trigger every night
-- #@ step_set_commit_status("pending", compiler + "-nightly")
-- #@ step_build_test(compiler, "branch-main", is_debug=False, is_nightly=True)
-
-#@ end
-

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -21,10 +21,9 @@
 
 #@ load("jobs.lib.yml",
 #@         "job_recreate_image",
-#@         "job_main_build_test_push",
-#@         "job_debug_main_build_test",
+#@         "job_main_push",
+#@         "job_main",
 #@         "job_pr_check",
-#@         "job_nightly_main_build_test",
 #@ )
 ---
 
@@ -100,15 +99,18 @@ jobs:
 - #@ job_recreate_image("build-env")
 - #@ job_recreate_image("run-env")
 
-#! Build, test and publish container images
-- #@ job_main_build_test_push("clang")
-- #@ job_main_build_test_push("gcc", also_latest=True)
+#! Commits to main will build, test and publish container images
+- #@ job_main_push("clang")
+- #@ job_main_push("gcc", also_latest=True)
+- #@ job_main("clang", is_debug=True)
+- #@ job_main("gcc", is_debug=True)
 
-- #@ job_debug_main_build_test("clang")
-- #@ job_debug_main_build_test("gcc")
-- #@ job_nightly_main_build_test("gcc")
+#! Nightly jobs which take too long to run per-PR
+- #@ job_main("gcc", trigger="nightly", test_nightly=True)
+- #@ job_main("gcc", trigger="nightly", sanitize="asan")
+- #@ job_main("gcc", trigger="nightly", sanitize="msan")
 
-#! first stage of pipeline, runs a few quick jobs
+#! Pull requests go through a fast stage and fan out to a slow stage
 #@ stage_one = ["pr-quick-check", "pr-clang-format", "pr-shell-scripts"]
 - #@ job_pr_check("clang-format", sequence_pr_clang_format(), description="check C source formatting")
 - #@ job_pr_check("shell-scripts", sequence_pr_shell_scripts(), description="lint and format any shell scripts")
@@ -117,22 +119,18 @@ jobs:
 #! second stage of pipeline, only triggers if all of the first-stage passes
 - #@ job_pr_check("clang", sequence_pr_build_test("clang"), depends_on=stage_one, description="build and test")
 - #@ job_pr_check("gcc", sequence_pr_build_test("gcc"), depends_on=stage_one, description="build and test")
-
 - #@ job_pr_check("debug-clang", sequence_pr_debug_build_test("clang"), depends_on=stage_one, description="debug build and test")
 - #@ job_pr_check("debug-gcc", sequence_pr_debug_build_test("gcc"), depends_on=stage_one, description="debug build and test")
 
-- #@ job_pr_check("asan", sequence_pr_debug_build_test("gcc", sanitize="asan"), depends_on=stage_one, description="address sanitizer")
-- #@ job_pr_check("msan", sequence_pr_debug_build_test("clang", sanitize="msan"), depends_on=stage_one, description="memory sanitizer")
 
 #! List of CI-groups of jobs
 groups:
 - name: main_branch
   jobs:
-  - main-build-test-clang
-  - main-build-test-gcc
-  - main-debug-build-test-clang
-  - main-debug-build-test-gcc
-  - main-nightly-build-test-gcc
+  - main-push-clang
+  - main-push-gcc
+  - main-debug-clang
+  - main-debug-gcc
 
 - name: pull_requests
   jobs:
@@ -143,8 +141,12 @@ groups:
   - pr-debug-gcc
   - pr-clang-format
   - pr-shell-scripts
-  - pr-asan
-  - pr-msan
+
+- name: nightly
+  jobs:
+  - main-nightly-test-gcc
+  - main-asan-gcc
+  - main-msan-gcc
 
 - name: env_images
   jobs:

--- a/ci/steps.lib.yml
+++ b/ci/steps.lib.yml
@@ -2,15 +2,15 @@
 #! SPDX-License-Identifier: Apache-2.0
 
 
-#@ def get_task_timeout(quick=False, sanitize="", is_nightly=False):
+#@ def get_task_timeout(quick=False, sanitize="", test_nightly=False):
 #@   if sanitize:
-#@     return "3h"
+#@     return "6h"
 #@   elif quick:
-#@     return "5m"
-#@   elif is_nightly:
+#@     return "10m"
+#@   elif test_nightly:
 #@     return "6h"
 #@   else:
-#@     return "1h"
+#@     return "2h"
 #@   end
 #@ end
 
@@ -87,13 +87,13 @@ config:
 
 ---
 
-#@ def step_build_test(compiler, input_name, is_debug=True, quick=False, sanitize="", is_nightly=False):
+#@ def step_build_test(compiler, input_name, is_debug=True, quick=False, sanitize="", test_nightly=False):
 #@ if is_debug:
 task: debug-build-test
 #@ else:
 task: release-build-test
 #@ end
-timeout: #@ get_task_timeout(quick=quick, sanitize=sanitize, is_nightly=is_nightly)
+timeout: #@ get_task_timeout(quick=quick, sanitize=sanitize, test_nightly=test_nightly)
 image: build-env-image-latest
 config:
   platform: linux
@@ -103,7 +103,7 @@ config:
     CC: #@ compiler
     LD: #@ compiler
     INCLUDE_SLOW_TESTS: #@ str(not quick).lower()
-    RUN_NIGHTLY_TESTS: #@ str(is_nightly).lower()
+    RUN_NIGHTLY_TESTS: #@ str(test_nightly).lower()
     BUILD_VERBOSE: "1"
 
     #! Exercise 'make help' in quick tests mode, to ensure 'help' still works.


### PR DESCRIPTION
msan CI jobs on pull-requests are timing out at 3 hours.

Two changes:
1. The sanitizer jobs (msan and asan) will now only run nightly, not on every pull-request
2. The timeouts on various jobs are longer, since recent test-runs have been hitting existing timeouts