### PR TITLE
(#446) Rename couple of memory allocation macros. Add comments; code cleanup in platform.h

### DIFF
--- a/src/platform_linux/laio.c
+++ b/src/platform_linux/laio.c
@@ -102,7 +102,7 @@ io_handle_init(laio_handle         *io,
    req_size =
       sizeof(io_async_req) + cfg->async_max_pages * sizeof(struct iovec);
    total_req_size = req_size * cfg->async_queue_size;
-   io->req        = TYPED_ZALLOC_MANUAL(io->heap_id, io->req, total_req_size);
+   io->req        = TYPED_MANUAL_ZALLOC(io->heap_id, io->req, total_req_size);
    platform_assert(io->req);
    for (i = 0; i < cfg->async_queue_size; i++) {
       req         = laio_get_kth_req(io, i);

--- a/src/platform_linux/platform.c
+++ b/src/platform_linux/platform.c
@@ -184,7 +184,7 @@ platform_histo_create(platform_heap_id       heap_id,
                       platform_histo_handle *histo)
 {
    platform_histo_handle hh;
-   hh = TYPED_MALLOC_MANUAL(
+   hh = TYPED_MANUAL_MALLOC(
       heap_id, hh, sizeof(hh) + num_buckets * sizeof(hh->count[0]));
    if (!hh) {
       return STATUS_NO_MEMORY;

--- a/src/platform_linux/platform.h
+++ b/src/platform_linux/platform.h
@@ -206,7 +206,23 @@ extern bool platform_use_mlock;
 typedef uint32 (*hash_fn)(const void *input, size_t length, unsigned int seed);
 
 /*
- * Utility macros to avoid common initialization mistakes.
+ * -----------------------------------------------------------------------------
+ * TYPED_MANUAL_MALLOC(), TYPED_MANUAL_ZALLOC() -
+ * TYPED_ARRAY_MALLOC(),  TYPED_ARRAY_ZALLOC() -
+ *
+ * Utility macros to avoid common memory allocation / initialization mistakes.
+ * NOTE: ZALLOC variants will also memset allocated memory chunk to 0.
+ *
+ * Call-flow is:
+ *  TYPED_MALLOC()
+ *   -> TYPED_ARRAY_MALLOC()
+ *        -> TYPED_MANUAL_MALLOC() -> platform_aligned_malloc()
+ *
+ *  TYPED_ZALLOC()
+ *   -> TYPED_ARRAY_ZALLOC()
+ *        -> TYPED_MANUAL_ZALLOC() -> platform_aligned_zalloc()
+ *
+ * -----------------------------------------------------------------------------
  * Common mistake to make is:
  *    TYPE *foo = platform_malloc(sizeof(WRONG_TYPE));
  * or
@@ -264,7 +280,6 @@ typedef uint32 (*hash_fn)(const void *input, size_t length, unsigned int seed);
  * Alternative solutions are to be careful with mallocs, and/or make ALL structs
  * be aligned.
  *
- *
  * Another common use case is if you have a struct with a flexible array member.
  * In that case you should use TYPED_FLEXIBLE_STRUCT_(M|Z)ALLOC
  *
@@ -278,28 +293,67 @@ typedef uint32 (*hash_fn)(const void *input, size_t length, unsigned int seed);
  * DO NOT USE these macros to assign to a void*.  The debug asserts will cause
  * a compile error when debug is on.  Assigning to a void* should be done by
  * calling aligned_alloc manually (or create a separate macro)
+ *
+ * Parameters:
+ *	hid - Platform heap-ID to allocate memory from.
+ *	v   - Structure to allocate memory for.
+ *	n   - Number of bytes of memory to allocate.
+ * -----------------------------------------------------------------------------
  */
-#define TYPED_MALLOC_MANUAL(id, v, n)                                          \
+#define TYPED_MANUAL_MALLOC(hid, v, n)                                         \
    ({                                                                          \
       debug_assert((n) >= sizeof(*(v)));                                       \
-      (typeof(v))platform_aligned_malloc(id, PLATFORM_CACHELINE_SIZE, (n));    \
+      (typeof(v))platform_aligned_malloc(hid, PLATFORM_CACHELINE_SIZE, (n));   \
    })
-#define TYPED_ZALLOC_MANUAL(id, v, n)                                          \
+#define TYPED_MANUAL_ZALLOC(hid, v, n)                                         \
    ({                                                                          \
       debug_assert((n) >= sizeof(*(v)));                                       \
-      (typeof(v))platform_aligned_zalloc(id, PLATFORM_CACHELINE_SIZE, (n));    \
+      (typeof(v))platform_aligned_zalloc(hid, PLATFORM_CACHELINE_SIZE, (n));   \
    })
 
 /*
+ * TYPED_ALIGNED_MALLOC(), TYPED_ALIGNED_ZALLOC()
+ *
+ * Allocate memory for a typed structure at caller-specified alignment.
+ * These are similar to TYPED_MANUAL_MALLOC() & TYPED_MANUAL_ZALLOC() but with
+ * the difference that the alignment is caller-specified.
+ *
+ * Parameters:
+ *	hid - Platform heap-ID to allocate memory from.
+ *	a   - Alignment needed for allocated memory.
+ *	v   - Structure to allocate memory for.
+ *	n   - Number of bytes of memory to allocate.
+ */
+#define TYPED_ALIGNED_MALLOC(hid, a, v, n)                                     \
+   ({                                                                          \
+      debug_assert((n) >= sizeof(*(v)));                                       \
+      (typeof(v))platform_aligned_malloc(hid, (a), (n));                       \
+   })
+#define TYPED_ALIGNED_ZALLOC(hid, a, v, n)                                     \
+   ({                                                                          \
+      debug_assert((n) >= sizeof(*(v)));                                       \
+      (typeof(v))platform_aligned_zalloc(hid, (a), (n));                       \
+   })
+
+/*
+ * FLEXIBLE_STRUCT_SIZE(): Compute the size of a structure 'v' with a nested
+ * flexible array member, array_field_name, with 'n' members.
+ *
  * Flexible array members don't necessarily start after sizeof(v)
  * They can start within the padding at the end, so the correct size
  * needed to allocate a struct with a flexible array member is the
  * larger of sizeof(struct v) or (offset of flexible array +
  * n*sizeof(arraymember))
+ *
  * The only reasonable static assert we can do is check that the flexible array
  * member is actually an array.  We cannot check size==0 (compile error), and
  * since it doesn't necessarily start at the end we also cannot check
  * offset==sizeof.
+ *
+ * Parameters:
+ *  v                   - Structure to allocate memory for.
+ *  array_field_name    - Name of flexible array field nested in 'v'
+ *  n                   - Number of members in array_field_name[].
  */
 #define FLEXIBLE_STRUCT_SIZE(v, array_field_name, n)                           \
    ({                                                                          \
@@ -310,23 +364,53 @@ typedef uint32 (*hash_fn)(const void *input, size_t length, unsigned int seed);
                     + offsetof(typeof(*(v)), array_field_name));               \
    })
 
-#define TYPED_FLEXIBLE_STRUCT_MALLOC(id, v, array_field_name, n)               \
-   TYPED_MALLOC_MANUAL(                                                        \
-      id, (v), FLEXIBLE_STRUCT_SIZE((v), array_field_name, (n)))
+/*
+ * -----------------------------------------------------------------------------
+ * TYPED_FLEXIBLE_STRUCT_MALLOC(), TYPED_FLEXIBLE_STRUCT_ZALLOC() -
+ *    Allocate memory for a structure with a nested flexible array member.
+ *
+ * Parameters:
+ *  hid                 - Platform heap-ID to allocate memory from.
+ *  v                   - Structure to allocate memory for.
+ *  array_field_name    - Name of flexible array field nested in 'v'
+ *  n                   - Number of members in array_field_name[].
+ * -----------------------------------------------------------------------------
+ */
+#define TYPED_FLEXIBLE_STRUCT_MALLOC(hid, v, array_field_name, n)              \
+   TYPED_MANUAL_MALLOC(                                                        \
+      hid, (v), FLEXIBLE_STRUCT_SIZE((v), array_field_name, (n)))
 
-#define TYPED_FLEXIBLE_STRUCT_ZALLOC(id, v, array_field_name, n)               \
-   TYPED_ZALLOC_MANUAL(                                                        \
-      id, (v), FLEXIBLE_STRUCT_SIZE((v), array_field_name, (n)))
-
-#define TYPED_ARRAY_MALLOC(id, v, n)                                           \
-   TYPED_MALLOC_MANUAL(id, (v), (n) * sizeof(*(v)))
-#define TYPED_ARRAY_ZALLOC(id, v, n)                                           \
-   TYPED_ZALLOC_MANUAL(id, (v), (n) * sizeof(*(v)))
-
-#define TYPED_MALLOC(id, v) TYPED_ARRAY_MALLOC(id, (v), 1)
-#define TYPED_ZALLOC(id, v) TYPED_ARRAY_ZALLOC(id, (v), 1)
+#define TYPED_FLEXIBLE_STRUCT_ZALLOC(hid, v, array_field_name, n)              \
+   TYPED_MANUAL_ZALLOC(                                                        \
+      hid, (v), FLEXIBLE_STRUCT_SIZE((v), array_field_name, (n)))
 
 /*
+ * TYPED_ARRAY_MALLOC(), TYPED_ARRAY_ZALLOC()
+ * Allocate memory for an array of 'n' elements of structure 'v'.
+ *
+ * Parameters:
+ *  hid - Platform heap-ID to allocate memory from.
+ *  v   - Structure to allocate memory for.
+ *  n   - Number of members of type 'v' in array.
+ */
+#define TYPED_ARRAY_MALLOC(hid, v, n)                                          \
+   TYPED_MANUAL_MALLOC(hid, (v), (n) * sizeof(*(v)))
+#define TYPED_ARRAY_ZALLOC(hid, v, n)                                          \
+   TYPED_MANUAL_ZALLOC(hid, (v), (n) * sizeof(*(v)))
+
+/*
+ * TYPED_ARRAY_MALLOC(), TYPED_ARRAY_ZALLOC()
+ * Allocate memory for one element of structure 'v'.
+ *
+ * Parameters:
+ *  hid - Platform heap-ID to allocate memory from.
+ *  v   - Structure to allocate memory for.
+ */
+#define TYPED_MALLOC(hid, v) TYPED_ARRAY_MALLOC(hid, (v), 1)
+#define TYPED_ZALLOC(hid, v) TYPED_ARRAY_ZALLOC(hid, (v), 1)
+
+/*
+ * -----------------------------------------------------------------------------
  * Utility macros to clear memory
  * They have similar usage/prevent similar mistakes to the TYPED_MALLOC
  * kind of macros.
@@ -338,8 +422,8 @@ typedef uint32 (*hash_fn)(const void *input, size_t length, unsigned int seed);
  * Passing any one type to a clearing function of another type is likely
  * to be a bug, so if the calling isn't perfect it will give a compile-time
  * error.
+ * -----------------------------------------------------------------------------
  */
-
 /*
  * Zero an array.
  * Cause compile-time error if used on pointer or non-indexible variable

--- a/src/rc_allocator.c
+++ b/src/rc_allocator.c
@@ -227,13 +227,14 @@ rc_allocator_init_meta_page(rc_allocator *al)
    platform_assert((1 + RC_ALLOCATOR_MAX_ROOT_IDS) * al->cfg->io_cfg->page_size
                    <= al->cfg->io_cfg->extent_size);
 
-   al->meta_page = platform_aligned_malloc(
-      al->heap_id, al->cfg->io_cfg->page_size, al->cfg->io_cfg->page_size);
+   al->meta_page = TYPED_ALIGNED_ZALLOC(al->heap_id,
+                                        al->cfg->io_cfg->page_size,
+                                        al->meta_page,
+                                        al->cfg->io_cfg->page_size);
    if (al->meta_page == NULL) {
       return STATUS_NO_MEMORY;
    }
 
-   memset(al->meta_page, 0, al->cfg->io_cfg->page_size);
    memset(al->meta_page->splinters,
           INVALID_ALLOCATOR_ROOT_ID,
           sizeof(al->meta_page->splinters));

--- a/src/task.c
+++ b/src/task.c
@@ -139,7 +139,7 @@ task_register_this_thread(task_system *ts, uint64 scratch_size)
 {
    char *scratch = NULL;
    if (scratch_size > 0) {
-      scratch = TYPED_ZALLOC_MANUAL(ts->heap_id, scratch, scratch_size);
+      scratch = TYPED_MANUAL_ZALLOC(ts->heap_id, scratch, scratch_size);
    }
    task_run_thread_hooks(ts);
    ts->thread_scratch[platform_get_tid()] = scratch;

--- a/tests/unit/btree_stress_test.c
+++ b/tests/unit/btree_stress_test.c
@@ -309,8 +309,8 @@ insert_tests(cache           *cc,
 
    int    keybuf_size = btree_page_size(cfg);
    int    msgbuf_size = btree_page_size(cfg);
-   uint8 *keybuf      = TYPED_MALLOC_MANUAL(hid, keybuf, keybuf_size);
-   uint8 *msgbuf      = TYPED_MALLOC_MANUAL(hid, msgbuf, msgbuf_size);
+   uint8 *keybuf      = TYPED_MANUAL_MALLOC(hid, keybuf, keybuf_size);
+   uint8 *msgbuf      = TYPED_MANUAL_MALLOC(hid, msgbuf, msgbuf_size);
 
    for (uint64 i = start; i < end; i++) {
       if (!SUCCESS(btree_insert(cc,
@@ -376,8 +376,8 @@ query_tests(cache           *cc,
             uint64           root_addr,
             int              nkvs)
 {
-   uint8 *keybuf = TYPED_MALLOC_MANUAL(hid, keybuf, btree_page_size(cfg));
-   uint8 *msgbuf = TYPED_MALLOC_MANUAL(hid, msgbuf, btree_page_size(cfg));
+   uint8 *keybuf = TYPED_MANUAL_MALLOC(hid, keybuf, btree_page_size(cfg));
+   uint8 *msgbuf = TYPED_MANUAL_MALLOC(hid, msgbuf, btree_page_size(cfg));
    memset(msgbuf, 0, btree_page_size(cfg));
 
    merge_accumulator result;
@@ -427,10 +427,10 @@ iterator_tests(cache           *cc,
 
    uint64 seen = 0;
    bool   at_end;
-   uint8 *prevbuf = TYPED_MALLOC_MANUAL(hid, prevbuf, btree_page_size(cfg));
+   uint8 *prevbuf = TYPED_MANUAL_MALLOC(hid, prevbuf, btree_page_size(cfg));
    slice  prev    = NULL_SLICE;
-   uint8 *keybuf  = TYPED_MALLOC_MANUAL(hid, keybuf, btree_page_size(cfg));
-   uint8 *msgbuf  = TYPED_MALLOC_MANUAL(hid, msgbuf, btree_page_size(cfg));
+   uint8 *keybuf  = TYPED_MANUAL_MALLOC(hid, keybuf, btree_page_size(cfg));
+   uint8 *msgbuf  = TYPED_MANUAL_MALLOC(hid, msgbuf, btree_page_size(cfg));
 
    while (SUCCESS(iterator_at_end(iter, &at_end)) && !at_end) {
       slice   key;

--- a/tests/unit/btree_test.c
+++ b/tests/unit/btree_test.c
@@ -161,7 +161,7 @@ static int
 leaf_hdr_tests(btree_config *cfg, btree_scratch *scratch, platform_heap_id hid)
 {
    char *leaf_buffer =
-      TYPED_MALLOC_MANUAL(hid, leaf_buffer, btree_page_size(cfg));
+      TYPED_MANUAL_MALLOC(hid, leaf_buffer, btree_page_size(cfg));
    btree_hdr *hdr  = (btree_hdr *)leaf_buffer;
    int        nkvs = 240;
 
@@ -238,7 +238,7 @@ static int
 leaf_hdr_search_tests(btree_config *cfg, platform_heap_id hid)
 {
    char *leaf_buffer =
-      TYPED_MALLOC_MANUAL(hid, leaf_buffer, btree_page_size(cfg));
+      TYPED_MANUAL_MALLOC(hid, leaf_buffer, btree_page_size(cfg));
    btree_hdr *hdr  = (btree_hdr *)leaf_buffer;
    int        nkvs = 256;
 
@@ -279,7 +279,7 @@ index_hdr_tests(btree_config *cfg, btree_scratch *scratch, platform_heap_id hid)
 {
 
    char *index_buffer =
-      TYPED_MALLOC_MANUAL(hid, index_buffer, btree_page_size(cfg));
+      TYPED_MANUAL_MALLOC(hid, index_buffer, btree_page_size(cfg));
    btree_hdr *hdr  = (btree_hdr *)index_buffer;
    int        nkvs = 100;
 
@@ -340,7 +340,7 @@ static int
 index_hdr_search_tests(btree_config *cfg, platform_heap_id hid)
 {
    char *leaf_buffer =
-      TYPED_MALLOC_MANUAL(hid, leaf_buffer, btree_page_size(cfg));
+      TYPED_MANUAL_MALLOC(hid, leaf_buffer, btree_page_size(cfg));
    btree_hdr        *hdr  = (btree_hdr *)leaf_buffer;
    int               nkvs = 256;
    btree_pivot_stats stats;
@@ -379,9 +379,9 @@ leaf_split_tests(btree_config    *cfg,
                  platform_heap_id hid)
 {
    char *leaf_buffer =
-      TYPED_MALLOC_MANUAL(hid, leaf_buffer, btree_page_size(cfg));
+      TYPED_MANUAL_MALLOC(hid, leaf_buffer, btree_page_size(cfg));
    char *msg_buffer =
-      TYPED_MALLOC_MANUAL(hid, msg_buffer, btree_page_size(cfg));
+      TYPED_MANUAL_MALLOC(hid, msg_buffer, btree_page_size(cfg));
 
    memset(msg_buffer, 0, btree_page_size(cfg));
 


### PR DESCRIPTION
This commit introduces a small renaming to a couple of memory-allocation caller-macros, and introduces couple of new ones. No functional changes are introduced.

- Rename: TYPED_MALLOC_MANUAL() -> TYPED_MANUAL_MALLOC(), TYPED_ZALLOC_MANUAL() -> TYPED_MANUAL_ZALLOC()

- Add: TYPED_ALIGNED_MALLOC(), TYPED_ALIGNED_ZALLOC()
- Replace raw call to platform memory allocation in one instance with use of TYPED_ALIGNED_ZALLOC().
- Add comments declaring parameters to various macros, and general improvement of comments related to these macros.