### PR TITLE
make install depends on libraries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -481,7 +481,7 @@ test-results: all-tests
 
 INSTALL_PATH ?= /usr/local
 
-install:
+install: $(LIBDIR)/libsplinterdb.so $(LIBDIR)/libsplinterdb.a
 	mkdir -p $(INSTALL_PATH)/include/splinterdb $(INSTALL_PATH)/lib
 	# -p retains the timestamp of the file being copied over
 	cp -p $(LIBDIR)/libsplinterdb.so $(LIBDIR)/libsplinterdb.a $(INSTALL_PATH)/lib


### PR DESCRIPTION
Without this, a clean checkout followed by `make install` will error.