### PR TITLE
simplify signature of lookup_result_value

### DIFF
--- a/examples/splinterdb_intro_example.c
+++ b/examples/splinterdb_intro_example.c
@@ -77,7 +77,7 @@ main()
    fruit = "Orange";
    key   = slice_create((size_t)strlen(fruit), fruit);
    rc    = splinterdb_lookup(spl_handle, key, &result);
-   rc    = splinterdb_lookup_result_value(spl_handle, &result, &value);
+   rc    = splinterdb_lookup_result_value(&result, &value);
    if (!rc) {
       printf("Found key: '%s', value: '%.*s'\n",
              fruit,
@@ -89,7 +89,7 @@ main()
    fruit = "Banana";
    key   = slice_create((size_t)strlen(fruit), fruit);
    rc    = splinterdb_lookup(spl_handle, key, &result);
-   rc    = splinterdb_lookup_result_value(spl_handle, &result, &value);
+   rc    = splinterdb_lookup_result_value(&result, &value);
    if (rc) {
       printf("Key: '%s' not found. (rc=%d)\n", fruit, rc);
    }

--- a/examples/splinterdb_wide_values_example.c
+++ b/examples/splinterdb_wide_values_example.c
@@ -93,7 +93,7 @@ main()
       rc        = splinterdb_lookup(spl_handle, key, &result);
 
       slice value;
-      rc = splinterdb_lookup_result_value(spl_handle, &result, &value);
+      rc = splinterdb_lookup_result_value(&result, &value);
       if (!rc) {
          printf(
             "  [%d] Found key (key_len=%d): '%.*s', value length found = %lu\n",

--- a/include/splinterdb/splinterdb.h
+++ b/include/splinterdb/splinterdb.h
@@ -194,8 +194,7 @@ splinterdb_lookup_found(const splinterdb_lookup_result *result); // IN
 //
 // Do not modify the memory pointed at by *value
 int
-splinterdb_lookup_result_value(const splinterdb               *kvs,
-                               const splinterdb_lookup_result *result, // IN
+splinterdb_lookup_result_value(const splinterdb_lookup_result *result, // IN
                                slice                          *value   // OUT
 );
 

--- a/src/splinterdb.c
+++ b/src/splinterdb.c
@@ -772,8 +772,7 @@ splinterdb_lookup_found(const splinterdb_lookup_result *result) // IN
 }
 
 int
-splinterdb_lookup_result_value(const splinterdb               *kvs,
-                               const splinterdb_lookup_result *result, // IN
+splinterdb_lookup_result_value(const splinterdb_lookup_result *result, // IN
                                slice                          *value)
 {
    _splinterdb_lookup_result *_result = (_splinterdb_lookup_result *)result;

--- a/tests/unit/splinterdb_quick_test.c
+++ b/tests/unit/splinterdb_quick_test.c
@@ -164,7 +164,7 @@ CTEST2(splinterdb_quick, test_basic_flow)
    ASSERT_TRUE(splinterdb_lookup_found(&result));
 
    slice value;
-   rc = splinterdb_lookup_result_value(data->kvsb, &result, &value);
+   rc = splinterdb_lookup_result_value(&result, &value);
    ASSERT_EQUAL(0, rc);
    ASSERT_EQUAL(to_insert_len, slice_length(value));
    ASSERT_STREQN(to_insert_data, slice_data(value), slice_length(value));
@@ -210,7 +210,7 @@ CTEST2(splinterdb_quick, test_apis_for_max_key_length)
    ASSERT_TRUE(splinterdb_lookup_found(&result));
 
    slice value;
-   rc = splinterdb_lookup_result_value(data->kvsb, &result, &value);
+   rc = splinterdb_lookup_result_value(&result, &value);
    ASSERT_EQUAL(0, rc);
 
    ASSERT_EQUAL(strlen(to_insert_data), slice_length(value));
@@ -339,7 +339,7 @@ CTEST2(splinterdb_quick, test_variable_length_values)
    rc = splinterdb_lookup(data->kvsb, key_empty, &result);
    ASSERT_EQUAL(0, rc);
    ASSERT_TRUE(splinterdb_lookup_found(&result));
-   rc = splinterdb_lookup_result_value(data->kvsb, &result, &value);
+   rc = splinterdb_lookup_result_value(&result, &value);
    ASSERT_EQUAL(0, rc);
    ASSERT_EQUAL(0, slice_length(value));
 
@@ -347,7 +347,7 @@ CTEST2(splinterdb_quick, test_variable_length_values)
    rc = splinterdb_lookup(data->kvsb, key_short, &result);
    ASSERT_EQUAL(0, rc);
    ASSERT_TRUE(splinterdb_lookup_found(&result));
-   rc = splinterdb_lookup_result_value(data->kvsb, &result, &value);
+   rc = splinterdb_lookup_result_value(&result, &value);
    ASSERT_EQUAL(0, rc);
    ASSERT_EQUAL(1, slice_length(value));
 
@@ -355,7 +355,7 @@ CTEST2(splinterdb_quick, test_variable_length_values)
    rc = splinterdb_lookup(data->kvsb, key_long, &result);
    ASSERT_EQUAL(0, rc);
    ASSERT_TRUE(splinterdb_lookup_found(&result));
-   rc = splinterdb_lookup_result_value(data->kvsb, &result, &value);
+   rc = splinterdb_lookup_result_value(&result, &value);
    ASSERT_EQUAL(0, rc);
    ASSERT_EQUAL(TEST_MAX_VALUE_SIZE - 1, slice_length(value));
    ASSERT_STREQN(
@@ -365,7 +365,7 @@ CTEST2(splinterdb_quick, test_variable_length_values)
    rc = splinterdb_lookup(data->kvsb, key_max, &result);
    ASSERT_EQUAL(0, rc);
    ASSERT_TRUE(splinterdb_lookup_found(&result));
-   rc = splinterdb_lookup_result_value(data->kvsb, &result, &value);
+   rc = splinterdb_lookup_result_value(&result, &value);
    ASSERT_EQUAL(0, rc);
    ASSERT_EQUAL(TEST_MAX_VALUE_SIZE, slice_length(value));
    ASSERT_STREQN(max_length_string, slice_data(value), slice_length(value));
@@ -387,7 +387,7 @@ CTEST2(splinterdb_quick, test_variable_length_values)
    ASSERT_EQUAL(0, rc);
    ASSERT_TRUE(splinterdb_lookup_found(&result));
 
-   rc = splinterdb_lookup_result_value(data->kvsb, &result, &value);
+   rc = splinterdb_lookup_result_value(&result, &value);
    ASSERT_EQUAL(0, rc);
    // we get the full result back, because internally splinterdb did an
    // allocation
@@ -405,7 +405,7 @@ CTEST2(splinterdb_quick, test_variable_length_values)
    rc = splinterdb_lookup(data->kvsb, key_max, &result);
    ASSERT_EQUAL(0, rc);
    ASSERT_TRUE(splinterdb_lookup_found(&result));
-   rc = splinterdb_lookup_result_value(data->kvsb, &result, &value);
+   rc = splinterdb_lookup_result_value(&result, &value);
    ASSERT_EQUAL(0, rc);
    // we get the full result back, because internally splinterdb did an
    // allocation
@@ -659,7 +659,7 @@ CTEST2(splinterdb_quick, test_close_and_reopen)
    ASSERT_EQUAL(0, rc);
 
    ASSERT_TRUE(splinterdb_lookup_found(&result));
-   rc = splinterdb_lookup_result_value(data->kvsb, &result, &value);
+   rc = splinterdb_lookup_result_value(&result, &value);
    ASSERT_EQUAL(0, rc);
    ASSERT_EQUAL(val_len, slice_length(value));
    ASSERT_STREQN(val,
@@ -725,7 +725,7 @@ CTEST2(splinterdb_quick, test_custom_data_config)
    ASSERT_TRUE(splinterdb_lookup_found(&result));
 
    slice value;
-   rc = splinterdb_lookup_result_value(data->kvsb, &result, &value);
+   rc = splinterdb_lookup_result_value(&result, &value);
    ASSERT_EQUAL(0, rc);
    ASSERT_EQUAL(0, slice_lex_cmp(value, msg_slice));
 


### PR DESCRIPTION
We don't need to pass the splinterdb instance in again on `splinterdb_lookup_result_value()`.

In the future, it could be stashed in the `lookup_result` when the `lookup_result` is first `init()`ed, and it could be checked at `lookup()` time.  But the `_value()` function is just an accessor.