### PR TITLE
Core changes to support Splinter memory allocation using shared memory segment.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ SRC := $(shell find $(SRCDIR) -name "*.c")
 # Generate list of common test source files, only from tests/ dir. Hence '-maxdepth 1'.
 # These objects are shared between functional/ and unit/ test binaries.
 COMMON_TESTSRC := $(shell find $(TESTS_DIR) -maxdepth 1 -name "*.c")
+COMMON_MISC_TESTSRC := $(shell find $(TESTS_DIR) -maxdepth 1 -name "*.c" | egrep -e "_misc_")
 FUNCTIONAL_TESTSRC := $(shell find $(FUNCTIONAL_TESTSDIR) -name "*.c")
 
 # Symbol for all unit-test sources, from which we will build standalone
@@ -35,7 +36,7 @@ TESTSRC := $(COMMON_TESTSRC) $(FUNCTIONAL_TESTSRC) $(UNIT_TESTSRC)
 
 # Some unit-tests will be excluded from the list of dot-oh's that are linked into
 # bin/unit_test, for various reasons:
-#  - Slow unit-tests will be skipped, as we want the#    resulting unit_test to
+#  - Slow unit-tests will be skipped, as we want the resulting unit_test to
 #    run as fast as it can.
 #  - Skip tests that are to be invoked with specialized command-line arguments.
 # These skipped tests which will have to be run stand-alone.
@@ -363,7 +364,8 @@ $(foreach unit,$(UNIT_TESTBINS),$(eval $(call unit_test_self_dependency,$(unit))
 #
 # These will need to be fleshed out for filters, io subsystem, trunk,
 # etc. as we create mini unit test executables for those subsystems.
-PLATFORM_SYS = $(OBJDIR)/$(SRCDIR)/$(PLATFORM_DIR)/platform.o
+PLATFORM_SYS = $(OBJDIR)/$(SRCDIR)/$(PLATFORM_DIR)/platform.o \
+			   $(OBJDIR)/$(SRCDIR)/$(PLATFORM_DIR)/shmem.o
 
 PLATFORM_IO_SYS = $(OBJDIR)/$(SRCDIR)/$(PLATFORM_DIR)/laio.o
 
@@ -404,17 +406,17 @@ $(BINDIR)/$(UNITDIR)/splinter_test: $(COMMON_TESTOBJ)                           
                                     $(OBJDIR)/$(FUNCTIONAL_TESTSDIR)/test_async.o \
                                     $(LIBDIR)/libsplinterdb.so
 
-$(BINDIR)/$(UNITDIR)/splinterdb_quick_test: $(COMMON_TESTOBJ)                             \
+$(BINDIR)/$(UNITDIR)/splinterdb_quick_test: $(COMMON_TESTOBJ)                       \
                                       $(OBJDIR)/$(FUNCTIONAL_TESTSDIR)/test_async.o \
                                       $(LIBDIR)/libsplinterdb.so
 
-$(BINDIR)/$(UNITDIR)/splinterdb_stress_test: $(COMMON_TESTOBJ)                             \
+$(BINDIR)/$(UNITDIR)/splinterdb_stress_test: $(COMMON_TESTOBJ)                                \
                                                 $(OBJDIR)/$(FUNCTIONAL_TESTSDIR)/test_async.o \
                                                 $(LIBDIR)/libsplinterdb.so
 
 $(BINDIR)/$(UNITDIR)/writable_buffer_test: $(UTIL_SYS)
 
-$(BINDIR)/$(UNITDIR)/limitations_test: $(COMMON_TESTOBJ)            \
+$(BINDIR)/$(UNITDIR)/limitations_test: $(COMMON_TESTOBJ)                             \
                                        $(OBJDIR)/$(FUNCTIONAL_TESTSDIR)/test_async.o \
                                        $(LIBDIR)/libsplinterdb.so
 
@@ -428,6 +430,10 @@ $(BINDIR)/$(UNITDIR)/task_system_test: $(UTIL_SYS)                              
                                        $(OBJDIR)/$(FUNCTIONAL_TESTSDIR)/test_async.o \
                                        $(LIBDIR)/libsplinterdb.so
 
+$(BINDIR)/$(UNITDIR)/splinter_shmem_test: $(UTIL_SYS) \
+
+$(BINDIR)/$(UNITDIR)/splinter_ipc_test:   $(UTIL_SYS)
+
 ########################################
 # Convenience mini unit-test targets
 unit/util_test:                    $(BINDIR)/$(UNITDIR)/util_test
@@ -438,6 +444,11 @@ unit/splinter_test:                $(BINDIR)/$(UNITDIR)/splinter_test
 unit/splinterdb_quick_test:        $(BINDIR)/$(UNITDIR)/splinterdb_quick_test
 unit/splinterdb_stress_test:       $(BINDIR)/$(UNITDIR)/splinterdb_stress_test
 unit/writable_buffer_test:         $(BINDIR)/$(UNITDIR)/writable_buffer_test
+unit/config_parse_test:            $(BINDIR)/$(UNITDIR)/config_parse_test
+unit/limitations_test:             $(BINDIR)/$(UNITDIR)/limitations_test
+unit/task_system_test:             $(BINDIR)/$(UNITDIR)/task_system_test
+unit/splinter_shmem_test:          $(BINDIR)/$(UNITDIR)/splinter_shmem_test
+unit/splinter_ipc_test:            $(BINDIR)/$(UNITDIR)/splinter_ipc_test
 unit_test:                         $(BINDIR)/unit_test
 
 # -----------------------------------------------------------------------------

--- a/include/splinterdb/splinterdb.h
+++ b/include/splinterdb/splinterdb.h
@@ -26,7 +26,16 @@
 const char *
 splinterdb_get_version();
 
-// Configuration options for SplinterDB
+/*
+ * Configuration options for SplinterDB:
+ *
+ * Physical configuration things such as file name, cache & disk-size,
+ * extent- and page-size are specified here. Application-specific data
+ * configuration is also provided through this struct. Additionally,
+ * user can select whether to use malloc()/free()-based memory allocation
+ * for all structures (default), or choose to setup a shared segment
+ * which will be used for shared structures.
+ */
 typedef struct {
    // required configuration
    const char *filename;
@@ -38,11 +47,11 @@ typedef struct {
    // For a simple reference implementation, see default_data_config.h
    data_config *data_cfg;
 
-
    // optional advanced config below
    // if unset, defaults will be used
    void *heap_handle;
    void *heap_id;
+   bool  use_shmem; // Default is FALSE.
 
    uint64 page_size;
    uint64 extent_size;
@@ -86,7 +95,7 @@ typedef struct splinterdb splinterdb;
 // But cfg->data_cfg will be referenced by the returned splinterdb object
 // So it must live at least as long as the splinterdb
 int
-splinterdb_create(const splinterdb_config *cfg, splinterdb **kvs);
+splinterdb_create(splinterdb_config *cfg, splinterdb **kvs);
 
 // Open an existing splinterdb from a file/device on disk
 //
@@ -97,7 +106,7 @@ splinterdb_create(const splinterdb_config *cfg, splinterdb **kvs);
 // But cfg->data_cfg will be referenced by the returned splinterdb object
 // So it must live at least as long as the splinterdb
 int
-splinterdb_open(const splinterdb_config *cfg, splinterdb **kvs);
+splinterdb_open(splinterdb_config *cfg, splinterdb **kvs);
 
 // Close a splinterdb
 //

--- a/include/splinterdb/splinterdb.h
+++ b/include/splinterdb/splinterdb.h
@@ -36,7 +36,7 @@ splinterdb_get_version();
  * for all structures (default), or choose to setup a shared segment
  * which will be used for shared structures.
  */
-typedef struct {
+typedef struct splinterdb_config {
    // required configuration
    const char *filename;
    uint64      cache_size;
@@ -51,7 +51,12 @@ typedef struct {
    // if unset, defaults will be used
    void *heap_handle;
    void *heap_id;
-   bool  use_shmem; // Default is FALSE.
+
+   // Shared memory suppot
+   bool use_shmem; // Default is FALSE.
+   bool trace_shmem_allocs;
+   bool trace_shmem_frees;
+   bool trace_shmem; // Trace both allocs & frees from shared memory
 
    uint64 page_size;
    uint64 extent_size;

--- a/src/btree.c
+++ b/src/btree.c
@@ -2525,7 +2525,15 @@ btree_iterator_advance(iterator *base_itor)
    }
 
    debug_assert(btree_iterator_is_at_end(itor)
-                || itor->idx < btree_num_entries(itor->curr.hdr));
+                   || itor->idx < btree_num_entries(itor->curr.hdr),
+                "BTree iterator state is invalid: "
+                "itor->{curr.addr=%lu, end_addr=%lu}, "
+                "idx=%lu, end_idx=%lu, btree_num_entries()=%u\n",
+                itor->curr.addr,
+                itor->end_addr,
+                itor->idx,
+                itor->end_idx,
+                btree_num_entries(itor->curr.hdr));
 
    return STATUS_OK;
 }

--- a/src/btree.h
+++ b/src/btree.h
@@ -352,7 +352,7 @@ btree_pack_req_init(btree_pack_req  *req,
    req->seed         = seed;
    if (hash != NULL && max_tuples > 0) {
       req->fingerprint_arr =
-         TYPED_ARRAY_MALLOC(hid, req->fingerprint_arr, max_tuples);
+         TYPED_ARRAY_MALLOC(NULL_HEAP_ID, req->fingerprint_arr, max_tuples);
    }
 }
 
@@ -360,7 +360,7 @@ static inline void
 btree_pack_req_deinit(btree_pack_req *req, platform_heap_id hid)
 {
    if (req->fingerprint_arr) {
-      platform_free(hid, req->fingerprint_arr);
+      platform_free(NULL_HEAP_ID, req->fingerprint_arr);
    }
 }
 

--- a/src/default_data_config.c
+++ b/src/default_data_config.c
@@ -69,6 +69,10 @@ message_to_string(const data_config *cfg,
 }
 
 
+/*
+ * Function to initialize application-specific data_config{} struct
+ * with default values.
+ */
 void
 default_data_config_init(const size_t max_key_size, // IN
                          data_config *out_cfg       // OUT

--- a/src/merge.c
+++ b/src/merge.c
@@ -414,7 +414,7 @@ merge_iterator_create(platform_heap_id hid,
                      == ARRAY_SIZE(merge_itor->ordered_iterators),
                   "size mismatch");
 
-   merge_itor = TYPED_ZALLOC(hid, merge_itor);
+   merge_itor = TYPED_ZALLOC(NULL_HEAP_ID, merge_itor);
    if (merge_itor == NULL) {
       return STATUS_NO_MEMORY;
    }
@@ -494,7 +494,7 @@ merge_iterator_create(platform_heap_id hid,
    goto out;
 
 destroy:
-   merge_iterator_rc = merge_iterator_destroy(hid, &merge_itor);
+   merge_iterator_rc = merge_iterator_destroy(NULL_HEAP_ID, &merge_itor);
    if (!SUCCESS(merge_iterator_rc)) {
       platform_error_log("merge_iterator_create: exception while releasing\n");
       if (SUCCESS(rc)) {
@@ -528,7 +528,7 @@ platform_status
 merge_iterator_destroy(platform_heap_id hid, merge_iterator **merge_itor)
 {
    merge_accumulator_deinit(&(*merge_itor)->merge_buffer);
-   platform_free(hid, *merge_itor);
+   platform_free(NULL_HEAP_ID, *merge_itor);
    *merge_itor = NULL;
 
    return STATUS_OK;

--- a/src/platform_linux/platform.c
+++ b/src/platform_linux/platform.c
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <stdarg.h>
-#include "platform.h"
-
 #include <sys/mman.h>
+#include "platform.h"
+#include "shmem.h"
 
 __thread threadid xxxtid;
 
@@ -26,10 +26,14 @@ void __attribute__((constructor)) platform_init_log_file_handles(void)
 
 platform_status
 platform_heap_create(platform_module_id    UNUSED_PARAM(module_id),
-                     uint32                max,
+                     size_t                max,
+                     bool                  use_shmem,
                      platform_heap_handle *heap_handle,
                      platform_heap_id     *heap_id)
 {
+   if (use_shmem) {
+      return platform_shmcreate(max, heap_handle, heap_id);
+   }
    *heap_handle = NULL;
    *heap_id     = NULL;
 
@@ -37,8 +41,13 @@ platform_heap_create(platform_module_id    UNUSED_PARAM(module_id),
 }
 
 void
-platform_heap_destroy(platform_heap_handle UNUSED_PARAM(*heap_handle))
-{}
+platform_heap_destroy(platform_heap_handle *heap_handle)
+{
+   // If shared segment was allocated, it's being tracked thru heap handle.
+   if (*heap_handle) {
+      return platform_shmdestroy(heap_handle);
+   }
+}
 
 buffer_handle *
 platform_buffer_create(size_t               length,

--- a/src/platform_linux/platform.h
+++ b/src/platform_linux/platform.h
@@ -458,7 +458,7 @@ typedef uint32 (*hash_fn)(const void *input, size_t length, unsigned int seed);
  */
 #define ZERO_ARRAY(v)                                                          \
    do {                                                                        \
-      _Static_assert(IS_ARRAY(v), "ZERO_ARRAY on non-array");                  \
+      _Static_assert(IS_ARRAY(v), "Use of ZERO_ARRAY on non-array object");    \
       memset((v), 0, sizeof(v));                                               \
    } while (0)
 
@@ -468,7 +468,7 @@ typedef uint32 (*hash_fn)(const void *input, size_t length, unsigned int seed);
  */
 #define ZERO_CONTENTS_N(v, n)                                                  \
    do {                                                                        \
-      _Static_assert(!IS_ARRAY(v), "ZERO_CONTENTS on array");                  \
+      _Static_assert(!IS_ARRAY(v), "Use of ZERO_CONTENTS on array");           \
       debug_assert((v) != NULL);                                               \
       memset((v), 0, (n) * sizeof(*(v)));                                      \
    } while (0)
@@ -807,4 +807,4 @@ platform_backtrace(void **buffer, int size)
    return backtrace(buffer, size);
 }
 
-#endif
+#endif // PLATFORM_H

--- a/src/platform_linux/platform_inline.h
+++ b/src/platform_linux/platform_inline.h
@@ -462,8 +462,10 @@ platform_aligned_malloc(const platform_heap_id heap_id,
    return retptr;
 }
 
-/* Reallocing to size 0 must be equivalent to freeing.
-   Reallocing from NULL must be equivalent to allocing. */
+/*
+ * Reallocing to size 0 must be equivalent to freeing.
+ * Reallocing from NULL must be equivalent to allocing.
+ */
 static inline void *
 platform_realloc(const platform_heap_id UNUSED_PARAM(heap_id),
                  void                  *ptr, // IN
@@ -521,4 +523,4 @@ platform_condvar_destroy(platform_condvar *cv)
    pthread_cond_destroy(&cv->cond);
 }
 
-#endif
+#endif // PLATFORM_LINUX_INLINE_H

--- a/src/platform_linux/shmem.c
+++ b/src/platform_linux/shmem.c
@@ -1,0 +1,432 @@
+// Copyright 2018-2023 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+ * shmem.c --
+ *
+ * This file contains the implementation for managing shared memory created
+ * for use by SplinterDB and all its innards.
+ */
+
+#include "platform.h"
+#include "shmem.h"
+
+// SplinterDB's shared segment magic identifier
+#define SPLINTERDB_SHMEM_MAGIC (uint64)0xDEFACADE
+
+/*
+ * -----------------------------------------------------------------------------
+ * Core structure describing shared memory segment created. This lives right
+ * at the start of the allocated shared segment.
+ * -----------------------------------------------------------------------------
+ */
+typedef struct shmem_info {
+   void  *shm_start;       // Points to start address of shared segment.
+   void  *shm_next;        // Points to next 'free' address to allocate from.
+   size_t shm_total_bytes; // Total size of shared segment allocated initially.
+   size_t shm_free_bytes;  // Free bytes of memory left (that can be allocated)
+   size_t shm_used_bytes;  // Used bytes of memory left (that were allocated)
+   uint64 shm_magic;       // Magic identifier for shared memory segment
+   int    shm_id;          // Shared memory ID returned by shmget()
+
+} PLATFORM_CACHELINE_ALIGNED shmem_info;
+
+/* Permissions for accessing shared memory and IPC objects */
+#define PLATFORM_IPC_OBJS_PERMS (S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP)
+
+/*
+ * PLATFORM_HEAP_ID_TO_HANDLE() --
+ * PLATFORM_HEAP_ID_TO_SHMADDR() --
+ *
+ * The shared memory create function returns the address of shmem_info->shm_id
+ * as the platform_heap_id heap-ID to the caller. Rest of Splinter will use this
+ * heap-ID as a 'handle' to manage / allocate shared memory. This macro converts
+ * the heap-ID handle to the shared memory's start address, from which the
+ * location of the next-free-byte can be tracked.
+ *
+ * RESOLVE - This ptr-math going back from address of heap-ID is prone to
+ *errors. In some code paths, e.g. tests/unit/btree_test.c, we pass-down the
+ *stack address of an on-stack scratch-buffer masquerading as the heap-ID
+ *handle.
+ */
+static inline platform_heap_handle
+platform_heap_id_to_handle(platform_heap_id hid)
+{
+   return (platform_heap_handle)((void *)hid - offsetof(shmem_info, shm_id));
+}
+
+static inline void *
+platform_heap_id_to_shmaddr(platform_heap_id hid)
+{
+   debug_assert(hid != NULL);
+   void *shmaddr = (void *)platform_heap_id_to_handle(hid);
+   return shmaddr;
+}
+
+/*
+ * -----------------------------------------------------------------------------
+ * platform_shmcreate() -- Create a new / attach to an existing shared segment.
+ *
+ * For a given set of heap ID/handle, we expect that this create method will
+ * only be called once. [ Otherwise, it means some code is erroneously creating
+ * the shared segment twice, clobbering previously established handles. ]
+ * -----------------------------------------------------------------------------
+ */
+platform_status
+platform_shmcreate(size_t                size,
+                   platform_heap_handle *heap_handle,
+                   platform_heap_id     *heap_id)
+{
+   platform_assert(*heap_handle == NULL);
+   platform_assert(*heap_id == NULL);
+
+   int shmid = shmget(0, size, (IPC_CREAT | PLATFORM_IPC_OBJS_PERMS));
+   if (shmid == -1) {
+      platform_error_log(
+         "Failed to created shared segment of size %lu bytes.\n", size);
+      return STATUS_NO_MEMORY;
+   }
+   platform_default_log(
+      "Created shared memory of size %lu bytes, shmid=%d.\n", size, shmid);
+
+   // Get start of allocated shared segment
+   void *shmaddr = shmat(shmid, NULL, 0);
+
+   if (shmaddr == (void *)-1) {
+      platform_error_log("Failed to attach to shared segment, shmid=%d.\n",
+                         shmid);
+      return STATUS_NO_MEMORY;
+   }
+
+   // Setup shared segment's control block at head of shared segment.
+   size_t      free_bytes;
+   shmem_info *shminfop = (shmem_info *)shmaddr;
+
+   shminfop->shm_start       = shmaddr;
+   shminfop->shm_next        = (shmaddr + sizeof(shmem_info));
+   shminfop->shm_total_bytes = size;
+   free_bytes                = (size - sizeof(shmem_info));
+   shminfop->shm_free_bytes  = free_bytes;
+   shminfop->shm_used_bytes  = 0;
+   shminfop->shm_id          = shmid;
+   shminfop->shm_magic       = SPLINTERDB_SHMEM_MAGIC;
+
+   // Return 'heap' handles, if requested, pointing to shared segment handles.
+   if (heap_handle) {
+      *heap_handle = (platform_heap_handle *)shmaddr;
+   }
+
+   if (heap_id) {
+      *heap_id = &shminfop->shm_id;
+   }
+
+   bool        use_MiB = (size < GiB);
+   const char *msg =
+      "Completed setup of shared memory of size %lu bytes (%lu %s), "
+      "shmaddr=%p, shmid=%d,"
+      " available memory = %lu bytes (~%lu.%d %s).\n";
+   if (use_MiB) {
+      platform_default_log(msg,
+                           size,
+                           B_TO_MiB(size),
+                           "MiB",
+                           shmaddr,
+                           shmid,
+                           free_bytes,
+                           B_TO_MiB(free_bytes),
+                           B_TO_MiB_FRACT(free_bytes),
+                           "MiB");
+   } else {
+      platform_default_log(msg,
+                           size,
+                           B_TO_GiB(size),
+                           "GiB",
+                           shmaddr,
+                           shmid,
+                           free_bytes,
+                           B_TO_GiB(free_bytes),
+                           B_TO_GiB_FRACT(free_bytes),
+                           "GiB");
+   }
+   return STATUS_OK;
+}
+
+/*
+ * -----------------------------------------------------------------------------
+ * platform_shmdestroy() -- Destroy a shared memory created for SplinterDB.
+ * -----------------------------------------------------------------------------
+ */
+void
+platform_shmdestroy(platform_heap_handle *heap_handle)
+{
+   if (!heap_handle) {
+      platform_error_log(
+         "Error! Attempt to destroy shared memory with NULL heap_handle!");
+      return;
+   }
+
+   // Establish shared memory handles and validate input addr to shared segment
+   const void *shmaddr = (void *)*heap_handle;
+
+   // Heap handle may be coming from the shared segment, itself, that we will
+   // be detaching from now and freeing, below. So, an attempt to NULL out
+   // this handle after memory is freed will run into an exception. Clear
+   // out this handle prior to all this circus.
+   *heap_handle = NULL;
+
+   // Use a cached copy in case we are dealing with bogus input shmem address.
+   shmem_info shmem_info_struct;
+   memmove(&shmem_info_struct, shmaddr, sizeof(shmem_info_struct));
+
+   shmem_info *shminfop = &shmem_info_struct;
+
+   if (shminfop->shm_magic != SPLINTERDB_SHMEM_MAGIC) {
+      platform_error_log(
+         "Input heap handle, %p, does not seem to be a valid "
+         "SplinterDB shared segment's start address."
+         " Found magic 0x%lX does not match expected magic 0x%lX.\n",
+         heap_handle,
+         shminfop->shm_magic,
+         SPLINTERDB_SHMEM_MAGIC);
+      return;
+   }
+
+   int shmid = shminfop->shm_id;
+   int rv    = shmdt(shmaddr);
+   if (rv != 0) {
+      platform_error_log(
+         "Failed to detach from shared segment at address %p, shmid=%d.\n",
+         shmaddr,
+         shmid);
+      return;
+   }
+
+   // Externally, heap_id is pointing to this field. In anticipation that the
+   // removal of shared segment will succeed, below, clear this out. This way,
+   // any future accesses to this shared segment by its heap-ID will run into
+   // assertions.
+   shminfop->shm_id = 0;
+
+   rv = shmctl(shmid, IPC_RMID, NULL);
+   if (rv != 0) {
+      platform_error_log(
+         "shmctl failed to remove shared segment at address %p, shmid=%d.\n",
+         shmaddr,
+         shmid);
+
+      // restore state
+      shminfop->shm_id = shmid;
+      return;
+   }
+   platform_default_log(
+      "Deallocated shared memory segment at %p, shmid=%d\n", shmaddr, shmid);
+}
+
+/*
+ * -----------------------------------------------------------------------------
+ * platform_shm_alloc() -- Allocate n-bytes from shared segment.
+ *
+ * Allocation request is expected to have added-in pad-bytes required for
+ * alignment. As a result, we can assert that the addr-of-next-free-byte is
+ * always aligned to PLATFORM_CACHELINE_SIZE.
+ * -----------------------------------------------------------------------------
+ */
+void *
+platform_shm_alloc(platform_heap_id hid,
+                   const size_t     size,
+                   const char      *objname,
+                   const char      *func,
+                   const char      *file,
+                   const int        lineno)
+{
+   shmem_info *shminfop = platform_heap_id_to_shmaddr(hid);
+
+   debug_assert(
+      (platform_shm_heap_handle_valid((platform_heap_handle *)shminfop)
+       == TRUE),
+      "Shared memory heap ID at %p is not a valid shared memory handle.",
+      hid);
+
+   platform_assert(
+      ((((uint64)shminfop->shm_next) % PLATFORM_CACHELINE_SIZE) == 0),
+      "[%s:%d] Next free-addr is not aligned: "
+      "shm_next=%p, shm_total_bytes=%lu, shm_used_bytes=%lu"
+      ", shm_free_bytes=%lu",
+      file,
+      lineno,
+      shminfop->shm_next,
+      shminfop->shm_total_bytes,
+      shminfop->shm_used_bytes,
+      shminfop->shm_free_bytes);
+
+   if (shminfop->shm_free_bytes < size) {
+      return NULL;
+   }
+   void *retptr = shminfop->shm_next;
+
+   // Advance next-free-ptr and track memory usage metrics
+   shminfop->shm_next += size;
+   shminfop->shm_used_bytes += size;
+   shminfop->shm_free_bytes -= size;
+
+   /*
+   bool        use_MiB = (shminfop->shm_free_bytes < GiB);
+   const char *msg     = "  [%s:%d::%s()] -> %s: Allocated %lu bytes "
+                         "for object '%s', at %p, "
+                         "free bytes=%lu (~%lu.%d %s).\n";
+   if (use_MiB) {
+      platform_default_log(msg,
+                           file,
+                           lineno,
+                           func,
+                           __FUNCTION__,
+                           size,
+                           objname,
+                           retptr,
+                           shminfop->shm_free_bytes,
+                           B_TO_MiB(shminfop->shm_free_bytes),
+                           B_TO_MiB_FRACT(shminfop->shm_free_bytes),
+                           "MiB");
+   } else {
+      platform_default_log(msg,
+                           file,
+                           lineno,
+                           func,
+                           __FUNCTION__,
+                           size,
+                           objname,
+                           retptr,
+                           shminfop->shm_free_bytes,
+                           B_TO_GiB(shminfop->shm_free_bytes),
+                           B_TO_GiB_FRACT(shminfop->shm_free_bytes),
+                           "GiB");
+   }
+   */
+   return retptr;
+}
+
+/*
+ * -----------------------------------------------------------------------------
+ * platform_shm_free() -- 'Free' the memory fragment at given address.
+ * -----------------------------------------------------------------------------
+ */
+void
+platform_shm_free(platform_heap_id hid,
+                  void            *ptr,
+                  const char      *objname,
+                  const char      *func,
+                  const char      *file,
+                  const int        lineno)
+{
+   /*
+   platform_default_log(
+      "  [%s:%d::%s()] -> %s: Request to free memory at %p for object '%s'.\n",
+      file,
+      lineno,
+      func,
+      __FUNCTION__,
+      ptr,
+      objname);
+   */
+   return;
+}
+
+/*
+ * -----------------------------------------------------------------------------
+ * Accessor interfaces - mainly intended as testing / debugging hooks.
+ * -----------------------------------------------------------------------------
+ */
+bool
+platform_shm_heap_handle_valid(platform_heap_handle heap_handle)
+{
+   // Establish shared memory handles and validate input addr to shared segment
+   const void *shmaddr = (void *)heap_handle;
+
+   // Use a cached copy in case we are dealing with a bogus input shmem address.
+   shmem_info shmem_info_struct;
+   memmove(&shmem_info_struct, shmaddr, sizeof(shmem_info_struct));
+
+   shmem_info *shminfop = &shmem_info_struct;
+
+   if (shminfop->shm_magic != SPLINTERDB_SHMEM_MAGIC) {
+      platform_error_log(
+         "Input heap handle, %p, does not seem to be a valid "
+         "SplinterDB shared segment's start address."
+         " Found magic 0x%lX does not match expected magic 0x%lX.\n",
+         heap_handle,
+         shminfop->shm_magic,
+         SPLINTERDB_SHMEM_MAGIC);
+      return FALSE;
+   }
+
+   return TRUE;
+}
+
+/* Size of control block at start of shared memory describing shared segment */
+size_t
+platform_shm_ctrlblock_size()
+{
+   return sizeof(shmem_info);
+}
+
+/*
+ * Shmem-accessor interfaces by heap_handle.
+ */
+size_t
+platform_shmsize_by_hh(platform_heap_handle heap_handle)
+{
+   return (platform_shm_heap_handle_valid(heap_handle)
+              ? ((shmem_info *)heap_handle)->shm_total_bytes
+              : 0);
+}
+
+size_t
+platform_shmused_by_hh(platform_heap_handle heap_handle)
+{
+   return (platform_shm_heap_handle_valid(heap_handle)
+              ? ((shmem_info *)heap_handle)->shm_used_bytes
+              : 0);
+}
+
+size_t
+platform_shmfree_by_hh(platform_heap_handle heap_handle)
+{
+   return (platform_shm_heap_handle_valid(heap_handle)
+              ? ((shmem_info *)heap_handle)->shm_free_bytes
+              : 0);
+}
+
+void *
+platform_shm_next_free_addr_by_hh(platform_heap_handle heap_handle)
+{
+   return (platform_shm_heap_handle_valid(heap_handle)
+              ? ((shmem_info *)heap_handle)->shm_next
+              : NULL);
+}
+
+/*
+ * Shmem-accessor interfaces by heap_id.
+ */
+size_t
+platform_shmsize(platform_heap_id heap_id)
+{
+   return (platform_shmsize_by_hh(platform_heap_id_to_handle(heap_id)));
+}
+
+size_t
+platform_shmused(platform_heap_id heap_id)
+{
+   return (platform_shmused_by_hh(platform_heap_id_to_handle(heap_id)));
+}
+size_t
+platform_shmfree(platform_heap_id heap_id)
+{
+   return (platform_shmfree_by_hh(platform_heap_id_to_handle(heap_id)));
+}
+
+void *
+platform_shm_next_free_addr(platform_heap_id heap_id)
+{
+   return (
+      platform_shm_next_free_addr_by_hh(platform_heap_id_to_handle(heap_id)));
+}

--- a/src/platform_linux/shmem.h
+++ b/src/platform_linux/shmem.h
@@ -1,0 +1,79 @@
+// Copyright 2018-2023 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef __PLATFORM_SHMEM_H__
+#define __PLATFORM_SHMEM_H__
+
+#include <sys/types.h>
+#include <sys/shm.h>
+
+typedef struct shmem_info shmem_info;
+
+platform_status
+platform_shmcreate(size_t                size,
+                   platform_heap_handle *heap_handle,
+                   platform_heap_id     *heap_id);
+
+void
+platform_shmdestroy(platform_heap_handle *heap_handle);
+
+void *
+platform_shm_alloc(platform_heap_id hid,
+                   const size_t     size,
+                   const char      *objname,
+                   const char      *func,
+                   const char      *file,
+                   const int        lineno);
+
+void
+platform_shm_free(platform_heap_id hid,
+                  void            *ptr,
+                  const char      *objname,
+                  const char      *func,
+                  const char      *file,
+                  const int        lineno);
+
+static inline int
+platform_shm_alignment()
+{
+   return PLATFORM_CACHELINE_SIZE;
+}
+
+bool
+platform_shm_heap_handle_valid(platform_heap_handle heap_handle);
+
+size_t
+platform_shm_ctrlblock_size();
+
+/*
+ * Interfaces to retrieve size(s) using heap_handle.
+ */
+size_t
+platform_shmsize_by_hh(platform_heap_handle heap_handle);
+
+size_t
+platform_shmfree_by_hh(platform_heap_handle heap_handle);
+
+size_t
+platform_shmused_by_hh(platform_heap_handle heap_handle);
+
+void *
+platform_shm_next_free_addr_by_hh(platform_heap_handle heap_handle);
+
+/*
+ * Interfaces to retrieve size(s) using heap_id, which is what's
+ * known externally to memory allocation interfaces.
+ */
+size_t
+platform_shmsize(platform_heap_id heap_id);
+
+size_t
+platform_shmfree(platform_heap_id heap_id);
+
+size_t
+platform_shmused(platform_heap_id heap_id);
+
+void *
+platform_shm_next_free_addr(platform_heap_id heap_id);
+
+#endif // __PLATFORM_SHMEM_H__

--- a/src/platform_linux/shmem.h
+++ b/src/platform_linux/shmem.h
@@ -9,6 +9,11 @@
 
 typedef struct shmem_info shmem_info;
 
+// Extern references to boolean shmem-related globals
+extern bool Trace_shmem_allocs;
+extern bool Trace_shmem_frees;
+extern bool Trace_shmem;
+
 platform_status
 platform_shmcreate(size_t                size,
                    platform_heap_handle *heap_handle,
@@ -41,6 +46,27 @@ platform_shm_alignment()
 
 bool
 platform_shm_heap_handle_valid(platform_heap_handle heap_handle);
+
+void
+platform_shm_tracing_init();
+
+void
+platform_enable_tracing_shm_ops();
+
+void
+platform_enable_tracing_shm_allocs();
+
+void
+platform_enable_tracing_shm_frees();
+
+void
+platform_disable_tracing_shm_ops();
+
+void
+platform_disable_tracing_shm_allocs();
+
+void
+platform_disable_tracing_shm_frees();
 
 size_t
 platform_shm_ctrlblock_size();

--- a/src/routing_filter.c
+++ b/src/routing_filter.c
@@ -101,7 +101,12 @@ RadixSort(uint32 *pData,
       for (i = 0; i < count; i++) {
          u = pSrc[i];
          c = ((uint8 *)&u)[j + fpshift];
-         platform_assert(mIndex[j][c] < count);
+         platform_assert((mIndex[j][c] < count),
+                         " mIndex[j=%u][c=%d] = %u, count=%u\n",
+                         j,
+                         c,
+                         mIndex[j][c],
+                         count);
          pDst[mIndex[j][c]++] = u;
       }
       pTmp = pSrc;
@@ -396,11 +401,28 @@ routing_filter_add(cache           *cc,
                               ROUTING_FPS_PER_PAGE +      // old_fp_buffer
                               ROUTING_FPS_PER_PAGE / 32;  // encoding_buffer
    debug_assert(temp_buffer_count < 100000000);
-   uint32 *temp = TYPED_ARRAY_ZALLOC(hid, temp, temp_buffer_count);
+   uint32 *temp = TYPED_ARRAY_ZALLOC(NULL_HEAP_ID, temp, temp_buffer_count);
 
    if (temp == NULL) {
+      platform_error_log("%s(): Insufficient memory to allocate %lu bytes"
+                         " for temp buffer."
+                         " num_new_fp=%lu"
+                         ", num_indices=%u"
+                         ", index_size=%lu"
+                         ", MATRIX_ROWS=%lu, MATRIX_COLS=%d"
+                         ", ROUTING_FPS_PER_PAGE=%d\n",
+                         __FUNCTION__,
+                         (temp_buffer_count * sizeof(*temp)),
+                         num_new_fp,
+                         num_indices,
+                         index_size,
+                         MATRIX_ROWS,
+                         MATRIX_COLS,
+                         ROUTING_FPS_PER_PAGE);
+
       return STATUS_NO_MEMORY;
    }
+
    index_count     = temp + num_new_fp;
    old_count       = index_count + num_indices;
    matrix          = old_count + cfg->index_size;

--- a/src/splinterdb.c
+++ b/src/splinterdb.c
@@ -442,6 +442,18 @@ splinterdb_create_or_open(splinterdb_config *kvs_cfg,      // IN
             platform_status_to_string(status));
          goto deinit_kvhandle;
       }
+
+      // Setup global tracing booleans for shared memory usage
+      if (kvs_cfg->trace_shmem_allocs) {
+         Trace_shmem_allocs = TRUE;
+      }
+      if (kvs_cfg->trace_shmem_frees) {
+         Trace_shmem_frees = TRUE;
+      }
+      if (kvs_cfg->trace_shmem) {
+         Trace_shmem_allocs = TRUE;
+         Trace_shmem_frees  = TRUE;
+      }
    }
 
    platform_assert(kvs_out != NULL);

--- a/src/trunk.c
+++ b/src/trunk.c
@@ -3215,7 +3215,7 @@ trunk_memtable_compact_and_build_filter(trunk_handle  *spl,
    cmt->req->fp_arr = req.fingerprint_arr;
    cmt->req->type   = TRUNK_COMPACTION_TYPE_MEMTABLE;
    uint32 *dup_fp_arr =
-      TYPED_ARRAY_MALLOC(spl->heap_id, dup_fp_arr, req.num_tuples);
+      TYPED_ARRAY_MALLOC(NULL_HEAP_ID, dup_fp_arr, req.num_tuples);
    memmove(dup_fp_arr, cmt->req->fp_arr, req.num_tuples * sizeof(uint32));
    routing_filter empty_filter = {0};
 

--- a/src/trunk.c
+++ b/src/trunk.c
@@ -7042,7 +7042,7 @@ trunk_range(trunk_handle  *spl,
             tuple_function func,
             void          *arg)
 {
-   trunk_range_iterator *range_itor = TYPED_MALLOC(spl->heap_id, range_itor);
+   trunk_range_iterator *range_itor = TYPED_MALLOC(NULL_HEAP_ID, range_itor);
    platform_status       rc =
       trunk_range_iterator_init(spl, range_itor, start_key, NULL, num_tuples);
    if (!SUCCESS(rc)) {
@@ -7063,7 +7063,7 @@ trunk_range(trunk_handle  *spl,
 
 destroy_range_itor:
    trunk_range_iterator_deinit(range_itor);
-   platform_free(spl->heap_id, range_itor);
+   platform_free(NULL_HEAP_ID, range_itor);
    return rc;
 }
 

--- a/src/trunk.h
+++ b/src/trunk.h
@@ -20,6 +20,7 @@
 #include "allocator.h"
 #include "log.h"
 #include "srq.h"
+#include "shmem.h"
 
 /*
  * Max height of the Trunk Tree; Limited for convenience to allow for static

--- a/src/util.h
+++ b/src/util.h
@@ -119,6 +119,7 @@ slice_lex_cmp(const slice a, const slice b)
  * When initializing a writable_buffer, you can provide an initial
  * buffer for it to use.  The writable_buffer will _never_ free the
  * buffer you give it during initialization.
+ * ----------------------------------------------------------------------
  */
 typedef struct writable_buffer {
    platform_heap_id heap_id;

--- a/test.sh
+++ b/test.sh
@@ -84,7 +84,7 @@ function record_elapsed_time() {
       # Provide wider test-tag for nightly tests which print verbose descriptions
       fmtstr="%-80s""${fmtstr}"
    else
-      fmtstr="%-50s""${fmtstr}"
+      fmtstr="%-60s""${fmtstr}"
    fi
 
    # Log a line in the /tmp log-file; for future cat of summary output
@@ -519,14 +519,16 @@ function test_example_programs() {
 
 # ##################################################################
 # Smoke Tests: Run a small collection of fast-running unit-tests
+# This can be invoked w/ or w/o "--use-shmem" arg.
 # ##################################################################
 function run_fast_unit_tests() {
-   "$BINDIR"/unit/splinterdb_quick_test
-   "$BINDIR"/unit/btree_test
-   "$BINDIR"/unit/util_test
-   "$BINDIR"/unit/misc_test
-   "$BINDIR"/unit/limitations_test
-   "$BINDIR"/unit/task_system_test
+   local use_shmem=$1
+
+   "$BINDIR"/unit/splinterdb_quick_test "$use_shmem"
+   "$BINDIR"/unit/btree_test "$use_shmem"
+   "$BINDIR"/unit/util_test "$use_shmem"
+   "$BINDIR"/unit/misc_test "$use_shmem"
+   "$BINDIR"/unit/limitations_test "$use_shmem"
 }
 
 # ##################################################################
@@ -534,17 +536,34 @@ function run_fast_unit_tests() {
 # Explicitly run individual cases from specific slow running unit-tests,
 # where appropriate with a different test-configuration that has been
 # found to to provide the required coverage.
+# Execute this set w/ and w/o "--use-shmem" arg.
 # ##################################################################
 function run_slower_unit_tests() {
+    local use_shmem=$1
 
-    run_with_timing "Splinter inserts test" "$BINDIR"/unit/splinter_test test_inserts
+    local use_msg=
+    if [ "$use_shmem" != "" ]; then
+        use_msg="using shared memory"
+   fi
+
+    local msg="Splinter inserts test ${use_msg}"
+
+    # Allow $use_shmem to come w/o quotes. Otherwise for default execution, we
+    # end up with empty '' parameter, which causes the argument parsing routine
+    # in the program to cough-up an error.
+    # shellcheck disable=SC2086
+    run_with_timing "${msg}" "$BINDIR"/unit/splinter_test ${use_shmem} test_inserts
 
     # Use fewer rows for this case, to keep elapsed times of MSAN runs reasonable.
-    run_with_timing "Splinter lookups test" \
-        "$BINDIR"/unit/splinter_test --num-inserts 2000000 test_lookups
+    msg="Splinter lookups test ${use_msg}"
+    # shellcheck disable=SC2086
+    run_with_timing "${msg}" \
+        "$BINDIR"/unit/splinter_test ${use_shmem} --num-inserts 2000000 test_lookups
 
-    run_with_timing "Splinter print diagnostics test" \
-        "$BINDIR"/unit/splinter_test test_splinter_print_diags
+    msg="Splinter print diagnostics test ${use_msg}"
+    # shellcheck disable=SC2086
+    run_with_timing "${msg}" \
+        "$BINDIR"/unit/splinter_test ${use_shmem} test_splinter_print_diags
 }
 
 # ##################################################################
@@ -708,7 +727,8 @@ if [ "$INCLUDE_SLOW_TESTS" != "true" ]; then
 
    start_seconds=$SECONDS
 
-   run_with_timing "Smoke tests" run_fast_unit_tests
+   run_with_timing "Smoke tests" run_fast_unit_tests ""
+   run_with_timing "Smoke tests using shared memory" run_fast_unit_tests "--use-shmem"
 
    run_with_timing "Test example programs" test_example_programs
 
@@ -728,20 +748,32 @@ run_with_timing "Fast unit tests" "$BINDIR"/unit_test
 # ------------------------------------------------------------------------
 # Run mini-unit-tests that were excluded from bin/unit_test binary:
 # ------------------------------------------------------------------------
-run_slower_unit_tests
+run_slower_unit_tests ""
 
 UNIT_TESTS_DB_DEV="unit_tests_db"
-if [ -f ${UNIT_TESTS_DB_DEV} ]; then
-    rm ${UNIT_TESTS_DB_DEV}
-fi
+if [ -f ${UNIT_TESTS_DB_DEV} ]; then rm ${UNIT_TESTS_DB_DEV}; fi
 
-run_splinter_functionality_tests
+if false; then # Skip this set of tests ... for now.
 
-run_splinter_perf_tests
+   run_splinter_functionality_tests
 
-run_btree_tests
+   run_splinter_perf_tests
 
-run_other_driver_tests
+   run_btree_tests
+
+   run_other_driver_tests
+
+fi #end if false;
+
+# ------------------------------------------------------------------------
+# Re-run a collection of tests using shared-memory. Currently, not every
+# test works cleanly in this mode, so we will incrementally online stuff.
+# ------------------------------------------------------------------------
+# Run all the unit-tests first, to get basic coverage of shared-memory support.
+run_with_timing "Fast unit tests using shared memory" "$BINDIR"/unit_test "--use-shmem"
+
+run_slower_unit_tests "--use-shmem"
+if [ -f ${UNIT_TESTS_DB_DEV} ]; then rm ${UNIT_TESTS_DB_DEV}; fi
 
 record_elapsed_time ${testRunStartSeconds} "All Tests"
 echo ALL PASSED

--- a/tests/config.c
+++ b/tests/config.c
@@ -61,6 +61,7 @@ config_set_defaults(master_config *cfg)
       .reclaim_threshold        = UINT64_MAX,
       .verbose_logging_enabled  = FALSE,
       .verbose_progress         = FALSE,
+	  .use_shmem				= FALSE,
       .log_handle               = NULL,
       .key_size                 = TEST_CONFIG_DEFAULT_KEY_SIZE,
       .message_size             = TEST_CONFIG_DEFAULT_MESSAGE_SIZE,
@@ -112,6 +113,7 @@ config_usage()
    platform_error_log("\t--verbose-logging\n");
    platform_error_log("\t--no-verbose-logging\n");
    platform_error_log("\t--verbose-progress\n");
+   platform_error_log("\t--use-shmem\n");
    platform_error_log("\t--key-size (%d)\n", TEST_CONFIG_DEFAULT_KEY_SIZE);
    platform_error_log("\t--data-size (%d)\n", TEST_CONFIG_DEFAULT_MESSAGE_SIZE);
    platform_error_log("\t--num-inserts (%d)\n",
@@ -267,6 +269,12 @@ config_parse(master_config *cfg, const uint8 num_config, int argc, char *argv[])
          {
             for (uint8 cfg_idx = 0; cfg_idx < num_config; cfg_idx++) {
                cfg[cfg_idx].verbose_progress = TRUE;
+            }
+         }
+         config_has_option("use-shmem")
+         {
+            for (uint8 cfg_idx = 0; cfg_idx < num_config; cfg_idx++) {
+               cfg[cfg_idx].use_shmem = TRUE;
             }
          }
 

--- a/tests/config.c
+++ b/tests/config.c
@@ -113,7 +113,11 @@ config_usage()
    platform_error_log("\t--verbose-logging\n");
    platform_error_log("\t--no-verbose-logging\n");
    platform_error_log("\t--verbose-progress\n");
-   platform_error_log("\t--use-shmem\n");
+
+   // clang-format off
+   platform_error_log("\t--use-shmem [ --trace-shmem | --trace-shmem-allocs | --trace-shmem-frees ]\n");
+   // // clang-format on
+
    platform_error_log("\t--key-size (%d)\n", TEST_CONFIG_DEFAULT_KEY_SIZE);
    platform_error_log("\t--data-size (%d)\n", TEST_CONFIG_DEFAULT_MESSAGE_SIZE);
    platform_error_log("\t--num-inserts (%d)\n",
@@ -275,6 +279,26 @@ config_parse(master_config *cfg, const uint8 num_config, int argc, char *argv[])
          {
             for (uint8 cfg_idx = 0; cfg_idx < num_config; cfg_idx++) {
                cfg[cfg_idx].use_shmem = TRUE;
+            }
+         }
+         config_has_option("trace-shmem-allocs")
+         {
+            for (uint8 cfg_idx = 0; cfg_idx < num_config; cfg_idx++) {
+               cfg[cfg_idx].trace_shmem_allocs = TRUE;
+            }
+         }
+         config_has_option("trace-shmem-frees")
+         {
+            for (uint8 cfg_idx = 0; cfg_idx < num_config; cfg_idx++) {
+               cfg[cfg_idx].trace_shmem_frees = TRUE;
+            }
+         }
+         config_has_option("trace-shmem")
+         {
+            // Trace both allocations & frees from shared memory segment.
+            for (uint8 cfg_idx = 0; cfg_idx < num_config; cfg_idx++) {
+               cfg[cfg_idx].trace_shmem_allocs = TRUE;
+               cfg[cfg_idx].trace_shmem_frees  = TRUE;
             }
          }
 

--- a/tests/config.h
+++ b/tests/config.h
@@ -72,14 +72,20 @@ typedef struct master_config {
    bool use_log;
 
    // splinter
-   uint64               memtable_capacity;
-   uint64               fanout;
-   uint64               max_branches_per_node;
-   uint64               use_stats;
-   uint64               reclaim_threshold;
-   bool                 verbose_logging_enabled;
-   bool                 verbose_progress;
-   bool                 use_shmem;
+   uint64 memtable_capacity;
+   uint64 fanout;
+   uint64 max_branches_per_node;
+   uint64 use_stats;
+   uint64 reclaim_threshold;
+   bool   verbose_logging_enabled;
+   bool   verbose_progress;
+
+   // Shared memory suppot
+   bool use_shmem; // Memory allocation done from shared segment
+   bool trace_shmem_allocs;
+   bool trace_shmem_frees;
+   bool trace_shmem; // Trace both allocs & frees from shared memory
+
    platform_log_handle *log_handle;
 
    // data

--- a/tests/config.h
+++ b/tests/config.h
@@ -79,6 +79,7 @@ typedef struct master_config {
    uint64               reclaim_threshold;
    bool                 verbose_logging_enabled;
    bool                 verbose_progress;
+   bool                 use_shmem;
    platform_log_handle *log_handle;
 
    // data

--- a/tests/functional/btree_test.c
+++ b/tests/functional/btree_test.c
@@ -1543,7 +1543,8 @@ btree_test(int argc, char *argv[])
    // Create a heap for io, allocator, cache and splinter
    platform_heap_handle hh;
    platform_heap_id     hid;
-   rc = platform_heap_create(platform_get_module_id(), 1 * GiB, &hh, &hid);
+   rc =
+      platform_heap_create(platform_get_module_id(), 1 * GiB, FALSE, &hh, &hid);
    platform_assert_status_ok(rc);
 
    data_config  *data_cfg;

--- a/tests/functional/cache_test.c
+++ b/tests/functional/cache_test.c
@@ -991,7 +991,8 @@ cache_test(int argc, char *argv[])
    // Create a heap for io, allocator, cache and splinter
    platform_heap_handle hh;
    platform_heap_id     hid;
-   rc = platform_heap_create(platform_get_module_id(), 1 * GiB, &hh, &hid);
+   rc =
+      platform_heap_create(platform_get_module_id(), 1 * GiB, FALSE, &hh, &hid);
    platform_assert_status_ok(rc);
 
    trunk_config *splinter_cfg = TYPED_MALLOC(hid, splinter_cfg);

--- a/tests/functional/filter_test.c
+++ b/tests/functional/filter_test.c
@@ -318,7 +318,8 @@ filter_test(int argc, char *argv[])
    // Create a heap for io, allocator, cache and splinter
    platform_heap_handle hh;
    platform_heap_id     hid;
-   rc = platform_heap_create(platform_get_module_id(), 1 * GiB, &hh, &hid);
+   rc =
+      platform_heap_create(platform_get_module_id(), 1 * GiB, FALSE, &hh, &hid);
    platform_assert_status_ok(rc);
 
    trunk_config *cfg = TYPED_MALLOC(hid, cfg);

--- a/tests/functional/log_test.c
+++ b/tests/functional/log_test.c
@@ -255,7 +255,8 @@ log_test(int argc, char *argv[])
    // Create a heap for io, allocator, cache and splinter
    platform_heap_handle hh;
    platform_heap_id     hid;
-   status = platform_heap_create(platform_get_module_id(), 1 * GiB, &hh, &hid);
+   status =
+      platform_heap_create(platform_get_module_id(), 1 * GiB, FALSE, &hh, &hid);
    platform_assert_status_ok(status);
 
    trunk_config *cfg = TYPED_MALLOC(hid, cfg);

--- a/tests/functional/splinter_test.c
+++ b/tests/functional/splinter_test.c
@@ -2490,6 +2490,7 @@ splinter_test(int argc, char *argv[])
    uint32 num_pthreads    = 0;
    uint8  num_tables      = 1;
    bool   cache_per_table = FALSE;
+   bool   use_shmem       = FALSE;
    // no bg threads by default.
    uint8                  num_bg_threads[NUM_TASK_TYPES] = {0};
    uint64                 insert_rate = 0; // no rate throttling by default.
@@ -2502,8 +2503,13 @@ splinter_test(int argc, char *argv[])
    // Defaults
    num_insert_threads = num_lookup_threads = num_range_lookup_threads = 1;
    max_async_inflight                                                 = 64;
+
    /*
-    * 1. Parse splinter_test options, see usage()
+    * 1. Parse splinter_test options to determine which type of test
+    *    is to be run. Code below will setup some defaults for parameters
+    *    that are applicable for a test type. These params can be further
+    *    over-ridden by extra args which will be parsed in the next block
+    *    below. See usage() for more details.
     */
    if (argc > 1 && strncmp(argv[1], "--help", sizeof("--help")) == 0) {
       usage(argv[0]);
@@ -2575,6 +2581,11 @@ splinter_test(int argc, char *argv[])
       config_argc = argc - 1;
       config_argv = argv + 1;
    }
+
+   /*
+    * IF there are any more arguments remaining, parse them in sequence.
+    * This set of args are expected to come in exactly this order.
+    */
    if (config_argc > 0
        && strncmp(config_argv[0], "--num-tables", sizeof("--num-tables")) == 0)
    {
@@ -2625,6 +2636,15 @@ splinter_test(int argc, char *argv[])
       config_argc -= 2;
       config_argv += 2;
    }
+   if (config_argc > 0
+       && strncmp(config_argv[0], "--use-shmem", sizeof("--use-shmem")) == 0)
+   {
+      use_shmem = TRUE;
+      config_argc -= 1;
+      config_argv += 1;
+   }
+
+
    if (splinter_test_parse_perf_args(&config_argv,
                                      &config_argc,
                                      &max_async_inflight,
@@ -2665,13 +2685,18 @@ splinter_test(int argc, char *argv[])
    uint8  num_caches    = cache_per_table ? num_tables : 1;
    uint64 heap_capacity = MAX(1024 * MiB * num_caches, 512 * MiB * num_tables);
    heap_capacity        = MIN(heap_capacity, UINT32_MAX);
-   heap_capacity        = MAX(heap_capacity, 2 * GiB);
+   heap_capacity        = MAX(heap_capacity, 8 * GiB);
+   if (use_shmem) {
+      platform_default_log(
+         "Attempt to create shared segment of size %lu bytes.\n",
+         heap_capacity);
+   }
 
    // Create a heap for io, allocator, cache and splinter
-   platform_heap_handle hh;
-   platform_heap_id     hid;
-   rc =
-      platform_heap_create(platform_get_module_id(), heap_capacity, &hh, &hid);
+   platform_heap_handle hh  = NULL;
+   platform_heap_id     hid = NULL;
+   rc                       = platform_heap_create(
+      platform_get_module_id(), heap_capacity, use_shmem, &hh, &hid);
    platform_assert_status_ok(rc);
 
    /*

--- a/tests/functional/test.h
+++ b/tests/functional/test.h
@@ -302,6 +302,7 @@ test_parse_args_n(trunk_config           *splinter_cfg,  // OUT
       config_set_defaults(&master_cfg[i]);
    }
 
+   // Parse config-related command-line arguments
    rc = config_parse(master_cfg, num_config, argc, argv);
    if (!SUCCESS(rc)) {
       return rc;
@@ -317,6 +318,14 @@ test_parse_args_n(trunk_config           *splinter_cfg,  // OUT
                        gen,
                        &master_cfg[i]);
    }
+
+   // Setup tracing of shared-memory mgmt, if so requested
+   for (i = 0; i < num_config; i++) {
+      platform_shm_tracing_init(master_cfg[i].trace_shmem,
+                                master_cfg[i].trace_shmem_allocs,
+                                master_cfg[i].trace_shmem_frees);
+   }
+
 
    // All the n-SplinterDB instances will work with the same set of
    // test execution parameters.

--- a/tests/functional/ycsb_test.c
+++ b/tests/functional/ycsb_test.c
@@ -1179,7 +1179,8 @@ ycsb_test(int argc, char *argv[])
    // Create a heap for io, allocator, cache and splinter
    platform_heap_handle hh;
    platform_heap_id     hid;
-   rc = platform_heap_create(platform_get_module_id(), 1 * GiB, &hh, &hid);
+   rc =
+      platform_heap_create(platform_get_module_id(), 1 * GiB, FALSE, &hh, &hid);
    platform_assert_status_ok(rc);
 
    data_config  *data_cfg;

--- a/tests/test_data.c
+++ b/tests/test_data.c
@@ -88,7 +88,10 @@ test_data_merge_tuples_final(const data_config *cfg,
                              merge_accumulator *oldest_raw_data) // IN/OUT
 {
    platform_assert(merge_accumulator_message_class(oldest_raw_data)
-                   == MESSAGE_TYPE_UPDATE);
+                      == MESSAGE_TYPE_UPDATE,
+                   "message_class=%d",
+                   merge_accumulator_message_class(oldest_raw_data));
+
    assert(sizeof(data_handle) <= merge_accumulator_length(oldest_raw_data));
 
    data_handle *old_data = merge_accumulator_data(oldest_raw_data);

--- a/tests/test_misc_common.h
+++ b/tests/test_misc_common.h
@@ -1,0 +1,33 @@
+// Copyright 2023 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+ * -----------------------------------------------------------------------------
+ * test_misc_common.h --
+ *
+ * Header file with shared prototypes and definitions for miscellaneous
+ * functions that are shared between functional/ and unit/ test sources.
+ * This interface is provided so that stand-alone unit-tests that need these
+ * routines can be built w/o having to link-in all of SplinterDB.
+ *
+ * NOTE: Right now, we don't see a need for a .c file, which will require
+ *       listing that object in the Makefile for every unit-test that needs to
+ *       use these helper methods.
+ * -----------------------------------------------------------------------------
+ */
+#ifndef __TEST_MISC_COMMON_H__
+#define __TEST_MISC_COMMON_H__
+
+#include "util.h" // For STRING_EQUALS_LITERAL()
+
+/*
+ * Check if the user has supplied very 1st arg as "--use-shmem", which will
+ * run the test(s) using shared memory segment setup & allocation.
+ */
+static inline bool
+test_using_shmem(int argc, char *argv[])
+{
+   return (argc && (STRING_EQUALS_LITERAL(argv[0], "--use-shmem")));
+}
+
+#endif /* __TEST_MISC_COMMON_H__ */

--- a/tests/unit/btree_stress_test.c
+++ b/tests/unit/btree_stress_test.c
@@ -25,6 +25,7 @@
 #include "clockcache.h"
 #include "btree_private.h"
 #include "btree_test_common.h"
+#include "test_misc_common.h"
 
 typedef struct insert_thread_params {
    cache           *cc;
@@ -115,7 +116,11 @@ CTEST_DATA(btree_stress)
 // Setup function for suite, called before every test in suite
 CTEST_SETUP(btree_stress)
 {
+   Platform_default_log_handle = fopen("/tmp/unit_test.stdout", "a+");
+   Platform_error_log_handle   = fopen("/tmp/unit_test.stderr", "a+");
+
    config_set_defaults(&data->master_cfg);
+
    data->master_cfg.cache_capacity = GiB_TO_B(5);
    data->data_cfg                  = test_data_config;
 
@@ -136,9 +141,11 @@ CTEST_SETUP(btree_stress)
       ASSERT_TRUE(FALSE, "Failed to parse args\n");
    }
 
+   bool use_shmem = test_using_shmem(Ctest_argc, (char **)Ctest_argv);
+
    // Create a heap for io, allocator, cache and splinter
    if (!SUCCESS(platform_heap_create(
-          platform_get_module_id(), 1 * GiB, &data->hh, &data->hid)))
+          platform_get_module_id(), 1 * GiB, use_shmem, &data->hh, &data->hid)))
    {
       ASSERT_TRUE(FALSE, "Failed to init heap\n");
    }
@@ -174,7 +181,10 @@ CTEST_SETUP(btree_stress)
 }
 
 // Optional teardown function for suite, called after every test in suite
-CTEST_TEARDOWN(btree_stress) {}
+CTEST_TEARDOWN(btree_stress)
+{
+   platform_heap_destroy(&data->hh);
+}
 
 /*
  * -------------------------------------------------------------------------
@@ -193,7 +203,7 @@ CTEST2(btree_stress, test_random_inserts_concurrent)
    uint64 root_addr = btree_create(
       (cache *)&data->cc, &data->dbtree_cfg, &mini, PAGE_TYPE_MEMTABLE);
 
-   platform_heap_id      hid     = platform_get_heap_id();
+   platform_heap_id      hid     = data->hid;
    insert_thread_params *params  = TYPED_ARRAY_ZALLOC(hid, params, nthreads);
    platform_thread      *threads = TYPED_ARRAY_ZALLOC(hid, threads, nthreads);
 

--- a/tests/unit/btree_test.c
+++ b/tests/unit/btree_test.c
@@ -20,6 +20,7 @@
 #include "clockcache.h"
 #include "btree_private.h"
 #include "btree_test_common.h"
+#include "test_misc_common.h"
 
 // Function Prototypes
 
@@ -62,22 +63,37 @@ btree_leaf_incorporate_tuple(const btree_config    *cfg,
  */
 CTEST_DATA(btree)
 {
-   master_config       master_cfg;
-   data_config        *data_cfg;
-   io_config           io_cfg;
-   rc_allocator_config allocator_cfg;
-   clockcache_config   cache_cfg;
-   btree_scratch       test_scratch;
-   btree_config        dbtree_cfg;
-   platform_heap_id    hid;
+   master_config        master_cfg;
+   data_config         *data_cfg;
+   io_config            io_cfg;
+   rc_allocator_config  allocator_cfg;
+   clockcache_config    cache_cfg;
+   btree_scratch        test_scratch;
+   btree_config         dbtree_cfg;
+   platform_heap_id     hid;
+   platform_heap_handle hh;
 };
 
 // Optional setup function for suite, called before every test in suite
 CTEST_SETUP(btree)
 {
+   Platform_default_log_handle = fopen("/tmp/unit_test.stdout", "a+");
+   Platform_error_log_handle   = fopen("/tmp/unit_test.stderr", "a+");
+
    config_set_defaults(&data->master_cfg);
+
+   uint64 heap_capacity = (1 * GiB);
+   bool   use_shmem     = test_using_shmem(Ctest_argc, (char **)Ctest_argv);
+
+   // Create a heap for io, allocator, cache and splinter
+   platform_status rc = platform_heap_create(platform_get_module_id(),
+                                             heap_capacity,
+                                             use_shmem,
+                                             &data->hh,
+                                             &data->hid);
+   platform_assert_status_ok(rc);
+
    data->data_cfg = test_data_config;
-   data->hid      = platform_get_heap_id();
 
    if (!SUCCESS(
           config_parse(&data->master_cfg, 1, Ctest_argc, (char **)Ctest_argv))
@@ -98,7 +114,10 @@ CTEST_SETUP(btree)
 }
 
 // Optional teardown function for suite, called after every test in suite
-CTEST_TEARDOWN(btree) {}
+CTEST_TEARDOWN(btree)
+{
+   platform_heap_destroy(&data->hh);
+}
 
 /*
  * Test leaf_hdr APIs.
@@ -413,6 +432,15 @@ leaf_split_tests(btree_config    *cfg,
 
       slice key = slice_create(1, &i);
 
+      /*
+       * RESOLVE: This usage of 'scratch' space buffer passed-down as
+       * heap-ID ptr is problematic when this test is run w/o --use-shmem.
+       * Way deep down, writable buffer code will use this as heap_id and
+       * will allocate buffer. Then, we end up going to free this via
+       * platform_shm_free(), which currently only does a msg print.
+       * If we try to 'implement' this free using free-list mgmt, it will
+       * become a problem.
+       */
       bool success = btree_leaf_incorporate_tuple(
          cfg, scratch, hdr, key, bigger_msg, &spec, &generation);
       if (success) {

--- a/tests/unit/config_parse_test.c
+++ b/tests/unit/config_parse_test.c
@@ -47,7 +47,7 @@ CTEST_SETUP(config_parse)
    uint64 heap_capacity = (1024 * MiB);
    // Create a heap for io, allocator, cache and splinter
    platform_status rc = platform_heap_create(
-      platform_get_module_id(), heap_capacity, &data->hh, &data->hid);
+      platform_get_module_id(), heap_capacity, FALSE, &data->hh, &data->hid);
    platform_assert_status_ok(rc);
 
    ZERO_STRUCT(data->test_exec_cfg);

--- a/tests/unit/limitations_test.c
+++ b/tests/unit/limitations_test.c
@@ -20,6 +20,7 @@
 #include "functional/test_async.h"
 #include "splinterdb/splinterdb.h"
 #include "splinterdb/default_data_config.h"
+#include "test_misc_common.h"
 #include "unit_tests.h"
 #include "ctest.h" // This is required for all test-case files.
 
@@ -77,9 +78,12 @@ CTEST_SETUP(limitations)
 
    uint64 heap_capacity = (1 * GiB);
 
+   bool use_shmem = test_using_shmem(Ctest_argc, (char **)Ctest_argv);
+
    // Create a heap for io, allocator, cache and splinter
    platform_status rc = platform_heap_create(platform_get_module_id(),
                                              heap_capacity,
+                                             use_shmem,
                                              &data->hh,
                                              &data->hid);
    platform_assert_status_ok(rc);
@@ -485,7 +489,7 @@ CTEST2(limitations, test_zero_cache_size)
 
 /*
  * Helper routine to create a valid Splinter configuration using default
- * page- and extent-size.
+ * page- and extent-size. Shared-memory usage is OFF by default.
  */
 static void
 create_default_cfg(splinterdb_config *out_cfg, data_config *default_data_cfg)
@@ -496,6 +500,7 @@ create_default_cfg(splinterdb_config *out_cfg, data_config *default_data_cfg)
                           .disk_size   = 127 * Mega,
                           .page_size   = TEST_CONFIG_DEFAULT_PAGE_SIZE,
                           .extent_size = TEST_CONFIG_DEFAULT_EXTENT_SIZE,
+                          .use_shmem   = FALSE,
                           .data_cfg    = default_data_cfg};
 }
 

--- a/tests/unit/main.c
+++ b/tests/unit/main.c
@@ -22,6 +22,7 @@
 
 #include "util.h"
 #include "ctest.h"
+#include "test_misc_common.h"
 
 #define MSG_SIZE 4096
 
@@ -268,8 +269,11 @@ ctest_main(int argc, const char *argv[])
    if (!suite_name && (num_suites == 1)) {
       suite_name = curr_suite_name;
    }
-   printf("Running %d CTests, suite name '%s', test case '%s'.\n",
+   // Utility fn expects to see "--use-shmem" as the 1st arg.
+   bool use_shmem = (argc > 1) && test_using_shmem(argc, (char **)(argv + 1));
+   printf("Running %d CTests%s, suite name '%s', test case '%s'.\n",
           num_suites,
+          (use_shmem ? " using shared memory" : ""),
           (suite_name ? suite_name : "all"),
           (testcase_name ? testcase_name : "all"));
 

--- a/tests/unit/splinter_ipc_test.c
+++ b/tests/unit/splinter_ipc_test.c
@@ -1,0 +1,32 @@
+// Copyright 2021 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+ * -----------------------------------------------------------------------------
+ * splinter_ipc_test.c --
+ *
+ * This is a correctness test to validate that inserts performed by one
+ * thread are "seen" correctly by a concurrently running thread. This test:q
+ *  Exercises the interfaces in splinter_shmem.c.
+ *  This is just a template file. Fill it out for your specific test suite.
+ * -----------------------------------------------------------------------------
+ */
+#include "splinterdb/public_platform.h"
+#include "unit_tests.h"
+#include "ctest.h" // This is required for all test-case files.
+
+/*
+ * Global data declaration macro:
+ */
+CTEST_DATA(splinter_ipc){};
+
+// Optional setup function for suite, called before every test in suite
+CTEST_SETUP(splinter_ipc) {}
+
+// Optional teardown function for suite, called after every test in suite
+CTEST_TEARDOWN(splinter_ipc) {}
+
+/*
+ * Basic test case.
+ */
+CTEST2(splinter_ipc, test_basic_flow) {}

--- a/tests/unit/splinter_shmem_test.c
+++ b/tests/unit/splinter_shmem_test.c
@@ -35,6 +35,9 @@ CTEST_SETUP(splinter_shmem)
                                              &data->hh,
                                              &data->hid);
    ASSERT_TRUE(SUCCESS(rc));
+
+   // Enable tracing all allocs / frees from shmem for this test.
+   platform_enable_tracing_shm_ops();
 }
 
 // Tear down the test shared segment.

--- a/tests/unit/splinter_shmem_test.c
+++ b/tests/unit/splinter_shmem_test.c
@@ -1,0 +1,170 @@
+// Copyright 2021 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+ * -----------------------------------------------------------------------------
+ * splinter_shmem_test.c --
+ *
+ *  Exercises the interfaces in SplinterDB shared memory allocation module.
+ * -----------------------------------------------------------------------------
+ */
+#include "splinterdb/public_platform.h"
+#include "platform.h"
+#include "unit_tests.h"
+#include "ctest.h" // This is required for all test-case files.
+#include "shmem.h"
+
+/*
+ * Global data declaration macro:
+ */
+CTEST_DATA(splinter_shmem)
+{
+   // Declare heap handles to shake out shared memory based allocation.
+   size_t               shmem_capacity; // In bytes
+   platform_heap_handle hh;
+   platform_heap_id     hid;
+};
+
+// By default, all test cases will deal with small shared memory segment.
+CTEST_SETUP(splinter_shmem)
+{
+   data->shmem_capacity = (256 * MiB); // bytes
+   platform_status rc   = platform_heap_create(platform_get_module_id(),
+                                             data->shmem_capacity,
+                                             TRUE,
+                                             &data->hh,
+                                             &data->hid);
+   ASSERT_TRUE(SUCCESS(rc));
+}
+
+// Tear down the test shared segment.
+CTEST_TEARDOWN(splinter_shmem)
+{
+   platform_heap_destroy(&data->hh);
+}
+
+/*
+ * Basic test case. This goes through the basic create / destroy
+ * interfaces to setup a shared memory segment. While at it, run through
+ * few lookup interfaces to validate sizes.
+ */
+CTEST2(splinter_shmem, test_create_destroy_shmem)
+{
+   platform_heap_handle hh            = NULL;
+   platform_heap_id     hid           = NULL;
+   size_t               requested     = (512 * MiB); // bytes
+   size_t               heap_capacity = requested;
+   platform_status      rc            = platform_heap_create(
+      platform_get_module_id(), heap_capacity, TRUE, &hh, &hid);
+   ASSERT_TRUE(SUCCESS(rc));
+
+   // Total size of shared segment must be what requested for.
+   ASSERT_EQUAL(platform_shmsize(hid), requested);
+
+   // A small chunk at the head is used for shmem_info{} tracking struct
+   ASSERT_EQUAL(platform_shmfree(hid),
+                (requested - platform_shm_ctrlblock_size()));
+
+   // Destroy shared memory and release memory.
+   platform_shmdestroy(&hh);
+   ASSERT_TRUE(hh == NULL);
+}
+
+/*
+ * Test that used space and pad-bytes tracking is happening correctly
+ * when all allocation requests are fully aligned. No pad bytes should
+ * have been generated for alignment.
+ */
+CTEST2(splinter_shmem, test_aligned_allocations)
+{
+   int keybuf_size = 64;
+   int msgbuf_size = (2 * keybuf_size);
+
+   // Self-documenting assertion ... to future-proof this area.
+   ASSERT_EQUAL(keybuf_size, PLATFORM_CACHELINE_SIZE);
+
+   void  *next_free = platform_shm_next_free_addr(data->hid);
+   uint8 *keybuf    = TYPED_MANUAL_MALLOC(data->hid, keybuf, keybuf_size);
+
+   // Validate returned memory-ptrs, knowing that no pad bytes were needed.
+   ASSERT_TRUE((void *)keybuf == next_free);
+
+   next_free     = platform_shm_next_free_addr(data->hid);
+   uint8 *msgbuf = TYPED_MANUAL_MALLOC(data->hid, msgbuf, msgbuf_size);
+   ASSERT_TRUE((void *)msgbuf == next_free);
+
+   // Sum of requested alloc-sizes == total # of used-bytes
+   ASSERT_EQUAL((keybuf_size + msgbuf_size), platform_shmused(data->hid));
+
+   // Free bytes left in shared segment == (sum of requested alloc sizes, less
+   // a small bit of the control block.)
+   ASSERT_EQUAL((data->shmem_capacity
+                 - (keybuf_size + msgbuf_size + platform_shm_ctrlblock_size())),
+                platform_shmfree(data->hid));
+}
+
+/*
+ * Test that used space and pad-bytes tracking is happening correctly
+ * when some allocation requests are not-fully aligned. Test verifies the
+ * tracking and computation of pad-bytes, free/used space.
+ */
+CTEST2(splinter_shmem, test_unaligned_allocations)
+{
+   void  *next_free   = platform_shm_next_free_addr(data->hid);
+   int    keybuf_size = 42;
+   uint8 *keybuf      = TYPED_MANUAL_MALLOC(data->hid, keybuf, keybuf_size);
+
+   int keybuf_pad = platform_alignment(PLATFORM_CACHELINE_SIZE, keybuf_size);
+
+   // Sum of requested allocation + pad-bytes == total # of used-bytes
+   ASSERT_EQUAL((keybuf_size + keybuf_pad), platform_shmused(data->hid));
+
+   ASSERT_TRUE((void *)keybuf == next_free);
+
+   // Validate returned memory-ptrs, knowing that pad bytes were needed.
+   next_free = platform_shm_next_free_addr(data->hid);
+   ASSERT_TRUE(next_free == (void *)keybuf + keybuf_size + keybuf_pad);
+
+   int    msgbuf_size = 100;
+   int    msgbuf_pad = platform_alignment(PLATFORM_CACHELINE_SIZE, msgbuf_size);
+   uint8 *msgbuf     = TYPED_MANUAL_MALLOC(data->hid, msgbuf, msgbuf_size);
+
+   // Next allocation will abut prev-allocation + pad-bytes
+   ASSERT_TRUE((void *)msgbuf == (void *)keybuf + keybuf_size + keybuf_pad);
+
+   // Sum of requested allocation + pad-bytes == total # of used-bytes
+   ASSERT_EQUAL((keybuf_size + keybuf_pad + msgbuf_size + msgbuf_pad),
+                platform_shmused(data->hid));
+
+   // After accounting for the control block, next-free-addr should be
+   // exactly past the 2 allocations + their pad-bytes.
+   next_free = platform_shm_next_free_addr(data->hid);
+   ASSERT_TRUE(next_free
+               == ((void *)data->hh + platform_shm_ctrlblock_size()
+                   + keybuf_size + keybuf_pad + msgbuf_size + msgbuf_pad));
+}
+
+/*
+ * Currently 'free' is a no-op; no space is released. Do minimal testing of
+ * this feature, to ensure that at least the code flow is exectuing correctly.
+ */
+CTEST2(splinter_shmem, test_free)
+{
+   int    keybuf_size = 64;
+   uint8 *keybuf      = TYPED_MANUAL_MALLOC(data->hid, keybuf, keybuf_size);
+
+   int    msgbuf_size = (2 * keybuf_size);
+   uint8 *msgbuf      = TYPED_MANUAL_MALLOC(data->hid, msgbuf, msgbuf_size);
+
+   size_t mem_used = platform_shmused(data->hid);
+
+   void *next_free = platform_shm_next_free_addr(data->hid);
+
+   platform_free(data->hid, keybuf);
+
+   // Even though we freed some memory, the next addr-to-allocate is unchanged.
+   ASSERT_TRUE(next_free == platform_shm_next_free_addr(data->hid));
+
+   // Space used remains unchanged, as free didn't quite return any memory
+   ASSERT_EQUAL(mem_used, platform_shmused(data->hid));
+}

--- a/tests/unit/splinter_test.c
+++ b/tests/unit/splinter_test.c
@@ -26,6 +26,7 @@
 #include "functional/test.h"
 #include "functional/test_async.h"
 #include "test_common.h"
+#include "test_misc_common.h"
 #include "unit_tests.h"
 #include "ctest.h" // This is required for all test-case files.
 
@@ -127,9 +128,15 @@ CTEST_SETUP(splinter)
    heap_capacity        = MIN(heap_capacity, UINT32_MAX);
    heap_capacity        = MAX(heap_capacity, 2 * GiB);
 
+   bool use_shmem = test_using_shmem(Ctest_argc, (char **)Ctest_argv);
+   if (use_shmem) {
+      platform_default_log("Run test using shared memory segment.\n");
+   }
+
    // Create a heap for io, allocator, cache and splinter
    platform_status rc = platform_heap_create(platform_get_module_id(),
                                              heap_capacity,
+                                             use_shmem,
                                              &data->hh,
                                              &data->hid);
    platform_assert_status_ok(rc);

--- a/tests/unit/splinterdb_quick_test.c
+++ b/tests/unit/splinterdb_quick_test.c
@@ -32,6 +32,7 @@
 #include "splinterdb/public_platform.h"
 #include "splinterdb/default_data_config.h"
 #include "splinterdb_private.h"
+#include "test_misc_common.h"
 #include "unit_tests.h"
 #include "util.h"
 #include "test_data.h"
@@ -101,6 +102,10 @@ CTEST_SETUP(splinterdb_quick)
 
    default_data_config_init(TEST_MAX_KEY_SIZE, &data->default_data_cfg.super);
    create_default_cfg(&data->cfg, &data->default_data_cfg.super);
+
+   if (test_using_shmem(Ctest_argc, (char **)Ctest_argv)) {
+      data->cfg.use_shmem = TRUE;
+   }
 
    int rc = splinterdb_create(&data->cfg, &data->kvsb);
    ASSERT_EQUAL(0, rc);
@@ -641,7 +646,6 @@ CTEST2(splinterdb_quick, test_close_and_reopen)
    const char  *val     = "some-value";
    const size_t val_len = strlen(val);
 
-
    int rc = splinterdb_insert(data->kvsb, key, slice_create(val_len, val));
    ASSERT_EQUAL(0, rc);
 
@@ -924,6 +928,7 @@ create_default_cfg(splinterdb_config *out_cfg, data_config *default_data_cfg)
    *out_cfg = (splinterdb_config){.filename   = TEST_DB_NAME,
                                   .cache_size = 64 * Mega,
                                   .disk_size  = 127 * Mega,
+                                  .use_shmem  = FALSE,
                                   .data_cfg   = default_data_cfg};
 }
 

--- a/tests/unit/splinterdb_stress_test.c
+++ b/tests/unit/splinterdb_stress_test.c
@@ -13,6 +13,7 @@
 #include "splinterdb/public_platform.h"
 #include "splinterdb/default_data_config.h"
 #include "splinterdb/splinterdb.h"
+#include "test_misc_common.h"
 #include "unit_tests.h"
 #include "util.h"
 #include "../functional/random.h"
@@ -57,6 +58,10 @@ CTEST_SETUP(splinterdb_stress)
                                              .data_cfg   = &data->default_data_config};
    size_t max_key_size = TEST_KEY_SIZE;
    default_data_config_init(max_key_size, data->cfg.data_cfg);
+
+   if (test_using_shmem(Ctest_argc, (char **)Ctest_argv)) {
+      data->cfg.use_shmem = TRUE;
+   }
 
    int rc = splinterdb_create(&data->cfg, &data->kvsb);
    ASSERT_EQUAL(0, rc);
@@ -112,9 +117,6 @@ CTEST2(splinterdb_stress, test_random_inserts_concurrent)
 // Do some inserts, and then some range-deletes
 CTEST2(splinterdb_stress, test_naive_range_delete)
 {
-   int rc = splinterdb_create(&data->cfg, &data->kvsb);
-   ASSERT_EQUAL(0, rc);
-
    random_state rand_state;
    random_init(&rand_state, 42, 0);
 

--- a/tests/unit/task_system_test.c
+++ b/tests/unit/task_system_test.c
@@ -30,6 +30,7 @@
 #include "config.h" // Reqd for definition of master_config{}
 #include "trunk.h"  // Needed for trunk_get_scratch_size()
 #include "task.h"
+#include "test_misc_common.h"
 
 // Configuration for each worker thread
 typedef struct {
@@ -84,11 +85,14 @@ CTEST_SETUP(task_system)
 
    uint64 heap_capacity = (256 * MiB); // small heap is sufficient.
 
-   platform_status rc = STATUS_OK;
+   bool use_shmem = test_using_shmem(Ctest_argc, (char **)Ctest_argv);
 
    // Create a heap for io and task system to use.
-   rc = platform_heap_create(
-      platform_get_module_id(), heap_capacity, &data->hh, &data->hid);
+   platform_status rc = platform_heap_create(platform_get_module_id(),
+                                             heap_capacity,
+                                             use_shmem,
+                                             &data->hh,
+                                             &data->hid);
    platform_assert_status_ok(rc);
 
    // Allocate and initialize the IO sub-system.

--- a/tests/unit/writable_buffer_test.c
+++ b/tests/unit/writable_buffer_test.c
@@ -10,6 +10,7 @@
  */
 #include "splinterdb/public_platform.h"
 #include "platform.h"
+#include "test_misc_common.h"
 #include "unit_tests.h"
 #include "ctest.h" // This is required for all test-case files.
 #include "util.h"
@@ -30,13 +31,19 @@ CTEST_DATA(writable_buffer)
 // Optional setup function for suite, called before every test in suite
 CTEST_SETUP(writable_buffer)
 {
+   Platform_default_log_handle = fopen("/tmp/unit_test.stdout", "a+");
+   Platform_error_log_handle   = fopen("/tmp/unit_test.stderr", "a+");
+
+   bool use_shmem = test_using_shmem(Ctest_argc, (char **)Ctest_argv);
+
    platform_status rc = platform_heap_create(
-      platform_get_module_id(), (1 * GiB), &data->hh, &data->hid);
+      platform_get_module_id(), (1 * GiB), use_shmem, &data->hh, &data->hid);
    platform_assert_status_ok(rc);
 }
 
 // Optional teardown function for suite, called after every test in suite
 CTEST_TEARDOWN(writable_buffer)
+
 {
    platform_heap_destroy(&data->hh);
 }


### PR DESCRIPTION
**NOTE**: This is dev-version of shared-memory support for Splinter. This is not meant to be merged into /main as-is.

**This is a draft PR** mainly for colleagues to view the diffs to understand the nature of the changes.

**Description of the changes**, synthesized from `git log` message(s):

Core changes to support running Splinter with allocated shared memory.

This commit brings in basic support to create a shared memory segment and to redirect all memory allocation primitives to shared memory. 

Currently, we only support a simplistic memory mgmt; i.e. only-allocs, and no frees. With shared segments of 1-2 GiB we can run many functional and unit tests.

Some caveats and fixes implemented to get some tests to run cleanly:

    o Redirect large allocations to use malloc(), and not the shmem allocation.

      We currently do not support free() for shared memory based allocation.
      Some sub-systems that allocate and free large chunks repeatedly use
      up too much shared memory, causing tests to fail  .

This commit fixes that issue by re-directing following clients to fall-back to using regular malloc() / free() interfaces:

      - merge_iterator_create()
      - merge_iterator_destroy(),
      - trunk_range() - trunk_range_iterator
      - trunk_range_iterator_deinit()
      - btree_pack_req_init()
      - btree_pack_req_deinit()

With these changes, unit-test splinter_test now succeeds using shared memory:

o Rework existing tests to support --use-shmem arg to run w/ shared segment.

Apply --use-shmem as the very 1st arg for different tests so that they can now leverage shared memory support. Following tests are / should be working with this fix:

     - limitations_test
     - splinterdb_quick_test
     - writable_buffer_test
     - task_system_test
     - splinter_test
     - btree_test

With this argument, splinterdb_create_or_open() will now create a heap, i.e., allocate shared segment, if the calling test has not already done so.

    NOTE: unit/btree_test still goes through shm-free code due to the use
          of scratch_buffer space in this test masquerading as heap-id.
          Investigate and resolve.

o Fix bugs & refactoring to enable unit stress-tests.

Minor rearrangement of code and fixing bugs. This commit now enables running btree_test and splinterdb_stress_test unit-tests with --use-shmem option.

o Enhances memory alloc/free diags to print name of object.

To better understand for which object memory allocation or free is occurring, this commit makes minor changes to caller-macros that allocate / free memory to also print object's name using STRINGIFY() on the parameter 'v'.

o Rework unit-testing, main.c, Makefile to support --use-shmem

Change test.sh also to run unit-tests with --use-shmem

