### PR TITLE
(#448) Clarify logic in task.c; Add unit-test to validate public interfaces.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -423,6 +423,11 @@ $(BINDIR)/$(UNITDIR)/config_parse_test: $(UTIL_SYS)                             
                                         $(OBJDIR)/$(FUNCTIONAL_TESTSDIR)/test_async.o \
                                         $(LIBDIR)/libsplinterdb.so
 
+$(BINDIR)/$(UNITDIR)/task_system_test: $(UTIL_SYS)                                   \
+                                       $(COMMON_TESTOBJ)                             \
+                                       $(OBJDIR)/$(FUNCTIONAL_TESTSDIR)/test_async.o \
+                                       $(LIBDIR)/libsplinterdb.so
+
 ########################################
 # Convenience mini unit-test targets
 unit/util_test:                    $(BINDIR)/$(UNITDIR)/util_test

--- a/src/platform_linux/platform.c
+++ b/src/platform_linux/platform.c
@@ -101,6 +101,9 @@ platform_buffer_destroy(buffer_handle *bh)
    return STATUS_OK;
 }
 
+/*
+ * platform_thread_create() - External interface to create a Splinter thread.
+ */
 platform_status
 platform_thread_create(platform_thread       *thread,
                        bool                   detached,
@@ -134,6 +137,12 @@ platform_thread_join(platform_thread thread)
    ret = pthread_join(thread, &retval);
 
    return CONST_STATUS(ret);
+}
+
+platform_thread
+platform_thread_id_self()
+{
+   return pthread_self();
 }
 
 platform_status

--- a/src/platform_linux/platform.h
+++ b/src/platform_linux/platform.h
@@ -665,6 +665,9 @@ platform_status
 platform_thread_join(platform_thread thread);
 
 
+platform_thread
+platform_thread_id_self();
+
 char *
 platform_strtok_r(char *str, const char *delim, platform_strtok_ctx *ctx);
 

--- a/src/task.c
+++ b/src/task.c
@@ -6,27 +6,31 @@
 
 #include "poison.h"
 
-#define MAX_HOOKS (2048)
+#define MAX_HOOKS (8)
 
 int              hook_init_done = 0;
 static int       num_hooks      = 0;
 static task_hook hooks[MAX_HOOKS];
 
 // forward declarations that aren't part of the public API of the task system
-platform_status
+static platform_status
 task_register_hook(task_hook newhook);
 
-threadid *
+static threadid *
 task_system_get_max_tid(task_system *ts);
 
-uint64 *
+static uint64 *
 task_system_get_tid_bitmask(task_system *ts);
 
-void
+static void
 task_system_io_register_thread(task_system *ts);
 // end forward declarations
 
-void
+/*
+ * task_init_tid_bitmask() - Initialize the global bitmask of active threads in
+ * the task system structure to indicate that no threads are currently active.
+ */
+static void
 task_init_tid_bitmask(uint64 *tid_bitmask)
 {
    // We use a 64 bit word to act as the thread bitmap.
@@ -40,8 +44,17 @@ task_init_tid_bitmask(uint64 *tid_bitmask)
    }
 }
 
+/*
+ * task_init_threadid() - Initialize a new thread's thread ID (index).
+
+ * The first thing a newly started thread that wants to use Splinter is expected
+ * to do is to "register itself" with the task system. This function is
+ * defined as a thread's hook and gets run as part of the thread's
+ * registration. This function initializes each thread's thread-ID, which
+ * is really an index into the array of thread-specific data structures.
+ */
 static void
-init_threadid(task_system *ts)
+task_init_threadid(task_system *ts)
 {
    threadid  tid         = INVALID_TID;
    uint64   *tid_bitmask = task_system_get_tid_bitmask(ts);
@@ -68,9 +81,15 @@ init_threadid(task_system *ts)
 
 out:
    debug_assert(tid != INVALID_TID);
+
+   // Sets thread-ID, for example tracked as thread-local storage.
    platform_set_tid(tid);
 }
 
+/*
+ * Return the max thread-index across all active tasks.
+ * Mainly intended as a testing hook.
+ */
 threadid
 task_get_max_tid(task_system *ts)
 {
@@ -88,17 +107,17 @@ task_get_max_tid(task_system *ts)
  * beginning of the main thread that uses the task, similar to how
  * __attribute__((constructor)) works.
  */
-void
+static void
 register_init_tid_hook(void)
 {
    // hooks need to be initialized only once.
    if (__sync_fetch_and_add(&hook_init_done, 1) == 0) {
-      task_register_hook(init_threadid);
+      task_register_hook(task_init_threadid);
       task_register_hook(task_system_io_register_thread);
    }
 }
 
-void
+static void
 task_run_thread_hooks(task_system *ts)
 {
    for (int i = 0; i < num_hooks; i++) {
@@ -106,22 +125,38 @@ task_run_thread_hooks(task_system *ts)
    }
 }
 
-void
+/*
+ * De-registering a task frees up the thread's index so that it can be re-used.
+ */
+static void
 task_clear_threadid(task_system *ts, threadid tid)
 {
    uint64 *tid_bitmask = task_system_get_tid_bitmask(ts);
-   platform_assert(!(*tid_bitmask & (1ULL << tid)));
+
+   uint64 bitmask_val = *tid_bitmask;
+
+   // Ensure that caller is only clearing for a thread that's in-use.
+   platform_assert(!(bitmask_val & (1ULL << tid)),
+                   "Thread [%lu] is expected to be in-use. Bitmap: 0x%lx",
+                   tid,
+                   bitmask_val);
+
    // set bit back to 1 to indicate a free slot.
    while (1) {
       uint64 tmp_bitmask = *tid_bitmask;
       uint64 new_value   = tmp_bitmask | (1ULL << tid);
       if (__sync_bool_compare_and_swap(tid_bitmask, tmp_bitmask, new_value)) {
+
+         // This is the reverse of registration, where tid is allocated by
+         // init(). So, clear this out as thread is being de-registered.
+         // (Useful for testing and used in other assertions.)
+         platform_set_tid(0);
          return;
       }
    }
 }
 
-platform_status
+static platform_status
 task_register_hook(task_hook newhook)
 {
    int my_hook_idx = __sync_fetch_and_add(&num_hooks, 1);
@@ -133,23 +168,86 @@ task_register_hook(task_hook newhook)
    return STATUS_OK;
 }
 
-// Register the calling thread and allocate scratch space for it
+/*
+ * task_register_thread(): Register this new thread with the task system.
+ *
+ * Registration implies:
+ *  - Acquire a new thread ID (index) for this to-be-active thread
+ *  - Allocate scratch space for this thread, and track this space..
+ */
 void
-task_register_this_thread(task_system *ts, uint64 scratch_size)
+task_register_thread(task_system *ts,
+                     uint64       scratch_size,
+                     const char  *file,
+                     const int    lineno,
+                     const char  *func)
 {
+   threadid thread_tid = platform_get_tid();
+   /*
+    * For all newly created threads, the thread-index will be 0 before the hook
+    * function, run below, generates this thread's index. We do not want to
+    * register a thread twice; otherwise, it will simply burn up an index and
+    * possibly also waste allocated scratch space.
+    * As threads generally will require scratch space to be allocated, an
+    * attempt to re-register a thread should find scratch space already
+    * allocated. Flag that.
+    */
+   platform_assert((thread_tid == 0)
+                      || (ts->thread_scratch[thread_tid] == NULL),
+                   "[%s:%d::%s()] Thread at index %lu is found to have scratch"
+                   " space already allocated, %p\n",
+                   file,
+                   lineno,
+                   func,
+                   thread_tid,
+                   ts->thread_scratch[thread_tid]);
+
    char *scratch = NULL;
    if (scratch_size > 0) {
       scratch = TYPED_MANUAL_ZALLOC(ts->heap_id, scratch, scratch_size);
    }
    task_run_thread_hooks(ts);
-   ts->thread_scratch[platform_get_tid()] = scratch;
+
+   // Ensure that we are not clobbering some scratch space previously allocated
+   // that might occur due to a code-bug or by an incorrectly generated tid.
+   thread_tid = platform_get_tid();
+   platform_assert(
+      (ts->thread_scratch[thread_tid] == NULL),
+      "[%s:%d::%s()] Scratch space found allocated at %p for thread with "
+      "index %lu.",
+      file,
+      lineno,
+      func,
+      ts->thread_scratch[thread_tid],
+      thread_tid);
+
+   ts->thread_scratch[thread_tid] = scratch;
 }
 
-// Deregister the calling thread and free its scratch space
+/*
+ * task_deregister_thread() - Deregister an active thread from the task system.
+ *
+ * Deregistration involves:
+ *  - Releasing any scratch space acquired for this thread.
+ *  - Clearing the thread ID (index) for this thread
+ */
 void
-task_deregister_this_thread(task_system *ts)
+task_deregister_thread(task_system *ts,
+                       const char  *file,
+                       const int    lineno,
+                       const char  *func)
 {
-   uint64 tid = platform_get_tid();
+   threadid tid = platform_get_tid();
+
+   // A registered thread should always have a non-zero tid (index).
+   if (tid == 0) {
+      platform_error_log("[%s:%d::%s()] Error! Thread is already "
+                         "found to be de-registered.\n",
+                         file,
+                         lineno,
+                         func);
+   }
+   platform_assert((tid != 0), "Error! Thread is already de-registered.\n");
 
    void *scratch = ts->thread_scratch[tid];
    if (scratch != NULL) {
@@ -168,24 +266,43 @@ typedef struct {
    platform_heap_id heap_id;
 } thread_invoke;
 
+/*
+ * -----------------------------------------------------------------------------
+ * task_invoke_with_hooks() - Single interface to invoke a user-specified
+ * call-back function, 'func', to perform Splinter work.
+ *
+ * A thread has been created with this function as the worker function. Also,
+ * the thread-creator has registered another call-back function to execute.
+ * This function invokes that call-back function bracketted by calls to
+ * register / deregister the thread with Splinter's task system. This allows
+ * the call-back function 'func' to now call Splinter APIs to do diff things.
+ * -----------------------------------------------------------------------------
+ */
 static void
 task_invoke_with_hooks(void *func_and_args)
 {
-   thread_invoke         *thread_to_start = (thread_invoke *)func_and_args;
-   platform_thread_worker func            = thread_to_start->func;
-   void                  *arg             = thread_to_start->arg;
+   thread_invoke         *thread_started = (thread_invoke *)func_and_args;
+   platform_thread_worker func           = thread_started->func;
+   void                  *arg            = thread_started->arg;
 
-   task_register_this_thread(thread_to_start->ts,
-                             thread_to_start->scratch_size);
+   task_register_this_thread(thread_started->ts, thread_started->scratch_size);
 
+   // Execute the user-provided call-back function which is where
+   // the actual Splinter work will be done.
    func(arg);
 
-   task_deregister_this_thread(thread_to_start->ts);
+   task_deregister_this_thread(thread_started->ts);
 
-   platform_free(thread_to_start->heap_id, func_and_args);
+   platform_free(thread_started->heap_id, func_and_args);
 }
 
-platform_status
+/*
+ * -----------------------------------------------------------------------------
+ * task_create_thread_with_hooks() - Creates a thread to execute func with
+ * argument 'arg'.
+ * -----------------------------------------------------------------------------
+ */
+static platform_status
 task_create_thread_with_hooks(platform_thread       *thread,
                               bool                   detached,
                               platform_thread_worker func,
@@ -215,6 +332,15 @@ task_create_thread_with_hooks(platform_thread       *thread,
    return ret;
 }
 
+/*
+ * -----------------------------------------------------------------------------
+ * task_thread_create() - Helper method to create a new task and to do the
+ *  required registration with Splinter.
+ *
+ * Currently, this is active mainly in tests. It's also used to create
+ * background tasks, a feature that is currently not enabled.
+ * -----------------------------------------------------------------------------
+ */
 platform_status
 task_thread_create(const char            *name,
                    platform_thread_worker func,
@@ -241,7 +367,7 @@ task_thread_create(const char            *name,
 }
 
 /* Worker function for the background task pool. */
-void
+static void
 task_worker_thread(void *arg)
 {
    task_group    *group = (task_group *)arg;
@@ -333,7 +459,7 @@ task_group_stop_and_wait_for_threads(task_group *group)
    }
 }
 
-void
+static void
 task_group_deinit(task_group *group)
 {
    task_group_stop_and_wait_for_threads(group);
@@ -395,6 +521,12 @@ out:
    return rc;
 }
 
+/*
+ * task_lock_task_queue(), task_unlock_task_queue():
+ *
+ * Primitives to lock / unlock task queues depending on whether we
+ * are dealing with foreground or background threads.
+ */
 static inline platform_status
 task_lock_task_queue(task_group *group)
 {
@@ -417,7 +549,9 @@ task_unlock_task_queue(task_group *group)
    }
 }
 
-/* Adds one task to the task queue. */
+/*
+ * task_enqueue() - Adds one task to the task queue.
+ */
 platform_status
 task_enqueue(task_system *ts,
              task_type    type,
@@ -469,7 +603,10 @@ task_enqueue(task_system *ts,
    return task_unlock_task_queue(group);
 }
 
-/* Returns as soon as it finds the queue is empty */
+/*
+ * task_perform_all() - Perform all tasks queued with the task system.
+ * Returns as soon as it finds the queue is empty.
+ */
 void
 task_perform_all(task_system *ts)
 {
@@ -563,8 +700,9 @@ out:
    return rc;
 }
 
-/* Checks if there is a task to run and runs it.
-   returns ETIMEDOUT if it didn't run any task;
+/*
+ * task_perform_one() - Checks if there is a task to run and runs it.
+ * Returns ETIMEDOUT if it didn't run any task;
  */
 platform_status
 task_perform_one(task_system *ts)
@@ -583,7 +721,8 @@ task_perform_one(task_system *ts)
 /*
  * -----------------------------------------------------------------------------
  * Task system initializer. Makes sure that the initial thread has an
- * adequately sized scratch.
+ * adequately sized scratch space.
+ *
  * Needs to be called at the beginning of the main thread that uses splinter,
  * similar to how __attribute__((constructor)) works.
  * -----------------------------------------------------------------------------
@@ -636,18 +775,26 @@ task_system_create(platform_heap_id    hid,
    return STATUS_OK;
 }
 
+/* Is the task system currently setup to use background threads? */
 bool
 task_system_use_bg_threads(task_system *ts)
 {
    return ts->use_bg_threads;
 }
 
-void
+static void
 task_system_io_register_thread(task_system *ts)
 {
    io_thread_register(&ts->ioh->super);
 }
 
+/*
+ * -----------------------------------------------------------------------------
+ * task_system_destroy() : Task system de-initializer.
+ *
+ * Tear down task system structures, free allocated memory.
+ * -----------------------------------------------------------------------------
+ */
 void
 task_system_destroy(platform_heap_id hid, task_system **ts_in)
 {
@@ -659,13 +806,22 @@ task_system_destroy(platform_heap_id hid, task_system **ts_in)
    *ts_in = (task_system *)NULL;
 }
 
-uint64 *
+static inline uint64 *
 task_system_get_tid_bitmask(task_system *ts)
 {
    return &ts->tid_bitmask;
 }
 
-threadid *
+/*
+ * Return the bitmasks of tasks active. Mainly intended as a testing hook.
+ */
+uint64
+task_active_tasks_mask(task_system *ts)
+{
+   return *task_system_get_tid_bitmask(ts);
+}
+
+static threadid *
 task_system_get_max_tid(task_system *ts)
 {
    return &ts->max_tid;
@@ -674,6 +830,7 @@ task_system_get_max_tid(task_system *ts)
 void *
 task_system_get_thread_scratch(task_system *ts, const threadid tid)
 {
+   platform_assert((tid < MAX_THREADS), "tid=%lu", tid);
    return ts->thread_scratch[tid];
 }
 

--- a/src/task.h
+++ b/src/task.h
@@ -127,12 +127,25 @@ task_thread_create(const char            *name,
                    platform_thread       *thread);
 
 // Register the calling thread, allocating scratch space for it
+#define task_register_this_thread(ts, scratch_size)                            \
+   task_register_thread((ts), (scratch_size), __FILE__, __LINE__, __FUNCTION__)
+
 void
-task_register_this_thread(task_system *ts, uint64 scratch_size);
+task_register_thread(task_system *ts,
+                     uint64       scratch_size,
+                     const char  *file,
+                     const int    lineno,
+                     const char  *func);
 
 // Unregister the calling thread and free its scratch space
+#define task_deregister_this_thread(ts)                                        \
+   task_deregister_thread((ts), __FILE__, __LINE__, __FUNCTION__)
+
 void
-task_deregister_this_thread(task_system *ts);
+task_deregister_thread(task_system *ts,
+                       const char  *file,
+                       const int    lineno,
+                       const char  *func);
 
 
 platform_status
@@ -169,6 +182,12 @@ task_perform_all(task_system *ts);
 
 void
 task_wait_for_completion(task_system *ts);
+
+threadid
+task_get_max_tid(task_system *ts);
+
+uint64
+task_active_tasks_mask(task_system *ts);
 
 void
 task_print_stats(task_system *ts);

--- a/test.sh
+++ b/test.sh
@@ -526,6 +526,7 @@ function run_fast_unit_tests() {
    "$BINDIR"/unit/util_test
    "$BINDIR"/unit/misc_test
    "$BINDIR"/unit/limitations_test
+   "$BINDIR"/unit/task_system_test
 }
 
 # ##################################################################

--- a/tests/unit/task_system_test.c
+++ b/tests/unit/task_system_test.c
@@ -1,0 +1,510 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+ * -----------------------------------------------------------------------------
+ * task_system_test.c --
+ *
+ *  These unit-tests are constructed to verify basic execution of interfaces
+ *  in the SplinterDB task system, as implemented in task.c .
+ *
+ * ***** NOTE **** Splinter's task system has external and internal APIs:
+ *
+ * External interfaces:
+ *  - task_thread_create()
+ *  - platform_thread_join()
+ *
+ * Internal-use-only interfaces:
+ *  - platform_thread_create(), platform_thread_join()
+ *  - task_register_this_thread()
+ *  - task_deregister_this_thread()
+ *
+ * This test exercises both variants for completeness. However, all new user
+ * programs must only use the external interfaces listed above.
+ * -----------------------------------------------------------------------------
+ */
+#include "splinterdb/public_platform.h"
+#include "unit_tests.h"
+#include "ctest.h" // This is required for all test-case files.
+#include "platform.h"
+#include "config.h" // Reqd for definition of master_config{}
+#include "trunk.h"  // Needed for trunk_get_scratch_size()
+#include "task.h"
+
+// Configuration for each worker thread
+typedef struct {
+   task_system    *tasks;
+   platform_thread this_thread_id; // OS-generated thread ID
+   threadid        exp_thread_idx; // Splinter-generated expected thread index
+   uint64          active_threads_bitmask;
+} thread_config;
+
+// Function prototypes
+static void
+exec_one_thread_use_lower_apis(void *arg);
+
+static void
+exec_one_thread_use_extern_apis(void *arg);
+
+static void
+exec_one_of_n_threads(void *arg);
+
+/*
+ * Global data declaration macro:
+ */
+CTEST_DATA(task_system)
+{
+   // Declare heap handles for io allocation.
+   platform_heap_handle hh;
+   platform_heap_id     hid;
+
+   // Config structs required, to exercise task subsystem
+   io_config io_cfg;
+
+   uint8 num_bg_threads[NUM_TASK_TYPES];
+
+   // Following get setup pointing to allocated memory
+   platform_io_handle *ioh; // Only prerequisite needed to setup task system
+   task_system        *tasks;
+
+   uint64 active_threads_bitmask;
+};
+
+/*
+ * ------------------------------------------------------------------------
+ * Do enough setup of IO-system and task-system, without setting up
+ * rest of Splinter sub-systems. This sets up just-enough to start
+ * exercising and testing the task system interfaces.
+ * ------------------------------------------------------------------------
+ */
+CTEST_SETUP(task_system)
+{
+   Platform_default_log_handle = fopen("/tmp/unit_test.stdout", "a+");
+   Platform_error_log_handle   = fopen("/tmp/unit_test.stderr", "a+");
+
+   uint64 heap_capacity = (256 * MiB); // small heap is sufficient.
+
+   platform_status rc = STATUS_OK;
+
+   // Create a heap for io and task system to use.
+   rc = platform_heap_create(
+      platform_get_module_id(), heap_capacity, &data->hh, &data->hid);
+   platform_assert_status_ok(rc);
+
+   // Allocate and initialize the IO sub-system.
+   data->ioh = TYPED_MALLOC(data->hid, data->ioh);
+   ASSERT_TRUE((data->ioh != NULL));
+
+   // Do minimal IO config setup, using default IO values.
+   master_config master_cfg;
+   config_set_defaults(&master_cfg);
+   io_config_init(&data->io_cfg,
+                  master_cfg.page_size,
+                  master_cfg.extent_size,
+                  master_cfg.io_flags,
+                  master_cfg.io_perms,
+                  master_cfg.io_async_queue_depth,
+                  master_cfg.io_filename);
+
+   rc = io_handle_init(data->ioh, &data->io_cfg, data->hh, data->hid);
+   ASSERT_TRUE(SUCCESS(rc),
+               "Failed to init IO handle: %s\n",
+               platform_status_to_string(rc));
+
+   // no background threads by default.
+   for (int idx = 0; idx < ARRAY_SIZE(data->num_bg_threads); idx++) {
+      data->num_bg_threads[idx] = 0;
+   }
+
+   // Background thread support is currently deactivated.
+   bool use_bg_threads = data->num_bg_threads[TASK_TYPE_NORMAL] != 0;
+
+   rc = task_system_create(data->hid,
+                           data->ioh,
+                           &data->tasks,
+                           TRUE,           // Use statistics,
+                           use_bg_threads, // False, currently.
+                           data->num_bg_threads,
+                           trunk_get_scratch_size());
+
+   // Main task (this thread) is at index 0
+   ASSERT_EQUAL(0, platform_get_tid());
+
+   // Main thread should now be marked as being active in the bitmask.
+   // Active threads have their bit turned -OFF- in this bitmask.
+   uint64 task_bitmask              = task_active_tasks_mask(data->tasks);
+   uint64 all_threads_inactive_mask = (~0L);
+   uint64 this_thread_active_mask   = (~0x1L);
+   uint64 exp_bitmask = (all_threads_inactive_mask & this_thread_active_mask);
+   ASSERT_EQUAL(exp_bitmask, task_bitmask);
+
+   // Save it off, so it can be used for verification in a test case.
+   data->active_threads_bitmask = exp_bitmask;
+}
+
+// Teardown function for suite, called after every test in suite
+CTEST_TEARDOWN(task_system)
+{
+   task_system_destroy(data->hid, &data->tasks);
+   platform_heap_destroy(&data->hh);
+}
+
+/*
+ * ------------------------------------------------------------------------
+ * Basic test case: This is a degenerate test case which essentially
+ * invokes the create() / destroy() interfaces of the task sub-system.
+ * Every other test case will also execute this pair. This test case
+ * solely serves the purpose of a minimalistic exerciser of those methods.
+ * While at it, report the value returned by platform_get_tid().
+ * ------------------------------------------------------------------------
+ */
+CTEST2(task_system, test_basic_create_destroy)
+{
+   threadid main_thread_idx = platform_get_tid();
+   ASSERT_EQUAL(main_thread_idx, 0);
+   platform_default_log("platform_get_tid() = %lu\n", main_thread_idx);
+}
+
+/*
+ * ------------------------------------------------------------------------
+ * Test creation of one new thread which will do the stuff required
+ * to start a thread using lower-level Splinter interfaces.
+ * We validate expected outputs from interfaces in this main thread and
+ * the thread's worker-function validates thread-specific expected outputs.
+ *
+ * This test case and its minion worker function,
+ * exec_one_thread_use_lower_apis(), is written to use lower-level platform
+ * and task-system APIs. In this pair of functions, we explicitly create
+ * a new thread and exercise lower-level register / deregister interfaces.
+
+ * In contrast, the test case, test_one_thread_using_extern_apis() does very
+ * similar testing of thread invocation but uses external Splinter task
+ * system APIs.
+ * ------------------------------------------------------------------------
+ */
+CTEST2(task_system, test_one_thread_using_lower_apis)
+{
+   platform_thread new_thread;
+   thread_config   thread_cfg;
+
+   ZERO_STRUCT(thread_cfg);
+
+   threadid main_thread_idx = platform_get_tid();
+   ASSERT_EQUAL(main_thread_idx, 0, "main_thread_idx=%lu", main_thread_idx);
+
+   // Setup thread-specific struct, needed for validation in thread's worker fn
+   thread_cfg.tasks                  = data->tasks;
+   thread_cfg.exp_thread_idx         = 1; // Main thread is at index 0.
+   thread_cfg.active_threads_bitmask = task_active_tasks_mask(data->tasks);
+
+   platform_status rc = STATUS_OK;
+
+   rc = platform_thread_create(&new_thread,
+                               FALSE,
+                               exec_one_thread_use_lower_apis,
+                               &thread_cfg,
+                               data->hid);
+   ASSERT_TRUE(SUCCESS(rc));
+
+   thread_cfg.this_thread_id = new_thread;
+
+   // This main-thread's thread-index remains unchanged.
+   ASSERT_EQUAL(main_thread_idx, platform_get_tid());
+
+   rc = platform_thread_join(new_thread);
+   ASSERT_TRUE(SUCCESS(rc));
+
+   // This main-thread's thread-index remains unchanged.
+   threadid get_tid_after_thread_exits = platform_get_tid();
+   ASSERT_EQUAL(main_thread_idx,
+                get_tid_after_thread_exits,
+                "main_thread_idx=%lu != get_tid_after_thread_exits=%lu",
+                main_thread_idx,
+                get_tid_after_thread_exits);
+}
+
+/*
+ * ------------------------------------------------------------------------
+ * Test creation of one new thread using external Splinter interfaces (like
+ * in a real application code-flow). These interfaces will do all the stuff
+ * required to start a thread and set it up to perform Splinter work.
+ *
+ * This test case and its minion worker function,
+ * exec_one_thread_use_extern_apis(), is written to use external platform
+ * and task-system APIs. Otherwise, the testing done is identical to what's
+ * done in its sibling test case, test_one_thread_using_lower_apis.
+ * ------------------------------------------------------------------------
+ */
+CTEST2(task_system, test_one_thread_using_extern_apis)
+{
+   platform_thread new_thread;
+   thread_config   thread_cfg;
+
+   ZERO_STRUCT(thread_cfg);
+
+   threadid main_thread_idx = platform_get_tid();
+   ASSERT_EQUAL(main_thread_idx, 0, "main_thread_idx=%lu", main_thread_idx);
+
+   // Setup thread-specific struct, needed for validation in thread's worker fn
+   thread_cfg.tasks                  = data->tasks;
+   thread_cfg.exp_thread_idx         = 1; // Main thread is at index 0.
+   thread_cfg.active_threads_bitmask = task_active_tasks_mask(data->tasks);
+
+   platform_status rc = STATUS_OK;
+
+   // This interface packages all the platform_thread_create() and
+   // register / deregister business, around the invocation of the
+   // user's worker function, exec_one_thread_use_extern_apis().
+   rc = task_thread_create("test_one_thread",
+                           exec_one_thread_use_extern_apis,
+                           &thread_cfg,
+                           trunk_get_scratch_size(),
+                           data->tasks,
+                           data->hid,
+                           &new_thread);
+   ASSERT_TRUE(SUCCESS(rc));
+
+   thread_cfg.this_thread_id = new_thread;
+
+   // This main-thread's thread-index remains unchanged.
+   ASSERT_EQUAL(main_thread_idx, platform_get_tid());
+
+   // task_thread_join(), if it were to exist, would have been
+   // a pass-through to platform-specific join() method, anyways.
+   rc = platform_thread_join(new_thread);
+   ASSERT_TRUE(SUCCESS(rc));
+
+   // This main-thread's thread-index remains unchanged.
+   threadid get_tid_after_thread_exits = platform_get_tid();
+   ASSERT_EQUAL(main_thread_idx,
+                get_tid_after_thread_exits,
+                "main_thread_idx=%lu != get_tid_after_thread_exits=%lu",
+                main_thread_idx,
+                get_tid_after_thread_exits);
+}
+
+/*
+ * ------------------------------------------------------------------------
+ * Test creation and execution of multiple threads which will do the stuff
+ * required to start threads using lower-level Splinter interfaces.
+ * ------------------------------------------------------------------------
+ */
+CTEST2(task_system, test_multiple_threads)
+{
+   platform_thread new_thread;
+   thread_config   thread_cfg[MAX_THREADS];
+   thread_config  *thread_cfgp = NULL;
+   int             tctr        = 0;
+   platform_status rc          = STATUS_OK;
+
+   ZERO_ARRAY(thread_cfg);
+   platform_default_log(" Before threads start, task_get_max_tid() = %lu\n",
+                        task_get_max_tid(data->tasks));
+
+   // Start-up n-threads, record their expected thread-IDs, which will be
+   // validated by the thread's execution function below.
+   for (tctr = 1, thread_cfgp = &thread_cfg[tctr];
+        tctr < ARRAY_SIZE(thread_cfg);
+        tctr++, thread_cfgp++)
+   {
+      // These are independent of the new thread's creation.
+      thread_cfgp->tasks          = data->tasks;
+      thread_cfgp->exp_thread_idx = tctr;
+
+      rc = platform_thread_create(
+         &new_thread, FALSE, exec_one_of_n_threads, thread_cfgp, data->hid);
+      ASSERT_TRUE(SUCCESS(rc));
+
+      thread_cfgp->this_thread_id = new_thread;
+   }
+
+   // Complete execution of n-threads. Worker fn does the validation.
+   for (tctr = 1, thread_cfgp = &thread_cfg[tctr];
+        tctr < ARRAY_SIZE(thread_cfg);
+        tctr++, thread_cfgp++)
+   {
+      rc = platform_thread_join(thread_cfgp->this_thread_id);
+      ASSERT_TRUE(SUCCESS(rc));
+   }
+}
+
+/*
+ * exec_one_thread_use_lower_apis() - Worker routine executed by a single
+ * thread.
+ *
+ * This worker method uses lower-level thread register / deregister APIs,
+ * as a way to exercise them and to check for correctness. In this method,
+ * we also do careful examination and validation of internal structures to
+ * follow the machinations of the task system.
+ */
+static void
+exec_one_thread_use_lower_apis(void *arg)
+{
+   thread_config *thread_cfg = (thread_config *)arg;
+
+   uint64 task_bitmask_before_register =
+      task_active_tasks_mask(thread_cfg->tasks);
+
+   // Verify that the state of active-threads bitmask (managed by Splinter) has
+   // not changed just by creating this pthread. It should be the same as what
+   // we had recorded just prior to platform_thread_create().
+   ASSERT_EQUAL(thread_cfg->active_threads_bitmask,
+                task_bitmask_before_register);
+
+   // This is the important call to initialize thread-specific stuff in
+   // Splinter's task-system, which sets up the thread-id (index) and records
+   // this thread as active with the task system.
+   task_register_this_thread(thread_cfg->tasks, trunk_get_scratch_size());
+
+   uint64 task_bitmask_after_register =
+      task_active_tasks_mask(thread_cfg->tasks);
+
+   // _Now, the active tasks bitmask should have changed.
+   ASSERT_NOT_EQUAL(task_bitmask_before_register, task_bitmask_after_register);
+
+   threadid this_threads_idx = platform_get_tid();
+   ASSERT_EQUAL(thread_cfg->exp_thread_idx, this_threads_idx);
+
+   // This thread is recorded as 'being active' by clearing its bit from the
+   // mask.
+   uint64 exp_bitmask = (0x1L << this_threads_idx);
+   exp_bitmask        = (task_bitmask_before_register & ~exp_bitmask);
+   ASSERT_EQUAL(task_bitmask_after_register, exp_bitmask);
+
+   // Registration should have allocated some scratch space memory.
+   ASSERT_TRUE(
+      task_system_get_thread_scratch(thread_cfg->tasks, platform_get_tid())
+      != NULL);
+
+   // Brain-dead cross-check, to understand what's going on with thread-IDs.
+   platform_thread thread_id = platform_thread_id_self();
+   ASSERT_TRUE((thread_cfg->this_thread_id == thread_id)
+               || (thread_cfg->this_thread_id == 0));
+
+   platform_default_log("platform_get_tid() = %lu,"
+                        "new_thread_ID == platform_thread_id_self()=%lu\n",
+                        platform_get_tid(),
+                        thread_id);
+
+   task_deregister_this_thread(thread_cfg->tasks);
+
+   uint64 task_bitmask_after_deregister =
+      task_active_tasks_mask(thread_cfg->tasks);
+
+   // De-registering this task removes it from the active tasks mask
+   ASSERT_EQUAL(task_bitmask_before_register, task_bitmask_after_deregister);
+
+   // Deregistration releases scratch space memory.
+   ASSERT_TRUE(
+      task_system_get_thread_scratch(thread_cfg->tasks, this_threads_idx)
+      == NULL);
+
+   // Register / de-register of thread with SplinterDB's task system is
+   // SplinterDB's jugglery to keep track of resources. get_tid() should
+   // now be reset.
+   threadid get_tid_after_deregister = platform_get_tid();
+   ASSERT_EQUAL(0,
+                get_tid_after_deregister,
+                "get_tid_after_deregister=%lu is != expected index into"
+                " thread array, %lu ",
+                get_tid_after_deregister,
+                thread_cfg->exp_thread_idx);
+}
+
+/*
+ * exec_one_thread_use_extern_apis() - Worker routine executed by a single
+ * thread.
+ *
+ * This worker method uses external interfaces to start a thread, thru
+ * task_invoke_with_hooks(). That interface registers the new thread with
+ * Splinter -before- invoking this worker function. Adjust the task-bitmask
+ * checks accordingly.
+ */
+static void
+exec_one_thread_use_extern_apis(void *arg)
+{
+   thread_config *thread_cfg = (thread_config *)arg;
+
+   uint64 bitmask_before_thread_create = thread_cfg->active_threads_bitmask;
+
+   uint64 bitmask_after_thread_create =
+      task_active_tasks_mask(thread_cfg->tasks);
+
+   // The task_thread_create() -> task_invoke_with_hooks() also registers this
+   // thread with Splinter. First, confirm that the bitmask has changed from
+   // what it was before this thread was invoked.
+   ASSERT_NOT_EQUAL(bitmask_before_thread_create, bitmask_after_thread_create);
+
+   threadid this_threads_idx = platform_get_tid();
+   ASSERT_EQUAL(thread_cfg->exp_thread_idx, this_threads_idx);
+
+   // This thread is recorded as 'being active' by clearing its bit from the
+   // mask. Verify the expected task bitmask.
+   uint64 exp_bitmask = (0x1L << this_threads_idx);
+   exp_bitmask        = (bitmask_before_thread_create & ~exp_bitmask);
+   ASSERT_EQUAL(bitmask_after_thread_create, exp_bitmask);
+
+   /*
+    * Dead Code Warning!
+    * The interface used here has already registered this thread. An attempt to
+    * re-register this thread will trip an assertion. (Left here for posterity.)
+    */
+   // task_register_this_thread(thread_cfg->tasks, trunk_get_scratch_size());
+
+   // Registration should have allocated some scratch space memory.
+   ASSERT_TRUE(
+      task_system_get_thread_scratch(thread_cfg->tasks, this_threads_idx)
+      != NULL);
+
+   /*
+    * Dead Code Warning!
+    * You cannot explicitly deregister this thread through this interface as
+    * that's done by task_invoke_with_hooks(). If you enable the call below,
+    * an assertion will trap in that other function when the thread is being
+    * torn down. (Left here for posterity.)
+    */
+   // task_deregister_this_thread(thread_cfg->tasks);
+}
+
+/*
+ * exec_one_of_n_threads() - Worker routine executed by one of a set of
+ * multiple threads.
+ *
+ * We don't have any sophisticated sync-points mechanism across threads, so we
+ * cannot do any deep validation of state while multiple threads are executing.
+ * Again this worker function is written to use lower-level register /
+ * deregister APIs of the task system.
+ */
+static void
+exec_one_of_n_threads(void *arg)
+{
+   thread_config *thread_cfg = (thread_config *)arg;
+
+   task_register_this_thread(thread_cfg->tasks, trunk_get_scratch_size());
+
+   threadid this_threads_index = platform_get_tid();
+
+   ASSERT_TRUE((this_threads_index < MAX_THREADS),
+               "Thread [%lu] Registered thread idx = %lu is invalid.",
+               thread_cfg->exp_thread_idx,
+               this_threads_index);
+
+   // Test case is carefully constructed to fire-up n-threads. Wait for
+   // them to all start-up.
+   while (task_get_max_tid(thread_cfg->tasks) < MAX_THREADS) {
+      platform_sleep(USEC_TO_NSEC(100000)); // 100 msec.
+   }
+
+   task_deregister_this_thread(thread_cfg->tasks);
+
+   // Register / de-register of thread with SplinterDB's task system is just
+   // SplinterDB's jugglery to keep track of resources. get_tid() should still
+   // remain the expected index into the threads[] array.
+   threadid get_tid_after_deregister = platform_get_tid();
+   ASSERT_EQUAL(0,
+                get_tid_after_deregister,
+                "get_tid_after_deregister=%lu is != the index into"
+                " thread array, %lu ",
+                get_tid_after_deregister,
+                this_threads_index);
+}


### PR DESCRIPTION
This commit adds a bit of code cleanup to the task system module, task.c . No new functionality or change-in-logic is being done. Add new unit-test, task_system_test, to validate internal state of the task system for simple task creation / execution.

---
NOTE: to the reviewer. This change set came out of my code walk through to understand the task system and its innards.
This was done in context of the design rework to support execution of Splinter using allocated shared memory segments.
While at it, I constructed a small C-unit test to work through task system interfaces and to confirm, via tests, expected outputs.

Some of this testing will also be helpful when we "cut-over" to running tests using shared segments.