### PR TITLE
Robj/trunk variable sized keys

### DIFF
--- a/include/splinterdb/data.h
+++ b/include/splinterdb/data.h
@@ -160,10 +160,10 @@ struct data_config {
    uint64 key_size;
 
    // FIXME: Planned for deprecation.
-   char   min_key[MAX_KEY_SIZE];
+   char   min_key[SPLINTERDB_MAX_KEY_SIZE];
    uint64 min_key_length;
 
-   char   max_key[MAX_KEY_SIZE];
+   char   max_key[SPLINTERDB_MAX_KEY_SIZE];
    uint64 max_key_length;
 
    key_compare_fn       key_compare;

--- a/include/splinterdb/limits.h
+++ b/include/splinterdb/limits.h
@@ -4,25 +4,26 @@
 #ifndef __LIMITS_H__
 #define __LIMITS_H__
 
-// MAX_KEY_SIZE is the limit, in bytes, on the length of *raw* keys
+// SPLINTERDB_MAX_KEY_SIZE is the limit, in bytes, on the length of *raw* keys
 // inserted into the trunk and branches.
 //
 // It must be at least 8, and no more than 105.
 //
-// When using the splinterdb.h API, the key size limit is MAX_KEY_SIZE-1
-// to accomodate the variable-length encoding.
-// See include/splinterdb/splinterdb.h for details.
+// When using the splinterdb.h API, the key size limit is
+// SPLINTERDB_MAX_KEY_SIZE-1 to accomodate the variable-length encoding. See
+// include/splinterdb/splinterdb.h for details.
 //
-// If your keys are always shorter than 105 bytes, you may reduce MAX_KEY_SIZE.
+// If your keys are always shorter than 105 bytes, you may reduce
+// SPLINTERDB_MAX_KEY_SIZE.
 //
 // To modify this at build time without editing this file, set it via
 // the CFLAGS env var, e.g.
-//   make clean && CFLAGS='-DMAX_KEY_SIZE=24' make
+//   make clean && CFLAGS='-DSPLINTERDB_MAX_KEY_SIZE=24' make
 //
 // Tests and example programs use test-data with keys of varying sizes.
 // When building with a smaller MAX_KEY_SIZE, expect some breakage.
-#ifndef MAX_KEY_SIZE
-#   define MAX_KEY_SIZE 105
+#ifndef SPLINTERDB_MAX_KEY_SIZE
+#   define SPLINTERDB_MAX_KEY_SIZE 103
 #endif // MAX_KEY_SIZE
 
 #endif // __LIMITS_H__

--- a/include/splinterdb/public_util.h
+++ b/include/splinterdb/public_util.h
@@ -29,6 +29,7 @@ slice_is_null(const slice b)
 static inline slice
 slice_create(uint64 len, const void *data)
 {
+   assert(data != NULL || len == 0);
    return (slice){.length = len, .data = data};
 }
 

--- a/include/splinterdb/public_util.h
+++ b/include/splinterdb/public_util.h
@@ -29,7 +29,6 @@ slice_is_null(const slice b)
 static inline slice
 slice_create(uint64 len, const void *data)
 {
-   assert(data != NULL || len == 0);
    return (slice){.length = len, .data = data};
 }
 

--- a/include/splinterdb/splinterdb.h
+++ b/include/splinterdb/splinterdb.h
@@ -16,11 +16,6 @@
 #include "splinterdb/data.h"
 
 
-// Hack to accomodate encoding variable-length keys
-// This will go away once real variable-length key support lands in trunk.c
-#define SPLINTERDB_MAX_KEY_SIZE (MAX_KEY_SIZE - 1)
-
-
 // Get a version string for this build of SplinterDB
 // Currently a git tag
 const char *

--- a/src/btree.h
+++ b/src/btree.h
@@ -147,8 +147,8 @@ typedef struct btree_iterator {
 
    // Variables used for debug only
    debug_code(bool debug_is_packed);
-   debug_code(char debug_prev_key[MAX_KEY_SIZE]);
-   debug_code(char debug_prev_end_key[MAX_KEY_SIZE]);
+   debug_code(char debug_prev_key[SPLINTERDB_MAX_KEY_SIZE]);
+   debug_code(char debug_prev_end_key[SPLINTERDB_MAX_KEY_SIZE]);
 } btree_iterator;
 
 typedef struct btree_pack_req {

--- a/src/btree.h
+++ b/src/btree.h
@@ -144,11 +144,6 @@ typedef struct btree_iterator {
    uint64     end_addr;
    uint64     end_idx;
    uint64     end_generation;
-
-   // Variables used for debug only
-   debug_code(bool debug_is_packed);
-   debug_code(char debug_prev_key[SPLINTERDB_MAX_KEY_SIZE]);
-   debug_code(char debug_prev_end_key[SPLINTERDB_MAX_KEY_SIZE]);
 } btree_iterator;
 
 typedef struct btree_pack_req {

--- a/src/data_internal.h
+++ b/src/data_internal.h
@@ -160,6 +160,18 @@ merge_accumulator_is_null(const merge_accumulator *ma)
    return r;
 }
 
+static inline slice
+data_min_key(const data_config *cfg)
+{
+   return slice_create(cfg->min_key_length, cfg->min_key);
+}
+
+static inline slice
+data_max_key(const data_config *cfg)
+{
+   return slice_create(cfg->max_key_length, cfg->max_key);
+}
+
 static inline int
 data_key_compare(const data_config *cfg, slice key1, slice key2)
 {

--- a/src/memtable.c
+++ b/src/memtable.c
@@ -116,13 +116,12 @@ platform_status
 memtable_insert(memtable_context *ctxt,
                 memtable         *mt,
                 platform_heap_id  heap_id,
-                const char       *key,
+                slice             key,
                 message           msg,
                 uint64           *leaf_generation)
 {
    const threadid tid = platform_get_tid();
    bool           was_unique;
-   slice          key_slice = slice_create(mt->cfg->data_cfg->key_size, key);
 
    platform_status rc = btree_insert(ctxt->cc,
                                      ctxt->cfg.btree_cfg,
@@ -130,7 +129,7 @@ memtable_insert(memtable_context *ctxt,
                                      &ctxt->scratch[tid],
                                      mt->root_addr,
                                      &mt->mini,
-                                     key_slice,
+                                     key,
                                      msg,
                                      leaf_generation,
                                      &was_unique);

--- a/src/memtable.h
+++ b/src/memtable.h
@@ -150,7 +150,7 @@ platform_status
 memtable_insert(memtable_context *ctxt,
                 memtable         *mt,
                 platform_heap_id  heap_id,
-                const char       *key,
+                slice             key,
                 message           msg,
                 uint64           *generation);
 

--- a/src/memtable.h
+++ b/src/memtable.h
@@ -296,11 +296,4 @@ memtable_print_stats(platform_log_handle *log_handle, cache *cc, memtable *mt)
    btree_print_tree_stats(log_handle, cc, mt->cfg, mt->root_addr);
 };
 
-static inline void
-memtable_key_to_string(memtable *mt, const char *key, char *key_str)
-{
-   slice key_slice = slice_create(mt->cfg->data_cfg->key_size, key);
-   btree_key_to_string(mt->cfg, key_slice, key_str);
-}
-
 #endif // __MEMTABLE_H

--- a/src/splinterdb.c
+++ b/src/splinterdb.c
@@ -137,9 +137,7 @@ splinterdb_validate_app_data_config(const data_config *cfg)
                    cfg->key_size);
 
    int min_max_cmp =
-      cfg->key_compare(cfg,
-                       slice_create(cfg->min_key_length, cfg->min_key),
-                       slice_create(cfg->max_key_length, cfg->max_key));
+      cfg->key_compare(cfg, data_min_key(cfg), data_max_key(cfg));
    platform_assert(min_max_cmp < 0, "min_key must compare < max_key");
    return STATUS_OK;
 }

--- a/src/splinterdb.c
+++ b/src/splinterdb.c
@@ -171,6 +171,7 @@ splinterdb_init_config(const splinterdb_config *kvs_cfg, // IN
    if (!SUCCESS(rc)) {
       return rc;
    }
+   kvs->data_cfg = kvs_cfg->data_cfg;
 
    if (kvs_cfg->filename == NULL || kvs_cfg->cache_size == 0
        || kvs_cfg->disk_size == 0)

--- a/src/trunk.c
+++ b/src/trunk.c
@@ -1519,13 +1519,12 @@ trunk_add_pivot_new_root(trunk_handle *spl,
                          page_handle  *child)
 {
    slice pivot_key                             = trunk_get_pivot(spl, child, 0);
-   __attribute__((unused)) const slice min_key = slice_create(
-      spl->cfg.data_cfg->min_key_length, spl->cfg.data_cfg->min_key);
+   __attribute__((unused)) const slice min_key =
+      data_min_key(spl->cfg.data_cfg);
    debug_only const int key_cmp_rv = trunk_key_compare(spl, pivot_key, min_key);
    debug_assert((key_cmp_rv == 0), "key_cmp_rv=%d\n", key_cmp_rv);
 
-   slice max_key = slice_create(spl->cfg.data_cfg->max_key_length,
-                                spl->cfg.data_cfg->max_key);
+   slice max_key = data_max_key(spl->cfg.data_cfg);
    trunk_set_initial_pivots(spl, parent, pivot_key, max_key);
    uint64 child_addr = child->disk_addr;
    trunk_set_pivot_data_new_root(spl, parent, child_addr);
@@ -3191,8 +3190,7 @@ trunk_memtable_compact_and_build_filter(trunk_handle  *spl,
    uint64         memtable_root_addr = mt->root_addr;
    btree_iterator btree_itor;
    iterator      *itor    = &btree_itor.super;
-   slice          min_key = slice_create(spl->cfg.data_cfg->min_key_length,
-                                spl->cfg.data_cfg->min_key);
+   slice          min_key = data_min_key(spl->cfg.data_cfg);
 
    trunk_memtable_iterator_init(
       spl, &btree_itor, memtable_root_addr, min_key, NULL_SLICE, FALSE, FALSE);

--- a/src/trunk.c
+++ b/src/trunk.c
@@ -5396,8 +5396,8 @@ trunk_split_leaf(trunk_handle *spl,
       btree_iterator *rough_btree_itor = scratch->btree_itor;
       iterator      **rough_itor       = scratch->rough_itor;
 
-      slice           pivot0 = trunk_get_pivot(spl, leaf, 0);
-      slice           pivot1 = trunk_get_pivot(spl, leaf, 1);
+      slice pivot0 = trunk_get_pivot(spl, leaf, 0);
+      slice pivot1 = trunk_get_pivot(spl, leaf, 1);
       SLICE_CREATE_LOCAL_COPY(min_key, spl->heap_id, pivot0);
       SLICE_CREATE_LOCAL_COPY(max_key, spl->heap_id, pivot1);
 
@@ -6293,7 +6293,7 @@ trunk_filter_lookup(trunk_handle      *spl,
       height = trunk_height(spl, node);
    }
 
-   uint64 found_values;
+   uint64          found_values;
    platform_status rc =
       routing_filter_lookup(spl->cc, cfg, filter, key, &found_values);
    platform_assert_status_ok(rc);
@@ -8033,7 +8033,7 @@ trunk_print_pivots(platform_log_handle *log_handle,
    for (uint16 pivot_no = 0; pivot_no < trunk_num_pivot_keys(spl, node);
         pivot_no++)
    {
-      slice pivot = trunk_get_pivot(spl, node, pivot_no);
+      slice             pivot = trunk_get_pivot(spl, node, pivot_no);
       trunk_pivot_data *pdata = trunk_get_pivot_data(spl, node, pivot_no);
       if (pivot_no == trunk_num_pivot_keys(spl, node) - 1) {
          platform_log(log_handle,

--- a/src/trunk.c
+++ b/src/trunk.c
@@ -567,7 +567,7 @@ typedef struct ONDISK trunk_pivot_data {
    uint16 start_bundle;        // first bundle live (not used in leaves)
    routing_filter filter;      // routing filter for keys in this pivot
    int64          srq_idx;     // index in the space rec queue
-   uint64         key_length;
+   uint16         key_length;
 } trunk_pivot_data;
 
 /*
@@ -7139,11 +7139,11 @@ trunk_create(trunk_config     *cfg,
    memmove(&spl->cfg, cfg, sizeof(*cfg));
 
    // Validate configured key-size is within limits.
-   if (trunk_key_size(spl) > MAX_KEY_SIZE) {
+   if (trunk_key_size(spl) > SPLINTERDB_MAX_KEY_SIZE) {
       platform_error_log("Trunk create failed. Configured key size, %lu, is "
                          "greater than the max key-size supported, %d bytes.\n",
                          trunk_key_size(spl),
-                         MAX_KEY_SIZE);
+                         SPLINTERDB_MAX_KEY_SIZE);
       platform_free(hid, spl);
       return (trunk_handle *)NULL;
    }
@@ -7256,11 +7256,11 @@ trunk_mount(trunk_config     *cfg,
    memmove(&spl->cfg, cfg, sizeof(*cfg));
 
    // Validate configured key-size is within limits.
-   if (trunk_key_size(spl) > MAX_KEY_SIZE) {
+   if (trunk_key_size(spl) > SPLINTERDB_MAX_KEY_SIZE) {
       platform_error_log("Trunk mount failed. Configured key size, %lu, is "
                          "greater than the max key-size supported, %d bytes.\n",
                          trunk_key_size(spl),
-                         MAX_KEY_SIZE);
+                         SPLINTERDB_MAX_KEY_SIZE);
       platform_free(hid, spl);
       return (trunk_handle *)NULL;
    }

--- a/src/trunk.c
+++ b/src/trunk.c
@@ -6227,6 +6227,10 @@ trunk_insert(trunk_handle *spl, slice key, message data)
       ts = platform_get_timestamp();
    }
 
+   if (trunk_key_size(spl) < slice_length(key)) {
+      return STATUS_BAD_PARAM;
+   }
+
    if (message_class(data) == MESSAGE_TYPE_DELETE) {
       data = DELETE_MESSAGE;
    }

--- a/src/trunk.c
+++ b/src/trunk.c
@@ -1518,7 +1518,7 @@ trunk_add_pivot_new_root(trunk_handle *spl,
                          page_handle  *parent,
                          page_handle  *child)
 {
-   slice pivot_key                             = trunk_get_pivot(spl, child, 0);
+   slice pivot_key = trunk_get_pivot(spl, child, 0);
    __attribute__((unused)) const slice min_key =
       data_min_key(spl->cfg.data_cfg);
    debug_only const int key_cmp_rv = trunk_key_compare(spl, pivot_key, min_key);

--- a/src/trunk.c
+++ b/src/trunk.c
@@ -5531,12 +5531,14 @@ trunk_split_leaf(trunk_handle *spl,
          new_leaf = leaf;
       }
 
-      // adjust min key
-      trunk_set_pivot(
-         spl, new_leaf, 0, key_buffer_slice(&scratch->pivot[leaf_no]));
+      /* Adjust max key first so that we always have ordered pivots (enforced by
+       * trunk_set_pivot in debug mode) */
       // adjust max key
       trunk_set_pivot(
          spl, new_leaf, 1, key_buffer_slice(&scratch->pivot[leaf_no + 1]));
+      // adjust min key
+      trunk_set_pivot(
+         spl, new_leaf, 0, key_buffer_slice(&scratch->pivot[leaf_no]));
 
       // set new_leaf tuple_count
       trunk_bundle *bundle = trunk_get_bundle(spl, new_leaf, bundle_no);
@@ -6038,7 +6040,9 @@ trunk_range_iterator_deinit(trunk_range_iterator *range_itor)
    }
 
    key_buffer_deinit(&range_itor->min_key);
-   key_buffer_deinit(&range_itor->max_key);
+   if (range_itor->has_max_key) {
+      key_buffer_deinit(&range_itor->max_key);
+   }
    key_buffer_deinit(&range_itor->local_max_key);
    key_buffer_deinit(&range_itor->rebuild_key);
 }

--- a/src/trunk.h
+++ b/src/trunk.h
@@ -54,7 +54,7 @@ typedef struct trunk_config {
    cache_config *cache_cfg;
 
    // parameters
-   uint64 fanout;              // children to trigger split
+   uint64 fanout; // children to trigger split
    uint64 max_pivot_keys;      // hard limit on number of pivot keys
    uint64 max_tuples_per_node; // deprecated
    uint64 max_kv_bytes_per_node;

--- a/src/trunk.h
+++ b/src/trunk.h
@@ -54,7 +54,7 @@ typedef struct trunk_config {
    cache_config *cache_cfg;
 
    // parameters
-   uint64 fanout; // children to trigger split
+   uint64 fanout;              // children to trigger split
    uint64 max_pivot_keys;      // hard limit on number of pivot keys
    uint64 max_tuples_per_node; // deprecated
    uint64 max_kv_bytes_per_node;

--- a/src/util.c
+++ b/src/util.c
@@ -348,3 +348,21 @@ debug_hex_encode(char        *dst,
 null_terminate:
    dst[max_len - 1] = '\0';
 }
+
+void
+debug_hex_dump(platform_log_handle *plh,
+               uint64               grouping,
+               uint64               length,
+               const char          *bytes)
+{
+   for (uint64 i = 0; i < length; i++) {
+      platform_log(
+         plh, "%02x%s", bytes[i], grouping && !((i + 1) % grouping) ? " " : "");
+   }
+}
+
+void
+debug_hex_dump_slice(platform_log_handle *plh, uint64 grouping, slice data)
+{
+   debug_hex_dump(plh, grouping, slice_length(data), slice_data(data));
+}

--- a/src/util.h
+++ b/src/util.h
@@ -257,6 +257,10 @@ writable_buffer_append(writable_buffer *wb, uint64 length, const void *newdata)
    return oldsize;
 }
 
+/*
+ * Creates a copy of src in newly declared slice dst.  Everything is
+ * automatically cleaned up when dst goes out of scope.
+ */
 #define SLICE_CREATE_LOCAL_COPY(dst, hid, src)                                 \
    WRITABLE_BUFFER_DEFAULT(dst##wb, hid);                                      \
    writable_buffer_copy_slice(&dst##wb, src);                                  \

--- a/test.sh
+++ b/test.sh
@@ -560,7 +560,7 @@ function run_splinter_functionality_tests() {
         "$BINDIR"/driver_test splinter_test --functionality 1000000 100 \
                                             --seed "$SEED"
 
-    max_key_size=105
+    max_key_size=103
     run_with_timing "Functionality test, key size=maximum (${max_key_size} bytes)" \
         "$BINDIR"/driver_test splinter_test --functionality 1000000 100 \
                                             --key-size ${max_key_size} --seed "$SEED"

--- a/tests/config.c
+++ b/tests/config.c
@@ -316,11 +316,11 @@ config_parse(master_config *cfg, const uint8 num_config, int argc, char *argv[])
                                TEST_CONFIG_MIN_KEY_SIZE);
             return STATUS_BAD_PARAM;
          }
-         if (cfg[cfg_idx].key_size > MAX_KEY_SIZE) {
+         if (cfg[cfg_idx].key_size > SPLINTERDB_MAX_KEY_SIZE) {
             platform_error_log("Configured key-size, %lu bytes, is larger than "
                                "the MAX_KEY_SIZE=%d bytes.\n",
                                cfg[cfg_idx].key_size,
-                               MAX_KEY_SIZE);
+                               SPLINTERDB_MAX_KEY_SIZE);
             return STATUS_BAD_PARAM;
          }
       }

--- a/tests/functional/btree_test.c
+++ b/tests/functional/btree_test.c
@@ -154,7 +154,7 @@ test_btree_tuple(test_memtable_context *ctxt,
 {
    test_btree_config *cfg = ctxt->cfg;
    writable_buffer_resize(key, cfg->mt_cfg->btree_cfg->data_cfg->key_size);
-   test_key(writable_buffer_data(key),
+   test_key(key,
             cfg->type,
             seq,
             thread_id,
@@ -1207,10 +1207,6 @@ test_btree_rough_iterator(cache             *cc,
    btree_config *btree_cfg = cfg->mt_cfg->btree_cfg;
 
    platform_status rc = STATUS_OK;
-
-   char min_key[MAX_KEY_SIZE], max_key[MAX_KEY_SIZE];
-   memset(min_key, 0, MAX_KEY_SIZE);
-   memset(max_key, UINT8_MAX, MAX_KEY_SIZE);
 
    uint64 num_pivots = 2 * num_trees;
 

--- a/tests/functional/btree_test.c
+++ b/tests/functional/btree_test.c
@@ -185,7 +185,7 @@ test_btree_insert_thread(void *arg)
    uint64                    thread_id   = params->thread_id;
    uint64                    num_inserts = params->num_ops;
 
-   uint64            start_time = platform_get_timestamp();
+   uint64 start_time = platform_get_timestamp();
    WRITABLE_BUFFER_DEFAULT(key, NULL);
    merge_accumulator data;
 
@@ -543,14 +543,14 @@ test_btree_basic(cache             *cc,
 
    test_memtable_context *ctxt = test_memtable_context_create(cc, cfg, 1, hid);
    memtable              *mt   = &ctxt->mt_ctxt->mt[0];
-   data_config             *data_cfg     = mt->cfg->data_cfg;
+   data_config           *data_cfg       = mt->cfg->data_cfg;
    btree_test_async_lookup *async_lookup = TYPED_MALLOC(hid, async_lookup);
 
    platform_assert(async_lookup);
 
    btree_test_async_ctxt_init(async_lookup);
 
-   uint64            start_time = platform_get_timestamp();
+   uint64 start_time = platform_get_timestamp();
    WRITABLE_BUFFER_DEFAULT(key, NULL);
    merge_accumulator expected_data;
    merge_accumulator_init(&expected_data, NULL);
@@ -1117,7 +1117,7 @@ test_btree_count_in_range(cache             *cc,
 
    uint64 root_addr;
    test_btree_create_packed_trees(cc, cfg, hid, 1, &root_addr);
-   btree_config  *btree_cfg = cfg->mt_cfg->btree_cfg;
+   btree_config    *btree_cfg = cfg->mt_cfg->btree_cfg;
    writable_buffer *bound_key = TYPED_ARRAY_MALLOC(hid, bound_key, 2);
    platform_assert(bound_key);
    writable_buffer_init(&bound_key[0], hid);

--- a/tests/functional/btree_test.c
+++ b/tests/functional/btree_test.c
@@ -543,7 +543,9 @@ test_btree_basic(cache             *cc,
 
    test_memtable_context *ctxt = test_memtable_context_create(cc, cfg, 1, hid);
    memtable              *mt   = &ctxt->mt_ctxt->mt[0];
+   data_config             *data_cfg     = mt->cfg->data_cfg;
    btree_test_async_lookup *async_lookup = TYPED_MALLOC(hid, async_lookup);
+
    platform_assert(async_lookup);
 
    btree_test_async_ctxt_init(async_lookup);
@@ -592,10 +594,10 @@ test_btree_basic(cache             *cc,
                                  merge_accumulator_to_message(&expected_data));
          if (!correct) {
             memtable_print(Platform_default_log_handle, cc, mt);
-            char key_string[128];
-            memtable_key_to_string(mt, writable_buffer_data(&key), key_string);
-            platform_default_log(
-               "key number %lu, %s not found\n", insert_num, key_string);
+            slice key_slice = writable_buffer_to_slice(&key);
+            platform_default_log("key number %lu, %s not found\n",
+                                 insert_num,
+                                 key_string(data_cfg, key_slice));
          }
          platform_assert(correct);
       } else {
@@ -608,11 +610,10 @@ test_btree_basic(cache             *cc,
          if (res == async_success) {
             if (!correct) {
                memtable_print(Platform_default_log_handle, cc, mt);
-               char key_string[128];
-               memtable_key_to_string(
-                  mt, writable_buffer_data(&async_ctxt->key), key_string);
-               platform_default_log(
-                  "key number %lu, %s not found\n", insert_num, key_string);
+               slice key_slice = writable_buffer_to_slice(&async_ctxt->key);
+               platform_default_log("key number %lu, %s not found\n",
+                                    insert_num,
+                                    key_string(data_cfg, key_slice));
             }
          }
       }
@@ -635,10 +636,10 @@ test_btree_basic(cache             *cc,
          ctxt, 0, writable_buffer_to_slice(&key), NULL_MESSAGE);
       if (!correct) {
          memtable_print(Platform_default_log_handle, cc, mt);
-         char key_string[128];
-         memtable_key_to_string(mt, writable_buffer_data(&key), key_string);
-         platform_default_log(
-            "key number %lu, %s found (negative)\n", insert_num, key_string);
+         slice key_slice = writable_buffer_to_slice(&key);
+         platform_default_log("key number %lu, %s not found\n",
+                              insert_num,
+                              key_string(data_cfg, key_slice));
          platform_assert(0);
       }
    }

--- a/tests/functional/filter_test.c
+++ b/tests/functional/filter_test.c
@@ -46,7 +46,7 @@ test_filter_basic(cache           *cc,
 
    uint32 *num_input_keys = TYPED_ARRAY_ZALLOC(hid, num_input_keys, num_values);
 
-   char  key[MAX_KEY_SIZE];
+   char  key[SPLINTERDB_MAX_KEY_SIZE];
    slice key_slice = slice_create(key_size, key);
    for (uint64 i = 0; i < num_values; i++) {
       if (i != 0) {
@@ -169,7 +169,7 @@ test_filter_perf(cache           *cc,
    if (fp_arr == NULL) {
       return STATUS_NO_MEMORY;
    }
-   char  key[MAX_KEY_SIZE];
+   char  key[SPLINTERDB_MAX_KEY_SIZE];
    slice key_slice = slice_create(key_size, key);
    for (uint64 k = 0; k < num_trees; k++) {
       for (uint64 i = 0; i < num_values * num_fingerprints; i++) {

--- a/tests/functional/splinter_test.c
+++ b/tests/functional/splinter_test.c
@@ -128,7 +128,7 @@ test_trunk_insert_thread(void *arg)
    platform_heap_id   heap_id        = platform_get_heap_id();
    platform_assert(num_tables <= 8);
    uint64 *insert_base = TYPED_ARRAY_ZALLOC(heap_id, insert_base, num_tables);
-   uint8 done = 0;
+   uint8   done        = 0;
 
    uint64    num_inserts     = 0;
    timestamp next_check_time = platform_get_timestamp();
@@ -241,7 +241,7 @@ test_trunk_lookup_thread(void *arg)
 
    platform_assert(num_tables <= 8);
    uint64 *lookup_base = TYPED_ARRAY_ZALLOC(heap_id, lookup_base, num_tables);
-   uint8 done = 0;
+   uint8   done        = 0;
 
    merge_accumulator data;
    merge_accumulator_init(&data, NULL);
@@ -364,7 +364,7 @@ test_trunk_range_thread(void *arg)
 
    platform_assert(num_tables <= 8);
    uint64 *range_base = TYPED_ARRAY_ZALLOC(heap_id, range_base, num_tables);
-   uint8 done = 0;
+   uint8   done       = 0;
 
    bool verbose_progress  = test_show_verbose_progress(test_cfg->test_exec_cfg);
    uint64 test_start_time = platform_get_timestamp();
@@ -581,7 +581,7 @@ do_operation(test_splinter_thread_params *params,
          if (test_is_done(*done, spl_idx)) {
             continue;
          }
-         trunk_handle *spl = spl_tables[spl_idx];
+         trunk_handle *spl    = spl_tables[spl_idx];
          uint64        op_num = base[spl_idx] + op_idx;
          timestamp     ts;
 

--- a/tests/functional/test.h
+++ b/tests/functional/test.h
@@ -77,15 +77,17 @@ test_deinit_task_system(platform_heap_id hid, task_system **ts)
    task_system_destroy(hid, ts);
 }
 
-static inline void
-test_key(char         *key,
-         test_key_type key_type,
-         uint64        idx,
-         uint64        thread_id,
-         uint64        semiseq_freq,
-         uint64        key_size,
-         uint64        period)
+static inline slice
+test_key(writable_buffer *keywb,
+         test_key_type    key_type,
+         uint64           idx,
+         uint64           thread_id,
+         uint64           semiseq_freq,
+         uint64           key_size,
+         uint64           period)
 {
+   writable_buffer_resize(keywb, key_size);
+   char *key = writable_buffer_data(keywb);
    memset(key, 0, key_size);
    switch (key_type) {
       case TEST_RANDOM:
@@ -110,6 +112,7 @@ test_key(char         *key,
          break;
       }
    }
+   return writable_buffer_to_slice(keywb);
 }
 
 static inline bool
@@ -128,10 +131,12 @@ test_range(uint64 idx, uint64 range_min, uint64 range_max)
 }
 
 static inline void
-test_int_to_key(char *key, uint64 idx, uint64 key_size)
+test_int_to_key(writable_buffer *key, uint64 idx, uint64 key_size)
 {
-   memset(key, 0, key_size);
-   *(uint64 *)key = htobe64(idx);
+   writable_buffer_resize(key, key_size);
+   uint64 *keybytes = writable_buffer_data(key);
+   memset(keybytes, 0, key_size);
+   *keybytes = htobe64(idx);
 }
 
 /*

--- a/tests/functional/test_async.c
+++ b/tests/functional/test_async.c
@@ -126,7 +126,7 @@ async_ctxt_process_one(trunk_handle         *spl,
    ts  = platform_get_timestamp();
    res = trunk_lookup_async(
       spl, writable_buffer_to_slice(&ctxt->key), &ctxt->data, &ctxt->ctxt);
-   ts  = platform_timestamp_elapsed(ts);
+   ts = platform_timestamp_elapsed(ts);
    if (latency_max != NULL && *latency_max < ts) {
       *latency_max = ts;
    }

--- a/tests/functional/test_async.h
+++ b/tests/functional/test_async.h
@@ -27,7 +27,7 @@ typedef struct {
       int8   refcount;   // Used by functionality test
       uint64 lookup_num; // Used by rest
    };
-   char              key[MAX_KEY_SIZE];
+   writable_buffer   key;
    merge_accumulator data;
 } test_async_ctxt;
 

--- a/tests/functional/ycsb_test.c
+++ b/tests/functional/ycsb_test.c
@@ -340,7 +340,8 @@ ycsb_thread(void *arg)
          switch (ops->cmd) {
             case 'r':
             {
-               rc = trunk_lookup(spl, ops->key, &value);
+               rc = trunk_lookup(
+                  spl, slice_create(YCSB_KEY_SIZE, ops->key), &value);
                platform_assert_status_ok(rc);
                // if (!ops->found) {
                //   char key_str[128];
@@ -358,14 +359,18 @@ ycsb_thread(void *arg)
                message val =
                   message_create(MESSAGE_TYPE_INSERT,
                                  slice_create(YCSB_DATA_SIZE, ops->value));
-               rc = trunk_insert(spl, ops->key, val);
+               rc =
+                  trunk_insert(spl, slice_create(YCSB_KEY_SIZE, ops->key), val);
                platform_assert_status_ok(rc);
                break;
             }
             case 's':
             {
-               rc = trunk_range(
-                  spl, ops->key, ops->range_len, nop_tuple_func, NULL);
+               rc = trunk_range(spl,
+                                slice_create(YCSB_KEY_SIZE, ops->key),
+                                ops->range_len,
+                                nop_tuple_func,
+                                NULL);
                platform_assert_status_ok(rc);
                break;
             }

--- a/tests/test_common.c
+++ b/tests/test_common.c
@@ -24,7 +24,7 @@ void
 verify_tuple(trunk_handle           *spl,
              test_message_generator *gen,
              uint64                  lookup_num,
-             char                   *key,
+             slice                   key,
              message                 data,
              bool                    expected_found)
 {

--- a/tests/test_common.h
+++ b/tests/test_common.h
@@ -34,7 +34,7 @@ void
 verify_tuple(trunk_handle           *spl,
              test_message_generator *gen,
              uint64                  lookup_num,
-             char                   *key,
+             slice                   key,
              message                 data,
              bool                    expected_found);
 

--- a/tests/unit/limitations_test.c
+++ b/tests/unit/limitations_test.c
@@ -314,7 +314,7 @@ CTEST2(limitations, test_splinterdb_mount_invalid_key_size)
    // We have carefully configured Splinter to use the default key-size
    // used by tests. Force-it to be an invalid value, to check that
    // core-Splinter trunk mount also properly generates an error message
-   cfg.data_cfg->key_size = (MAX_KEY_SIZE + 1);
+   cfg.data_cfg->key_size = (SPLINTERDB_MAX_KEY_SIZE + 1);
 
    // This should fail.
    rc = splinterdb_open(&cfg, &kvsb);
@@ -337,7 +337,7 @@ CTEST2(limitations, test_trunk_create_invalid_key_size)
    // We have carefully configured Splinter to use the default key-size
    // used by tests. Force-it to be an invalid value, to check that
    // core-Splinter trunk creation properly generates an error message
-   data->splinter_cfg->data_cfg->key_size = (MAX_KEY_SIZE + 1);
+   data->splinter_cfg->data_cfg->key_size = (SPLINTERDB_MAX_KEY_SIZE + 1);
 
    trunk_handle *spl = trunk_create(data->splinter_cfg,
                                     alp,
@@ -376,7 +376,7 @@ CTEST2(limitations, test_trunk_mount_invalid_key_size)
    // We have carefully configured Splinter to use the default key-size
    // used by tests. Force-it to be an invalid value, to check that
    // core-Splinter trunk creation properly generates an error message
-   data->splinter_cfg->data_cfg->key_size = (MAX_KEY_SIZE + 1);
+   data->splinter_cfg->data_cfg->key_size = (SPLINTERDB_MAX_KEY_SIZE + 1);
 
    spl = trunk_mount(data->splinter_cfg,
                      alp,

--- a/tests/unit/splinter_test.c
+++ b/tests/unit/splinter_test.c
@@ -714,8 +714,8 @@ splinter_do_inserts(void         *datap,
                         data->splinter_cfg[0].mt_cfg.max_extents_per_memtable,
                         num_inserts);
 
-   uint64       start_time = platform_get_timestamp();
-   uint64       insert_num;
+   uint64 start_time = platform_get_timestamp();
+   uint64 insert_num;
    WRITABLE_BUFFER_DEFAULT(key, spl->heap_id);
    const size_t key_size = trunk_key_size(spl);
 

--- a/tests/unit/splinterdb_quick_test.c
+++ b/tests/unit/splinterdb_quick_test.c
@@ -1002,7 +1002,7 @@ check_current_tuple(splinterdb_iterator *it, const int expected_i)
    int rc = 0;
 
    char expected_key[SPLINTERDB_MAX_KEY_SIZE] = {0};
-   char expected_val[TEST_MAX_VALUE_SIZE] = {0};
+   char expected_val[TEST_MAX_VALUE_SIZE]     = {0};
    ASSERT_EQUAL(
       6, snprintf(expected_key, sizeof(expected_key), key_fmt, expected_i));
    ASSERT_EQUAL(

--- a/tests/unit/splinterdb_quick_test.c
+++ b/tests/unit/splinterdb_quick_test.c
@@ -247,9 +247,6 @@ CTEST2(splinterdb_quick, test_key_size_gt_max_key_size)
    splinterdb_lookup_result result;
    splinterdb_lookup_result_init(data->kvsb, &result, 0, NULL);
 
-   rc = splinterdb_lookup(data->kvsb, too_large_key, &result);
-   ASSERT_EQUAL(EINVAL, rc);
-
    rc = splinterdb_delete(data->kvsb, too_large_key);
    ASSERT_EQUAL(EINVAL, rc);
 

--- a/tests/unit/splinterdb_quick_test.c
+++ b/tests/unit/splinterdb_quick_test.c
@@ -1001,7 +1001,7 @@ check_current_tuple(splinterdb_iterator *it, const int expected_i)
 {
    int rc = 0;
 
-   char expected_key[MAX_KEY_SIZE]        = {0};
+   char expected_key[SPLINTERDB_MAX_KEY_SIZE] = {0};
    char expected_val[TEST_MAX_VALUE_SIZE] = {0};
    ASSERT_EQUAL(
       6, snprintf(expected_key, sizeof(expected_key), key_fmt, expected_i));


### PR DESCRIPTION
Modify trunk.c to support variable-sized keys.

Eliminates key padding in splinterdb.c.
