### PR TITLE
fix alignment of lookup_result

### DIFF
--- a/include/splinterdb/splinterdb.h
+++ b/include/splinterdb/splinterdb.h
@@ -154,7 +154,7 @@ splinterdb_update(const splinterdb *kvsb, slice key, slice delta);
 // lookups. It is not safe to use from multiple threads.
 typedef struct {
    char opaque[SPLINTERDB_LOOKUP_BUFSIZE];
-} splinterdb_lookup_result;
+} __attribute__((__aligned__(8))) splinterdb_lookup_result;
 
 // Initialize a lookup result object.
 //

--- a/src/splinterdb.c
+++ b/src/splinterdb.c
@@ -741,6 +741,10 @@ _Static_assert(sizeof(_splinterdb_lookup_result)
                   <= sizeof(splinterdb_lookup_result),
                "sizeof(splinterdb_lookup_result) is too small");
 
+_Static_assert(alignof(splinterdb_lookup_result)
+                  == alignof(_splinterdb_lookup_result),
+               "mismatched alignment for splinterdb_lookup_result");
+
 void
 splinterdb_lookup_result_init(const splinterdb         *kvs,        // IN
                               splinterdb_lookup_result *result,     // IN/OUT


### PR DESCRIPTION
The application-facing, opaque `splinterdb_lookup_result` and its internal representation `_splinterdb_lookup_result` should have the same alignment.