### PR TITLE
Expose stats in splinterdb layer

### DIFF
--- a/include/splinterdb/splinterdb.h
+++ b/include/splinterdb/splinterdb.h
@@ -307,4 +307,23 @@ splinterdb_iterator_get_current(splinterdb_iterator *iter, // IN
 int
 splinterdb_iterator_status(const splinterdb_iterator *iter);
 
+/*
+ * Statistics Printing
+ *
+ * Must set the use_stats config option.
+ *
+ * Prints insertion or lookup statistics. Both print cache statistics.
+ *
+ * Reset statistics clears all statistics, including cache statistics.
+ */
+
+void
+splinterdb_stats_print_insertion(const splinterdb *kvs);
+
+void
+splinterdb_stats_print_lookup(const splinterdb *kvs);
+
+void
+splinterdb_stats_reset(splinterdb *kvs);
+
 #endif // _SPLINTERDB_H_

--- a/src/splinterdb.c
+++ b/src/splinterdb.c
@@ -941,3 +941,21 @@ splinterdb_iterator_get_current(splinterdb_iterator *iter, // IN
    *key   = slice_create(kenc->length, kenc->data);
    *value = message_slice(msg);
 }
+
+void
+splinterdb_stats_print_insertion(const splinterdb *kvs)
+{
+   trunk_print_insertion_stats(Platform_default_log_handle, kvs->spl);
+}
+
+void
+splinterdb_stats_print_lookup(const splinterdb *kvs)
+{
+   trunk_print_lookup_stats(Platform_default_log_handle, kvs->spl);
+}
+
+void
+splinterdb_stats_reset(splinterdb *kvs)
+{
+   trunk_reset_stats(kvs->spl);
+}

--- a/src/trunk.c
+++ b/src/trunk.c
@@ -8554,6 +8554,9 @@ trunk_print_insertion_stats(platform_log_handle *log_handle, trunk_handle *spl)
    platform_log(log_handle, "------------------------------------------------------------------------------------\n");
    task_print_stats(spl->ts);
    platform_log(log_handle, "\n");
+   platform_log(log_handle, "------------------------------------------------------------------------------------\n");
+   cache_print_stats(log_handle, spl->cc);
+   platform_log(log_handle, "\n");
    platform_free(spl->heap_id, global);
 }
 
@@ -8641,6 +8644,9 @@ trunk_print_lookup_stats(platform_log_handle *log_handle, trunk_handle *spl)
    platform_log(log_handle, "------------------------------------------------------------------------------------|\n");
    platform_log(log_handle, "\n");
    platform_free(spl->heap_id, global);
+   platform_log(log_handle, "------------------------------------------------------------------------------------\n");
+   cache_print_stats(log_handle, spl->cc);
+   platform_log(log_handle, "\n");
 }
 // clang-format on
 


### PR DESCRIPTION
Adds splinterdb_print_[insertion,lookup]_stats and splinterdb_reset stats to include/splinterdb/splinterdb.h.