### PR TITLE
clarify lifetimes in code comments

### DIFF
--- a/include/splinterdb/splinterdb.h
+++ b/include/splinterdb/splinterdb.h
@@ -163,6 +163,16 @@ typedef struct {
 // If the caller provides a buffer, that will be used, unless a lookup
 // requires a larger buffer, at which time the library will allocate.
 // Regardless, the library will never free a buffer supplied by the application.
+//
+// After this function returns, the caller must ensure that
+// 1. *result is only used in conjunction with the kvs
+//    Attempting to use one lookup_result with multiple instances of splinterdb
+//    may cause problems in future versions of splinterdb
+// 2. The lifetime of *result must not exceed the lifetime of kvs
+//    The result should be deinit'ed before calling splinterdb_close on kvs
+//
+// While the current version of SplinterDB does not rely on these rules, future
+// versions may store pointers to Splinter's own memory in the lookup_result.
 void
 splinterdb_lookup_result_init(const splinterdb         *kvs,        // IN
                               splinterdb_lookup_result *result,     // IN/OUT
@@ -181,6 +191,8 @@ bool
 splinterdb_lookup_found(const splinterdb_lookup_result *result); // IN
 
 // Decode the value from a found result
+//
+// Do not modify the memory pointed at by *value
 int
 splinterdb_lookup_result_value(const splinterdb               *kvs,
                                const splinterdb_lookup_result *result, // IN

--- a/include/splinterdb/splinterdb.h
+++ b/include/splinterdb/splinterdb.h
@@ -82,7 +82,9 @@ typedef struct splinterdb splinterdb;
 // The library will allocate and own the memory for splinterdb
 // and will free it on splinterdb_close().
 //
-// It is ok for the caller to stack-allocate cfg, since it is not retained
+// It is ok for the caller to stack-allocate cfg, since it is not retained.
+// But cfg->data_cfg will be referenced by the returned splinterdb object
+// So it must live at least as long as the splinterdb
 int
 splinterdb_create(const splinterdb_config *cfg, splinterdb **kvs);
 
@@ -91,7 +93,9 @@ splinterdb_create(const splinterdb_config *cfg, splinterdb **kvs);
 // The library will allocate and own the memory for splinterdb
 // and will free it on splinterdb_close().
 //
-// It is ok for the caller to stack-allocate cfg, since it is not retained
+// It is ok for the caller to stack-allocate cfg, since it is not retained.
+// But cfg->data_cfg will be referenced by the returned splinterdb object
+// So it must live at least as long as the splinterdb
 int
 splinterdb_open(const splinterdb_config *cfg, splinterdb **kvs);
 

--- a/src/splinterdb.c
+++ b/src/splinterdb.c
@@ -258,7 +258,7 @@ splinterdb_shim_key_to_string(const data_config *cfg,
 
 
 // create a shim data_config that handles variable-length key encoding
-// the output retains a reference to app_cfg (via the context field)
+// the output retains a reference to app_cfg
 // so the lifetime of app_cfg must be at least as long as out_shim
 static int
 splinterdb_shim_data_config(const data_config *app_cfg,
@@ -307,6 +307,9 @@ splinterdb_shim_data_config(const data_config *app_cfg,
  *
  *      Translate splinterdb_config to configs for individual subsystems.
  *
+ *      The resulting splinterdb object will retain a reference to data_config
+ *      So kvs_cfg->data_config must live at least that long.
+ *
  * Results:
  *      STATUS_OK on success, appropriate error on failure.
  *
@@ -339,6 +342,8 @@ splinterdb_init_config(const splinterdb_config *kvs_cfg, // IN
    memcpy(&cfg, kvs_cfg, sizeof(cfg));
    splinterdb_config_set_defaults(&cfg);
 
+   // this line carries a reference, so kvs_cfg->data_cfg must live
+   // at least as long as kvs does
    platform_assert(
       0 == splinterdb_shim_data_config(kvs_cfg->data_cfg, &kvs->shim_data_cfg),
       "error shimming data_config.  This is probably an invalid data_config");


### PR DESCRIPTION
Header comments should explain to callers how long certain objects need to live.
- The user-provided `data_config` needs to live at least as long as the `splinterdb`
- The `splinterdb` needs to live at least as long as any `lookup_result` objects used with it