### PR TITLE
Fix memory leak in verify_tuple

### DIFF
--- a/tests/test_common.c
+++ b/tests/test_common.c
@@ -55,6 +55,7 @@ verify_tuple(trunk_handle           *spl,
          platform_error_log("expected data: %s\n", data_str);
          platform_assert(FALSE);
       }
+      merge_accumulator_deinit(&expected_msg);
    }
 }
 


### PR DESCRIPTION
Thanks to @mdcallag finding the bug and suggesting this fix.

Fixes #440 