### PR TITLE
Refactor Trunk Node Handles

### DIFF
--- a/src/trunk.c
+++ b/src/trunk.c
@@ -99,7 +99,6 @@ static const int64 latency_histo_buckets[LATENCYHISTO_SIZE] = {
 #define TRUNK_EXTRA_PIVOT_KEYS (6)
 
 #define TRUNK_INVALID_PIVOT_NO (UINT16_MAX)
-
 /*
  * Trunk logging functions.
  *
@@ -159,12 +158,12 @@ trunk_close_log_stream_if_enabled(trunk_handle           *spl,
 void
 trunk_print_locked_node(platform_log_handle *log_handle,
                         trunk_handle        *spl,
-                        page_handle         *node);
+                        trunk_node          *node);
 
 static inline void
 trunk_log_node_if_enabled(platform_stream_handle *stream,
                           trunk_handle           *spl,
-                          page_handle            *node)
+                          trunk_node             *node)
 {
    if (trunk_verbose_logging_enabled(spl)) {
       platform_log_handle *log_handle =
@@ -572,6 +571,125 @@ typedef struct ONDISK trunk_pivot_data {
 } trunk_pivot_data;
 
 /*
+ *
+ *-----------------------------------------------------------------------------
+ * Trunk Node Access Wrappers
+ *-----------------------------------------------------------------------------
+ */
+
+static inline void
+trunk_node_get(cache *cc, uint64 addr, trunk_node *node)
+{
+   debug_assert(addr != 0);
+   node->addr = addr;
+   node->page = cache_get(cc, node->addr, TRUE, PAGE_TYPE_TRUNK);
+   node->hdr  = (trunk_hdr *)(node->page->data);
+}
+
+static inline void
+trunk_node_unget(cache *cc, trunk_node *node)
+{
+   cache_unget(cc, node->page);
+   node->page = NULL;
+   node->hdr  = NULL;
+}
+
+static inline void
+trunk_node_claim(cache *cc, trunk_node *node)
+{
+   uint64 wait = 1;
+   while (!cache_claim(cc, node->page)) {
+      uint64 addr = node->addr;
+      trunk_node_unget(cc, node);
+      platform_sleep(wait);
+      wait = wait > 2048 ? wait : 2 * wait;
+      trunk_node_get(cc, addr, node);
+   }
+}
+
+static inline void
+trunk_node_unclaim(cache *cc, trunk_node *node)
+{
+   cache_unclaim(cc, node->page);
+}
+
+static inline void
+trunk_node_lock(cache *cc, trunk_node *node)
+{
+   cache_lock(cc, node->page);
+   cache_mark_dirty(cc, node->page);
+}
+
+static inline void
+trunk_node_unlock(cache *cc, trunk_node *node)
+{
+   cache_unlock(cc, node->page);
+}
+
+static inline void
+trunk_alloc(cache *cc, mini_allocator *mini, uint64 height, trunk_node *node)
+{
+   node->addr = mini_alloc(mini, height, NULL_SLICE, NULL);
+   debug_assert(node->addr != 0);
+   node->page = cache_alloc(cc, node->addr, PAGE_TYPE_TRUNK);
+   node->hdr  = (trunk_hdr *)(node->page->data);
+}
+
+static inline cache_async_result
+trunk_node_get_async(cache *cc, uint64 addr, trunk_async_ctxt *ctxt)
+{
+   return cache_get_async(cc, addr, PAGE_TYPE_TRUNK, &ctxt->cache_ctxt);
+}
+
+static inline void
+trunk_node_async_done(trunk_handle *spl, trunk_async_ctxt *ctxt)
+{
+   cache_async_done(spl->cc, PAGE_TYPE_TRUNK, &ctxt->cache_ctxt);
+}
+
+/*
+ *-----------------------------------------------------------------------------
+ * Basic Header Access/Manipulation Functions
+ *-----------------------------------------------------------------------------
+ */
+
+static inline uint16
+trunk_height(trunk_node *node)
+{
+   return node->hdr->height;
+}
+
+static inline bool
+trunk_is_leaf(trunk_node *node)
+{
+   return trunk_height(node) == 0;
+}
+
+static inline bool
+trunk_is_index(trunk_node *node)
+{
+   return !trunk_is_leaf(node);
+}
+
+static inline uint64
+trunk_next_addr(trunk_node *node)
+{
+   return node->hdr->next_addr;
+}
+
+static inline void
+trunk_set_next_addr(trunk_node *node, uint64 addr)
+{
+   node->hdr->next_addr = addr;
+}
+
+/*
+ *-----------------------------------------------------------------------------
+ * Compaction Requests
+ *-----------------------------------------------------------------------------
+ */
+
+/*
  * Used to specify compaction bundle "task" request. These enums specify
  * the compaction bundle request type. (Not disk-resident.)
  */
@@ -592,7 +710,7 @@ struct trunk_compact_bundle_req {
    uint16                height;
    uint16                bundle_no;
    trunk_compaction_type type;
-   uint64                generation;
+   uint64                generation; // node generation
    uint64                pivot_generation[TRUNK_MAX_PIVOTS];
    uint64                max_pivot_generation;
    uint64                input_pivot_tuple_count[TRUNK_MAX_PIVOTS];
@@ -659,54 +777,45 @@ typedef union {
 
 // clang-format off
 static inline uint64               trunk_pivot_size                (trunk_handle *spl);
-static inline bool                 trunk_is_leaf                   (trunk_handle *spl, page_handle *node);
-static inline uint64               trunk_next_addr                 (trunk_handle *spl, page_handle *node);
-static inline page_handle *        trunk_node_get                  (trunk_handle *spl, uint64 addr);
-static inline void                 trunk_node_unget                (trunk_handle *spl, page_handle **node);
-static inline void                 trunk_node_claim                (trunk_handle *spl, page_handle **node);
-static inline void                 trunk_node_unclaim              (trunk_handle *spl, page_handle *node);
-static inline void                 trunk_node_lock                 (trunk_handle *spl, page_handle *node);
-static inline void                 trunk_node_unlock               (trunk_handle *spl, page_handle *node);
-page_handle *                      trunk_alloc                     (trunk_handle *spl, uint64 height);
-static inline key                trunk_get_pivot                 (trunk_handle *spl, page_handle *node, uint16 pivot_no);
-static inline trunk_pivot_data    *trunk_get_pivot_data            (trunk_handle *spl, page_handle *node, uint16 pivot_no);
-static inline uint16               trunk_find_pivot                (trunk_handle *spl, page_handle *node, key target, lookup_type comp);
-platform_status                    trunk_add_pivot                 (trunk_handle *spl, page_handle *parent, page_handle *child, uint16 pivot_no);
-static inline uint16               trunk_num_children              (trunk_handle *spl, page_handle *node);
-static inline uint16               trunk_num_pivot_keys            (trunk_handle *spl, page_handle *node);
-static inline void                 trunk_inc_num_pivot_keys        (trunk_handle *spl, page_handle *node);
-static inline key                trunk_max_key                   (trunk_handle *spl, page_handle *node);
-static inline uint64               trunk_pivot_num_tuples          (trunk_handle *spl, page_handle *node, uint16 pivot_no);
-static inline uint64               trunk_pivot_kv_bytes            (trunk_handle *spl, page_handle *node, uint16 pivot_no);
-static inline void                 trunk_pivot_branch_tuple_counts (trunk_handle *spl, page_handle  *node, uint16 pivot_no, uint16 branch_no, uint64 *num_tuples, uint64 *num_kv_bytes);
-void                               trunk_pivot_recount_num_tuples_and_kv_bytes  (trunk_handle *spl, page_handle *node, uint64 pivot_no);
-static inline bool                 trunk_has_vacancy               (trunk_handle *spl, page_handle *node, uint16 num_new_branches);
+static inline key                  trunk_get_pivot                 (trunk_handle *spl, trunk_node *node, uint16 pivot_no);
+static inline trunk_pivot_data    *trunk_get_pivot_data            (trunk_handle *spl, trunk_node *node, uint16 pivot_no);
+static inline uint16               trunk_find_pivot                (trunk_handle *spl, trunk_node *node, key target, lookup_type comp);
+platform_status                    trunk_add_pivot                 (trunk_handle *spl, trunk_node *parent, trunk_node *child, uint16 pivot_no);
+static inline uint16               trunk_num_children              (trunk_handle *spl, trunk_node *node);
+static inline uint16               trunk_num_pivot_keys            (trunk_handle *spl, trunk_node *node);
+static inline void                 trunk_inc_num_pivot_keys        (trunk_handle *spl, trunk_node *node);
+static inline char *               trunk_max_key                   (trunk_handle *spl, trunk_node *node);
+static inline uint64               trunk_pivot_num_tuples          (trunk_handle *spl, trunk_node *node, uint16 pivot_no);
+static inline uint64               trunk_pivot_kv_bytes            (trunk_handle *spl, trunk_node *node, uint16 pivot_no);
+static inline void                 trunk_pivot_branch_tuple_counts (trunk_handle *spl, trunk_node  *node, uint16 pivot_no, uint16 branch_no, uint64 *num_tuples, uint64 *num_kv_bytes);
+void                               trunk_pivot_recount_num_tuples_and_kv_bytes  (trunk_handle *spl, trunk_node *node, uint64 pivot_no);
+//static inline bool                 trunk_has_vacancy               (trunk_handle *spl, trunk_node *node, uint16 num_new_branches);
 static inline uint16               trunk_add_bundle_number         (trunk_handle *spl, uint16 start, uint16 end);
 static inline uint16               trunk_subtract_bundle_number    (trunk_handle *spl, uint16 start, uint16 end);
-static inline trunk_bundle        *trunk_get_bundle                (trunk_handle *spl, page_handle *node, uint16 bundle_no);
-static inline uint16               trunk_get_new_bundle            (trunk_handle *spl, page_handle *node);
-static inline uint16               trunk_bundle_start_branch       (trunk_handle *spl, page_handle *node, trunk_bundle *bundle);
-static inline uint16               trunk_start_bundle              (trunk_handle *spl, page_handle *node);
-static inline uint16               trunk_inc_start_bundle          (trunk_handle *spl, page_handle *node);
-static inline uint16               trunk_end_bundle                (trunk_handle *spl, page_handle *node);
-static inline uint16               trunk_bundle_clear_subbundles   (trunk_handle *spl, page_handle *node, trunk_bundle *bundle);
+static inline trunk_bundle        *trunk_get_bundle                (trunk_handle *spl, trunk_node *node, uint16 bundle_no);
+static inline uint16               trunk_get_new_bundle            (trunk_handle *spl, trunk_node *node);
+static inline uint16               trunk_bundle_start_branch       (trunk_handle *spl, trunk_node *node, trunk_bundle *bundle);
+static inline uint16               trunk_start_bundle              (trunk_handle *spl, trunk_node *node);
+static inline uint16               trunk_inc_start_bundle          (trunk_handle *spl, trunk_node *node);
+static inline uint16               trunk_end_bundle                (trunk_handle *spl, trunk_node *node);
+static inline uint16               trunk_bundle_clear_subbundles   (trunk_handle *spl, trunk_node *node, trunk_bundle *bundle);
 static inline uint16               trunk_add_subbundle_number      (trunk_handle *spl, uint16 start, uint16 end);
 static inline uint16               trunk_subtract_subbundle_number (trunk_handle *spl, uint16 start, uint16 end);
-static inline uint16               trunk_end_subbundle             (trunk_handle *spl, page_handle *node);
-static inline uint16               trunk_end_sb_filter             (trunk_handle *spl, page_handle *node);
-static inline trunk_branch        *trunk_get_branch                (trunk_handle *spl, page_handle *node, uint32 k);
-static inline trunk_branch        *trunk_get_new_branch            (trunk_handle *spl, page_handle *node);
-static inline uint16               trunk_start_branch              (trunk_handle *spl, page_handle *node);
-static inline uint16               trunk_end_branch                (trunk_handle *spl, page_handle *node);
-static inline uint16               trunk_start_frac_branch         (trunk_handle *spl, page_handle *node);
-static inline void                 trunk_set_start_frac_branch     (trunk_handle *spl, page_handle *node, uint16 branch_no);
-static inline uint16               trunk_branch_count              (trunk_handle *spl, page_handle *node);
-static inline bool                 trunk_branch_valid              (trunk_handle *spl, page_handle *node, uint64 branch_no);
-static inline bool                 trunk_branch_live               (trunk_handle *spl, page_handle *node, uint64 branch_no);
-static inline bool                 trunk_branch_live_for_pivot     (trunk_handle *spl, page_handle *node, uint64 branch_no, uint16 pivot_no);
-static inline bool                 trunk_branch_is_whole           (trunk_handle *spl, page_handle *node, uint64 branch_no);
-trunk_bundle *                     trunk_flush_into_bundle         (trunk_handle *spl, page_handle *parent, page_handle *child, trunk_pivot_data *pdata, trunk_compact_bundle_req *req);
-void                               trunk_replace_bundle_branches   (trunk_handle *spl, page_handle *node, trunk_branch *new_branch, trunk_compact_bundle_req *req);
+static inline uint16               trunk_end_subbundle             (trunk_handle *spl, trunk_node *node);
+static inline uint16               trunk_end_sb_filter             (trunk_handle *spl, trunk_node *node);
+static inline trunk_branch        *trunk_get_branch                (trunk_handle *spl, trunk_node *node, uint32 k);
+static inline trunk_branch        *trunk_get_new_branch            (trunk_handle *spl, trunk_node *node);
+static inline uint16               trunk_start_branch              (trunk_handle *spl, trunk_node *node);
+static inline uint16               trunk_end_branch                (trunk_handle *spl, trunk_node *node);
+static inline uint16               trunk_start_frac_branch         (trunk_handle *spl, trunk_node *node);
+static inline void                 trunk_set_start_frac_branch     (trunk_handle *spl, trunk_node *node, uint16 branch_no);
+static inline uint16               trunk_branch_count              (trunk_handle *spl, trunk_node *node);
+static inline bool                 trunk_branch_valid              (trunk_handle *spl, trunk_node *node, uint64 branch_no);
+static inline bool                 trunk_branch_live               (trunk_handle *spl, trunk_node *node, uint64 branch_no);
+static inline bool                 trunk_branch_live_for_pivot     (trunk_handle *spl, trunk_node *node, uint64 branch_no, uint16 pivot_no);
+static inline bool                 trunk_branch_is_whole           (trunk_handle *spl, trunk_node *node, uint64 branch_no);
+trunk_bundle *                     trunk_flush_into_bundle         (trunk_handle *spl, trunk_node *parent, trunk_node *child, trunk_pivot_data *pdata, trunk_compact_bundle_req *req);
+void                               trunk_replace_bundle_branches   (trunk_handle *spl, trunk_node *node, trunk_branch *new_branch, trunk_compact_bundle_req *req);
 static inline uint16               trunk_add_branch_number         (trunk_handle *spl, uint16 branch_no, uint16 offset);
 static inline uint16               trunk_subtract_branch_number    (trunk_handle *spl, uint16 branch_no, uint16 offset);
 static inline void                 trunk_dec_ref                   (trunk_handle *spl, trunk_branch *branch, bool is_memtable);
@@ -718,23 +827,23 @@ void                               trunk_bundle_build_filters      (void *arg, v
 static inline void                 trunk_inc_filter                (trunk_handle *spl, routing_filter *filter);
 static inline void                 trunk_dec_filter                (trunk_handle *spl, routing_filter *filter);
 void                               trunk_compact_bundle            (void *arg, void *scratch);
-platform_status                    trunk_flush                     (trunk_handle *spl, page_handle *parent, trunk_pivot_data *pdata, bool is_space_rec);
-platform_status                    trunk_flush_fullest             (trunk_handle *spl, page_handle *node);
-static inline bool                 trunk_needs_split               (trunk_handle *spl, page_handle *node);
-int                                trunk_split_index               (trunk_handle *spl, page_handle *parent, page_handle *child, uint64 pivot_no);
-void                               trunk_split_leaf                (trunk_handle *spl, page_handle *parent, page_handle *leaf, uint16 child_idx);
-int                                trunk_split_root                (trunk_handle *spl, page_handle     *root);
+platform_status                    trunk_flush                     (trunk_handle *spl, trunk_node *parent, trunk_pivot_data *pdata, bool is_space_rec);
+platform_status                    trunk_flush_fullest             (trunk_handle *spl, trunk_node *node);
+static inline bool                 trunk_needs_split               (trunk_handle *spl, trunk_node *node);
+int                                trunk_split_index               (trunk_handle *spl, trunk_node *parent, trunk_node *child, uint64 pivot_no);
+void                               trunk_split_leaf                (trunk_handle *spl, trunk_node *parent, trunk_node *leaf, uint16 child_idx);
+int                                trunk_split_root                (trunk_handle *spl, trunk_node     *root);
 void                               trunk_print                     (platform_log_handle *log_handle, trunk_handle *spl);
 void                               trunk_print_node                (platform_log_handle *log_handle, trunk_handle *spl, uint64 addr);
-static void                        trunk_print_pivots              (platform_log_handle *log_handle, trunk_handle *spl, page_handle *node);
-static void                        trunk_print_branches_and_bundles(platform_log_handle *log_handle, trunk_handle *spl, page_handle *node);
-static void                        trunk_btree_skiperator_init     (trunk_handle *spl, trunk_btree_skiperator *skip_itor, page_handle *node, uint16 branch_idx, key_buffer pivots[static TRUNK_MAX_PIVOTS]);
+static void                        trunk_print_pivots              (platform_log_handle *log_handle, trunk_handle *spl, trunk_node *node);
+static void                        trunk_print_branches_and_bundles(platform_log_handle *log_handle, trunk_handle *spl, trunk_node *node);
+static void                        trunk_btree_skiperator_init     (trunk_handle *spl, trunk_btree_skiperator *skip_itor, trunk_node *node, uint16 branch_idx, key_buffer pivots[static TRUNK_MAX_PIVOTS]);
 void                               trunk_btree_skiperator_get_curr (iterator *itor, key *curr_key, message *data);
 platform_status                    trunk_btree_skiperator_advance  (iterator *itor);
 platform_status                    trunk_btree_skiperator_at_end   (iterator *itor, bool *at_end);
 void                               trunk_btree_skiperator_print    (iterator *itor);
 void                               trunk_btree_skiperator_deinit   (trunk_handle *spl, trunk_btree_skiperator *skip_itor);
-bool                               trunk_verify_node               (trunk_handle *spl, page_handle *node);
+bool                               trunk_verify_node               (trunk_handle *spl, trunk_node *node);
 void                               trunk_maybe_reclaim_space       (trunk_handle *spl);
 const static iterator_ops trunk_btree_skiperator_ops = {
    .get_curr = trunk_btree_skiperator_get_curr,
@@ -761,6 +870,16 @@ static inline uint64
 trunk_pages_per_extent(const trunk_config *cfg)
 {
    return cache_config_pages_per_extent(cfg->cache_cfg);
+}
+
+static inline uint16
+trunk_tree_height(trunk_handle *spl)
+{
+   trunk_node root;
+   trunk_node_get(spl->cc, spl->root_addr, &root);
+   uint16 tree_height = trunk_height(&root);
+   trunk_node_unget(spl->cc, &root);
+   return tree_height;
 }
 
 /*
@@ -849,32 +968,9 @@ trunk_release_super_block(trunk_handle *spl, page_handle *super_page)
 
 /*
  *-----------------------------------------------------------------------------
- * Helper/wrapper functions
+ * Higher-level Branch and Bundle Functions
  *-----------------------------------------------------------------------------
  */
-
-static inline uint16
-trunk_height(trunk_handle *spl, page_handle *node)
-{
-   trunk_hdr *hdr = (trunk_hdr *)node->data;
-   return hdr->height;
-}
-
-static inline uint16
-trunk_tree_height(trunk_handle *spl)
-{
-   page_handle *root        = trunk_node_get(spl, spl->root_addr);
-   uint16       tree_height = trunk_height(spl, root);
-   trunk_node_unget(spl, &root);
-   return tree_height;
-}
-
-static inline bool
-trunk_is_leaf(trunk_handle *spl, page_handle *node)
-{
-   return trunk_height(spl, node) == 0;
-}
-
 uint64
 trunk_hdr_size()
 {
@@ -887,15 +983,14 @@ trunk_hdr_size()
  * number of bundles.
  */
 static inline uint16
-trunk_logical_branch_count(trunk_handle *spl, page_handle *node)
+trunk_logical_branch_count(trunk_handle *spl, trunk_node *node)
 {
-   trunk_hdr *hdr = (trunk_hdr *)node->data;
    // whole branches
    uint16 num_branches = trunk_subtract_branch_number(
-      spl, hdr->start_frac_branch, hdr->start_branch);
+      spl, node->hdr->start_frac_branch, node->hdr->start_branch);
    // bundles
-   uint16 num_bundles =
-      trunk_subtract_bundle_number(spl, hdr->end_bundle, hdr->start_bundle);
+   uint16 num_bundles = trunk_subtract_bundle_number(
+      spl, node->hdr->end_bundle, node->hdr->start_bundle);
    return num_branches + num_bundles;
 }
 
@@ -904,7 +999,7 @@ trunk_logical_branch_count(trunk_handle *spl, page_handle *node)
  * logical branches.
  */
 static inline bool
-trunk_node_is_full(trunk_handle *spl, page_handle *node)
+trunk_node_is_full(trunk_handle *spl, trunk_node *node)
 {
    uint64 num_kv_bytes = 0;
    if (trunk_logical_branch_count(spl, node) > spl->cfg.max_branches_per_node) {
@@ -914,20 +1009,6 @@ trunk_node_is_full(trunk_handle *spl, page_handle *node)
       num_kv_bytes += trunk_pivot_kv_bytes(spl, node, i);
    }
    return num_kv_bytes > spl->cfg.max_kv_bytes_per_node;
-}
-
-static inline uint64
-trunk_next_addr(trunk_handle *spl, page_handle *node)
-{
-   trunk_hdr *hdr = (trunk_hdr *)node->data;
-   return hdr->next_addr;
-}
-
-static inline void
-trunk_set_next_addr(trunk_handle *spl, page_handle *node, uint64 addr)
-{
-   trunk_hdr *hdr = (trunk_hdr *)node->data;
-   hdr->next_addr = addr;
 }
 
 /*
@@ -940,21 +1021,22 @@ trunk_set_next_addr(trunk_handle *spl, page_handle *node, uint64 addr)
 bool
 trunk_for_each_node(trunk_handle *spl, node_fn func, void *arg)
 {
-   page_handle *root   = trunk_node_get(spl, spl->root_addr);
-   uint16       height = trunk_height(spl, root);
-   trunk_node_unget(spl, &root);
+   uint16 tree_height     = trunk_tree_height(spl);
    uint64 next_level_addr = spl->root_addr;
-   for (uint64 i = 0; i <= height; i++) {
-      page_handle *node = trunk_node_get(spl, next_level_addr);
-      uint64       addr = next_level_addr;
-      next_level_addr   = trunk_get_pivot_data(spl, node, 0)->addr;
-      trunk_node_unget(spl, &node);
+   for (uint64 i = 0; i <= tree_height; i++) {
+      trunk_node node;
+      trunk_node_get(spl->cc, next_level_addr, &node);
+      uint64            addr  = next_level_addr;
+      trunk_pivot_data *pdata = trunk_get_pivot_data(spl, &node, 0);
+      next_level_addr         = pdata->addr;
+      trunk_node_unget(spl->cc, &node);
       while (addr != 0) {
          // first get the next_addr, then apply func, in case func
          // deletes the node for example
-         node             = trunk_node_get(spl, addr);
-         uint64 next_addr = trunk_next_addr(spl, node);
-         trunk_node_unget(spl, &node);
+         trunk_node node;
+         trunk_node_get(spl->cc, addr, &node);
+         uint64 next_addr = trunk_next_addr(&node);
+         trunk_node_unget(spl->cc, &node);
          bool rc = func(spl, addr, arg);
          if (rc != TRUE) {
             return rc;
@@ -969,76 +1051,6 @@ static inline btree_config *
 trunk_btree_config(trunk_handle *spl)
 {
    return &spl->cfg.btree_cfg;
-}
-
-
-/*
- *-----------------------------------------------------------------------------
- * Cache Wrappers
- *-----------------------------------------------------------------------------
- */
-static inline page_handle *
-trunk_node_get(trunk_handle *spl, uint64 addr)
-{
-   return cache_get(spl->cc, addr, TRUE, PAGE_TYPE_TRUNK);
-}
-
-static inline cache_async_result
-trunk_node_get_async(trunk_handle *spl, uint64 addr, trunk_async_ctxt *ctxt)
-{
-   return cache_get_async(spl->cc, addr, PAGE_TYPE_TRUNK, &ctxt->cache_ctxt);
-}
-
-static inline void
-trunk_node_async_done(trunk_handle *spl, trunk_async_ctxt *ctxt)
-{
-   cache_async_done(spl->cc, PAGE_TYPE_TRUNK, &ctxt->cache_ctxt);
-}
-
-static inline void
-trunk_node_unget(trunk_handle *spl, page_handle **node)
-{
-   cache_unget(spl->cc, *node);
-   *node = NULL;
-}
-
-static inline void
-trunk_node_claim(trunk_handle *spl, page_handle **node)
-{
-   uint64 wait = 1;
-   while (!cache_claim(spl->cc, *node)) {
-      uint64 addr = (*node)->disk_addr;
-      trunk_node_unget(spl, node);
-      platform_sleep(wait);
-      wait  = wait > 2048 ? wait : 2 * wait;
-      *node = trunk_node_get(spl, addr);
-   }
-}
-
-static inline void
-trunk_node_unclaim(trunk_handle *spl, page_handle *node)
-{
-   cache_unclaim(spl->cc, node);
-}
-
-static inline void
-trunk_node_lock(trunk_handle *spl, page_handle *node)
-{
-   cache_lock(spl->cc, node);
-   cache_mark_dirty(spl->cc, node);
-}
-
-static inline void
-trunk_node_unlock(trunk_handle *spl, page_handle *node)
-{
-   cache_unlock(spl->cc, node);
-}
-
-page_handle *
-trunk_alloc(trunk_handle *spl, uint64 height)
-{
-   uint64 addr = mini_alloc(&spl->mini, height, NULL_KEY, NULL);
-   return cache_alloc(spl->cc, addr, PAGE_TYPE_TRUNK);
 }
 
 /*
@@ -1142,15 +1154,14 @@ trunk_pivot_size(trunk_handle *spl)
 }
 
 static inline trunk_pivot_data *
-trunk_get_pivot_data(trunk_handle *spl, page_handle *node, uint16 pivot_no)
+trunk_get_pivot_data(trunk_handle *spl, trunk_node *node, uint16 pivot_no)
 {
-   trunk_hdr *hdr = (trunk_hdr *)node->data;
-   return (trunk_pivot_data *)(((char *)hdr) + sizeof(*hdr)
+   return (trunk_pivot_data *)(((char *)node->hdr) + sizeof(*hdr)
                                + pivot_no * trunk_pivot_size(spl));
 }
 
 static inline key
-trunk_get_pivot(trunk_handle *spl, page_handle *node, uint16 pivot_no)
+trunk_get_pivot(trunk_handle *spl, trunk_node *node, uint16 pivot_no)
 {
    platform_assert((pivot_no < spl->cfg.max_pivot_keys),
                    "pivot_no = %d, cfg.max_pivot_keys = %lu",
@@ -1162,7 +1173,7 @@ trunk_get_pivot(trunk_handle *spl, page_handle *node, uint16 pivot_no)
 
 static inline void
 trunk_set_pivot(trunk_handle *spl,
-                page_handle  *node,
+                trunk_node   *node,
                 uint16        pivot_no,
                 key           pivot_key)
 {
@@ -1183,10 +1194,9 @@ trunk_set_pivot(trunk_handle *spl,
 }
 
 static inline void
-trunk_set_initial_pivots(trunk_handle *spl, page_handle *node)
+trunk_set_initial_pivots(trunk_handle *spl, trunk_node *node)
 {
-   trunk_hdr *hdr      = (trunk_hdr *)node->data;
-   hdr->num_pivot_keys = 2;
+   trunk_set_num_pivot_keys(spl, node, 2);
 
    trunk_pivot_data *pdata = trunk_get_pivot_data(spl, node, 0);
    ZERO_CONTENTS(pdata);
@@ -1198,37 +1208,36 @@ trunk_set_initial_pivots(trunk_handle *spl, page_handle *node)
 }
 
 debug_only static inline key
-trunk_min_key(trunk_handle *spl, page_handle *node)
+trunk_min_key(trunk_handle *spl, trunk_node *node)
 {
    return trunk_get_pivot(spl, node, 0);
 }
 
 static inline key
 trunk_max_key(trunk_handle *spl, page_handle *node)
+trunk_max_key(trunk_handle *spl, trunk_node *node)
 {
    return trunk_get_pivot(spl, node, trunk_num_children(spl, node));
 }
 
 static inline uint64
-trunk_pivot_generation(trunk_handle *spl, page_handle *node)
+trunk_pivot_generation(trunk_handle *spl, trunk_node *node)
 {
-   trunk_hdr *hdr = (trunk_hdr *)node->data;
-   return hdr->pivot_generation;
+   return node->hdr->pivot_generation;
 }
 
 static inline uint64
-trunk_inc_pivot_generation(trunk_handle *spl, page_handle *node)
+trunk_inc_pivot_generation(trunk_handle *spl, trunk_node *node)
 {
-   trunk_hdr *hdr = (trunk_hdr *)node->data;
-   return hdr->pivot_generation++;
+   return node->hdr->pivot_generation++;
 }
 
 static inline void
 trunk_set_pivot_data_new_root(trunk_handle *spl,
-                              page_handle  *node,
+                              trunk_node   *node,
                               uint64        child_addr)
 {
-   debug_assert(trunk_height(spl, node) != 0);
+   debug_assert(trunk_height(node) != 0);
    trunk_pivot_data *pdata = trunk_get_pivot_data(spl, node, 0);
 
    pdata->addr                = child_addr;
@@ -1243,12 +1252,12 @@ trunk_set_pivot_data_new_root(trunk_handle *spl,
 
 static inline void
 trunk_init_pivot_data_from_pred(trunk_handle *spl,
-                                page_handle  *node,
+                                trunk_node  *node,
                                 uint16        pivot_no,
                                 uint64        child_addr,
                                 key           new_pivot)
 {
-   debug_assert(trunk_height(spl, node) != 0);
+   debug_assert(trunk_height(node) != 0);
    debug_assert(pivot_no != 0);
    trunk_pivot_data *pdata      = trunk_get_pivot_data(spl, node, pivot_no);
    trunk_pivot_data *pred_pdata = trunk_get_pivot_data(spl, node, pivot_no - 1);
@@ -1267,31 +1276,29 @@ trunk_init_pivot_data_from_pred(trunk_handle *spl,
 
 // Return the start branch number for the pivot_no'th pivot entry
 static inline uint16
-trunk_pivot_start_branch(trunk_handle *spl, page_handle *node, uint16 pivot_no)
+trunk_pivot_start_branch(trunk_handle *spl, trunk_node *node, uint16 pivot_no)
 {
    trunk_pivot_data *pdata = trunk_get_pivot_data(spl, node, pivot_no);
    return pdata->start_branch;
 }
 
 static inline uint64
-trunk_generation(trunk_handle *spl, page_handle *node)
+trunk_generation(trunk_handle *spl, trunk_node *node)
 {
-   trunk_hdr *hdr = (trunk_hdr *)node->data;
-   return hdr->generation;
+   return node->hdr->generation;
 }
 
 static inline uint16
-trunk_pivot_start_bundle(trunk_handle *spl, page_handle *node, uint16 pivot_no)
+trunk_pivot_start_bundle(trunk_handle *spl, trunk_node *node, uint16 pivot_no)
 {
    trunk_pivot_data *pdata = trunk_get_pivot_data(spl, node, pivot_no);
    return pdata->start_bundle;
 }
 
 static inline void
-trunk_inc_generation(trunk_handle *spl, page_handle *node)
+trunk_inc_generation(trunk_handle *spl, trunk_node *node)
 {
-   trunk_hdr *hdr = (trunk_hdr *)node->data;
-   hdr->generation++;
+   node->hdr->generation++;
 }
 
 /*
@@ -1334,8 +1341,8 @@ trunk_update_lowerbound(uint16 *lo, uint16 *mid, int cmp, lookup_type comp)
  */
 static inline uint16
 trunk_find_pivot(trunk_handle *spl,
-                 page_handle  *node,
                  key           target,
+                 trunk_node   *node,
                  lookup_type   comp)
 {
    debug_assert(node != NULL);
@@ -1401,15 +1408,14 @@ trunk_find_pivot(trunk_handle *spl,
  */
 static inline bool
 trunk_branch_live_for_pivot(trunk_handle *spl,
-                            page_handle  *node,
+                            trunk_node   *node,
                             uint64        branch_no,
                             uint16        pivot_no)
 {
-   trunk_hdr        *hdr   = (trunk_hdr *)node->data;
    trunk_pivot_data *pdata = trunk_get_pivot_data(spl, node, pivot_no);
    return trunk_subtract_branch_number(spl, branch_no, pdata->start_branch)
           < trunk_subtract_branch_number(
-             spl, hdr->end_branch, pdata->start_branch);
+             spl, node->hdr->end_branch, pdata->start_branch);
 }
 
 /*
@@ -1417,21 +1423,20 @@ trunk_branch_live_for_pivot(trunk_handle *spl,
  * fractional (part of a bundle) or dead.
  */
 static inline bool
-trunk_branch_is_whole(trunk_handle *spl, page_handle *node, uint64 branch_no)
+trunk_branch_is_whole(trunk_handle *spl, trunk_node *node, uint64 branch_no)
 {
-   trunk_hdr *hdr = (trunk_hdr *)node->data;
-   return trunk_subtract_branch_number(spl, branch_no, hdr->start_branch)
+   return trunk_subtract_branch_number(spl, branch_no, node->hdr->start_branch)
           < trunk_subtract_branch_number(
-             spl, hdr->start_frac_branch, hdr->start_branch);
+             spl, node->hdr->start_frac_branch, node->hdr->start_branch);
 }
 
 static inline void
 trunk_shift_pivots(trunk_handle *spl,
-                   page_handle  *node,
+                   trunk_node   *node,
                    uint16        pivot_no,
                    uint16        shift)
 {
-   debug_assert(trunk_height(spl, node) != 0);
+   debug_assert(trunk_height(node) != 0);
    debug_assert(trunk_num_pivot_keys(spl, node) + shift
                 < spl->cfg.max_pivot_keys);
    debug_assert(pivot_no < trunk_num_pivot_keys(spl, node));
@@ -1449,8 +1454,8 @@ trunk_shift_pivots(trunk_handle *spl,
  */
 platform_status
 trunk_add_pivot(trunk_handle *spl,
-                page_handle  *parent,
-                page_handle  *child,
+                trunk_node   *parent,
+                trunk_node   *child,
                 uint16        pivot_no) // position of new pivot
 {
    // equality is allowed, because we can be adding a pivot at the end
@@ -1478,8 +1483,8 @@ trunk_add_pivot(trunk_handle *spl,
 
 void
 trunk_add_pivot_new_root(trunk_handle *spl,
-                         page_handle  *parent,
-                         page_handle  *child)
+                         trunk_node   *parent,
+                         trunk_node   *child)
 {
    trunk_set_initial_pivots(spl, parent);
    uint64 child_addr = child->disk_addr;
@@ -1494,17 +1499,17 @@ trunk_add_pivot_new_root(trunk_handle *spl,
  */
 void
 trunk_pivot_recount_num_tuples_and_kv_bytes(trunk_handle *spl,
-                                            page_handle  *node,
+                                            trunk_node   *node,
                                             uint64        pivot_no)
 {
-   trunk_hdr        *hdr      = (trunk_hdr *)node->data;
    trunk_pivot_data *pdata    = trunk_get_pivot_data(spl, node, pivot_no);
    pdata->num_tuples_whole    = 0;
    pdata->num_tuples_bundle   = 0;
    pdata->num_kv_bytes_whole  = 0;
    pdata->num_kv_bytes_bundle = 0;
-   for (uint64 branch_no = pdata->start_branch; branch_no != hdr->end_branch;
-        branch_no        = trunk_add_branch_number(spl, branch_no, 1))
+   for (uint64 branch_no = pdata->start_branch;
+        branch_no != node->hdr->end_branch;
+        branch_no = trunk_add_branch_number(spl, branch_no, 1))
    {
       uint64 num_tuples;
       uint64 num_kv_bytes;
@@ -1521,7 +1526,7 @@ trunk_pivot_recount_num_tuples_and_kv_bytes(trunk_handle *spl,
 }
 
 static inline uint64
-trunk_pivot_num_tuples(trunk_handle *spl, page_handle *node, uint16 pivot_no)
+trunk_pivot_num_tuples(trunk_handle *spl, trunk_node *node, uint16 pivot_no)
 {
    trunk_pivot_data *pdata = trunk_get_pivot_data(spl, node, pivot_no);
    return pdata->num_tuples_whole + pdata->num_tuples_bundle;
@@ -1529,7 +1534,7 @@ trunk_pivot_num_tuples(trunk_handle *spl, page_handle *node, uint16 pivot_no)
 
 static inline uint64
 trunk_pivot_num_tuples_whole(trunk_handle *spl,
-                             page_handle  *node,
+                             trunk_node   *node,
                              uint16        pivot_no)
 {
    trunk_pivot_data *pdata = trunk_get_pivot_data(spl, node, pivot_no);
@@ -1538,7 +1543,7 @@ trunk_pivot_num_tuples_whole(trunk_handle *spl,
 
 static inline uint64
 trunk_pivot_num_tuples_bundle(trunk_handle *spl,
-                              page_handle  *node,
+                              trunk_node   *node,
                               uint16        pivot_no)
 {
    trunk_pivot_data *pdata = trunk_get_pivot_data(spl, node, pivot_no);
@@ -1546,16 +1551,14 @@ trunk_pivot_num_tuples_bundle(trunk_handle *spl,
 }
 
 static inline uint64
-trunk_pivot_kv_bytes(trunk_handle *spl, page_handle *node, uint16 pivot_no)
+trunk_pivot_kv_bytes(trunk_handle *spl, trunk_node *node, uint16 pivot_no)
 {
    trunk_pivot_data *pdata = trunk_get_pivot_data(spl, node, pivot_no);
    return pdata->num_kv_bytes_whole + pdata->num_kv_bytes_bundle;
 }
 
 static inline int64
-trunk_pivot_kv_bytes_whole(trunk_handle *spl,
-                           page_handle  *node,
-                           uint16        pivot_no)
+trunk_pivot_kv_bytes_whole(trunk_handle *spl, trunk_node *node, uint16 pivot_no)
 {
    trunk_pivot_data *pdata = trunk_get_pivot_data(spl, node, pivot_no);
    return pdata->num_kv_bytes_whole;
@@ -1563,7 +1566,7 @@ trunk_pivot_kv_bytes_whole(trunk_handle *spl,
 
 static inline int64
 trunk_pivot_kv_bytes_bundle(trunk_handle *spl,
-                            page_handle  *node,
+                            trunk_node   *node,
                             uint16        pivot_no)
 {
    trunk_pivot_data *pdata = trunk_get_pivot_data(spl, node, pivot_no);
@@ -1572,7 +1575,7 @@ trunk_pivot_kv_bytes_bundle(trunk_handle *spl,
 
 void
 trunk_pivot_set_bundle_counts(trunk_handle *spl,
-                              page_handle  *node,
+                              trunk_node   *node,
                               uint16        pivot_no,
                               uint64        num_tuples,
                               uint64        num_kv_bytes)
@@ -1583,7 +1586,7 @@ trunk_pivot_set_bundle_counts(trunk_handle *spl,
 }
 
 void
-trunk_pivot_clear_counts(trunk_handle *spl, page_handle *node, uint16 pivot_no)
+trunk_pivot_clear_counts(trunk_handle *spl, trunk_node *node, uint16 pivot_no)
 {
    trunk_pivot_data *pdata    = trunk_get_pivot_data(spl, node, pivot_no);
    pdata->num_tuples_whole    = 0;
@@ -1608,14 +1611,13 @@ trunk_pivot_tuples_to_reclaim(trunk_handle *spl, trunk_pivot_data *pdata)
  */
 static inline uint64
 trunk_pivot_whole_branch_count(trunk_handle     *spl,
-                               page_handle      *node,
+                               trunk_node       *node,
                                trunk_pivot_data *pdata)
 {
-   trunk_hdr *hdr = (trunk_hdr *)node->data;
    if (!trunk_branch_is_whole(spl, node, pdata->start_branch))
       return 0;
    return trunk_subtract_branch_number(
-      spl, hdr->start_frac_branch, pdata->start_branch);
+      spl, node->hdr->start_frac_branch, pdata->start_branch);
 }
 
 /*
@@ -1623,12 +1625,11 @@ trunk_pivot_whole_branch_count(trunk_handle     *spl,
  */
 static inline uint16
 trunk_pivot_bundle_count(trunk_handle     *spl,
-                         page_handle      *node,
+                         trunk_node       *node,
                          trunk_pivot_data *pdata)
 {
-   trunk_hdr *hdr = (trunk_hdr *)node->data;
    return trunk_subtract_bundle_number(
-      spl, hdr->end_bundle, pdata->start_bundle);
+      spl, node->hdr->end_bundle, pdata->start_bundle);
 }
 
 /*
@@ -1636,10 +1637,9 @@ trunk_pivot_bundle_count(trunk_handle     *spl,
  */
 static inline uint16
 trunk_pivot_subbundle_count(trunk_handle     *spl,
-                            page_handle      *node,
+                            trunk_node       *node,
                             trunk_pivot_data *pdata)
 {
-   trunk_hdr    *hdr = (trunk_hdr *)node->data;
    uint16        pivot_start_subbundle;
    trunk_bundle *bundle;
    if (trunk_pivot_bundle_count(spl, node, pdata) == 0) {
@@ -1649,12 +1649,12 @@ trunk_pivot_subbundle_count(trunk_handle     *spl,
    bundle                = trunk_get_bundle(spl, node, pdata->start_bundle);
    pivot_start_subbundle = bundle->start_subbundle;
    return trunk_subtract_subbundle_number(
-      spl, hdr->end_subbundle, pivot_start_subbundle);
+      spl, node->hdr->end_subbundle, pivot_start_subbundle);
 }
 
 static inline uint16
 trunk_pivot_start_subbundle(trunk_handle     *spl,
-                            page_handle      *node,
+                            trunk_node       *node,
                             trunk_pivot_data *pdata)
 {
    if (pdata->start_bundle == trunk_end_bundle(spl, node)) {
@@ -1666,7 +1666,7 @@ trunk_pivot_start_subbundle(trunk_handle     *spl,
 
 static inline uint16
 trunk_pivot_end_subbundle_for_lookup(trunk_handle     *spl,
-                                     page_handle      *node,
+                                     trunk_node       *node,
                                      trunk_pivot_data *pdata)
 {
    return trunk_subtract_subbundle_number(
@@ -1679,7 +1679,7 @@ trunk_pivot_end_subbundle_for_lookup(trunk_handle     *spl,
  */
 static inline uint16
 trunk_pivot_logical_branch_count(trunk_handle     *spl,
-                                 page_handle      *node,
+                                 trunk_node       *node,
                                  trunk_pivot_data *pdata)
 {
    return trunk_pivot_whole_branch_count(spl, node, pdata)
@@ -1696,7 +1696,7 @@ trunk_pivot_logical_branch_count(trunk_handle     *spl,
  */
 static inline bool
 trunk_pivot_needs_flush(trunk_handle     *spl,
-                        page_handle      *node,
+                        trunk_node       *node,
                         trunk_pivot_data *pdata)
 {
    return trunk_pivot_logical_branch_count(spl, node, pdata)
@@ -1711,17 +1711,16 @@ trunk_pivot_needs_flush(trunk_handle     *spl,
  */
 static inline uint16
 trunk_pivot_branch_count(trunk_handle     *spl,
-                         page_handle      *node,
+                         trunk_node       *node,
                          trunk_pivot_data *pdata)
 {
-   trunk_hdr *hdr = (trunk_hdr *)node->data;
    return trunk_subtract_branch_number(
-      spl, hdr->end_branch, pdata->start_branch);
+      spl, node->hdr->end_branch, pdata->start_branch);
 }
 
 static inline void
 trunk_pivot_btree_tuple_counts(trunk_handle *spl,
-                               page_handle  *node,
+                               trunk_node   *node,
                                uint16        pivot_no,
                                uint64        root_addr,
                                uint64       *num_tuples,
@@ -1738,7 +1737,7 @@ trunk_pivot_btree_tuple_counts(trunk_handle *spl,
 
 static inline void
 trunk_pivot_branch_tuple_counts(trunk_handle *spl,
-                                page_handle  *node,
+                                trunk_node   *node,
                                 uint16        pivot_no,
                                 uint16        branch_no,
                                 uint64       *num_tuples,
@@ -1751,7 +1750,7 @@ trunk_pivot_branch_tuple_counts(trunk_handle *spl,
 
 debug_only static inline uint64
 trunk_pivot_tuples_in_branch_slow(trunk_handle *spl,
-                                  page_handle  *node,
+                                  trunk_node   *node,
                                   uint16        pivot_no,
                                   uint16        branch_no)
 {
@@ -1777,10 +1776,9 @@ trunk_pivot_tuples_in_branch_slow(trunk_handle *spl,
  * sure they are dereferenced and updates the values in the header.
  */
 static inline void
-trunk_reset_start_branch(trunk_handle *spl, page_handle *node)
+trunk_reset_start_branch(trunk_handle *spl, trunk_node *node)
 {
-   trunk_hdr    *hdr          = (trunk_hdr *)node->data;
-   uint16        start_branch = hdr->end_branch;
+   uint16        start_branch = node->hdr->end_branch;
    uint16        pivot_no, branch_no, bundle_no;
    trunk_bundle *bundle;
 
@@ -1788,21 +1786,22 @@ trunk_reset_start_branch(trunk_handle *spl, page_handle *node)
    for (pivot_no = 0; pivot_no < trunk_num_children(spl, node); pivot_no++) {
       trunk_pivot_data *pdata = trunk_get_pivot_data(spl, node, pivot_no);
       if (trunk_subtract_branch_number(
-             spl, hdr->end_branch, pdata->start_branch)
-          > trunk_subtract_branch_number(spl, hdr->end_branch, start_branch))
+             spl, node->hdr->end_branch, pdata->start_branch)
+          > trunk_subtract_branch_number(
+             spl, node->hdr->end_branch, start_branch))
       {
          start_branch = pdata->start_branch;
       }
    }
 
    // reset the start branch (and maybe the fractional branch)
-   hdr->start_branch = start_branch;
-   if (!trunk_branch_valid(spl, node, hdr->start_frac_branch)) {
-      hdr->start_frac_branch = hdr->start_branch;
+   node->hdr->start_branch = start_branch;
+   if (!trunk_branch_valid(spl, node, node->hdr->start_frac_branch)) {
+      node->hdr->start_frac_branch = node->hdr->start_branch;
    }
 
    // kill any bundles that have no live branches
-   for (bundle_no = hdr->start_bundle; bundle_no != hdr->end_bundle;
+   for (bundle_no = node->hdr->start_bundle; bundle_no != node->hdr->end_bundle;
         bundle_no = trunk_add_bundle_number(spl, bundle_no, 1))
    {
       bundle    = trunk_get_bundle(spl, node, bundle_no);
@@ -1815,7 +1814,7 @@ trunk_reset_start_branch(trunk_handle *spl, page_handle *node)
          trunk_bundle_clear_subbundles(spl, node, bundle);
          trunk_inc_start_bundle(spl, node);
          trunk_default_log_if_enabled(
-            spl, "node %lu evicting bundle %hu\n", node->disk_addr, bundle_no);
+            spl, "node %lu evicting bundle %hu\n", node->addr, bundle_no);
       }
    }
 }
@@ -1826,18 +1825,17 @@ trunk_reset_start_branch(trunk_handle *spl, page_handle *node)
  * Used when flushing the pivot.
  */
 static inline void
-trunk_pivot_clear(trunk_handle *spl, page_handle *node, trunk_pivot_data *pdata)
+trunk_pivot_clear(trunk_handle *spl, trunk_node *node, trunk_pivot_data *pdata)
 {
-   trunk_hdr *hdr             = (trunk_hdr *)node->data;
-   uint16     start_branch    = pdata->start_branch;
-   pdata->start_branch        = hdr->end_branch;
-   pdata->start_bundle        = hdr->end_bundle;
+   uint16 start_branch        = pdata->start_branch;
+   pdata->start_branch        = node->hdr->end_branch;
+   pdata->start_bundle        = node->hdr->end_bundle;
    pdata->num_tuples_whole    = 0;
    pdata->num_tuples_bundle   = 0;
    pdata->num_kv_bytes_whole  = 0;
    pdata->num_kv_bytes_bundle = 0;
    pdata->srq_idx             = -1;
-   if (start_branch == hdr->start_branch) {
+   if (start_branch == node->hdr->start_branch) {
       trunk_reset_start_branch(spl, node);
    }
    pdata->filter.addr             = 0;
@@ -1850,7 +1848,7 @@ trunk_pivot_clear(trunk_handle *spl, page_handle *node, trunk_pivot_data *pdata)
  */
 static inline uint16
 trunk_pdata_to_pivot_index(trunk_handle     *spl,
-                           page_handle      *node,
+                           trunk_node       *node,
                            trunk_pivot_data *pdata)
 {
    uint64 byte_difference =
@@ -1863,11 +1861,10 @@ trunk_pdata_to_pivot_index(trunk_handle     *spl,
  * Returns the number of children of the node
  */
 static inline uint16
-trunk_num_children(trunk_handle *spl, page_handle *node)
+trunk_num_children(trunk_handle *spl, trunk_node *node)
 {
-   trunk_hdr *hdr = (trunk_hdr *)node->data;
-   debug_assert(hdr->num_pivot_keys >= 2);
-   return hdr->num_pivot_keys - 1;
+   debug_assert(node->hdr->num_pivot_keys >= 2);
+   return node->hdr->num_pivot_keys - 1;
 }
 
 /*
@@ -1875,20 +1872,26 @@ trunk_num_children(trunk_handle *spl, page_handle *node)
  * children + 1 for the upper bound pivot key.
  */
 static inline uint16
-trunk_num_pivot_keys(trunk_handle *spl, page_handle *node)
+trunk_num_pivot_keys(trunk_handle *spl, trunk_node *node)
 {
-   trunk_hdr *hdr = (trunk_hdr *)node->data;
-   debug_assert(hdr->num_pivot_keys >= 2);
-   return hdr->num_pivot_keys;
+   debug_assert(node->hdr->num_pivot_keys >= 2);
+   return node->hdr->num_pivot_keys;
 }
 
 static inline void
-trunk_inc_num_pivot_keys(trunk_handle *spl, page_handle *node)
+trunk_set_num_pivot_keys(trunk_handle *spl, trunk_node *node, uint16 num_pivot_keys)
 {
-   trunk_hdr *hdr = (trunk_hdr *)node->data;
-   debug_assert(hdr->num_pivot_keys >= 2);
-   hdr->num_pivot_keys++;
-   debug_assert(hdr->num_pivot_keys <= spl->cfg.max_pivot_keys);
+   debug_assert(num_pivot_keys >= 2);
+   debug_assert(num_pivot_keys <= spl->cfg.max_pivot_keys);
+   node->hdr->num_pivot_keys = num_pivot_keys;
+}
+
+static inline void
+trunk_inc_num_pivot_keys(trunk_handle *spl, trunk_node *node)
+{
+   debug_assert(node->hdr->num_pivot_keys >= 2);
+   node->hdr->num_pivot_keys++;
+   debug_assert(node->hdr->num_pivot_keys <= spl->cfg.max_pivot_keys);
 }
 
 
@@ -1902,21 +1905,23 @@ trunk_inc_num_pivot_keys(trunk_handle *spl, page_handle *node)
 uint64
 trunk_find_node(trunk_handle *spl, key target, uint64 height)
 {
-   page_handle *node        = trunk_node_get(spl, spl->root_addr);
-   uint16       tree_height = trunk_height(spl, node);
+   trunk_node node;
+   trunk_node_get(spl->cc, spl->root_addr, &node);
+   uint16 tree_height = trunk_height(&node);
    for (uint16 h = tree_height; h > height + 1; h--) {
-      uint32 pivot_no = trunk_find_pivot(spl, node, target, less_than_or_equal);
-      debug_assert(pivot_no < trunk_num_children(spl, node));
-      trunk_pivot_data *pdata = trunk_get_pivot_data(spl, node, pivot_no);
-      page_handle      *child = trunk_node_get(spl, pdata->addr);
-      trunk_node_unget(spl, &node);
+      uint32 pivot_no = trunk_find_pivot(spl, &node, target, less_than_or_equal);
+      debug_assert(pivot_no < trunk_num_children(spl, &node));
+      trunk_pivot_data *pdata = trunk_get_pivot_data(spl, &node, pivot_no);
+      trunk_node        child;
+      trunk_node_get(spl->cc, pdata->addr, &child);
+      trunk_node_unget(spl->cc, &node);
       node = child;
    }
-   uint32 pivot_no = trunk_find_pivot(spl, node, target, less_than_or_equal);
-   debug_assert(pivot_no < trunk_num_children(spl, node));
-   trunk_pivot_data *pdata    = trunk_get_pivot_data(spl, node, pivot_no);
+   uint32 pivot_no = trunk_find_pivot(spl, &node, target, less_than_or_equal);
+   debug_assert(pivot_no < trunk_num_children(spl, &node));
+   trunk_pivot_data *pdata    = trunk_get_pivot_data(spl, &node, pivot_no);
    uint64            ret_addr = pdata->addr;
-   trunk_node_unget(spl, &node);
+   trunk_node_unget(spl->cc, &node);
    return ret_addr;
 }
 
@@ -1930,7 +1935,7 @@ trunk_find_node(trunk_handle *spl, key target, uint64 height)
  * Returns TRUE if the bundle is live in the node and FALSE otherwise.
  */
 static inline bool
-trunk_bundle_live(trunk_handle *spl, page_handle *node, uint16 bundle_no)
+trunk_bundle_live(trunk_handle *spl, trunk_node *node, uint16 bundle_no)
 {
    return trunk_bundle_in_range(spl,
                                 bundle_no,
@@ -1939,65 +1944,61 @@ trunk_bundle_live(trunk_handle *spl, page_handle *node, uint16 bundle_no)
 }
 
 static inline trunk_bundle *
-trunk_get_bundle(trunk_handle *spl, page_handle *node, uint16 bundle_no)
+trunk_get_bundle(trunk_handle *spl, trunk_node *node, uint16 bundle_no)
 {
-   trunk_hdr *hdr = (trunk_hdr *)node->data;
    debug_assert(trunk_bundle_live(spl, node, bundle_no),
                 "Attempt to get a dead bundle.\n"
                 "addr: %lu, bundle_no: %u, start_bundle: %u, end_bundle: %u\n",
-                node->disk_addr,
+                node->addr,
                 bundle_no,
                 trunk_start_bundle(spl, node),
                 trunk_end_bundle(spl, node));
-   return &hdr->bundle[bundle_no];
+   return &node->hdr->bundle[bundle_no];
 }
 
 static inline uint16
-trunk_get_new_bundle(trunk_handle *spl, page_handle *node)
+trunk_get_new_bundle(trunk_handle *spl, trunk_node *node)
 {
-   trunk_hdr *hdr           = (trunk_hdr *)node->data;
-   uint16     new_bundle_no = hdr->end_bundle;
-   hdr->end_bundle          = trunk_add_bundle_number(spl, hdr->end_bundle, 1);
-   platform_assert((hdr->end_bundle != hdr->start_bundle),
+   uint16 new_bundle_no = node->hdr->end_bundle;
+   node->hdr->end_bundle =
+      trunk_add_bundle_number(spl, node->hdr->end_bundle, 1);
+   platform_assert((node->hdr->end_bundle != node->hdr->start_bundle),
                    "No available bundles in trunk node. "
                    "page disk_addr=%lu, end_bundle=%d, start_bundle=%d",
-                   node->disk_addr,
-                   hdr->end_bundle,
-                   hdr->start_bundle);
+                   node->addr,
+                   node->hdr->end_bundle,
+                   node->hdr->start_bundle);
    return new_bundle_no;
 }
 
 static inline uint16
-trunk_start_bundle(trunk_handle *spl, page_handle *node)
+trunk_start_bundle(trunk_handle *spl, trunk_node *node)
 {
-   trunk_hdr *hdr = (trunk_hdr *)node->data;
-   return hdr->start_bundle;
+   return node->hdr->start_bundle;
 }
 
 static inline uint16
-trunk_end_bundle(trunk_handle *spl, page_handle *node)
+trunk_end_bundle(trunk_handle *spl, trunk_node *node)
 {
-   trunk_hdr *hdr = (trunk_hdr *)node->data;
-   return hdr->end_bundle;
+   return node->hdr->end_bundle;
 }
 
 static inline uint16
-trunk_inc_start_bundle(trunk_handle *spl, page_handle *node)
+trunk_inc_start_bundle(trunk_handle *spl, trunk_node *node)
 {
-   trunk_hdr *hdr    = (trunk_hdr *)node->data;
-   hdr->start_bundle = trunk_add_bundle_number(spl, hdr->start_bundle, 1);
-   return hdr->start_bundle;
+   node->hdr->start_bundle =
+      trunk_add_bundle_number(spl, node->hdr->start_bundle, 1);
+   return node->hdr->start_bundle;
 }
 
 static inline trunk_subbundle *
-trunk_get_subbundle(trunk_handle *spl, page_handle *node, uint16 subbundle_no)
+trunk_get_subbundle(trunk_handle *spl, trunk_node *node, uint16 subbundle_no)
 {
-   trunk_hdr *hdr = (trunk_hdr *)node->data;
-   return &hdr->subbundle[subbundle_no];
+   return &node->hdr->subbundle[subbundle_no];
 }
 
 static inline uint16
-trunk_subbundle_no(trunk_handle *spl, page_handle *node, trunk_subbundle *sb)
+trunk_subbundle_no(trunk_handle *spl, trunk_node *node, trunk_subbundle *sb)
 {
    return sb - trunk_get_subbundle(spl, node, 0);
 }
@@ -2007,73 +2008,67 @@ trunk_subbundle_no(trunk_handle *spl, page_handle *node, trunk_subbundle *sb)
  * index.
  */
 static inline trunk_subbundle *
-trunk_get_new_subbundle(trunk_handle *spl,
-                        page_handle  *node,
-                        uint16        num_filters)
+trunk_get_new_subbundle(trunk_handle *spl, trunk_node *node, uint16 num_filters)
 {
-   trunk_hdr *hdr              = (trunk_hdr *)node->data;
-   uint16     new_subbundle_no = hdr->end_subbundle;
-   hdr->end_subbundle = trunk_add_subbundle_number(spl, hdr->end_subbundle, 1);
+   uint16 new_subbundle_no = node->hdr->end_subbundle;
+   node->hdr->end_subbundle =
+      trunk_add_subbundle_number(spl, node->hdr->end_subbundle, 1);
    // ALEX: Need a way to handle this better
-   platform_assert(hdr->end_subbundle != hdr->start_subbundle);
+   platform_assert(node->hdr->end_subbundle != node->hdr->start_subbundle);
 
    // get filters
-   trunk_subbundle *sb = trunk_get_subbundle(spl, node, new_subbundle_no);
-   sb->start_filter    = trunk_end_sb_filter(spl, node);
-   hdr->end_sb_filter =
-      trunk_add_subbundle_filter_number(spl, hdr->end_sb_filter, num_filters);
+   trunk_subbundle *sb      = trunk_get_subbundle(spl, node, new_subbundle_no);
+   sb->start_filter         = trunk_end_sb_filter(spl, node);
+   node->hdr->end_sb_filter = trunk_add_subbundle_filter_number(
+      spl, node->hdr->end_sb_filter, num_filters);
    sb->end_filter = trunk_end_sb_filter(spl, node);
    sb->state      = SB_STATE_COMPACTED;
    return sb;
 }
 
 static inline trunk_subbundle *
-trunk_leaf_get_new_subbundle_at_head(trunk_handle *spl, page_handle *node)
+trunk_leaf_get_new_subbundle_at_head(trunk_handle *spl, trunk_node *node)
 {
-   trunk_hdr *hdr = (trunk_hdr *)node->data;
-   uint16     new_subbundle_no =
-      trunk_subtract_subbundle_number(spl, hdr->start_subbundle, 1);
-   platform_assert(new_subbundle_no != hdr->end_subbundle);
-   hdr->start_subbundle = new_subbundle_no;
+   uint16 new_subbundle_no =
+      trunk_subtract_subbundle_number(spl, node->hdr->start_subbundle, 1);
+   platform_assert(new_subbundle_no != node->hdr->end_subbundle);
+   node->hdr->start_subbundle = new_subbundle_no;
 
    // get filters
    trunk_subbundle *sb = trunk_get_subbundle(spl, node, new_subbundle_no);
-   sb->end_filter      = hdr->start_sb_filter;
+   sb->end_filter      = node->hdr->start_sb_filter;
    sb->start_filter =
-      trunk_subtract_subbundle_number(spl, hdr->start_sb_filter, 1);
-   platform_assert(sb->start_filter != hdr->end_sb_filter);
-   hdr->start_sb_filter = sb->start_filter;
-   sb->state            = SB_STATE_UNCOMPACTED_LEAF;
+      trunk_subtract_subbundle_number(spl, node->hdr->start_sb_filter, 1);
+   platform_assert(sb->start_filter != node->hdr->end_sb_filter);
+   node->hdr->start_sb_filter = sb->start_filter;
+   sb->state                  = SB_STATE_UNCOMPACTED_LEAF;
    return sb;
 }
 
 static inline routing_filter *
-trunk_get_sb_filter(trunk_handle *spl, page_handle *node, uint16 filter_no)
+trunk_get_sb_filter(trunk_handle *spl, trunk_node *node, uint16 filter_no)
 {
-   trunk_hdr *hdr = (trunk_hdr *)node->data;
    debug_assert(filter_no < TRUNK_MAX_SUBBUNDLE_FILTERS,
                 "filter_no=%u should be < TRUNK_MAX_SUBBUNDLE_FILTERS (%u)",
                 filter_no,
                 TRUNK_MAX_SUBBUNDLE_FILTERS);
-   return &hdr->sb_filter[filter_no];
+   return &node->hdr->sb_filter[filter_no];
 }
 
 static inline uint16
-trunk_start_sb_filter(trunk_handle *spl, page_handle *node)
+trunk_start_sb_filter(trunk_handle *spl, trunk_node *node)
 {
-   trunk_hdr *hdr = (trunk_hdr *)node->data;
-   return hdr->start_sb_filter;
+   return node->hdr->start_sb_filter;
 }
 
 static inline uint16
-trunk_end_sb_filter(trunk_handle *spl, page_handle *node)
+trunk_end_sb_filter(trunk_handle *spl, trunk_node *node)
 {
-   trunk_hdr *hdr = (trunk_hdr *)node->data;
-   return hdr->end_sb_filter;
+   return node->hdr->end_sb_filter;
 }
 
 static inline bool
-trunk_sb_filter_valid(trunk_handle *spl, page_handle *node, uint16 filter_no)
+trunk_sb_filter_valid(trunk_handle *spl, trunk_node *node, uint16 filter_no)
 {
    uint16 start_filter = trunk_start_sb_filter(spl, node);
    uint16 end_filter   = trunk_end_sb_filter(spl, node);
@@ -2084,7 +2079,7 @@ trunk_sb_filter_valid(trunk_handle *spl, page_handle *node, uint16 filter_no)
 
 static inline uint16
 trunk_subbundle_filter_count(trunk_handle    *spl,
-                             page_handle     *node,
+                             trunk_node      *node,
                              trunk_subbundle *sb)
 {
    return trunk_subtract_subbundle_number(
@@ -2093,7 +2088,7 @@ trunk_subbundle_filter_count(trunk_handle    *spl,
 
 static inline uint16
 trunk_bundle_filter_count(trunk_handle *spl,
-                          page_handle  *node,
+                          trunk_node   *node,
                           trunk_bundle *bundle)
 {
    uint16 filter_count = 0;
@@ -2108,7 +2103,7 @@ trunk_bundle_filter_count(trunk_handle *spl,
 
 static inline uint16
 trunk_bundle_start_filter(trunk_handle *spl,
-                          page_handle  *node,
+                          trunk_node   *node,
                           trunk_bundle *bundle)
 {
    uint16           sb_no = bundle->start_subbundle;
@@ -2118,7 +2113,7 @@ trunk_bundle_start_filter(trunk_handle *spl,
 
 static inline uint16
 trunk_bundle_end_filter(trunk_handle *spl,
-                        page_handle  *node,
+                        trunk_node   *node,
                         trunk_bundle *bundle)
 {
    uint16 last_sb_no =
@@ -2129,7 +2124,7 @@ trunk_bundle_end_filter(trunk_handle *spl,
 
 static inline routing_filter *
 trunk_subbundle_filter(trunk_handle    *spl,
-                       page_handle     *node,
+                       trunk_node      *node,
                        trunk_subbundle *sb,
                        uint16           filter_off)
 {
@@ -2142,28 +2137,26 @@ trunk_subbundle_filter(trunk_handle    *spl,
 
 debug_only static inline uint16
 trunk_subbundle_branch_count(trunk_handle    *spl,
-                             page_handle     *node,
+                             trunk_node      *node,
                              trunk_subbundle *sb)
 {
    return trunk_subtract_branch_number(spl, sb->end_branch, sb->start_branch);
 }
 
 static inline uint16
-trunk_start_subbundle(trunk_handle *spl, page_handle *node)
+trunk_start_subbundle(trunk_handle *spl, trunk_node *node)
 {
-   trunk_hdr *hdr = (trunk_hdr *)node->data;
-   return hdr->start_subbundle;
+   return node->hdr->start_subbundle;
 }
 
 static inline uint16
-trunk_end_subbundle(trunk_handle *spl, page_handle *node)
+trunk_end_subbundle(trunk_handle *spl, trunk_node *node)
 {
-   trunk_hdr *hdr = (trunk_hdr *)node->data;
-   return hdr->end_subbundle;
+   return node->hdr->end_subbundle;
 }
 
 static inline uint16
-trunk_start_subbundle_for_lookup(trunk_handle *spl, page_handle *node)
+trunk_start_subbundle_for_lookup(trunk_handle *spl, trunk_node *node)
 {
    return trunk_subtract_subbundle_number(
       spl, trunk_end_subbundle(spl, node), 1);
@@ -2171,21 +2164,20 @@ trunk_start_subbundle_for_lookup(trunk_handle *spl, page_handle *node)
 
 static inline uint16
 trunk_bundle_clear_subbundles(trunk_handle *spl,
-                              page_handle  *node,
+                              trunk_node   *node,
                               trunk_bundle *bundle)
 {
-   trunk_hdr *hdr          = (trunk_hdr *)node->data;
-   uint16     start_filter = trunk_bundle_start_filter(spl, node, bundle);
-   uint16     end_filter   = trunk_bundle_end_filter(spl, node, bundle);
+   uint16 start_filter = trunk_bundle_start_filter(spl, node, bundle);
+   uint16 end_filter   = trunk_bundle_end_filter(spl, node, bundle);
    for (uint16 filter_no = start_filter; filter_no != end_filter;
         filter_no        = trunk_add_subbundle_filter_number(spl, filter_no, 1))
    {
       routing_filter *filter = trunk_get_sb_filter(spl, node, filter_no);
       trunk_dec_filter(spl, filter);
    }
-   hdr->start_sb_filter = end_filter;
-   hdr->start_subbundle = bundle->end_subbundle;
-   return hdr->start_subbundle;
+   node->hdr->start_sb_filter = end_filter;
+   node->hdr->start_subbundle = bundle->end_subbundle;
+   return node->hdr->start_subbundle;
 }
 
 /*
@@ -2198,17 +2190,16 @@ trunk_bundle_clear_subbundles(trunk_handle *spl,
  */
 static inline void
 trunk_leaf_remove_bundles_except(trunk_handle *spl,
-                                 page_handle  *node,
+                                 trunk_node   *node,
                                  uint16        bundle_no)
 {
-   debug_assert(trunk_height(spl, node) == 0);
-   trunk_hdr *hdr            = (trunk_hdr *)node->data;
-   uint16     last_bundle_no = trunk_end_bundle(spl, node);
-   last_bundle_no = trunk_subtract_bundle_number(spl, last_bundle_no, 1);
+   debug_assert(trunk_height(node) == 0);
+   uint16 last_bundle_no = trunk_end_bundle(spl, node);
+   last_bundle_no        = trunk_subtract_bundle_number(spl, last_bundle_no, 1);
    debug_assert(bundle_no == last_bundle_no);
-   hdr->start_bundle       = bundle_no;
+   node->hdr->start_bundle = bundle_no;
    trunk_pivot_data *pdata = trunk_get_pivot_data(spl, node, 0);
-   pdata->start_bundle     = hdr->start_bundle;
+   pdata->start_bundle     = node->hdr->start_bundle;
 }
 
 /*
@@ -2218,12 +2209,12 @@ trunk_leaf_remove_bundles_except(trunk_handle *spl,
  */
 static inline uint16
 trunk_leaf_rebundle_all_branches(trunk_handle *spl,
-                                 page_handle  *node,
+                                 trunk_node   *node,
                                  uint64        target_num_tuples,
                                  uint64        target_kv_bytes,
                                  bool          is_space_rec)
 {
-   debug_assert(trunk_height(spl, node) == 0);
+   debug_assert(trunk_height(node) == 0);
    uint16 bundle_no = trunk_get_new_bundle(spl, node);
    if (trunk_branch_is_whole(spl, node, trunk_start_branch(spl, node))) {
       trunk_subbundle *sb = trunk_leaf_get_new_subbundle_at_head(spl, node);
@@ -2264,7 +2255,7 @@ trunk_leaf_rebundle_all_branches(trunk_handle *spl,
  */
 static inline uint16
 trunk_bundle_start_branch(trunk_handle *spl,
-                          page_handle  *node,
+                          trunk_node   *node,
                           trunk_bundle *bundle)
 {
    trunk_subbundle *subbundle =
@@ -2277,7 +2268,7 @@ trunk_bundle_start_branch(trunk_handle *spl,
  */
 static inline uint16
 trunk_bundle_end_branch(trunk_handle *spl,
-                        page_handle  *node,
+                        trunk_node   *node,
                         trunk_bundle *bundle)
 {
    uint16 last_subbundle_no =
@@ -2292,7 +2283,7 @@ trunk_bundle_end_branch(trunk_handle *spl,
  */
 static inline uint16
 trunk_bundle_branch_count(trunk_handle *spl,
-                          page_handle  *node,
+                          trunk_node   *node,
                           trunk_bundle *bundle)
 {
    return trunk_subtract_branch_number(
@@ -2303,7 +2294,7 @@ trunk_bundle_branch_count(trunk_handle *spl,
 
 static inline uint16
 trunk_bundle_subbundle_count(trunk_handle *spl,
-                             page_handle  *node,
+                             trunk_node   *node,
                              trunk_bundle *bundle)
 {
    return trunk_subtract_subbundle_number(
@@ -2314,21 +2305,20 @@ trunk_bundle_subbundle_count(trunk_handle *spl,
  * Returns the number of live bundles in the node.
  */
 static inline uint16
-trunk_bundle_count(trunk_handle *spl, page_handle *node)
+trunk_bundle_count(trunk_handle *spl, trunk_node *node)
 {
-   trunk_hdr *hdr = (trunk_hdr *)node->data;
-   return trunk_subtract_bundle_number(spl, hdr->end_bundle, hdr->start_bundle);
+   return trunk_subtract_bundle_number(
+      spl, node->hdr->end_bundle, node->hdr->start_bundle);
 }
 
 /*
  * Returns the number of live subbundles in the node.
  */
 static inline uint16
-trunk_subbundle_count(trunk_handle *spl, page_handle *node)
+trunk_subbundle_count(trunk_handle *spl, trunk_node *node)
 {
-   trunk_hdr *hdr = (trunk_hdr *)node->data;
    return trunk_subtract_subbundle_number(
-      spl, hdr->end_subbundle, hdr->start_subbundle);
+      spl, node->hdr->end_subbundle, node->hdr->start_subbundle);
 }
 
 /*
@@ -2336,12 +2326,11 @@ trunk_subbundle_count(trunk_handle *spl, page_handle *node)
  * FALSE otherwise.
  */
 static inline bool
-trunk_bundle_valid(trunk_handle *spl, page_handle *node, uint16 bundle_no)
+trunk_bundle_valid(trunk_handle *spl, trunk_node *node, uint16 bundle_no)
 {
-   trunk_hdr *hdr = (trunk_hdr *)node->data;
-   return trunk_subtract_bundle_number(spl, bundle_no, hdr->start_bundle)
+   return trunk_subtract_bundle_number(spl, bundle_no, node->hdr->start_bundle)
           <= trunk_subtract_bundle_number(
-             spl, hdr->end_bundle, hdr->start_bundle);
+             spl, node->hdr->end_bundle, node->hdr->start_bundle);
 }
 
 /*
@@ -2349,7 +2338,7 @@ trunk_bundle_valid(trunk_handle *spl, page_handle *node, uint16 bundle_no)
  */
 static inline bool
 trunk_bundle_live_for_pivot(trunk_handle *spl,
-                            page_handle  *node,
+                            trunk_node   *node,
                             uint16        bundle_no,
                             uint16        pivot_no)
 {
@@ -2361,23 +2350,21 @@ trunk_bundle_live_for_pivot(trunk_handle *spl,
 }
 
 static inline uint16
-trunk_start_frac_branch(trunk_handle *spl, page_handle *node)
+trunk_start_frac_branch(trunk_handle *spl, trunk_node *node)
 {
-   trunk_hdr *hdr = (trunk_hdr *)node->data;
-   return hdr->start_frac_branch;
+   return node->hdr->start_frac_branch;
 }
 
 static inline void
 trunk_set_start_frac_branch(trunk_handle *spl,
-                            page_handle  *node,
+                            trunk_node   *node,
                             uint16        branch_no)
 {
-   trunk_hdr *hdr         = (trunk_hdr *)node->data;
-   hdr->start_frac_branch = branch_no;
+   node->hdr->start_frac_branch = branch_no;
 }
 
 static inline void
-trunk_reset_start_frac_branch(trunk_handle *spl, page_handle *node)
+trunk_reset_start_frac_branch(trunk_handle *spl, trunk_node *node)
 {
    if (trunk_bundle_count(spl, node) == 0) {
       trunk_set_start_frac_branch(spl, node, trunk_end_branch(spl, node));
@@ -2390,7 +2377,7 @@ trunk_reset_start_frac_branch(trunk_handle *spl, page_handle *node)
 }
 
 static inline void
-trunk_clear_bundle(trunk_handle *spl, page_handle *node, uint16 bundle_no)
+trunk_clear_bundle(trunk_handle *spl, trunk_node *node, uint16 bundle_no)
 {
    platform_assert(bundle_no == trunk_start_bundle(spl, node));
 
@@ -2414,7 +2401,7 @@ trunk_clear_bundle(trunk_handle *spl, page_handle *node, uint16 bundle_no)
 
 static inline void
 trunk_tuples_in_bundle(trunk_handle *spl,
-                       page_handle  *node,
+                       trunk_node   *node,
                        trunk_bundle *bundle,
                        uint64        pivot_tuple_count[static TRUNK_MAX_PIVOTS],
                        uint64 pivot_kv_byte_count[static TRUNK_MAX_PIVOTS])
@@ -2446,7 +2433,7 @@ trunk_tuples_in_bundle(trunk_handle *spl,
 static inline void
 trunk_pivot_add_bundle_tuple_counts(
    trunk_handle *spl,
-   page_handle  *node,
+   trunk_node   *node,
    trunk_bundle *bundle,
    uint64        pivot_tuple_count[TRUNK_MAX_PIVOTS],
    uint64        pivot_kv_byte_count[TRUNK_MAX_PIVOTS])
@@ -2465,7 +2452,7 @@ trunk_pivot_add_bundle_tuple_counts(
 
 static inline void
 trunk_bundle_inc_pivot_rc(trunk_handle *spl,
-                          page_handle  *node,
+                          trunk_node   *node,
                           trunk_bundle *bundle)
 {
    uint16        num_children = trunk_num_children(spl, node);
@@ -2499,14 +2486,14 @@ trunk_bundle_inc_pivot_rc(trunk_handle *spl,
  * Returns the number of live branches (including fractional branches).
  */
 static inline uint16
-trunk_branch_count(trunk_handle *spl, page_handle *node)
+trunk_branch_count(trunk_handle *spl, trunk_node *node)
 {
-   trunk_hdr *hdr = (trunk_hdr *)node->data;
-   return trunk_subtract_branch_number(spl, hdr->end_branch, hdr->start_branch);
+   return trunk_subtract_branch_number(
+      spl, node->hdr->end_branch, node->hdr->start_branch);
 }
 
 static inline bool
-trunk_has_vacancy(trunk_handle *spl, page_handle *node, uint16 num_new_branches)
+trunk_has_vacancy(trunk_handle *spl, trunk_node *node, uint16 num_new_branches)
 {
    uint16 branch_count = trunk_branch_count(spl, node);
    uint16 max_branches = spl->cfg.hard_max_branches_per_node;
@@ -2514,14 +2501,14 @@ trunk_has_vacancy(trunk_handle *spl, page_handle *node, uint16 num_new_branches)
 }
 
 static inline trunk_branch *
-trunk_get_branch(trunk_handle *spl, page_handle *node, uint32 k)
+trunk_get_branch(trunk_handle *spl, trunk_node *node, uint32 k)
 {
    debug_assert(sizeof(trunk_hdr)
                    + spl->cfg.max_pivot_keys * trunk_pivot_size(spl)
                    + (k + 1) * sizeof(trunk_branch)
                 < trunk_page_size(&spl->cfg));
 
-   char *cursor = node->data;
+   char *cursor = node->page->data;
    cursor += sizeof(trunk_hdr) + spl->cfg.max_pivot_keys * trunk_pivot_size(spl)
              + k * sizeof(trunk_branch);
    return (trunk_branch *)cursor;
@@ -2532,44 +2519,42 @@ trunk_get_branch(trunk_handle *spl, page_handle *node, uint32 k)
  * it.
  */
 static inline trunk_branch *
-trunk_get_new_branch(trunk_handle *spl, page_handle *node)
+trunk_get_new_branch(trunk_handle *spl, trunk_node *node)
 {
-   trunk_hdr    *hdr        = (trunk_hdr *)node->data;
-   trunk_branch *new_branch = trunk_get_branch(spl, node, hdr->end_branch);
-   hdr->end_branch          = trunk_add_branch_number(spl, hdr->end_branch, 1);
-   debug_assert(hdr->end_branch != hdr->start_branch);
+   trunk_branch *new_branch =
+      trunk_get_branch(spl, node, node->hdr->end_branch);
+   node->hdr->end_branch =
+      trunk_add_branch_number(spl, node->hdr->end_branch, 1);
+   debug_assert(node->hdr->end_branch != node->hdr->start_branch);
    return new_branch;
 }
 
 static inline uint16
-trunk_branch_no(trunk_handle *spl, page_handle *node, trunk_branch *branch)
+trunk_branch_no(trunk_handle *spl, trunk_node *node, trunk_branch *branch)
 {
    return branch - trunk_get_branch(spl, node, 0);
 }
 
 static inline uint16
-trunk_start_branch(trunk_handle *spl, page_handle *node)
+trunk_start_branch(trunk_handle *spl, trunk_node *node)
 {
-   trunk_hdr *hdr = (trunk_hdr *)node->data;
-   return hdr->start_branch;
+   return node->hdr->start_branch;
 }
 
 static inline uint16
-trunk_end_branch(trunk_handle *spl, page_handle *node)
+trunk_end_branch(trunk_handle *spl, trunk_node *node)
 {
-   trunk_hdr *hdr = (trunk_hdr *)node->data;
-   return hdr->end_branch;
+   return node->hdr->end_branch;
 }
 
 /*
  * branch_live checks if branch_no is live for any pivot in the node.
  */
 static inline bool
-trunk_branch_live(trunk_handle *spl, page_handle *node, uint64 branch_no)
+trunk_branch_live(trunk_handle *spl, trunk_node *node, uint64 branch_no)
 {
-   trunk_hdr *hdr = (trunk_hdr *)node->data;
    return trunk_branch_in_range(
-      spl, branch_no, hdr->start_branch, hdr->end_branch);
+      spl, branch_no, node->hdr->start_branch, node->hdr->end_branch);
 }
 
 /*
@@ -2577,12 +2562,11 @@ trunk_branch_live(trunk_handle *spl, page_handle *node, uint64 branch_no)
  * end_branch. Used to verify if a given entry is valid.
  */
 static inline bool
-trunk_branch_valid(trunk_handle *spl, page_handle *node, uint64 branch_no)
+trunk_branch_valid(trunk_handle *spl, trunk_node *node, uint64 branch_no)
 {
-   trunk_hdr *hdr = (trunk_hdr *)node->data;
-   return trunk_subtract_branch_number(spl, branch_no, hdr->start_branch)
+   return trunk_subtract_branch_number(spl, branch_no, node->hdr->start_branch)
           <= trunk_subtract_branch_number(
-             spl, hdr->end_branch, hdr->start_branch);
+             spl, node->hdr->end_branch, node->hdr->start_branch);
 }
 
 static inline uint64
@@ -2613,12 +2597,11 @@ trunk_process_generation_to_pos(trunk_handle             *spl,
  */
 void
 trunk_replace_bundle_branches(trunk_handle             *spl,
-                              page_handle              *node,
+                              trunk_node               *node,
                               trunk_branch             *repl_branch,
                               trunk_compact_bundle_req *req)
 {
-   trunk_hdr *hdr = (trunk_hdr *)node->data;
-   debug_assert(req->height == trunk_height(spl, node));
+   debug_assert(req->height == trunk_height(node));
 
    uint16        bundle_no    = req->bundle_no;
    trunk_bundle *bundle       = trunk_get_bundle(spl, node, bundle_no);
@@ -2670,8 +2653,9 @@ trunk_replace_bundle_branches(trunk_handle             *spl,
    }
 
    // move any remaining branches to maintain a contiguous array
-   for (uint16 branch_no = bundle_end_branch; branch_no != hdr->end_branch;
-        branch_no        = trunk_add_branch_number(spl, branch_no, 1))
+   for (uint16 branch_no = bundle_end_branch;
+        branch_no != node->hdr->end_branch;
+        branch_no = trunk_add_branch_number(spl, branch_no, 1))
    {
       uint16 dst_branch_no =
          trunk_subtract_branch_number(spl, branch_no, branch_diff);
@@ -2705,8 +2689,8 @@ trunk_replace_bundle_branches(trunk_handle             *spl,
       }
 
       // adjust the end filter
-      hdr->end_sb_filter = trunk_subtract_subbundle_filter_number(
-         spl, hdr->end_sb_filter, filter_diff);
+      node->hdr->end_sb_filter = trunk_subtract_subbundle_filter_number(
+         spl, node->hdr->end_sb_filter, filter_diff);
    }
 
    /*
@@ -2725,7 +2709,7 @@ trunk_replace_bundle_branches(trunk_handle             *spl,
       bundle->end_subbundle = trunk_add_subbundle_number(spl, sb_no, 1);
    }
 
-   for (uint16 sb_no = first_later_sb; sb_no != hdr->end_subbundle;
+   for (uint16 sb_no = first_later_sb; sb_no != node->hdr->end_subbundle;
         sb_no        = trunk_add_subbundle_number(spl, sb_no, 1))
    {
       trunk_subbundle *sb = trunk_get_subbundle(spl, node, sb_no);
@@ -2736,10 +2720,10 @@ trunk_replace_bundle_branches(trunk_handle             *spl,
       uint16 dst_sb_no = trunk_subtract_subbundle_number(spl, sb_no, sb_diff);
       *trunk_get_subbundle(spl, node, dst_sb_no) = *sb;
    }
-   hdr->end_subbundle =
-      trunk_subtract_subbundle_number(spl, hdr->end_subbundle, sb_diff);
+   node->hdr->end_subbundle =
+      trunk_subtract_subbundle_number(spl, node->hdr->end_subbundle, sb_diff);
    for (uint16 later_bundle_no = trunk_add_bundle_number(spl, bundle_no, 1);
-        later_bundle_no != hdr->end_bundle;
+        later_bundle_no != node->hdr->end_bundle;
         later_bundle_no = trunk_add_bundle_number(spl, later_bundle_no, 1))
    {
       trunk_bundle *bundle = trunk_get_bundle(spl, node, later_bundle_no);
@@ -2788,7 +2772,7 @@ trunk_replace_bundle_branches(trunk_handle             *spl,
    if (repl_branch == NULL) {
       for (uint16 later_bundle_no = bundle_no;
            later_bundle_no
-           != trunk_subtract_bundle_number(spl, hdr->end_bundle, 1);
+           != trunk_subtract_bundle_number(spl, node->hdr->end_bundle, 1);
            later_bundle_no = trunk_add_bundle_number(spl, later_bundle_no, 1))
       {
          uint16 src_later_bundle_no =
@@ -2808,7 +2792,8 @@ trunk_replace_bundle_branches(trunk_handle             *spl,
                trunk_subtract_bundle_number(spl, pdata->start_bundle, 1);
          }
       }
-      hdr->end_bundle = trunk_subtract_bundle_number(spl, hdr->end_bundle, 1);
+      node->hdr->end_bundle =
+         trunk_subtract_bundle_number(spl, node->hdr->end_bundle, 1);
    }
 
    // fix the pivot start branches
@@ -2823,8 +2808,8 @@ trunk_replace_bundle_branches(trunk_handle             *spl,
    }
 
    // update the end_branch
-   hdr->end_branch =
-      trunk_subtract_branch_number(spl, hdr->end_branch, branch_diff);
+   node->hdr->end_branch =
+      trunk_subtract_branch_number(spl, node->hdr->end_branch, branch_diff);
 }
 
 static inline void
@@ -3280,10 +3265,11 @@ trunk_memtable_incorporate(trunk_handle  *spl,
    memtable_increment_to_generation_retired(spl->mt_ctxt, generation);
 
    // X. Get, claim and lock the root
-   page_handle *root = trunk_node_get(spl, spl->root_addr);
-   trunk_node_claim(spl, &root);
-   platform_assert(trunk_has_vacancy(spl, root, 1));
-   trunk_node_lock(spl, root);
+   trunk_node root;
+   trunk_node_get(spl->cc, spl->root_addr, &root);
+   trunk_node_claim(spl->cc, &root);
+   platform_assert(trunk_has_vacancy(spl, &root, 1));
+   trunk_node_lock(spl->cc, &root);
 
    platform_stream_handle stream;
    platform_status        rc = trunk_open_log_stream_if_enabled(spl, &stream);
@@ -3293,7 +3279,7 @@ trunk_memtable_incorporate(trunk_handle  *spl,
                                "incorporate memtable gen %lu into root %lu\n",
                                generation,
                                spl->root_addr);
-   trunk_log_node_if_enabled(&stream, spl, root);
+   trunk_log_node_if_enabled(&stream, spl, &root);
    trunk_log_stream_if_enabled(
       spl, &stream, "----------------------------------------\n");
 
@@ -3306,25 +3292,25 @@ trunk_memtable_incorporate(trunk_handle  *spl,
    trunk_compacted_memtable *cmt =
       trunk_get_compacted_memtable(spl, generation);
    trunk_compact_bundle_req *req = cmt->req;
-   req->bundle_no                = trunk_get_new_bundle(spl, root);
-   trunk_bundle    *bundle       = trunk_get_bundle(spl, root, req->bundle_no);
-   trunk_subbundle *sb           = trunk_get_new_subbundle(spl, root, 1);
-   trunk_branch    *branch       = trunk_get_new_branch(spl, root);
+   req->bundle_no                = trunk_get_new_bundle(spl, &root);
+   trunk_bundle    *bundle       = trunk_get_bundle(spl, &root, req->bundle_no);
+   trunk_subbundle *sb           = trunk_get_new_subbundle(spl, &root, 1);
+   trunk_branch    *branch       = trunk_get_new_branch(spl, &root);
    *branch                       = cmt->branch;
-   bundle->start_subbundle       = trunk_subbundle_no(spl, root, sb);
-   bundle->end_subbundle         = trunk_end_subbundle(spl, root);
-   sb->start_branch              = trunk_branch_no(spl, root, branch);
-   sb->end_branch                = trunk_end_branch(spl, root);
+   bundle->start_subbundle       = trunk_subbundle_no(spl, &root, sb);
+   bundle->end_subbundle         = trunk_end_subbundle(spl, &root);
+   sb->start_branch              = trunk_branch_no(spl, &root, branch);
+   sb->end_branch                = trunk_end_branch(spl, &root);
    sb->state                     = SB_STATE_COMPACTED;
-   routing_filter *filter        = trunk_subbundle_filter(spl, root, sb, 0);
+   routing_filter *filter        = trunk_subbundle_filter(spl, &root, sb, 0);
    *filter                       = cmt->filter;
    req->spl                      = spl;
    req->addr                     = spl->root_addr;
-   req->height                   = trunk_height(spl, root);
-   req->generation               = trunk_generation(spl, root);
-   req->max_pivot_generation     = trunk_pivot_generation(spl, root);
+   req->height                   = trunk_height(&root);
+   req->generation               = trunk_generation(spl, &root);
+   req->max_pivot_generation     = trunk_pivot_generation(spl, &root);
    trunk_tuples_in_bundle(spl,
-                          root,
+                          &root,
                           bundle,
                           req->output_pivot_tuple_count,
                           req->output_pivot_kv_byte_count);
@@ -3335,20 +3321,20 @@ trunk_memtable_incorporate(trunk_handle  *spl,
            req->output_pivot_kv_byte_count,
            sizeof(req->input_pivot_kv_byte_count));
    trunk_pivot_add_bundle_tuple_counts(spl,
-                                       root,
+                                       &root,
                                        bundle,
                                        req->output_pivot_tuple_count,
                                        req->output_pivot_kv_byte_count);
-   uint16 num_children = trunk_num_children(spl, root);
+   uint16 num_children = trunk_num_children(spl, &root);
    for (uint16 pivot_no = 0; pivot_no < num_children; pivot_no++) {
       if (pivot_no != 0) {
-         key pivot_key = trunk_get_pivot(spl, root, pivot_no);
+         key pivot_key = trunk_get_pivot(spl, &root, pivot_no);
          trunk_inc_intersection(spl, branch, pivot_key, FALSE);
       }
-      trunk_pivot_data *pdata = trunk_get_pivot_data(spl, root, pivot_no);
+      trunk_pivot_data *pdata = trunk_get_pivot_data(spl, &root, pivot_no);
       req->pivot_generation[pivot_no] = pdata->generation;
    }
-   debug_assert(trunk_subbundle_branch_count(spl, root, sb) != 0);
+   debug_assert(trunk_subbundle_branch_count(spl, &root, sb) != 0);
    trunk_log_stream_if_enabled(spl,
                                &stream,
                                "enqueuing build filter %lu-%u\n",
@@ -3373,7 +3359,7 @@ trunk_memtable_incorporate(trunk_handle  *spl,
 
    memtable_transition(
       mt, MEMTABLE_STATE_INCORPORATING, MEMTABLE_STATE_INCORPORATED);
-   trunk_log_node_if_enabled(&stream, spl, root);
+   trunk_log_node_if_enabled(&stream, spl, &root);
    trunk_log_stream_if_enabled(
       spl, &stream, "----------------------------------------\n");
    trunk_log_stream_if_enabled(spl, &stream, "\n");
@@ -3386,25 +3372,25 @@ trunk_memtable_incorporate(trunk_handle  *spl,
    }
 
    uint64 wait = 1;
-   while (trunk_node_is_full(spl, root)) {
-      platform_status rc = trunk_flush_fullest(spl, root);
+   while (trunk_node_is_full(spl, &root)) {
+      platform_status rc = trunk_flush_fullest(spl, &root);
       if (!SUCCESS(rc)) {
-         trunk_node_unlock(spl, root);
+         trunk_node_unlock(spl->cc, &root);
          platform_sleep(wait);
          wait = wait > 2048 ? 2048 : 2 * wait;
-         trunk_node_lock(spl, root);
+         trunk_node_lock(spl->cc, &root);
       }
    }
 
-   // X. If necessary, split the root
-   if (trunk_needs_split(spl, root)) {
-      trunk_split_root(spl, root);
+   // X. If necessary, split the &root
+   if (trunk_needs_split(spl, &root)) {
+      trunk_split_root(spl, &root);
    }
 
-   // X. Unlock the root
-   trunk_node_unlock(spl, root);
-   trunk_node_unclaim(spl, root);
-   trunk_node_unget(spl, &root);
+   // X. Unlock the &root
+   trunk_node_unlock(spl->cc, &root);
+   trunk_node_unclaim(spl->cc, &root);
+   trunk_node_unget(spl->cc, &root);
 
    // X. Dec-ref the now-incorporated memtable
    memtable_dec_ref_maybe_recycle(spl->mt_ctxt, mt);
@@ -3583,12 +3569,14 @@ trunk_filter_req_init(trunk_compact_bundle_req *compact_req,
    filter_req->fp_arr = compact_req->fp_arr;
 }
 
-static inline page_handle *
-trunk_node_get_maybe_descend(trunk_handle *spl, trunk_compact_bundle_req *req)
+static inline void
+trunk_node_get_maybe_descend(trunk_handle             *spl,
+                             trunk_compact_bundle_req *req,
+                             trunk_node               *node)
 {
-   page_handle *node = trunk_node_get(spl, req->addr);
-   while (trunk_height(spl, node) != req->height) {
-      debug_assert(trunk_height(spl, node) > req->height);
+   trunk_node_get(spl->cc, req->addr, node);
+   while (trunk_height(node) != req->height) {
+      debug_assert(trunk_height(node) > req->height);
       debug_assert(req->height != 0);
       trunk_pivot_data *pdata = trunk_get_pivot_data(spl, node, 0);
       req->addr               = pdata->addr;
@@ -3603,36 +3591,34 @@ trunk_node_get_maybe_descend(trunk_handle *spl, trunk_compact_bundle_req *req)
                                   req->addr,
                                   req->bundle_no);
       trunk_log_node_if_enabled(&stream, spl, node);
-      trunk_node_unget(spl, &node);
-      node = trunk_node_get(spl, req->addr);
+      trunk_node_unget(spl->cc, node);
+      // Load the node at new req->addr into node
+      trunk_node_get(spl->cc, req->addr, node);
    }
-   return node;
 }
 
-static inline page_handle *
+static inline void
 trunk_node_get_claim_maybe_descend(trunk_handle             *spl,
-                                   trunk_compact_bundle_req *req)
+                                   trunk_compact_bundle_req *req,
+                                   trunk_node               *node)
 {
-   page_handle *node;
-   uint64       wait = 1;
+   uint64 wait = 1;
    while (1) {
-      node = trunk_node_get_maybe_descend(spl, req);
-      if (cache_claim(spl->cc, node)) {
+      trunk_node_get_maybe_descend(spl, req, node);
+      if (cache_claim(spl->cc, node->page)) {
          break;
       }
-      trunk_node_unget(spl, &node);
+      trunk_node_unget(spl->cc, node);
       platform_sleep(wait);
       wait = wait > 2048 ? wait : 2 * wait;
    }
-   return node;
 }
 
 static inline bool
-trunk_build_filter_should_abort(trunk_compact_bundle_req *req,
-                                page_handle              *node)
+trunk_build_filter_should_abort(trunk_compact_bundle_req *req, trunk_node *node)
 {
    trunk_handle *spl    = req->spl;
-   uint16        height = trunk_height(spl, node);
+   uint16        height = trunk_height(node);
    if (height == 0 && req->generation < trunk_generation(spl, node)) {
       platform_stream_handle stream;
       platform_status rc = trunk_open_log_stream_if_enabled(spl, &stream);
@@ -3650,7 +3636,7 @@ trunk_build_filter_should_abort(trunk_compact_bundle_req *req,
 }
 
 static inline bool
-trunk_build_filter_should_skip(trunk_compact_bundle_req *req, page_handle *node)
+trunk_build_filter_should_skip(trunk_compact_bundle_req *req, trunk_node *node)
 {
    trunk_handle *spl = req->spl;
    if (!trunk_bundle_live(spl, node, req->bundle_no)) {
@@ -3672,7 +3658,7 @@ trunk_build_filter_should_skip(trunk_compact_bundle_req *req, page_handle *node)
 
 static inline bool
 trunk_build_filter_should_reenqueue(trunk_compact_bundle_req *req,
-                                    page_handle              *node)
+                                    trunk_node               *node)
 {
    trunk_handle *spl = req->spl;
    if (req->bundle_no != trunk_start_bundle(spl, node)) {
@@ -3700,9 +3686,9 @@ static inline void
 trunk_prepare_build_filter(trunk_handle             *spl,
                            trunk_compact_bundle_req *compact_req,
                            trunk_filter_req         *filter_req,
-                           page_handle              *node)
+                           trunk_node               *node)
 {
-   uint16 height = trunk_height(spl, node);
+   uint16 height = trunk_height(node);
    platform_assert(compact_req->height == height);
    platform_assert(compact_req->bundle_no == trunk_start_bundle(spl, node));
 
@@ -3806,7 +3792,7 @@ static inline void
 trunk_replace_routing_filter(trunk_handle             *spl,
                              trunk_compact_bundle_req *compact_req,
                              trunk_filter_req         *filter_req,
-                             page_handle              *node)
+                             trunk_node               *node)
 {
    uint16 num_children = trunk_num_children(spl, node);
    for (uint16 pivot_no = 0; pivot_no < num_children; pivot_no++) {
@@ -3846,7 +3832,7 @@ trunk_replace_routing_filter(trunk_handle             *spl,
       } else if ((num_tuples_to_reclaim > TRUNK_MIN_SPACE_RECL)
                  && (spl->cfg.reclaim_threshold != UINT64_MAX))
       {
-         srq_data data  = {.addr             = node->disk_addr,
+         srq_data data  = {.addr             = node->addr,
                            .pivot_generation = pdata->generation,
                            .priority         = num_tuples_to_reclaim};
          pdata->srq_idx = srq_insert(&spl->srq, data);
@@ -3868,8 +3854,8 @@ trunk_bundle_build_filters(void *arg, void *scratch)
 
    uint64 generation;
    do {
-      page_handle *node = trunk_node_get_maybe_descend(spl, compact_req);
-      platform_assert(node != NULL);
+      trunk_node node;
+      trunk_node_get_maybe_descend(spl, compact_req, &node);
 
       platform_stream_handle stream;
       trunk_open_log_stream_if_enabled(spl, &stream);
@@ -3880,19 +3866,19 @@ trunk_bundle_build_filters(void *arg, void *scratch)
          compact_req->addr,
          compact_req->bundle_no,
          compact_req->max_pivot_generation);
-      trunk_log_node_if_enabled(&stream, spl, node);
-      if (trunk_build_filter_should_abort(compact_req, node)) {
+      trunk_log_node_if_enabled(&stream, spl, &node);
+      if (trunk_build_filter_should_abort(compact_req, &node)) {
          trunk_log_stream_if_enabled(spl, &stream, "leaf split, aborting\n");
-         trunk_node_unget(spl, &node);
+         trunk_node_unget(spl->cc, &node);
          goto out;
       }
-      if (trunk_build_filter_should_skip(compact_req, node)) {
+      if (trunk_build_filter_should_skip(compact_req, &node)) {
          trunk_log_stream_if_enabled(
             spl, &stream, "bundle flushed, skipping\n");
          goto next_node;
       }
 
-      if (trunk_build_filter_should_reenqueue(compact_req, node)) {
+      if (trunk_build_filter_should_reenqueue(compact_req, &node)) {
          task_enqueue(spl->ts,
                       TASK_TYPE_NORMAL,
                       trunk_bundle_build_filters,
@@ -3901,15 +3887,15 @@ trunk_bundle_build_filters(void *arg, void *scratch)
          trunk_log_stream_if_enabled(
             spl, &stream, "out of order, reequeuing\n");
          trunk_close_log_stream_if_enabled(spl, &stream);
-         trunk_node_unget(spl, &node);
+         trunk_node_unget(spl->cc, &node);
          return;
       }
 
-      debug_assert(trunk_verify_node(spl, node));
+      debug_assert(trunk_verify_node(spl, &node));
       trunk_filter_req filter_req = {0};
-      trunk_prepare_build_filter(spl, compact_req, &filter_req, node);
-      uint64 filter_generation = trunk_generation(spl, node);
-      trunk_node_unget(spl, &node);
+      trunk_prepare_build_filter(spl, compact_req, &filter_req, &node);
+      uint64 filter_generation = trunk_generation(spl, &node);
+      trunk_node_unget(spl->cc, &node);
 
       trunk_build_filters(spl, compact_req, &filter_req);
 
@@ -3917,30 +3903,30 @@ trunk_bundle_build_filters(void *arg, void *scratch)
          spl, &stream, "----------------------------------------\n");
 
       do {
-         node = trunk_node_get_claim_maybe_descend(spl, compact_req);
-         if (trunk_build_filter_should_abort(compact_req, node)) {
+         trunk_node_get_claim_maybe_descend(spl, compact_req, &node);
+         if (trunk_build_filter_should_abort(compact_req, &node)) {
             trunk_log_stream_if_enabled(
                spl,
                &stream,
                "replace_filter abort leaf split (%lu)\n",
                compact_req->addr);
-            trunk_node_unclaim(spl, node);
-            trunk_node_unget(spl, &node);
+            trunk_node_unclaim(spl->cc, &node);
+            trunk_node_unget(spl->cc, &node);
             for (uint64 pos = 0; pos < TRUNK_MAX_PIVOTS; pos++) {
                trunk_dec_filter(spl, &filter_req.filter[pos]);
             }
             goto out;
          }
-         trunk_node_lock(spl, node);
-         trunk_replace_routing_filter(spl, compact_req, &filter_req, node);
-         if (trunk_bundle_live(spl, node, compact_req->bundle_no)) {
-            trunk_clear_bundle(spl, node, compact_req->bundle_no);
+         trunk_node_lock(spl->cc, &node);
+         trunk_replace_routing_filter(spl, compact_req, &filter_req, &node);
+         if (trunk_bundle_live(spl, &node, compact_req->bundle_no)) {
+            trunk_clear_bundle(spl, &node, compact_req->bundle_no);
          }
-         trunk_node_unlock(spl, node);
-         trunk_node_unclaim(spl, node);
-         compact_req->addr = trunk_next_addr(spl, node);
-         generation        = trunk_generation(spl, node);
-         debug_assert(trunk_verify_node(spl, node));
+         trunk_node_unlock(spl->cc, &node);
+         trunk_node_unclaim(spl->cc, &node);
+         compact_req->addr = trunk_next_addr(&node);
+         generation        = trunk_generation(spl, &node);
+         debug_assert(trunk_verify_node(spl, &node));
          if (generation != filter_generation) {
             trunk_log_stream_if_enabled(spl,
                                         &stream,
@@ -3948,7 +3934,7 @@ trunk_bundle_build_filters(void *arg, void *scratch)
                                         compact_req->addr);
             debug_assert(compact_req->height != 0);
             debug_assert(compact_req->addr != 0);
-            trunk_node_unget(spl, &node);
+            trunk_node_unget(spl->cc, &node);
          }
       } while (generation != filter_generation);
 
@@ -3956,16 +3942,16 @@ trunk_bundle_build_filters(void *arg, void *scratch)
          trunk_dec_filter(spl, &filter_req.filter[pos]);
       }
 
-      trunk_log_node_if_enabled(&stream, spl, node);
+      trunk_log_node_if_enabled(&stream, spl, &node);
       trunk_log_stream_if_enabled(
          spl, &stream, "----------------------------------------\n");
       trunk_log_stream_if_enabled(spl, &stream, "\n");
 
    next_node:
-      compact_req->addr = trunk_next_addr(spl, node);
-      generation        = trunk_generation(spl, node);
-      debug_assert(trunk_verify_node(spl, node));
-      trunk_node_unget(spl, &node);
+      compact_req->addr = trunk_next_addr(&node);
+      generation        = trunk_generation(spl, &node);
+      debug_assert(trunk_verify_node(spl, &node));
+      trunk_node_unget(spl->cc, &node);
       if (compact_req->generation != generation) {
          trunk_log_stream_if_enabled(
             spl, &stream, "build_filter split to %lu\n", compact_req->addr);
@@ -4009,27 +3995,24 @@ trunk_filter_lookup_async(trunk_handle       *spl,
  */
 trunk_bundle *
 trunk_flush_into_bundle(trunk_handle             *spl,    // IN
-                        page_handle              *parent, // IN (modified)
-                        page_handle              *child,  // IN (modified)
+                        trunk_node               *parent, // IN (modified)
+                        trunk_node               *child,  // IN (modified)
                         trunk_pivot_data         *pdata,  // IN
                         trunk_compact_bundle_req *req)    // IN/OUT
 {
    platform_stream_handle stream;
    platform_status        rc = trunk_open_log_stream_if_enabled(spl, &stream);
    platform_assert_status_ok(rc);
-   trunk_log_stream_if_enabled(spl,
-                               &stream,
-                               "flush from %lu to %lu\n",
-                               parent->disk_addr,
-                               child->disk_addr);
+   trunk_log_stream_if_enabled(
+      spl, &stream, "flush from %lu to %lu\n", parent->addr, child->addr);
    trunk_log_node_if_enabled(&stream, spl, parent);
    trunk_log_node_if_enabled(&stream, spl, child);
    trunk_log_stream_if_enabled(
       spl, &stream, "----------------------------------------\n");
 
    req->spl    = spl;
-   req->addr   = child->disk_addr;
-   req->height = trunk_height(spl, child);
+   req->addr   = child->addr;
+   req->height = trunk_height(child);
    debug_assert(req->addr != 0);
    req->bundle_no            = trunk_get_new_bundle(spl, child);
    req->generation           = trunk_generation(spl, child);
@@ -4144,8 +4127,8 @@ trunk_flush_into_bundle(trunk_handle             *spl,    // IN
  */
 static inline bool
 trunk_room_to_flush(trunk_handle     *spl,
-                    page_handle      *parent,
-                    page_handle      *child,
+                    trunk_node       *parent,
+                    trunk_node       *child,
                     trunk_pivot_data *pdata)
 {
    uint16 child_branches   = trunk_branch_count(spl, child);
@@ -4168,7 +4151,7 @@ trunk_room_to_flush(trunk_handle     *spl,
  */
 platform_status
 trunk_flush(trunk_handle     *spl,
-            page_handle      *parent,
+            trunk_node       *parent,
             trunk_pivot_data *pdata,
             bool              is_space_rec)
 {
@@ -4181,21 +4164,21 @@ trunk_flush(trunk_handle     *spl,
       wait_start = platform_get_timestamp();
    }
 
-   page_handle *child = trunk_node_get(spl, pdata->addr);
-   trunk_node_claim(spl, &child);
+   trunk_node child;
+   trunk_node_get(spl->cc, pdata->addr, &child);
+   trunk_node_claim(spl->cc, &child);
 
-   if (!trunk_room_to_flush(spl, parent, child, pdata)) {
-      platform_error_log(
-         "Flush failed: %lu %lu\n", parent->disk_addr, child->disk_addr);
+   if (!trunk_room_to_flush(spl, parent, &child, pdata)) {
+      platform_error_log("Flush failed: %lu %lu\n", parent->addr, child.addr);
       if (spl->cfg.use_stats) {
-         if (parent->disk_addr == spl->root_addr) {
+         if (parent->addr == spl->root_addr) {
             spl->stats[tid].root_failed_flushes++;
          } else {
-            spl->stats[tid].failed_flushes[trunk_height(spl, parent)]++;
+            spl->stats[tid].failed_flushes[trunk_height(parent)]++;
          }
       }
-      trunk_node_unclaim(spl, child);
-      trunk_node_unget(spl, &child);
+      trunk_node_unclaim(spl->cc, &child);
+      trunk_node_unget(spl->cc, &child);
       return STATUS_INVALID_STATE;
    }
 
@@ -4208,14 +4191,14 @@ trunk_flush(trunk_handle     *spl,
       srq_print(&spl->srq);
       pdata->srq_idx = -1;
    }
-   trunk_node_lock(spl, child);
+   trunk_node_lock(spl->cc, &child);
 
    if (spl->cfg.use_stats) {
-      if (parent->disk_addr == spl->root_addr) {
+      if (parent->addr == spl->root_addr) {
          spl->stats[tid].root_flush_wait_time_ns +=
             platform_timestamp_elapsed(wait_start);
       } else {
-         spl->stats[tid].flush_wait_time_ns[trunk_height(spl, parent)] +=
+         spl->stats[tid].flush_wait_time_ns[trunk_height(parent)] +=
             platform_timestamp_elapsed(wait_start);
       }
       flush_start = platform_get_timestamp();
@@ -4224,40 +4207,39 @@ trunk_flush(trunk_handle     *spl,
    // flush the branch references into a new bundle in the child
    trunk_compact_bundle_req *req = TYPED_ZALLOC(spl->heap_id, req);
    trunk_bundle             *bundle =
-      trunk_flush_into_bundle(spl, parent, child, pdata, req);
+      trunk_flush_into_bundle(spl, parent, &child, pdata, req);
    trunk_tuples_in_bundle(spl,
-                          child,
+                          &child,
                           bundle,
                           req->input_pivot_tuple_count,
                           req->input_pivot_kv_byte_count);
    trunk_pivot_add_bundle_tuple_counts(spl,
-                                       child,
+                                       &child,
                                        bundle,
                                        req->input_pivot_tuple_count,
                                        req->input_pivot_kv_byte_count);
-   trunk_bundle_inc_pivot_rc(spl, child, bundle);
+   trunk_bundle_inc_pivot_rc(spl, &child, bundle);
    debug_assert(cache_page_valid(spl->cc, req->addr));
    req->type = is_space_rec ? TRUNK_COMPACTION_TYPE_FLUSH
                             : TRUNK_COMPACTION_TYPE_SPACE_REC;
 
    // split child if necessary
-   if (trunk_needs_split(spl, child)) {
-      if (trunk_is_leaf(spl, child)) {
+   if (trunk_needs_split(spl, &child)) {
+      if (trunk_is_leaf(&child)) {
          platform_free(spl->heap_id, req);
          uint16 child_idx = trunk_pdata_to_pivot_index(spl, parent, pdata);
-         trunk_split_leaf(spl, parent, child, child_idx);
-         debug_assert(trunk_verify_node(spl, child));
+         trunk_split_leaf(spl, parent, &child, child_idx);
          return STATUS_OK;
       } else {
          uint64 child_idx = trunk_pdata_to_pivot_index(spl, parent, pdata);
-         trunk_split_index(spl, parent, child, child_idx);
+         trunk_split_index(spl, parent, &child, child_idx);
       }
    }
 
-   debug_assert(trunk_verify_node(spl, child));
-   trunk_node_unlock(spl, child);
-   trunk_node_unclaim(spl, child);
-   trunk_node_unget(spl, &child);
+   debug_assert(trunk_verify_node(spl, &child));
+   trunk_node_unlock(spl->cc, &child);
+   trunk_node_unclaim(spl->cc, &child);
+   trunk_node_unget(spl->cc, &child);
 
    trunk_default_log_if_enabled(
       spl, "enqueuing compact_bundle %lu-%u\n", req->addr, req->bundle_no);
@@ -4266,13 +4248,13 @@ trunk_flush(trunk_handle     *spl,
    platform_assert_status_ok(rc);
    if (spl->cfg.use_stats) {
       flush_start = platform_timestamp_elapsed(flush_start);
-      if (parent->disk_addr == spl->root_addr) {
+      if (parent->addr == spl->root_addr) {
          spl->stats[tid].root_flush_time_ns += flush_start;
          if (flush_start > spl->stats[tid].root_flush_time_max_ns) {
             spl->stats[tid].root_flush_time_max_ns = flush_start;
          }
       } else {
-         const uint32 h = trunk_height(spl, parent);
+         const uint32 h = trunk_height(parent);
          spl->stats[tid].flush_time_ns[h] += flush_start;
          if (flush_start > spl->stats[tid].flush_time_max_ns[h]) {
             spl->stats[tid].flush_time_max_ns[h] = flush_start;
@@ -4287,7 +4269,7 @@ trunk_flush(trunk_handle     *spl,
  * If the node is still full, it then flushes the pivot with the most tuples.
  */
 platform_status
-trunk_flush_fullest(trunk_handle *spl, page_handle *node)
+trunk_flush_fullest(trunk_handle *spl, trunk_node *node)
 {
    platform_status rc               = STATUS_OK;
    uint16          fullest_pivot_no = TRUNK_INVALID_PIVOT_NO;
@@ -4311,10 +4293,10 @@ trunk_flush_fullest(trunk_handle *spl, page_handle *node)
             return rc;
          }
          if (spl->cfg.use_stats) {
-            if (node->disk_addr == spl->root_addr) {
+            if (node->addr == spl->root_addr) {
                spl->stats[tid].root_count_flushes++;
             } else {
-               spl->stats[tid].count_flushes[trunk_height(spl, node)]++;
+               spl->stats[tid].count_flushes[trunk_height(node)]++;
             }
          }
       } else if (fullest_pivot_no == TRUNK_INVALID_PIVOT_NO
@@ -4326,10 +4308,10 @@ trunk_flush_fullest(trunk_handle *spl, page_handle *node)
    }
    if (trunk_node_is_full(spl, node)) {
       if (spl->cfg.use_stats) {
-         if (node->disk_addr == spl->root_addr) {
+         if (node->addr == spl->root_addr) {
             spl->stats[tid].root_full_flushes++;
          } else {
-            spl->stats[tid].full_flushes[trunk_height(spl, node)]++;
+            spl->stats[tid].full_flushes[trunk_height(node)]++;
          }
       }
       platform_assert(fullest_pivot_no != TRUNK_INVALID_PIVOT_NO);
@@ -4342,7 +4324,7 @@ trunk_flush_fullest(trunk_handle *spl, page_handle *node)
 
 static void
 save_pivots_to_compact_bundle_scratch(trunk_handle           *spl,     // IN
-                                      page_handle            *node,    // IN
+                                      trunk_node             *node,    // IN
                                       compact_bundle_scratch *scratch) // IN/OUT
 {
    platform_status rc;
@@ -4426,7 +4408,7 @@ trunk_branch_iterator_deinit(trunk_handle   *spl,
 static void
 trunk_btree_skiperator_init(trunk_handle           *spl,
                             trunk_btree_skiperator *skip_itor,
-                            page_handle            *node,
+                            trunk_node             *node,
                             uint16                  branch_idx,
                             key_buffer pivots[static TRUNK_MAX_PIVOTS])
 {
@@ -4641,21 +4623,22 @@ trunk_compact_bundle(void *arg, void *scratch_buf)
    /*
     * 1. Acquire node read lock
     */
-   page_handle *node = trunk_node_get(spl, req->addr);
+   trunk_node node;
+   trunk_node_get(spl->cc, req->addr, &node);
 
    /*
     * 2. Flush if node is full (acquires write lock)
     */
-   uint16 height = trunk_height(spl, node);
-   if (height != 0 && trunk_node_is_full(spl, node)) {
-      trunk_node_claim(spl, &node);
-      trunk_node_lock(spl, node);
+   uint16 height = trunk_height(&node);
+   if (height != 0 && trunk_node_is_full(spl, &node)) {
+      trunk_node_claim(spl->cc, &node);
+      trunk_node_lock(spl->cc, &node);
       rc = STATUS_OK;
-      while (SUCCESS(rc) && trunk_node_is_full(spl, node)) {
-         rc = trunk_flush_fullest(spl, node);
+      while (SUCCESS(rc) && trunk_node_is_full(spl, &node)) {
+         rc = trunk_flush_fullest(spl, &node);
       }
-      trunk_node_unlock(spl, node);
-      trunk_node_unclaim(spl, node);
+      trunk_node_unlock(spl->cc, &node);
+      trunk_node_unclaim(spl->cc, &node);
    }
 
    // timers for stats if enabled
@@ -4672,16 +4655,16 @@ trunk_compact_bundle(void *arg, void *scratch_buf)
     *    bundle was copied to the new sibling[s], so issue compact_bundles for
     *    those nodes
     */
-   if (req->generation < trunk_generation(spl, node)) {
+   if (req->generation < trunk_generation(spl, &node)) {
       if (height != 0) {
-         debug_assert(trunk_next_addr(spl, node) != 0);
+         debug_assert(trunk_next_addr(&node) != 0);
          trunk_compact_bundle_req *next_req =
             TYPED_MALLOC(spl->heap_id, next_req);
          memmove(next_req, req, sizeof(trunk_compact_bundle_req));
-         next_req->addr = trunk_next_addr(spl, node);
+         next_req->addr = trunk_next_addr(&node);
          debug_assert(next_req->addr != 0);
 
-         req->generation = trunk_generation(spl, node);
+         req->generation = trunk_generation(spl, &node);
 
          trunk_default_log_if_enabled(spl,
                                       "compact_bundle split from %lu to %lu\n",
@@ -4694,7 +4677,7 @@ trunk_compact_bundle(void *arg, void *scratch_buf)
          /*
           * 4. Abort if node is a splitting leaf (interaction 6)
           */
-         trunk_node_unget(spl, &node);
+         trunk_node_unget(spl->cc, &node);
          trunk_default_log_if_enabled(
             spl, "compact_bundle abort leaf split %lu\n", req->addr);
          platform_free(spl->heap_id, req);
@@ -4708,7 +4691,7 @@ trunk_compact_bundle(void *arg, void *scratch_buf)
    }
 
    // store the generation of the node so we can detect splits after compaction
-   uint64 start_generation = trunk_generation(spl, node);
+   uint64 start_generation = trunk_generation(spl, &node);
 
    /*
     * 5. The bundle may have been completely flushed by 2., if so abort
@@ -4716,9 +4699,9 @@ trunk_compact_bundle(void *arg, void *scratch_buf)
     *          generation number would change and it would be caught by step 4
     *          above).
     */
-   if (!trunk_bundle_live(spl, node, req->bundle_no)) {
+   if (!trunk_bundle_live(spl, &node, req->bundle_no)) {
       debug_assert(height != 0);
-      trunk_node_unget(spl, &node);
+      trunk_node_unget(spl->cc, &node);
       trunk_default_log_if_enabled(
          spl, "compact_bundle abort flushed %lu\n", req->addr);
       platform_free(spl->heap_id, req);
@@ -4730,10 +4713,10 @@ trunk_compact_bundle(void *arg, void *scratch_buf)
       return;
    }
 
-   trunk_bundle *bundle       = trunk_get_bundle(spl, node, req->bundle_no);
-   uint16 bundle_start_branch = trunk_bundle_start_branch(spl, node, bundle);
-   uint16 bundle_end_branch   = trunk_bundle_end_branch(spl, node, bundle);
-   uint16 num_branches        = trunk_bundle_branch_count(spl, node, bundle);
+   trunk_bundle *bundle       = trunk_get_bundle(spl, &node, req->bundle_no);
+   uint16 bundle_start_branch = trunk_bundle_start_branch(spl, &node, bundle);
+   uint16 bundle_end_branch   = trunk_bundle_end_branch(spl, &node, bundle);
+   uint16 num_branches        = trunk_bundle_branch_count(spl, &node, bundle);
 
    /*
     * Update and delete messages need to be kept around until/unless they have
@@ -4743,7 +4726,7 @@ trunk_compact_bundle(void *arg, void *scratch_buf)
     * branch).
     */
    merge_behavior merge_mode;
-   if (height == 0 && bundle_start_branch == trunk_start_branch(spl, node)) {
+   if (height == 0 && bundle_start_branch == trunk_start_branch(spl, &node)) {
       merge_mode = MERGE_FULL;
    } else {
       merge_mode = MERGE_INTERMEDIATE;
@@ -4765,7 +4748,7 @@ trunk_compact_bundle(void *arg, void *scratch_buf)
    trunk_btree_skiperator *skip_itor_arr = scratch->skip_itor;
    iterator              **itor_arr      = scratch->itor_arr;
 
-   save_pivots_to_compact_bundle_scratch(spl, node, scratch);
+   save_pivots_to_compact_bundle_scratch(spl, &node, scratch);
 
    uint16 tree_offset = 0;
    for (uint16 branch_no = bundle_start_branch; branch_no != bundle_end_branch;
@@ -4776,18 +4759,18 @@ trunk_compact_bundle(void *arg, void *scratch_buf)
        */
       trunk_btree_skiperator_init(spl,
                                   &skip_itor_arr[tree_offset],
-                                  node,
+                                  &node,
                                   branch_no,
                                   scratch->saved_pivot_keys);
       itor_arr[tree_offset] = &skip_itor_arr[tree_offset].super;
       tree_offset++;
    }
-   trunk_log_node_if_enabled(&stream, spl, node);
+   trunk_log_node_if_enabled(&stream, spl, &node);
 
    /*
     * 7. Release read lock
     */
-   trunk_node_unget(spl, &node);
+   trunk_node_unget(spl->cc, &node);
 
    /*
     * 8. Perform compaction
@@ -4854,8 +4837,7 @@ trunk_compact_bundle(void *arg, void *scratch_buf)
    /*
     * 11. Reacquire read lock
     */
-   node = trunk_node_get(spl, req->addr);
-   platform_assert(node != NULL);
+   trunk_node_get(spl->cc, req->addr, &node);
 
    /*
     * 12. For each newly split sibling replace bundle with new branch
@@ -4864,11 +4846,10 @@ trunk_compact_bundle(void *arg, void *scratch_buf)
    uint64 num_replacements = 0;
    uint64 generation;
    do {
-      platform_assert(node != NULL);
-      trunk_node_claim(spl, &node);
-      trunk_node_lock(spl, node);
+      trunk_node_claim(spl->cc, &node);
+      trunk_node_lock(spl->cc, &node);
 
-      trunk_log_node_if_enabled(&stream, spl, node);
+      trunk_log_node_if_enabled(&stream, spl, &node);
 
       /*
        * 12a. ...unless node is a leaf which has split, in which case discard
@@ -4878,7 +4859,7 @@ trunk_compact_bundle(void *arg, void *scratch_buf)
        *      need to look for the bundle in the split siblings, so simply
        *      exit.
        */
-      if (height == 0 && req->generation < trunk_generation(spl, node)) {
+      if (height == 0 && req->generation < trunk_generation(spl, &node)) {
          trunk_log_stream_if_enabled(
             spl, &stream, "compact_bundle discard split %lu\n", req->addr);
          if (spl->cfg.use_stats) {
@@ -4886,9 +4867,9 @@ trunk_compact_bundle(void *arg, void *scratch_buf)
             spl->stats[tid].compaction_time_wasted_ns[height] +=
                platform_timestamp_elapsed(compaction_start);
          }
-         trunk_node_unlock(spl, node);
-         trunk_node_unclaim(spl, node);
-         trunk_node_unget(spl, &node);
+         trunk_node_unlock(spl->cc, &node);
+         trunk_node_unclaim(spl->cc, &node);
+         trunk_node_unget(spl->cc, &node);
 
          if (num_tuples != 0) {
             trunk_dec_ref(spl, &new_branch, FALSE);
@@ -4898,9 +4879,9 @@ trunk_compact_bundle(void *arg, void *scratch_buf)
          goto out;
       }
 
-      if (trunk_bundle_live(spl, node, req->bundle_no)) {
+      if (trunk_bundle_live(spl, &node, req->bundle_no)) {
          if (num_tuples != 0) {
-            trunk_replace_bundle_branches(spl, node, &new_branch, req);
+            trunk_replace_bundle_branches(spl, &node, &new_branch, req);
             num_replacements++;
             trunk_log_stream_if_enabled(spl,
                                         &stream,
@@ -4908,7 +4889,7 @@ trunk_compact_bundle(void *arg, void *scratch_buf)
                                         new_branch.root_addr,
                                         addr);
          } else {
-            trunk_replace_bundle_branches(spl, node, NULL, req);
+            trunk_replace_bundle_branches(spl, &node, NULL, req);
             trunk_log_stream_if_enabled(
                spl, &stream, "compact_bundle empty %lu\n", addr);
          }
@@ -4921,25 +4902,26 @@ trunk_compact_bundle(void *arg, void *scratch_buf)
             spl, &stream, "compact_bundle discarded flushed %lu\n", addr);
       }
 
-      addr       = trunk_next_addr(spl, node);
-      generation = trunk_generation(spl, node);
-      trunk_log_node_if_enabled(&stream, spl, node);
-      debug_assert(trunk_verify_node(spl, node));
+      addr       = trunk_next_addr(&node);
+      generation = trunk_generation(spl, &node);
+      trunk_log_node_if_enabled(&stream, spl, &node);
+      debug_assert(trunk_verify_node(spl, &node));
 
       if (num_replacements != 0 && num_tuples != 0
-          && start_generation == generation) {
+          && start_generation == generation)
+      {
          key max_key = trunk_max_key(spl, node);
          trunk_zap_branch_range(
             spl, &new_branch, max_key, max_key, PAGE_TYPE_BRANCH);
       }
 
-      trunk_node_unlock(spl, node);
-      trunk_node_unclaim(spl, node);
-      trunk_node_unget(spl, &node);
+      trunk_node_unlock(spl->cc, &node);
+      trunk_node_unclaim(spl->cc, &node);
+      trunk_node_unget(spl->cc, &node);
       if (start_generation != generation) {
          debug_assert(height != 0);
          debug_assert(addr != 0);
-         node = trunk_node_get(spl, addr);
+         trunk_node_get(spl->cc, addr, &node);
       }
    } while (start_generation != generation);
 
@@ -4992,45 +4974,47 @@ out:
 bool
 trunk_flush_node(trunk_handle *spl, uint64 addr, void *arg)
 {
-   page_handle *node = trunk_node_get(spl, addr);
-   trunk_node_claim(spl, &node);
-   trunk_node_lock(spl, node);
+   trunk_node node;
+   trunk_node_get(spl->cc, addr, &node);
+   trunk_node_claim(spl->cc, &node);
+   trunk_node_lock(spl->cc, &node);
 
-   if (trunk_height(spl, node) != 0) {
-      for (uint16 pivot_no = 0; pivot_no < trunk_num_children(spl, node);
+   if (trunk_height(&node) != 0) {
+      for (uint16 pivot_no = 0; pivot_no < trunk_num_children(spl, &node);
            pivot_no++) {
-         trunk_pivot_data *pdata = trunk_get_pivot_data(spl, node, pivot_no);
-         if (trunk_pivot_branch_count(spl, node, pdata) != 0) {
-            platform_status rc = trunk_flush(spl, node, pdata, FALSE);
+         trunk_pivot_data *pdata = trunk_get_pivot_data(spl, &node, pivot_no);
+         if (trunk_pivot_branch_count(spl, &node, pdata) != 0) {
+            platform_status rc = trunk_flush(spl, &node, pdata, FALSE);
             platform_assert_status_ok(rc);
          }
       }
    }
 
-   trunk_node_unlock(spl, node);
-   trunk_node_unclaim(spl, node);
-   trunk_node_unget(spl, &node);
+   trunk_node_unlock(spl->cc, &node);
+   trunk_node_unclaim(spl->cc, &node);
+   trunk_node_unget(spl->cc, &node);
 
    task_perform_all(spl->ts);
 
-   node = trunk_node_get(spl, addr);
-   trunk_node_claim(spl, &node);
-   trunk_node_lock(spl, node);
+   trunk_node_get(spl->cc, addr, &node);
+   trunk_node_claim(spl->cc, &node);
+   trunk_node_lock(spl->cc, &node);
 
-   if (trunk_height(spl, node) == 1) {
-      for (uint16 pivot_no = 0; pivot_no < trunk_num_children(spl, node);
+   if (trunk_height(&node) == 1) {
+      for (uint16 pivot_no = 0; pivot_no < trunk_num_children(spl, &node);
            pivot_no++) {
-         trunk_pivot_data *pdata = trunk_get_pivot_data(spl, node, pivot_no);
-         page_handle      *leaf  = trunk_node_get(spl, pdata->addr);
-         trunk_node_claim(spl, &leaf);
-         trunk_node_lock(spl, leaf);
-         trunk_split_leaf(spl, node, leaf, pivot_no);
+         trunk_pivot_data *pdata = trunk_get_pivot_data(spl, &node, pivot_no);
+         trunk_node        leaf;
+         trunk_node_get(spl->cc, pdata->addr, &leaf);
+         trunk_node_claim(spl->cc, &leaf);
+         trunk_node_lock(spl->cc, &leaf);
+         trunk_split_leaf(spl, &node, &leaf, pivot_no);
       }
    }
 
-   trunk_node_unlock(spl, node);
-   trunk_node_unclaim(spl, node);
-   trunk_node_unget(spl, &node);
+   trunk_node_unlock(spl->cc, &node);
+   trunk_node_unclaim(spl->cc, &node);
+   trunk_node_unget(spl->cc, &node);
 
    task_perform_all(spl->ts);
 
@@ -5060,9 +5044,9 @@ trunk_force_flush(trunk_handle *spl)
  */
 
 static inline bool
-trunk_needs_split(trunk_handle *spl, page_handle *node)
+trunk_needs_split(trunk_handle *spl, trunk_node *node)
 {
-   if (trunk_is_leaf(spl, node)) {
+   if (trunk_is_leaf(node)) {
       uint64 num_tuples = trunk_pivot_num_tuples(spl, node, 0);
       uint64 kv_bytes   = trunk_pivot_kv_bytes(spl, node, 0);
       return num_tuples > spl->cfg.max_tuples_per_node
@@ -5075,8 +5059,8 @@ trunk_needs_split(trunk_handle *spl, page_handle *node)
 
 int
 trunk_split_index(trunk_handle *spl,
-                  page_handle  *parent,
-                  page_handle  *child,
+                  trunk_node   *parent,
+                  trunk_node   *child,
                   uint64        pivot_no)
 {
    platform_stream_handle stream;
@@ -5085,23 +5069,24 @@ trunk_split_index(trunk_handle *spl,
    trunk_log_stream_if_enabled(spl,
                                &stream,
                                "split index %lu with parent %lu\n",
-                               child->disk_addr,
-                               parent->disk_addr);
+                               child->addr,
+                               parent->addr);
    trunk_log_node_if_enabled(&stream, spl, parent);
    trunk_log_node_if_enabled(&stream, spl, child);
-   page_handle *left_node           = child;
-   uint16       target_num_children = trunk_num_children(spl, left_node) / 2;
-   uint16       height              = trunk_height(spl, left_node);
+   trunk_node *left_node           = child;
+   uint16      target_num_children = trunk_num_children(spl, left_node) / 2;
+   uint16      height              = trunk_height(left_node);
 
    if (spl->cfg.use_stats)
       spl->stats[platform_get_tid()].index_splits++;
 
    // allocate right node and write lock it
-   page_handle *right_node = trunk_alloc(spl, height);
-   uint64       right_addr = right_node->disk_addr;
+   trunk_node right_node;
+   trunk_alloc(spl->cc, &spl->mini, height, &right_node);
+   uint64 right_addr = right_node.addr;
 
    // ALEX: Maybe worth figuring out the real page size
-   memmove(right_node->data, left_node->data, trunk_page_size(&spl->cfg));
+   memmove(right_node.hdr, left_node->hdr, trunk_page_size(&spl->cfg));
    trunk_pivot_data *right_start_pivot =
       trunk_get_pivot_data(spl, right_node, 0);
    trunk_pivot_data *left_split_pivot =
@@ -5121,23 +5106,22 @@ trunk_split_index(trunk_handle *spl,
    }
 
    // set the headers appropriately
-   trunk_hdr *left_hdr  = (trunk_hdr *)left_node->data;
-   trunk_hdr *right_hdr = (trunk_hdr *)right_node->data;
+   right_node.hdr->num_pivot_keys =
+      left_node->hdr->num_pivot_keys - target_num_children;
+   left_node->hdr->num_pivot_keys = target_num_children + 1;
 
-   right_hdr->num_pivot_keys = left_hdr->num_pivot_keys - target_num_children;
-   left_hdr->num_pivot_keys  = target_num_children + 1;
+   right_node.hdr->next_addr = left_node->hdr->next_addr;
+   left_node->hdr->next_addr = right_addr;
 
-   right_hdr->next_addr = left_hdr->next_addr;
-   left_hdr->next_addr  = right_addr;
-
-   left_hdr->generation++;
-   trunk_reset_start_branch(spl, right_node);
+   left_node->hdr->generation++;
+   trunk_reset_start_branch(spl, &right_node);
    trunk_reset_start_branch(spl, left_node);
 
    // fix the entries in the reclamation queue
-   uint16 right_num_children = trunk_num_children(spl, right_node);
+   uint16 right_num_children = trunk_num_children(spl, &right_node);
    for (uint16 pivot_no = 0; pivot_no < right_num_children; pivot_no++) {
-      trunk_pivot_data *pdata = trunk_get_pivot_data(spl, right_node, pivot_no);
+      trunk_pivot_data *pdata =
+         trunk_get_pivot_data(spl, &right_node, pivot_no);
       if (pdata->srq_idx != -1 && spl->cfg.reclaim_threshold != UINT64_MAX) {
          // platform_default_log("Deleting %12lu-%lu (index %lu) from SRQ\n",
          //       left_node->disk_addr, pdata->generation, pdata->srq_idx);
@@ -5150,7 +5134,7 @@ trunk_split_index(trunk_handle *spl,
    }
 
    // add right child to parent
-   rc = trunk_add_pivot(spl, parent, right_node, pivot_no + 1);
+   rc = trunk_add_pivot(spl, parent, &right_node, pivot_no + 1);
    platform_assert(SUCCESS(rc));
    trunk_pivot_recount_num_tuples_and_kv_bytes(spl, parent, pivot_no);
    trunk_pivot_recount_num_tuples_and_kv_bytes(spl, parent, pivot_no + 1);
@@ -5159,12 +5143,12 @@ trunk_split_index(trunk_handle *spl,
       spl, &stream, "----------------------------------------\n");
    trunk_log_node_if_enabled(&stream, spl, parent);
    trunk_log_node_if_enabled(&stream, spl, left_node);
-   trunk_log_node_if_enabled(&stream, spl, right_node);
+   trunk_log_node_if_enabled(&stream, spl, &right_node);
    trunk_close_log_stream_if_enabled(spl, &stream);
 
-   trunk_node_unlock(spl, right_node);
-   trunk_node_unclaim(spl, right_node);
-   trunk_node_unget(spl, &right_node);
+   trunk_node_unlock(spl->cc, &right_node);
+   trunk_node_unclaim(spl->cc, &right_node);
+   trunk_node_unget(spl->cc, &right_node);
 
    return 0;
 }
@@ -5174,7 +5158,7 @@ trunk_split_index(trunk_handle *spl,
  */
 static inline uint64
 trunk_pivot_estimate_unique_keys(trunk_handle     *spl,
-                                 page_handle      *node,
+                                 trunk_node       *node,
                                  trunk_pivot_data *pdata)
 {
    routing_filter filter[MAX_FILTERS];
@@ -5263,8 +5247,8 @@ trunk_single_leaf_threshold(trunk_handle *spl)
  */
 void
 trunk_split_leaf(trunk_handle *spl,
-                 page_handle  *parent,
-                 page_handle  *leaf,
+                 trunk_node   *parent,
+                 trunk_node   *leaf,
                  uint16        child_idx)
 {
    const threadid      tid = platform_get_tid();
@@ -5274,14 +5258,14 @@ trunk_split_leaf(trunk_handle *spl,
    uint64              num_branches = trunk_branch_count(spl, leaf);
    uint64              start_branch = trunk_start_branch(spl, leaf);
 
-   trunk_node_unlock(spl, parent);
-   trunk_node_unlock(spl, leaf);
+   trunk_node_unlock(spl->cc, parent);
+   trunk_node_unlock(spl->cc, leaf);
 
    platform_stream_handle stream;
    platform_status        rc = trunk_open_log_stream_if_enabled(spl, &stream);
    platform_assert_status_ok(rc);
    trunk_log_stream_if_enabled(
-      spl, &stream, "split_leaf addr %lu\n", leaf->disk_addr);
+      spl, &stream, "split_leaf addr %lu\n", leaf->addr);
 
    uint64 split_start;
    if (spl->cfg.use_stats) {
@@ -5445,15 +5429,15 @@ trunk_split_leaf(trunk_handle *spl,
    /*
     * 3. Clear old bundles from leaf and put all branches in a new bundle
     */
-   trunk_node_lock(spl, parent);
+   trunk_node_lock(spl->cc, parent);
    trunk_log_node_if_enabled(&stream, spl, parent);
-   trunk_node_lock(spl, leaf);
+   trunk_node_lock(spl->cc, leaf);
    trunk_log_node_if_enabled(&stream, spl, leaf);
 
    uint16 bundle_no = trunk_leaf_rebundle_all_branches(
       spl, leaf, leaf0_num_tuples, leaf0_kv_bytes, FALSE);
    trunk_inc_generation(spl, leaf);
-   uint64 last_next_addr = trunk_next_addr(spl, leaf);
+   uint64 last_next_addr = trunk_next_addr(leaf);
 
    for (uint16 leaf_no = 0; leaf_no < num_leaves; leaf_no++) {
       /*
@@ -5470,16 +5454,17 @@ trunk_split_leaf(trunk_handle *spl,
        *    7. adds new_leaf to parent
        */
 
-      page_handle *new_leaf;
+      trunk_node new_leaf;
       if (leaf_no != 0) {
          // allocate a new leaf
-         new_leaf = trunk_alloc(spl, 0);
+         trunk_alloc(spl->cc, &spl->mini, 0, &new_leaf);
 
          // copy leaf to new leaf
-         memmove(new_leaf->data, leaf->data, trunk_page_size(&spl->cfg));
+         memmove(
+            new_leaf.page->data, leaf->page->data, trunk_page_size(&spl->cfg));
       } else {
          // just going to edit the min/max keys, etc. of original leaf
-         new_leaf = leaf;
+         new_leaf = *leaf;
       }
 
       /* Adjust max key first so that we always have ordered pivots (enforced by
@@ -5491,39 +5476,40 @@ trunk_split_leaf(trunk_handle *spl,
       trunk_set_pivot(
          spl, new_leaf, 0, key_buffer_key(&scratch->pivot[leaf_no]));
 
-      // set new_leaf tuple_count
-      trunk_bundle *bundle = trunk_get_bundle(spl, new_leaf, bundle_no);
+      // set &new_leaf tuple_count
+      trunk_bundle *bundle = trunk_get_bundle(spl, &new_leaf, bundle_no);
       uint64        new_leaf_num_tuples[TRUNK_MAX_PIVOTS];
       uint64        new_leaf_kv_bytes[TRUNK_MAX_PIVOTS];
       trunk_tuples_in_bundle(
-         spl, new_leaf, bundle, new_leaf_num_tuples, new_leaf_kv_bytes);
-      trunk_pivot_clear_counts(spl, new_leaf, 0);
+         spl, &new_leaf, bundle, new_leaf_num_tuples, new_leaf_kv_bytes);
+      trunk_pivot_clear_counts(spl, &new_leaf, 0);
       trunk_pivot_set_bundle_counts(
-         spl, new_leaf, 0, new_leaf_num_tuples[0], new_leaf_kv_bytes[0]);
+         spl, &new_leaf, 0, new_leaf_num_tuples[0], new_leaf_kv_bytes[0]);
 
       if (leaf_no != 0) {
          // set next_addr of leaf
-         trunk_set_next_addr(spl, leaf, new_leaf->disk_addr);
+         trunk_set_next_addr(leaf, new_leaf.addr);
 
          // inc the refs of all the branches
-         for (uint16 branch_no = trunk_start_branch(spl, new_leaf);
-              branch_no != trunk_end_branch(spl, new_leaf);
+         for (uint16 branch_no = trunk_start_branch(spl, &new_leaf);
+              branch_no != trunk_end_branch(spl, &new_leaf);
               branch_no = trunk_add_branch_number(spl, branch_no, 1))
          {
-            trunk_branch *branch  = trunk_get_branch(spl, new_leaf, branch_no);
-            key           min_key = trunk_min_key(spl, new_leaf);
+            trunk_branch *branch  = trunk_get_branch(spl, &new_leaf, branch_no);
+            key           min_key = trunk_min_key(spl, &new_leaf);
             trunk_inc_intersection(spl, branch, min_key, FALSE);
          }
 
          // inc the refs of all the filters
-         trunk_bundle *bundle = trunk_get_bundle(spl, new_leaf, bundle_no);
-         uint16 start_filter = trunk_bundle_start_filter(spl, new_leaf, bundle);
-         uint16 end_filter   = trunk_bundle_end_filter(spl, new_leaf, bundle);
+         trunk_bundle *bundle = trunk_get_bundle(spl, &new_leaf, bundle_no);
+         uint16        start_filter =
+            trunk_bundle_start_filter(spl, &new_leaf, bundle);
+         uint16 end_filter = trunk_bundle_end_filter(spl, &new_leaf, bundle);
          for (uint16 filter_no = start_filter; filter_no != end_filter;
               filter_no = trunk_add_subbundle_filter_number(spl, filter_no, 1))
          {
             routing_filter *filter =
-               trunk_get_sb_filter(spl, new_leaf, filter_no);
+               trunk_get_sb_filter(spl, &new_leaf, filter_no);
             trunk_inc_filter(spl, filter);
          }
 
@@ -5531,7 +5517,7 @@ trunk_split_leaf(trunk_handle *spl,
           * 5. Add new leaf to parent
           */
          platform_status rc =
-            trunk_add_pivot(spl, parent, new_leaf, child_idx + leaf_no);
+            trunk_add_pivot(spl, parent, &new_leaf, child_idx + leaf_no);
          platform_assert(SUCCESS(rc));
 
          /*
@@ -5539,7 +5525,7 @@ trunk_split_leaf(trunk_handle *spl,
           */
          trunk_compact_bundle_req *req = TYPED_ZALLOC(spl->heap_id, req);
          req->spl                      = spl;
-         req->addr                     = leaf->disk_addr;
+         req->addr                     = leaf->addr;
          req->type                     = comp_type;
          req->bundle_no                = bundle_no;
          req->generation               = trunk_generation(spl, leaf);
@@ -5559,12 +5545,12 @@ trunk_split_leaf(trunk_handle *spl,
          trunk_log_node_if_enabled(&stream, spl, leaf);
 
          debug_assert(trunk_verify_node(spl, leaf));
-         trunk_node_unlock(spl, leaf);
-         trunk_node_unclaim(spl, leaf);
-         trunk_node_unget(spl, &leaf);
+         trunk_node_unlock(spl->cc, leaf);
+         trunk_node_unclaim(spl->cc, leaf);
+         trunk_node_unget(spl->cc, leaf);
       }
 
-      leaf = new_leaf;
+      *leaf = new_leaf;
    }
 
    for (uint16 leaf_no = 0; leaf_no <= num_leaves; leaf_no++) {
@@ -5572,10 +5558,10 @@ trunk_split_leaf(trunk_handle *spl,
    }
 
    // set next_addr of leaf (from last iteration)
-   trunk_set_next_addr(spl, leaf, last_next_addr);
+   trunk_set_next_addr(leaf, last_next_addr);
    trunk_compact_bundle_req *req = TYPED_ZALLOC(spl->heap_id, req);
    req->spl                      = spl;
-   req->addr                     = leaf->disk_addr;
+   req->addr                     = leaf->addr;
    // req->height already 0
    req->bundle_no                    = bundle_no;
    req->generation                   = trunk_generation(spl, leaf);
@@ -5596,9 +5582,9 @@ trunk_split_leaf(trunk_handle *spl,
    trunk_log_node_if_enabled(&stream, spl, leaf);
 
    debug_assert(trunk_verify_node(spl, leaf));
-   trunk_node_unlock(spl, leaf);
-   trunk_node_unclaim(spl, leaf);
-   trunk_node_unget(spl, &leaf);
+   trunk_node_unlock(spl->cc, leaf);
+   trunk_node_unclaim(spl->cc, leaf);
+   trunk_node_unget(spl->cc, leaf);
 
    /*
     * 8. Clean up
@@ -5619,37 +5605,35 @@ trunk_split_leaf(trunk_handle *spl,
 
 
 int
-trunk_split_root(trunk_handle *spl, page_handle *root)
+trunk_split_root(trunk_handle *spl, trunk_node *root)
 {
-   trunk_hdr *root_hdr = (trunk_hdr *)root->data;
-
    // allocate a new child node
-   page_handle *child     = trunk_alloc(spl, root_hdr->height);
-   trunk_hdr   *child_hdr = (trunk_hdr *)child->data;
+   trunk_node child;
+   trunk_alloc(spl->cc, &spl->mini, root->hdr->height, &child);
 
    // copy root to child, fix up root, then split
-   memmove(child_hdr, root_hdr, trunk_page_size(&spl->cfg));
+   memmove(child.hdr, root->hdr, trunk_page_size(&spl->cfg));
    // num_pivot_keys is changed by add_pivot_new_root below
-   root_hdr->height++;
-   debug_assert(root_hdr->next_addr == 0);
+   root->hdr->height++;
+   debug_assert(root->hdr->next_addr == 0);
    // leave generation and pivot_generation
-   root_hdr->start_branch      = 0;
-   root_hdr->start_frac_branch = 0;
-   root_hdr->end_branch        = 0;
-   root_hdr->start_bundle      = 0;
-   root_hdr->end_bundle        = 0;
-   root_hdr->start_subbundle   = 0;
-   root_hdr->end_subbundle     = 0;
-   root_hdr->start_sb_filter   = 0;
-   root_hdr->end_sb_filter     = 0;
+   root->hdr->start_branch      = 0;
+   root->hdr->start_frac_branch = 0;
+   root->hdr->end_branch        = 0;
+   root->hdr->start_bundle      = 0;
+   root->hdr->end_bundle        = 0;
+   root->hdr->start_subbundle   = 0;
+   root->hdr->end_subbundle     = 0;
+   root->hdr->start_sb_filter   = 0;
+   root->hdr->end_sb_filter     = 0;
 
-   trunk_add_pivot_new_root(spl, root, child);
+   trunk_add_pivot_new_root(spl, root, &child);
 
-   trunk_split_index(spl, root, child, 0);
+   trunk_split_index(spl, root, &child, 0);
 
-   trunk_node_unlock(spl, child);
-   trunk_node_unclaim(spl, child);
-   trunk_node_unget(spl, &child);
+   trunk_node_unlock(spl->cc, &child);
+   trunk_node_unclaim(spl->cc, &child);
+   trunk_node_unget(spl->cc, &child);
 
    return 0;
 }
@@ -5741,19 +5725,20 @@ trunk_range_iterator_init(trunk_handle         *spl,
       range_itor->num_branches++;
    }
 
-   page_handle *node = trunk_node_get(spl, spl->root_addr);
+   trunk_node node;
+   trunk_node_get(spl->cc, spl->root_addr, &node);
    memtable_unget_lookup_lock(spl->mt_ctxt, mt_lookup_lock_page);
 
    // index btrees
-   uint16 height = trunk_height(spl, node);
+   uint16 height = trunk_height(&node);
    for (uint16 h = height; h > 0; h--) {
       uint16 pivot_no = trunk_find_pivot(
-         spl, node, key_buffer_key(&range_itor->min_key), less_than_or_equal);
-      debug_assert(pivot_no < trunk_num_children(spl, node));
-      trunk_pivot_data *pdata = trunk_get_pivot_data(spl, node, pivot_no);
+         spl, &node, key_buffer_key(&range_itor->min_key), less_than_or_equal);
+      debug_assert(pivot_no < trunk_num_children(spl, &node));
+      trunk_pivot_data *pdata = trunk_get_pivot_data(spl, &node, pivot_no);
 
       for (uint16 branch_offset = 0;
-           branch_offset != trunk_pivot_branch_count(spl, node, pdata);
+           branch_offset != trunk_pivot_branch_count(spl, &node, pdata);
            branch_offset++)
       {
          platform_assert(
@@ -5766,9 +5751,9 @@ trunk_range_iterator_init(trunk_handle         *spl,
          debug_assert(range_itor->num_branches
                       < ARRAY_SIZE(range_itor->branch));
          uint16 branch_no = trunk_subtract_branch_number(
-            spl, trunk_end_branch(spl, node), branch_offset + 1);
+            spl, trunk_end_branch(spl, &node), branch_offset + 1);
          range_itor->branch[range_itor->num_branches] =
-            *trunk_get_branch(spl, node, branch_no);
+            *trunk_get_branch(spl, &node, branch_no);
          range_itor->compacted[range_itor->num_branches] = TRUE;
          uint64 root_addr =
             range_itor->branch[range_itor->num_branches].root_addr;
@@ -5776,20 +5761,21 @@ trunk_range_iterator_init(trunk_handle         *spl,
          range_itor->num_branches++;
       }
 
-      page_handle *child = trunk_node_get(spl, pdata->addr);
-      trunk_node_unget(spl, &node);
+      trunk_node child;
+      trunk_node_get(spl->cc, pdata->addr, &child);
+      trunk_node_unget(spl->cc, &node);
       node = child;
    }
 
    // leaf btrees
    for (uint16 branch_offset = 0;
-        branch_offset != trunk_branch_count(spl, node);
+        branch_offset != trunk_branch_count(spl, &node);
         branch_offset++)
    {
       uint16 branch_no = trunk_subtract_branch_number(
-         spl, trunk_end_branch(spl, node), branch_offset + 1);
+         spl, trunk_end_branch(spl, &node), branch_offset + 1);
       range_itor->branch[range_itor->num_branches] =
-         *trunk_get_branch(spl, node, branch_no);
+         *trunk_get_branch(spl, &node, branch_no);
       uint64 root_addr = range_itor->branch[range_itor->num_branches].root_addr;
       btree_block_dec_ref(spl->cc, &spl->cfg.btree_cfg, root_addr);
       range_itor->compacted[range_itor->num_branches] = TRUE;
@@ -5798,8 +5784,8 @@ trunk_range_iterator_init(trunk_handle         *spl,
 
    // have a leaf, use to get rebuild key
    key rebuild_key =
-      trunk_key_compare(spl, trunk_max_key(spl, node), max_key) < 0
-         ? trunk_max_key(spl, node)
+      trunk_key_compare(spl, trunk_max_key(spl, &node), max_key) < 0
+         ? trunk_max_key(spl, &node)
          : max_key;
    key_buffer_init_from_key(
       &range_itor->rebuild_key, spl->heap_id, rebuild_key);
@@ -5811,7 +5797,7 @@ trunk_range_iterator_init(trunk_handle         *spl,
          &range_itor->local_max_key, spl->heap_id, rebuild_key);
    }
 
-   trunk_node_unget(spl, &node);
+   trunk_node_unget(spl->cc, &node);
 
    for (uint64 i = 0; i < range_itor->num_branches; i++) {
       uint64          branch_no  = range_itor->num_branches - i - 1;
@@ -5988,11 +5974,11 @@ trunk_range_iterator_deinit(trunk_range_iterator *range_itor)
  * Given a node addr and pivot generation, find the pivot with that generation
  * among the node and its split descendents
  *
- * Returns node with a write loc
+ * Returns node with a write lock
  */
 trunk_pivot_data *
 trunk_find_pivot_from_generation(trunk_handle *spl,
-                                 page_handle  *leaf,
+                                 trunk_node   *leaf,
                                  uint64        pivot_generation)
 {
    uint16 num_children = trunk_num_children(spl, leaf);
@@ -6006,7 +5992,7 @@ trunk_find_pivot_from_generation(trunk_handle *spl,
 }
 
 platform_status
-trunk_compact_leaf(trunk_handle *spl, page_handle *leaf)
+trunk_compact_leaf(trunk_handle *spl, trunk_node *leaf)
 {
    const threadid tid = platform_get_tid();
 
@@ -6014,7 +6000,7 @@ trunk_compact_leaf(trunk_handle *spl, page_handle *leaf)
    platform_status        rc = trunk_open_log_stream_if_enabled(spl, &stream);
    platform_assert_status_ok(rc);
    trunk_log_stream_if_enabled(
-      spl, &stream, "compact_leaf addr %lu\n", leaf->disk_addr);
+      spl, &stream, "compact_leaf addr %lu\n", leaf->addr);
    trunk_log_node_if_enabled(&stream, spl, leaf);
 
    uint64 sr_start;
@@ -6033,7 +6019,7 @@ trunk_compact_leaf(trunk_handle *spl, page_handle *leaf)
    // Issue compact_bundle for leaf and release
    trunk_compact_bundle_req *req = TYPED_ZALLOC(spl->heap_id, req);
    req->spl                      = spl;
-   req->addr                     = leaf->disk_addr;
+   req->addr                     = leaf->addr;
    // req->height already 0
    req->bundle_no                    = bundle_no;
    req->generation                   = trunk_generation(spl, leaf);
@@ -6096,13 +6082,14 @@ trunk_reclaim_space(trunk_handle *spl)
       if (!srq_data_found(&space_rec)) {
          return STATUS_NOT_FOUND;
       }
-      page_handle *node = trunk_node_get(spl, space_rec.addr);
-      trunk_node_claim(spl, &node);
+      trunk_node node;
+      trunk_node_get(spl->cc, space_rec.addr, &node);
+      trunk_node_claim(spl->cc, &node);
       trunk_pivot_data *pdata = trunk_find_pivot_from_generation(
-         spl, node, space_rec.pivot_generation);
+         spl, &node, space_rec.pivot_generation);
       if (pdata == NULL) {
-         trunk_node_unclaim(spl, node);
-         trunk_node_unget(spl, &node);
+         trunk_node_unclaim(spl->cc, &node);
+         trunk_node_unget(spl->cc, &node);
          continue;
       }
       pdata->srq_idx = -1;
@@ -6111,32 +6098,32 @@ trunk_reclaim_space(trunk_handle *spl)
       //       node->disk_addr, trunk_pdata_to_pivot_index(spl, node,
       //       pdata));
 
-      trunk_node_lock(spl, node);
-      if (trunk_is_leaf(spl, node)) {
-         trunk_compact_leaf(spl, node);
+      trunk_node_lock(spl->cc, &node);
+      if (trunk_is_leaf(&node)) {
+         trunk_compact_leaf(spl, &node);
       } else {
          uint64 sr_start;
          if (spl->cfg.use_stats) {
             sr_start = platform_get_timestamp();
          }
-         platform_status rc = trunk_flush(spl, node, pdata, TRUE);
+         platform_status rc = trunk_flush(spl, &node, pdata, TRUE);
          if (spl->cfg.use_stats) {
             const threadid tid    = platform_get_tid();
-            uint16         height = trunk_height(spl, node);
+            uint16         height = trunk_height(&node);
             spl->stats[tid].space_recs[height]++;
             spl->stats[tid].space_rec_time_ns[height] +=
                platform_timestamp_elapsed(sr_start);
          }
          if (!SUCCESS(rc)) {
-            trunk_node_unlock(spl, node);
-            trunk_node_unclaim(spl, node);
-            trunk_node_unget(spl, &node);
+            trunk_node_unlock(spl->cc, &node);
+            trunk_node_unclaim(spl->cc, &node);
+            trunk_node_unget(spl->cc, &node);
             continue;
          }
       }
-      trunk_node_unlock(spl, node);
-      trunk_node_unclaim(spl, node);
-      trunk_node_unget(spl, &node);
+      trunk_node_unlock(spl->cc, &node);
+      trunk_node_unclaim(spl->cc, &node);
+      trunk_node_unget(spl->cc, &node);
       return STATUS_OK;
    }
 }
@@ -6216,7 +6203,7 @@ out:
 
 bool
 trunk_filter_lookup(trunk_handle      *spl,
-                    page_handle       *node,
+                    trunk_node        *node,
                     routing_filter    *filter,
                     routing_config    *cfg,
                     uint16             start_branch,
@@ -6227,7 +6214,7 @@ trunk_filter_lookup(trunk_handle      *spl,
    threadid tid;
    if (spl->cfg.use_stats) {
       tid    = platform_get_tid();
-      height = trunk_height(spl, node);
+      height = trunk_height(node);
    }
 
    uint64          found_values;
@@ -6265,7 +6252,7 @@ trunk_filter_lookup(trunk_handle      *spl,
 
 bool
 trunk_compacted_subbundle_lookup(trunk_handle      *spl,
-                                 page_handle       *node,
+                                 trunk_node        *node,
                                  trunk_subbundle   *sb,
                                  key                target,
                                  merge_accumulator *data)
@@ -6276,7 +6263,7 @@ trunk_compacted_subbundle_lookup(trunk_handle      *spl,
    threadid tid;
    if (spl->cfg.use_stats) {
       tid    = platform_get_tid();
-      height = trunk_height(spl, node);
+      height = trunk_height(node);
    }
 
    uint16 filter_count = trunk_subbundle_filter_count(spl, node, sb);
@@ -6317,7 +6304,7 @@ trunk_compacted_subbundle_lookup(trunk_handle      *spl,
 
 bool
 trunk_bundle_lookup(trunk_handle      *spl,
-                    page_handle       *node,
+                    trunk_node        *node,
                     trunk_bundle      *bundle,
                     key                target,
                     merge_accumulator *data)
@@ -6347,7 +6334,7 @@ trunk_bundle_lookup(trunk_handle      *spl,
 
 bool
 trunk_pivot_lookup(trunk_handle      *spl,
-                   page_handle       *node,
+                   trunk_node        *node,
                    trunk_pivot_data  *pdata,
                    key                target,
                    merge_accumulator *data)
@@ -6400,30 +6387,32 @@ trunk_lookup(trunk_handle *spl, key target, merge_accumulator *result)
    }
 
    // hold root read lock to prevent memtable flush
-   page_handle *node = trunk_node_get(spl, spl->root_addr);
+   trunk_node node;
+   trunk_node_get(spl->cc, spl->root_addr, &node);
 
    // release memtable lookup lock
    memtable_unget_lookup_lock(spl->mt_ctxt, mt_lookup_lock_page);
 
    // look in index nodes
-   uint16 height = trunk_height(spl, node);
+   uint16 height = trunk_height(&node);
    for (uint16 h = height; h > 0; h--) {
-      uint16 pivot_no = trunk_find_pivot(spl, node, target, less_than_or_equal);
-      debug_assert(pivot_no < trunk_num_children(spl, node));
-      trunk_pivot_data *pdata = trunk_get_pivot_data(spl, node, pivot_no);
+      uint16 pivot_no = trunk_find_pivot(spl, &node, key, less_than_or_equal);
+      debug_assert(pivot_no < trunk_num_children(spl, &node));
+      trunk_pivot_data *pdata = trunk_get_pivot_data(spl, &node, pivot_no);
       bool              should_continue =
-         trunk_pivot_lookup(spl, node, pdata, target, result);
+         trunk_pivot_lookup(spl, &node, pdata, target, result);
       if (!should_continue) {
          goto found_final_answer_early;
       }
-      page_handle *child = trunk_node_get(spl, pdata->addr);
-      trunk_node_unget(spl, &node);
+      trunk_node child;
+      trunk_node_get(spl->cc, pdata->addr, &child);
+      trunk_node_unget(spl->cc, &node);
       node = child;
    }
 
    // look in leaf
-   trunk_pivot_data *pdata = trunk_get_pivot_data(spl, node, 0);
-   bool should_continue = trunk_pivot_lookup(spl, node, pdata, target, result);
+   trunk_pivot_data *pdata = trunk_get_pivot_data(spl, &node, 0);
+   bool should_continue = trunk_pivot_lookup(spl, &node, pdata, target, result);
    if (!should_continue) {
       goto found_final_answer_early;
    }
@@ -6440,7 +6429,7 @@ found_final_answer_early:
       // release memtable lookup lock
       memtable_unget_lookup_lock(spl->mt_ctxt, mt_lookup_lock_page);
    } else {
-      trunk_node_unget(spl, &node);
+      trunk_node_unget(spl->cc, &node);
    }
    if (spl->cfg.use_stats) {
       threadid tid = platform_get_tid();
@@ -6589,8 +6578,8 @@ trunk_lookup_async(trunk_handle      *spl,    // IN
    if (spl->cfg.use_stats) {
       tid = platform_get_tid();
    }
-   page_handle *node = ctxt->trunk_node;
-   bool         done = FALSE;
+   trunk_node *node = &ctxt->trunk_node;
+   bool        done = FALSE;
 
    do {
       switch (ctxt->state) {
@@ -6621,7 +6610,7 @@ trunk_lookup_async(trunk_handle      *spl,    // IN
          {
             cache_ctxt_init(
                spl->cc, trunk_async_callback, NULL, &ctxt->cache_ctxt);
-            res = trunk_node_get_async(spl, spl->root_addr, ctxt);
+            res = trunk_node_get_async(spl->cc, spl->root_addr, ctxt);
             switch (res) {
                case async_locked:
                case async_no_reqs:
@@ -6647,8 +6636,9 @@ trunk_lookup_async(trunk_handle      *spl,    // IN
                case async_success:
                   ctxt->was_async = FALSE;
                   trunk_async_set_state(ctxt, async_state_trunk_node_lookup);
-                  platform_assert(node == NULL);
-                  ctxt->trunk_node = node = ctxt->cache_ctxt.page;
+                  ctxt->trunk_node.page = ctxt->cache_ctxt.page;
+                  ctxt->trunk_node.hdr =
+                     (trunk_hdr *)(ctxt->cache_ctxt.page->data);
                   memtable_unget_lookup_lock(spl->mt_ctxt, ctxt->mt_lock_page);
                   ctxt->mt_lock_page = NULL;
                   break;
@@ -6659,7 +6649,7 @@ trunk_lookup_async(trunk_handle      *spl,    // IN
          }
          case async_state_trunk_node_lookup:
          {
-            ctxt->height = trunk_height(spl, node);
+            ctxt->height = trunk_height(node);
             uint16 pivot_no =
                trunk_find_pivot(spl, node, target, less_than_or_equal);
             debug_assert(pivot_no < trunk_num_children(spl, node));
@@ -6854,7 +6844,7 @@ trunk_lookup_async(trunk_handle      *spl,    // IN
                         ctxt, async_state_found_final_answer_early);
                      break;
                   } else if (spl->cfg.use_stats) {
-                     const uint16 height = trunk_height(spl, node);
+                     const uint16 height = trunk_height(node);
                      spl->stats[tid].filter_false_positives[height]++;
                   }
                   trunk_async_set_state(ctxt, async_state_next_in_node);
@@ -6935,7 +6925,7 @@ trunk_lookup_async(trunk_handle      *spl,    // IN
             cache_ctxt_init(
                spl->cc, trunk_async_callback, NULL, &ctxt->cache_ctxt);
             debug_assert(ctxt->pdata != NULL);
-            res = trunk_node_get_async(spl, ctxt->pdata->addr, ctxt);
+            res = trunk_node_get_async(spl->cc, ctxt->pdata->addr, ctxt);
             switch (res) {
                case async_locked:
                case async_no_reqs:
@@ -6973,9 +6963,10 @@ trunk_lookup_async(trunk_handle      *spl,    // IN
             if (ctxt->was_async) {
                trunk_node_async_done(spl, ctxt);
             }
-            trunk_node_unget(spl, &node);
-            ctxt->pdata      = NULL;
-            ctxt->trunk_node = node = ctxt->cache_ctxt.page;
+            trunk_node_unget(spl->cc, node);
+            ctxt->pdata           = NULL;
+            ctxt->trunk_node.page = ctxt->cache_ctxt.page;
+            ctxt->trunk_node.hdr  = (trunk_hdr *)(ctxt->cache_ctxt.page->data);
             trunk_async_set_state(ctxt, async_state_trunk_node_lookup);
             break;
          }
@@ -6989,11 +6980,10 @@ trunk_lookup_async(trunk_handle      *spl,    // IN
             if (ctxt->mt_lock_page != NULL) {
                memtable_unget_lookup_lock(spl->mt_ctxt, ctxt->mt_lock_page);
                ctxt->mt_lock_page = NULL;
-               debug_assert(node == NULL);
             } else {
-               trunk_node_unget(spl, &node);
+               trunk_node_unget(spl->cc, node);
             }
-            ctxt->trunk_node = NULL;
+            ZERO_CONTENTS(&ctxt->trunk_node);
             if (spl->cfg.use_stats) {
                if (!merge_accumulator_is_null(result)) {
                   spl->stats[tid].lookups_found++;
@@ -7094,9 +7084,12 @@ trunk_create(trunk_config     *cfg,
    platform_status rc =
       allocator_alloc(spl->al, &spl->root_addr, PAGE_TYPE_TRUNK);
    platform_assert_status_ok(rc);
-   page_handle *root = cache_alloc(spl->cc, spl->root_addr, PAGE_TYPE_TRUNK);
-   trunk_hdr   *root_hdr = (trunk_hdr *)root->data;
-   ZERO_CONTENTS(root_hdr);
+   trunk_node root;
+   root.addr = spl->root_addr;
+   root.page = cache_alloc(spl->cc, root.addr, PAGE_TYPE_TRUNK);
+   root.hdr  = (trunk_hdr *)root.page->data;
+
+   ZERO_CONTENTS(root.hdr);
 
    // set up the mini allocator
    //    we use the root extent as the initial mini_allocator head
@@ -7125,24 +7118,24 @@ trunk_create(trunk_config     *cfg,
    trunk_set_super_block(spl, FALSE, FALSE, TRUE);
 
    // set up the initial leaf
-   page_handle *leaf     = trunk_alloc(spl, 0);
-   trunk_hdr   *leaf_hdr = (trunk_hdr *)leaf->data;
-   memset(leaf_hdr, 0, trunk_page_size(&spl->cfg));
+   trunk_node leaf;
+   trunk_alloc(spl->cc, &spl->mini, 0, &leaf);
+   memset(leaf.hdr, 0, trunk_page_size(&spl->cfg));
    trunk_set_initial_pivots(spl, leaf);
-   trunk_inc_pivot_generation(spl, leaf);
+   trunk_inc_pivot_generation(spl, &leaf);
 
-   // add leaf to root and fix up root
-   root_hdr->height = 1;
-   trunk_add_pivot_new_root(spl, root, leaf);
-   trunk_inc_pivot_generation(spl, root);
+   // add &leaf to root and fix up root
+   root.hdr->height = 1;
+   trunk_add_pivot_new_root(spl, &root, &leaf);
+   trunk_inc_pivot_generation(spl, &root);
 
-   trunk_node_unlock(spl, leaf);
-   trunk_node_unclaim(spl, leaf);
-   trunk_node_unget(spl, &leaf);
+   trunk_node_unlock(spl->cc, &leaf);
+   trunk_node_unclaim(spl->cc, &leaf);
+   trunk_node_unget(spl->cc, &leaf);
 
-   trunk_node_unlock(spl, root);
-   trunk_node_unclaim(spl, root);
-   trunk_node_unget(spl, &root);
+   trunk_node_unlock(spl->cc, &root);
+   trunk_node_unclaim(spl->cc, &root);
+   trunk_node_unget(spl->cc, &root);
 
    if (spl->cfg.use_stats) {
       spl->stats = TYPED_ARRAY_ZALLOC(spl->heap_id, spl->stats, MAX_THREADS);
@@ -7303,37 +7296,38 @@ trunk_prepare_for_shutdown(trunk_handle *spl)
 bool
 trunk_node_destroy(trunk_handle *spl, uint64 addr, void *arg)
 {
-   page_handle *node = trunk_node_get(spl, addr);
-   trunk_node_claim(spl, &node);
-   trunk_node_lock(spl, node);
-   uint16 num_children = trunk_num_children(spl, node);
+   trunk_node node;
+   trunk_node_get(spl->cc, addr, &node);
+   trunk_node_claim(spl->cc, &node);
+   trunk_node_lock(spl->cc, &node);
+   uint16 num_children = trunk_num_children(spl, &node);
    for (uint16 pivot_no = 0; pivot_no < num_children; pivot_no++) {
-      trunk_pivot_data *pdata = trunk_get_pivot_data(spl, node, pivot_no);
+      trunk_pivot_data *pdata = trunk_get_pivot_data(spl, &node, pivot_no);
       if (pdata->filter.addr != 0) {
          trunk_dec_filter(spl, &pdata->filter);
       }
       for (uint16 branch_no = pdata->start_branch;
-           branch_no != trunk_end_branch(spl, node);
+           branch_no != trunk_end_branch(spl, &node);
            branch_no = trunk_add_branch_number(spl, branch_no, 1))
       {
-         trunk_branch *branch    = trunk_get_branch(spl, node, branch_no);
-         key           start_key = trunk_get_pivot(spl, node, pivot_no);
-         key           end_key   = trunk_get_pivot(spl, node, pivot_no + 1);
+         trunk_branch *branch    = trunk_get_branch(spl, &node, branch_no);
+         key           start_key = trunk_get_pivot(spl, &node, pivot_no);
+         key           end_key   = trunk_get_pivot(spl, &node, pivot_no + 1);
 
          trunk_zap_branch_range(
             spl, branch, start_key, end_key, PAGE_TYPE_BRANCH);
       }
    }
-   uint16 start_filter = trunk_start_sb_filter(spl, node);
-   uint16 end_filter   = trunk_end_sb_filter(spl, node);
+   uint16 start_filter = trunk_start_sb_filter(spl, &node);
+   uint16 end_filter   = trunk_end_sb_filter(spl, &node);
    for (uint16 filter_no = start_filter; filter_no != end_filter; filter_no++) {
-      routing_filter *filter = trunk_get_sb_filter(spl, node, filter_no);
+      routing_filter *filter = trunk_get_sb_filter(spl, &node, filter_no);
       trunk_dec_filter(spl, filter);
    }
 
-   trunk_node_unlock(spl, node);
-   trunk_node_unclaim(spl, node);
-   trunk_node_unget(spl, &node);
+   trunk_node_unlock(spl->cc, &node);
+   trunk_node_unclaim(spl->cc, &node);
+   trunk_node_unget(spl->cc, &node);
    return TRUE;
 }
 
@@ -7425,12 +7419,12 @@ trunk_perform_tasks(trunk_handle *spl)
  *    6. start_frac (resp end_branch) is first (resp last) branch in a subbundle
  */
 bool
-trunk_verify_node(trunk_handle *spl, page_handle *node)
+trunk_verify_node(trunk_handle *spl, trunk_node *node)
 {
    bool   is_valid = FALSE;
-   uint64 addr     = node->disk_addr;
+   uint64 addr     = node->addr;
 
-   // check values in trunk hdr (currently just num_pivot_keys)
+   // check values in trunk node->hdr (currently just num_pivot_keys)
    if (trunk_num_pivot_keys(spl, node) > spl->cfg.max_pivot_keys) {
       platform_error_log("trunk_verify: too many pivots\n");
       platform_error_log("addr: %lu\n", addr);
@@ -7449,7 +7443,7 @@ trunk_verify_node(trunk_handle *spl, page_handle *node)
       }
    }
 
-   // check that pivot generations are < hdr->pivot_generation
+   // check that pivot generations are < node->hdr->pivot_generation
    for (uint16 pivot_no = 0; pivot_no < num_children; pivot_no++) {
       trunk_pivot_data *pdata = trunk_get_pivot_data(spl, node, pivot_no);
       if (pdata->generation >= trunk_pivot_generation(spl, node)) {
@@ -7626,7 +7620,7 @@ trunk_verify_node(trunk_handle *spl, page_handle *node)
       last_sb = sb;
    }
 
-   // check that sb filters match in hdr and subbundles
+   // check that sb filters match in node->hdr and subbundles
    if (trunk_subbundle_count(spl, node) != 0) {
       uint16           hdr_sb_filter_start = trunk_start_sb_filter(spl, node);
       uint16           sb_start            = trunk_start_subbundle(spl, node);
@@ -7727,7 +7721,7 @@ trunk_verify_node(trunk_handle *spl, page_handle *node)
 
 
    // check that leaves only have a single pivot
-   if (trunk_height(spl, node) == 0) {
+   if (trunk_height(node) == 0) {
       if (trunk_num_children(spl, node) != 1) {
          platform_error_log("trunk_verify: leaf with multiple children\n");
          platform_error_log("addr: %lu\n", addr);
@@ -7749,28 +7743,29 @@ out:
  * 2. coherent pivots with children's min/max keys
  */
 bool
-trunk_verify_node_with_neighbors(trunk_handle *spl, page_handle *node)
+trunk_verify_node_with_neighbors(trunk_handle *spl, trunk_node *node)
 {
    bool   is_valid = FALSE;
-   uint64 addr     = node->disk_addr;
+   uint64 addr     = node->addr;
 
    // check node and successor have coherent pivots
-   uint64 succ_addr = trunk_next_addr(spl, node);
+   uint64 succ_addr = trunk_next_addr(node);
    if (succ_addr != 0) {
-      page_handle *succ     = trunk_node_get(spl, succ_addr);
+      trunk_node succ;
+      trunk_node_get(spl->cc, succ_addr, &succ);
       key          ube      = trunk_max_key(spl, node);
-      key          succ_lbi = trunk_min_key(spl, succ);
+      key          succ_lbi = trunk_min_key(spl, &succ);
       if (trunk_key_compare(spl, ube, succ_lbi) != 0) {
          platform_default_log("trunk_verify_node_with_neighbors: "
                               "mismatched pivots with successor\n");
          platform_default_log("addr: %lu\n", addr);
-         trunk_node_unget(spl, &succ);
+         trunk_node_unget(spl->cc, &succ);
          goto out;
       }
-      trunk_node_unget(spl, &succ);
+      trunk_node_unget(spl->cc, &succ);
    }
 
-   if (trunk_height(spl, node) == 0) {
+   if (trunk_height(node) == 0) {
       is_valid = TRUE;
       goto out;
    }
@@ -7780,11 +7775,12 @@ trunk_verify_node_with_neighbors(trunk_handle *spl, page_handle *node)
    for (uint16 pivot_no = 0; pivot_no != num_children; pivot_no++) {
       trunk_pivot_data *pdata      = trunk_get_pivot_data(spl, node, pivot_no);
       uint64            child_addr = pdata->addr;
-      page_handle      *child      = trunk_node_get(spl, child_addr);
+      trunk_node        child;
+      trunk_node_get(spl->cc, child_addr, &child);
 
       // check pivot == child min key
       key pivot         = trunk_get_pivot(spl, node, pivot_no);
-      key child_min_key = trunk_min_key(spl, child);
+      key child_min_key = trunk_min_key(spl, &child);
       if (trunk_key_compare(spl, pivot, child_min_key) != 0) {
          platform_default_log("trunk_verify_node_with_neighbors: "
                               "mismatched pivot with child min key\n");
@@ -7793,21 +7789,21 @@ trunk_verify_node_with_neighbors(trunk_handle *spl, page_handle *node)
                               key_string(spl->cfg.data_cfg, child_min_key));
          platform_default_log("addr: %lu\n", addr);
          platform_default_log("child addr: %lu\n", child_addr);
-         trunk_node_unget(spl, &child);
+         trunk_node_unget(spl->cc, &child);
          goto out;
       }
       key next_pivot    = trunk_get_pivot(spl, node, pivot_no + 1);
-      key child_max_key = trunk_max_key(spl, child);
+      key child_max_key = trunk_max_key(spl, &child);
       if (trunk_key_compare(spl, next_pivot, child_max_key) != 0) {
          platform_default_log("trunk_verify_node_with_neighbors: "
                               "mismatched pivot with child max key\n");
          platform_default_log("addr: %lu\n", addr);
          platform_default_log("child addr: %lu\n", child_addr);
-         trunk_node_unget(spl, &child);
+         trunk_node_unget(spl->cc, &child);
          goto out;
       }
 
-      trunk_node_unget(spl, &child);
+      trunk_node_unget(spl->cc, &child);
    }
 
    is_valid = TRUE;
@@ -7824,15 +7820,16 @@ out:
 bool
 trunk_verify_node_and_neighbors(trunk_handle *spl, uint64 addr, void *arg)
 {
-   page_handle *node     = trunk_node_get(spl, addr);
-   bool         is_valid = trunk_verify_node(spl, node);
+   trunk_node node;
+   trunk_node_get(spl->cc, addr, &node);
+   bool is_valid = trunk_verify_node(spl, &node);
    if (!is_valid) {
       goto out;
    }
-   is_valid = trunk_verify_node_with_neighbors(spl, node);
+   is_valid = trunk_verify_node_with_neighbors(spl, &node);
 
 out:
-   trunk_node_unget(spl, &node);
+   trunk_node_unget(spl->cc, &node);
    return is_valid;
 }
 
@@ -7851,28 +7848,29 @@ trunk_verify_tree(trunk_handle *spl)
 bool
 trunk_node_space_use(trunk_handle *spl, uint64 addr, void *arg)
 {
-   uint64      *bytes_used_on_level = (uint64 *)arg;
-   uint64       bytes_used_in_node  = 0;
-   page_handle *node                = trunk_node_get(spl, addr);
-   uint16       num_pivot_keys      = trunk_num_pivot_keys(spl, node);
-   uint16       num_children        = trunk_num_children(spl, node);
-   for (uint16 branch_no = trunk_start_branch(spl, node);
-        branch_no != trunk_end_branch(spl, node);
+   uint64    *bytes_used_on_level = (uint64 *)arg;
+   uint64     bytes_used_in_node  = 0;
+   trunk_node node;
+   trunk_node_get(spl->cc, addr, &node);
+   uint16 num_pivot_keys = trunk_num_pivot_keys(spl, &node);
+   uint16 num_children   = trunk_num_children(spl, &node);
+   for (uint16 branch_no = trunk_start_branch(spl, &node);
+        branch_no != trunk_end_branch(spl, &node);
         branch_no = trunk_add_branch_number(spl, branch_no, 1))
    {
-      trunk_branch *branch    = trunk_get_branch(spl, node, branch_no);
+      trunk_branch *branch    = trunk_get_branch(spl, &node, branch_no);
       key           start_key = NULL_KEY;
       key           end_key   = NULL_KEY;
       for (uint16 pivot_no = 0; pivot_no < num_pivot_keys; pivot_no++) {
          if (1 && pivot_no != num_children
-             && trunk_branch_live_for_pivot(spl, node, branch_no, pivot_no))
+             && trunk_branch_live_for_pivot(spl, &node, branch_no, pivot_no))
          {
             if (key_is_null(start_key)) {
-               start_key = trunk_get_pivot(spl, node, pivot_no);
+               start_key = trunk_get_pivot(spl, &node, pivot_no);
             }
          } else {
             if (!key_is_null(start_key)) {
-               end_key = trunk_get_pivot(spl, node, pivot_no);
+               end_key = trunk_get_pivot(spl, &node, pivot_no);
                uint64 bytes_used_in_branch_range =
                   btree_space_use_in_range(spl->cc,
                                            &spl->cfg.btree_cfg,
@@ -7888,9 +7886,9 @@ trunk_node_space_use(trunk_handle *spl, uint64 addr, void *arg)
       }
    }
 
-   uint16 height = trunk_height(spl, node);
+   uint16 height = trunk_height(&node);
    bytes_used_on_level[height] += bytes_used_in_node;
-   trunk_node_unget(spl, &node);
+   trunk_node_unget(spl->cc, &node);
    return TRUE;
 }
 
@@ -7913,16 +7911,16 @@ trunk_print_space_use(platform_log_handle *log_handle, trunk_handle *spl)
 void
 trunk_print_locked_node(platform_log_handle *log_handle,
                         trunk_handle        *spl,
-                        page_handle         *node)
+                        trunk_node          *node)
 {
-   uint16 height = trunk_height(spl, node);
+   uint16 height = trunk_height(node);
    // clang-format off
    platform_log(log_handle, "----------------------------------------------------------------------------------------------------\n");
    platform_log(log_handle, "|          |     addr     |   next addr  | height |   gen   | pvt gen |                            |\n");
    platform_log(log_handle, "|  HEADER  |--------------|--------------|--------|---------|---------|----------------------------|\n");
    platform_log(log_handle, "|          | %12lu | %12lu | %6u | %7lu | %7lu |                            |\n",
-      node->disk_addr,
-      trunk_next_addr(spl, node),
+      node->addr,
+      trunk_next_addr(node),
       height,
       trunk_generation(spl, node),
       trunk_pivot_generation(spl, node));
@@ -7941,7 +7939,7 @@ trunk_print_locked_node(platform_log_handle *log_handle,
 static void
 trunk_print_pivots(platform_log_handle *log_handle,
                    trunk_handle        *spl,
-                   page_handle         *node)
+                   trunk_node          *node)
 {
    // clang-format off
    platform_log(log_handle, "|--------------------------------------------------------------------------------------------------|\n");
@@ -7996,7 +7994,7 @@ trunk_print_pivots(platform_log_handle *log_handle,
 static void
 trunk_print_branches_and_bundles(platform_log_handle *log_handle,
                                  trunk_handle        *spl,
-                                 page_handle         *node)
+                                 trunk_node          *node)
 {
    uint16 start_branch = trunk_start_branch(spl, node);
    uint16 end_branch   = trunk_end_branch(spl, node);
@@ -8103,9 +8101,10 @@ trunk_print_node(platform_log_handle *log_handle,
       return;
    }
 
-   page_handle *node = trunk_node_get(spl, addr);
-   trunk_print_locked_node(log_handle, spl, node);
-   cache_unget(spl->cc, node);
+   trunk_node node;
+   trunk_node_get(spl->cc, addr, &node);
+   trunk_print_locked_node(log_handle, spl, &node);
+   trunk_node_unget(spl->cc, &node);
 }
 
 /*
@@ -8120,16 +8119,16 @@ trunk_print_subtree(platform_log_handle *log_handle,
                     uint64               addr)
 {
    trunk_print_node(log_handle, spl, addr);
-   page_handle *node = trunk_node_get(spl, addr);
-   trunk_hdr   *hdr  = (trunk_hdr *)node->data;
+   trunk_node node;
+   trunk_node_get(spl->cc, addr, &node);
 
-   if (hdr->height != 0) {
-      for (uint32 i = 0; i < trunk_num_children(spl, node); i++) {
-         trunk_pivot_data *data = trunk_get_pivot_data(spl, node, i);
+   if (trunk_is_index(&node)) {
+      for (uint32 i = 0; i < trunk_num_children(spl, &node); i++) {
+         trunk_pivot_data *data = trunk_get_pivot_data(spl, &node, i);
          trunk_print_subtree(log_handle, spl, data->addr);
       }
    }
-   cache_unget(spl->cc, node);
+   trunk_node_unget(spl->cc, &node);
 }
 
 /*
@@ -8221,9 +8220,10 @@ trunk_print_insertion_stats(platform_log_handle *log_handle, trunk_handle *spl)
    uint64 avg_filter_tuples, avg_filter_time, filter_time_per_tuple;
    uint32 h, rev_h;
    threadid thr_i;
-   page_handle *node = trunk_node_get(spl, spl->root_addr);
-   uint32 height = trunk_height(spl, node);
-   trunk_node_unget(spl, &node);
+   trunk_node node;
+   trunk_node_get(spl->cc, spl->root_addr, &node);
+   uint32 height = trunk_height(&node);
+   trunk_node_unget(spl->cc, &node);
 
    trunk_stats *global;
 
@@ -8537,9 +8537,10 @@ trunk_print_lookup_stats(platform_log_handle *log_handle, trunk_handle *spl)
    uint32 h, rev_h;
    uint64 lookups;
    fraction avg_filter_lookups, avg_filter_false_positives, avg_branch_lookups;
-   page_handle *node = trunk_node_get(spl, spl->root_addr);
-   uint32 height = trunk_height(spl, node);
-   trunk_node_unget(spl, &node);
+   trunk_node node;
+   trunk_node_get(spl->cc, spl->root_addr, &node);
+   uint32 height = trunk_height(&node);
+   trunk_node_unget(spl->cc, &node);
 
    trunk_stats *global;
 
@@ -8663,15 +8664,16 @@ trunk_print_lookup(trunk_handle        *spl,
       }
    }
 
-   page_handle *node   = trunk_node_get(spl, spl->root_addr);
-   uint16       height = trunk_height(spl, node);
+   trunk_node node;
+   trunk_node_get(spl->cc, spl->root_addr, &node);
+   uint16 height = trunk_height(&node);
    for (uint16 h = height; h > 0; h--) {
-      trunk_print_locked_node(Platform_default_log_handle, spl, node);
-      uint16 pivot_no = trunk_find_pivot(spl, node, target, less_than_or_equal);
-      debug_assert(pivot_no < trunk_num_children(spl, node));
-      trunk_pivot_data *pdata = trunk_get_pivot_data(spl, node, pivot_no);
+      trunk_print_locked_node(Platform_default_log_handle, spl, &node);
+      uint16 pivot_no = trunk_find_pivot(spl, &node, target, less_than_or_equal);
+      debug_assert(pivot_no < trunk_num_children(spl, &node));
+      trunk_pivot_data *pdata = trunk_get_pivot_data(spl, &node, pivot_no);
       merge_accumulator_set_to_null(&data);
-      trunk_pivot_lookup(spl, node, pdata, target, &data);
+      trunk_pivot_lookup(spl, &node, pdata, target, &data);
       if (!merge_accumulator_is_null(&data)) {
          char key_str[128];
          char message_str[128];
@@ -8681,15 +8683,15 @@ trunk_print_lookup(trunk_handle        *spl,
          platform_log_stream(&stream,
                              "Key %s found in node %lu pivot %u with data %s\n",
                              key_str,
-                             node->disk_addr,
+                             node.addr,
                              pivot_no,
                              message_str);
       } else {
          for (uint16 branch_no = pdata->start_branch;
-              branch_no != trunk_end_branch(spl, node);
+              branch_no != trunk_end_branch(spl, &node);
               branch_no = trunk_add_branch_number(spl, branch_no, 1))
          {
-            trunk_branch   *branch = trunk_get_branch(spl, node, branch_no);
+            trunk_branch   *branch = trunk_get_branch(spl, &node, branch_no);
             platform_status rc;
             bool            local_found;
             merge_accumulator_set_to_null(&data);
@@ -8708,22 +8710,23 @@ trunk_print_lookup(trunk_handle        *spl,
                   "with data %s\n",
                   key_str,
                   branch_no,
-                  node->disk_addr,
+                  node.addr,
                   pivot_no,
                   message_str);
             }
          }
       }
-      page_handle *child = trunk_node_get(spl, pdata->addr);
-      trunk_node_unget(spl, &node);
+      trunk_node child;
+      trunk_node_get(spl->cc, pdata->addr, &child);
+      trunk_node_unget(spl->cc, &node);
       node = child;
    }
 
    // look in leaf
-   trunk_print_locked_node(Platform_default_log_handle, spl, node);
-   trunk_pivot_data *pdata = trunk_get_pivot_data(spl, node, 0);
+   trunk_print_locked_node(Platform_default_log_handle, spl, &node);
+   trunk_pivot_data *pdata = trunk_get_pivot_data(spl, &node, 0);
    merge_accumulator_set_to_null(&data);
-   trunk_pivot_lookup(spl, node, pdata, target, &data);
+   trunk_pivot_lookup(spl, &node, pdata, target, &data);
    if (!merge_accumulator_is_null(&data)) {
       char key_str[128];
       char message_str[128];
@@ -8733,15 +8736,15 @@ trunk_print_lookup(trunk_handle        *spl,
       platform_log_stream(&stream,
                           "Key %s found in node %lu pivot %u with data %s\n",
                           key_str,
-                          node->disk_addr,
+                          node.addr,
                           0,
                           message_str);
    } else {
       for (uint16 branch_no = pdata->start_branch;
-           branch_no != trunk_end_branch(spl, node);
+           branch_no != trunk_end_branch(spl, &node);
            branch_no = trunk_add_branch_number(spl, branch_no, 1))
       {
-         trunk_branch   *branch = trunk_get_branch(spl, node, branch_no);
+         trunk_branch   *branch = trunk_get_branch(spl, &node, branch_no);
          platform_status rc;
          bool            local_found;
          merge_accumulator_set_to_null(&data);
@@ -8760,13 +8763,13 @@ trunk_print_lookup(trunk_handle        *spl,
                "with data %s\n",
                key_str,
                branch_no,
-               node->disk_addr,
+               node.addr,
                0,
                message_str);
          }
       }
    }
-   trunk_node_unget(spl, &node);
+   trunk_node_unget(spl->cc, &node);
    merge_accumulator_deinit(&data);
    platform_close_log_stream(&stream, Platform_default_log_handle);
 }
@@ -8781,7 +8784,7 @@ trunk_reset_stats(trunk_handle *spl)
 
 void
 trunk_branch_count_num_tuples(trunk_handle *spl,
-                              page_handle  *node,
+                              trunk_node   *node,
                               uint16        branch_no,
                               uint64       *num_tuples,
                               uint64       *kv_bytes)
@@ -8805,21 +8808,22 @@ bool
 trunk_node_print_branches(trunk_handle *spl, uint64 addr, void *arg)
 {
    platform_log_handle *log_handle = (platform_log_handle *)arg;
-   page_handle         *node       = trunk_node_get(spl, addr);
+   trunk_node           node;
+   trunk_node_get(spl->cc, addr, &node);
 
    platform_log(
       log_handle,
       "------------------------------------------------------------------\n");
    platform_log(
-      log_handle, "| node %12lu height %u\n", addr, trunk_height(spl, node));
+      log_handle, "| node %12lu height %u\n", addr, trunk_height(&node));
    platform_log(
       log_handle,
       "------------------------------------------------------------------\n");
-   uint16 num_pivot_keys = trunk_num_pivot_keys(spl, node);
+   uint16 num_pivot_keys = trunk_num_pivot_keys(spl, &node);
    platform_log(log_handle, "| pivots:\n");
    for (uint16 pivot_no = 0; pivot_no < num_pivot_keys; pivot_no++) {
       char key_str[128];
-      trunk_key_to_string(spl, trunk_get_pivot(spl, node, pivot_no), key_str);
+      trunk_key_to_string(spl, trunk_get_pivot(spl, &node, pivot_no), key_str);
       platform_log(log_handle, "| %u: %s\n", pivot_no, key_str);
    }
 
@@ -8831,18 +8835,18 @@ trunk_node_print_branches(trunk_handle *spl, uint64 addr, void *arg)
    platform_log(log_handle,
          "-----------------------------------------------------------------------------------\n");
    // clang-format on
-   uint16 start_branch = trunk_start_branch(spl, node);
-   uint16 end_branch   = trunk_end_branch(spl, node);
+   uint16 start_branch = trunk_start_branch(spl, &node);
+   uint16 end_branch   = trunk_end_branch(spl, &node);
    for (uint16 branch_no = start_branch; branch_no != end_branch;
         branch_no        = trunk_add_branch_number(spl, branch_no, 1))
    {
-      uint64 addr = trunk_get_branch(spl, node, branch_no)->root_addr;
+      uint64 addr = trunk_get_branch(spl, &node, branch_no)->root_addr;
       uint64 num_tuples_in_branch;
       uint64 kv_bytes_in_branch;
       trunk_branch_count_num_tuples(
-         spl, node, branch_no, &num_tuples_in_branch, &kv_bytes_in_branch);
+         spl, &node, branch_no, &num_tuples_in_branch, &kv_bytes_in_branch);
       uint64 kib_in_branch = 0;
-      // trunk_branch_extent_count(spl, node, branch_no);
+      // trunk_branch_extent_count(spl, &node, branch_no);
       kib_in_branch *= trunk_extent_size(&spl->cfg) / 1024;
       fraction space_amp =
          init_fraction(kib_in_branch * 1024, kv_bytes_in_branch);
@@ -8861,7 +8865,7 @@ trunk_node_print_branches(trunk_handle *spl, uint64 addr, void *arg)
       log_handle,
       "------------------------------------------------------------------\n");
    platform_log(log_handle, "\n");
-   trunk_node_unget(spl, &node);
+   trunk_node_unget(spl->cc, &node);
    return TRUE;
 }
 
@@ -8876,7 +8880,7 @@ trunk_print_branches(platform_log_handle *log_handle, trunk_handle *spl)
 //                                 uint64           addr,
 //                                 void            *arg)
 //{
-//   page_handle *node = trunk_node_get(spl, addr);
+//   trunk_node *node = trunk_node_get(spl, addr);
 //
 //   uint16 start_branch = trunk_start_branch(spl, node);
 //   uint16 end_branch = trunk_end_branch(spl, node);
@@ -8888,7 +8892,7 @@ trunk_print_branches(platform_log_handle *log_handle, trunk_handle *spl)
 //      num_extents += trunk_branch_extent_count(spl, node, branch_no);
 //   }
 //   platform_default_log("%8lu\n", num_extents);
-//   trunk_node_unget(spl, &node);
+//   trunk_node_unget(spl->cc, &node);
 //   return TRUE;
 //}
 //
@@ -8972,7 +8976,7 @@ trunk_config_init(trunk_config        *trunk_cfg,
       available_bytes_per_pivot - sizeof(trunk_pivot_data);
    platform_assert(trunk_node_min_size < cache_config_page_size(cache_cfg),
                    "\nTrunk node does not fit in page size as configured.\n"
-                   "hdr: %luB\n"
+                   "node->hdr: %luB\n"
                    "pivots: %luB (max_pivot=%lu x %luB)\n"
                    "branches %luB (max_branches=%lu x %luB).\n"
                    "Maximum key size supported with current config: %luB.\n",

--- a/src/trunk.h
+++ b/src/trunk.h
@@ -275,6 +275,15 @@ struct trunk_subbundle;
 
 typedef void (*trunk_async_cb)(struct trunk_async_ctxt *ctxt);
 
+struct trunk_hdr;
+typedef struct trunk_hdr trunk_hdr;
+
+typedef struct trunk_node {
+   uint64       addr;
+   page_handle *page;
+   trunk_hdr   *hdr;
+} trunk_node;
+
 typedef struct trunk_async_ctxt {
    trunk_async_cb cb; // IN: callback (requeues ctxt
                       // for dispatch)
@@ -282,7 +291,7 @@ typedef struct trunk_async_ctxt {
    trunk_async_state prev_state;   // state machine's previous state
    trunk_async_state state;        // state machine's current state
    page_handle      *mt_lock_page; // Memtable lock page
-   page_handle      *trunk_node;   // Current trunk node
+   trunk_node        trunk_node;   // Current trunk node
    uint16            height;       // height of trunk_node
 
    uint16 sb_no;     // subbundle number (newest)


### PR DESCRIPTION
Refactors handling of trunk nodes to a new trunk_node struct, rather than using page_handles. This is now analagous to the handing of btree_nodes.

Moves the related low-level trunk node functionality to a new header src/trunk_node.h. This header will eventually hold all low-level trunk node functionality.

Moves the trunk node logging functionality to a new header src/trunk_log.h.

Moves the superblock functionality to a new header src/superblock.c. This should simplify the eventual change to calling these functions from src/splinterdb.c.

Fixes a use-after-free bug where `trunk_node_verify` is called on the child in a debug_assert after a trunk_split_leaf, which ungets the child.