### PR TITLE
Allow overriding MAX_KEY_SIZE via CFLAGS env var

### DIFF
--- a/include/splinterdb/limits.h
+++ b/include/splinterdb/limits.h
@@ -1,17 +1,28 @@
 // Copyright 2018-2021 VMware, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-/*
- * limits.h --
- *
- *     This file contains constants and functions the pertain to
- *     limits of keys and messages supported by the Key Value Store.
- */
-
 #ifndef __LIMITS_H__
 #define __LIMITS_H__
 
-#define MAX_KEY_SIZE    105 /* bytes */
-#define MAX_KEY_STR_LEN 128 /* bytes */
+// MAX_KEY_SIZE is the limit, in bytes, on the length of *raw* keys
+// inserted into the trunk and branches.
+//
+// It must be at least 8, and no more than 105.
+//
+// When using the splinterdb.h API, the key size limit is MAX_KEY_SIZE-1
+// to accomodate the variable-length encoding.
+// See include/splinterdb/splinterdb.h for details.
+//
+// If your keys are always shorter than 105 bytes, you may reduce MAX_KEY_SIZE.
+//
+// To modify this at build time without editing this file, set it via
+// the CFLAGS env var, e.g.
+//   make clean && CFLAGS='-DMAX_KEY_SIZE=24' make
+//
+// Tests and example programs use test-data with keys of varying sizes.
+// When building with a smaller MAX_KEY_SIZE, expect some breakage.
+#ifndef MAX_KEY_SIZE
+#   define MAX_KEY_SIZE 105
+#endif // MAX_KEY_SIZE
 
 #endif // __LIMITS_H__

--- a/src/splinterdb.c
+++ b/src/splinterdb.c
@@ -165,6 +165,10 @@ typedef struct ONDISK {
    uint8 data[0];
 } var_len_key_encoding;
 
+static_assert((MAX_KEY_SIZE >= 8), "MAX_KEY_SIZE must be at least 8 bytes");
+static_assert((MAX_KEY_SIZE <= 105),
+              "Keys larger than 105 bytes are currently not supported");
+
 static_assert((SPLINTERDB_MAX_KEY_SIZE + sizeof(var_len_key_encoding)
                == MAX_KEY_SIZE),
               "Variable-length key encoding header size mismatch");


### PR DESCRIPTION
This change lets you set `MAX_KEY_SIZE` at build-time without editing the source code, e.g.
```sh
CFLAGS='-DMAX_KEY_SIZE=24' make
```

Also removes an old `#define MAX_KEY_STR_LEN 128` which has been unused since 11481016abf9779b397b4ff14eb3e744376c2040