### PR TITLE
eliminate vestigial task handle from cache

### DIFF
--- a/src/clockcache.c
+++ b/src/clockcache.c
@@ -1803,7 +1803,6 @@ clockcache_init(clockcache          *cc,   // OUT
                 io_handle           *io,   // IN
                 allocator           *al,   // IN
                 char                *name, // IN
-                task_system         *ts,   // IN
                 platform_heap_handle hh,   // IN
                 platform_heap_id     hid,  // IN
                 platform_module_id   mid)    // IN
@@ -1902,7 +1901,6 @@ clockcache_init(clockcache          *cc,   // OUT
    if (!cc->batch_busy) {
       goto alloc_error;
    }
-   cc->ts = ts;
 
    return STATUS_OK;
 

--- a/src/clockcache.h
+++ b/src/clockcache.h
@@ -142,8 +142,6 @@ struct clockcache {
 
    // Stats
    cache_stats stats[MAX_THREADS];
-
-   task_system *ts;
 };
 
 
@@ -166,7 +164,6 @@ clockcache_init(clockcache          *cc,   // OUT
                 io_handle           *io,   // IN
                 allocator           *al,   // IN
                 char                *name, // IN
-                task_system         *ts,   // IN
                 platform_heap_handle hh,   // IN
                 platform_heap_id     hid,  // IN
                 platform_module_id   mid);   // IN

--- a/src/splinterdb.c
+++ b/src/splinterdb.c
@@ -475,7 +475,6 @@ splinterdb_create_or_open(const splinterdb_config *kvs_cfg,      // IN
                             (io_handle *)&kvs->io_handle,
                             (allocator *)&kvs->allocator_handle,
                             "splinterdb",
-                            kvs->task_sys,
                             kvs->heap_handle,
                             kvs->heap_id,
                             platform_get_module_id());

--- a/tests/functional/btree_test.c
+++ b/tests/functional/btree_test.c
@@ -1619,7 +1619,6 @@ btree_test(int argc, char *argv[])
                         (io_handle *)io,
                         (allocator *)&al,
                         "test",
-                        ts,
                         hh,
                         hid,
                         platform_get_module_id());

--- a/tests/functional/cache_test.c
+++ b/tests/functional/cache_test.c
@@ -1053,7 +1053,6 @@ cache_test(int argc, char *argv[])
                         (io_handle *)io,
                         (allocator *)&al,
                         "test",
-                        ts,
                         hh,
                         hid,
                         platform_get_module_id());

--- a/tests/functional/filter_test.c
+++ b/tests/functional/filter_test.c
@@ -303,7 +303,6 @@ filter_test(int argc, char *argv[])
    bool                   run_perf_test;
    platform_status        rc;
    uint64                 seed;
-   task_system           *ts;
    test_message_generator gen;
 
    if (argc > 1 && strncmp(argv[1], "--perf", sizeof("--perf")) == 0) {
@@ -352,16 +351,6 @@ filter_test(int argc, char *argv[])
       goto free_iohandle;
    }
 
-   uint8 num_bg_threads[NUM_TASK_TYPES] = {0}; // no bg threads
-
-   rc = test_init_task_system(
-      hid, io, &ts, cfg->use_stats, FALSE, num_bg_threads);
-   if (!SUCCESS(rc)) {
-      platform_error_log("Failed to init splinter ts: %s\n",
-                         platform_status_to_string(rc));
-      goto deinit_iohandle;
-   }
-
    rc = rc_allocator_init(
       &al, &allocator_cfg, (io_handle *)io, hh, hid, platform_get_module_id());
    platform_assert_status_ok(rc);
@@ -373,7 +362,6 @@ filter_test(int argc, char *argv[])
                         (io_handle *)io,
                         (allocator *)&al,
                         "test",
-                        ts,
                         hh,
                         hid,
                         platform_get_module_id());
@@ -416,8 +404,6 @@ filter_test(int argc, char *argv[])
    clockcache_deinit(cc);
    platform_free(hid, cc);
    rc_allocator_deinit(&al);
-   test_deinit_task_system(hid, &ts);
-deinit_iohandle:
    io_handle_deinit(io);
 free_iohandle:
    platform_free(hid, io);

--- a/tests/functional/log_test.c
+++ b/tests/functional/log_test.c
@@ -69,15 +69,8 @@ test_log_crash(clockcache             *cc,
 
    if (crash) {
       clockcache_deinit(cc);
-      rc = clockcache_init(cc,
-                           cache_cfg,
-                           io,
-                           al,
-                           "crashed",
-                           ts,
-                           hh,
-                           hid,
-                           platform_get_module_id());
+      rc = clockcache_init(
+         cc, cache_cfg, io, al, "crashed", hh, hid, platform_get_module_id());
       platform_assert_status_ok(rc);
    }
 
@@ -319,7 +312,6 @@ log_test(int argc, char *argv[])
                             (io_handle *)io,
                             (allocator *)&al,
                             "test",
-                            ts,
                             hh,
                             hid,
                             platform_get_module_id());

--- a/tests/functional/splinter_test.c
+++ b/tests/functional/splinter_test.c
@@ -2795,7 +2795,6 @@ splinter_test(int argc, char *argv[])
                            (io_handle *)io,
                            (allocator *)&al,
                            "test",
-                           ts,
                            hh,
                            hid,
                            platform_get_module_id());

--- a/tests/functional/ycsb_test.c
+++ b/tests/functional/ycsb_test.c
@@ -1296,7 +1296,6 @@ ycsb_test(int argc, char *argv[])
                            (io_handle *)io,
                            (allocator *)&al,
                            "test",
-                           ts,
                            hh,
                            hid,
                            platform_get_module_id());
@@ -1320,7 +1319,6 @@ ycsb_test(int argc, char *argv[])
                            (io_handle *)io,
                            (allocator *)&al,
                            "test",
-                           ts,
                            hh,
                            hid,
                            platform_get_module_id());

--- a/tests/unit/btree_stress_test.c
+++ b/tests/unit/btree_stress_test.c
@@ -163,7 +163,6 @@ CTEST_SETUP(btree_stress)
                                    (io_handle *)&data->io,
                                    (allocator *)&data->al,
                                    "test",
-                                   data->ts,
                                    data->hh,
                                    data->hid,
                                    platform_get_module_id())))

--- a/tests/unit/limitations_test.c
+++ b/tests/unit/limitations_test.c
@@ -575,7 +575,6 @@ splinter_init_subsystems(void *arg)
                            (io_handle *)data->io,
                            (allocator *)&data->al,
                            "test",
-                           data->tasks,
                            data->hh,
                            data->hid,
                            platform_get_module_id());

--- a/tests/unit/splinter_test.c
+++ b/tests/unit/splinter_test.c
@@ -204,7 +204,6 @@ CTEST_SETUP(splinter)
                            (io_handle *)data->io,
                            (allocator *)&data->al,
                            "test",
-                           data->tasks,
                            data->hh,
                            data->hid,
                            platform_get_module_id());


### PR DESCRIPTION
`clockcache_init` took a handle on the task system but clockcache never used it anywhere.  Removing it makes it easier to instantiate the cache.
