### PR TITLE
Enable use of background threads in Splinter. Engage tests to verify basic stability of this existing feature.

### DIFF
--- a/include/splinterdb/splinterdb.h
+++ b/include/splinterdb/splinterdb.h
@@ -15,7 +15,6 @@
 
 #include "splinterdb/data.h"
 
-
 // Get a version string for this build of SplinterDB
 // Currently a git tag
 const char *
@@ -67,6 +66,23 @@ typedef struct {
    uint64 max_branches_per_node;
    uint64 use_stats;
    uint64 reclaim_threshold;
+
+   // Background threads configuration: Both have to be non-zero in order for
+   // background threads to be started. (It is an error for one to be zero
+   // while the other is non-zero.)
+   //
+   // - Memtable bg-threads work on Memtables tasks which are short but latency
+   //   sensitive. A rule of thumb is to allocate around 1 memtable bg-thread
+   //   for every 10 threads performing insertions. Too few memtable threads
+   //   can cause some insertions to have high latency.
+   // - Normal bg-threads work on task such as compacting branches in the trunk
+   //   and building filters. These tasks take longer and are less latency
+   //   sensitive. A rule of thumb is to allocate 1-2 normal background
+   //   threads for every thread performing insertions. Too few "normal"
+   //   background threads can cause disk I/O bandwidth to go underutilized.
+   uint64 num_memtable_bg_threads;
+   uint64 num_normal_bg_threads;
+
 } splinterdb_config;
 
 // Opaque handle to an opened instance of SplinterDB

--- a/src/task.h
+++ b/src/task.h
@@ -152,8 +152,7 @@ task_system_create(platform_heap_id    hid,
                    platform_io_handle *ioh,
                    task_system       **system,
                    bool                use_stats,
-                   bool                use_bg_threads,
-                   uint8               num_bg_threads[NUM_TASK_TYPES],
+                   uint64              num_bg_threads[NUM_TASK_TYPES],
                    uint64              scratch_size);
 
 void

--- a/test.sh
+++ b/test.sh
@@ -84,7 +84,7 @@ function record_elapsed_time() {
       # Provide wider test-tag for nightly tests which print verbose descriptions
       fmtstr="%-80s""${fmtstr}"
    else
-      fmtstr="%-50s""${fmtstr}"
+      fmtstr="%-70s""${fmtstr}"
    fi
 
    # Log a line in the /tmp log-file; for future cat of summary output
@@ -510,6 +510,7 @@ function test_make_run_tests() {
 # Smoke Tests: Run a small collection of fast-running unit-tests
 # ##################################################################
 function run_fast_unit_tests() {
+
    "$BINDIR"/unit/splinterdb_quick_test
    "$BINDIR"/unit/btree_test
    "$BINDIR"/unit/util_test
@@ -522,7 +523,7 @@ function run_fast_unit_tests() {
 # Run mini-unit-tests that were excluded from bin/unit_test binary:
 # Explicitly run individual cases from specific slow running unit-tests,
 # where appropriate with a different test-configuration that has been
-# found to to provide the required coverage.
+# found to provide the required coverage.
 # ##################################################################
 function run_slower_unit_tests() {
 
@@ -549,6 +550,11 @@ function run_splinter_functionality_tests() {
         "$BINDIR"/driver_test splinter_test --functionality 1000000 100 \
                                             --seed "$SEED"
 
+    run_with_timing "Functionality test, default key size, with background threads" \
+        "$BINDIR"/driver_test splinter_test --functionality 1000000 100 \
+                                            --num-normal-bg-threads 4 --num-memtable-bg-threads 2 \
+                                            --seed "$SEED"
+
     max_key_size=102
     run_with_timing "Functionality test, key size=maximum (${max_key_size} bytes)" \
         "$BINDIR"/driver_test splinter_test --functionality 1000000 100 \
@@ -572,6 +578,17 @@ function run_splinter_perf_tests() {
                                             --num-inserts 10000 \
                                             --cache-capacity-mib 512 \
                                             --verbose-progress
+
+   # Re-run small perf test configuring background threads. This scenario
+   # validates that we can configure bg- and user-threads in one go.
+   run_with_timing "Quick Performance test with bg-threads" \
+        "$BINDIR"/driver_test splinter_test --perf \
+                                            --num-insert-threads 4 \
+                                            --num-lookup-threads 4 \
+                                            --num-inserts 10000 \
+                                            --cache-capacity-mib 512 \
+                                            --num-normal-bg-threads 1 \
+                                            --num-memtable-bg-threads 1
 
    run_with_timing "Performance test" \
         "$BINDIR"/driver_test splinter_test --perf \

--- a/tests/config.c
+++ b/tests/config.c
@@ -36,7 +36,23 @@
 #define TEST_CONFIG_DEFAULT_SEED        0
 #define TEST_CONFIG_DEFAULT_NUM_INSERTS 0
 
+// By default, background threads are disabled in Splinter task system.
+// Most tests run w/o background threads. Very small # of tests exercise
+// background threads through the --num-normal-bg-threads and
+// --num-memtable-bg-threads options.
+#define TEST_CONFIG_DEFAULT_NUM_NORMAL_BG_THREADS   0
+#define TEST_CONFIG_DEFAULT_NUM_MEMTABLE_BG_THREADS 0
+
+
 // clang-format off
+/*
+ * ---------------------------------------------------------------------------
+ * Helper function to initialize master_config{} used to run tests with some
+ * useful default values. The expectation is that the input 'cfg' is zero'ed
+ * out before calling this initializer, so that all other fields will have
+ * some reasonable 0-defaults.
+ * ---------------------------------------------------------------------------
+ */
 void
 config_set_defaults(master_config *cfg)
 {
@@ -59,10 +75,12 @@ config_set_defaults(master_config *cfg)
       .max_branches_per_node    = TEST_CONFIG_DEFAULT_MAX_BRANCHES_PER_NODE,
       .use_stats                = FALSE,
       .reclaim_threshold        = UINT64_MAX,
+      .num_normal_bg_threads    = TEST_CONFIG_DEFAULT_NUM_NORMAL_BG_THREADS,
+      .num_memtable_bg_threads  = TEST_CONFIG_DEFAULT_NUM_MEMTABLE_BG_THREADS,
       .verbose_logging_enabled  = FALSE,
       .verbose_progress         = FALSE,
       .log_handle               = NULL,
-      .max_key_size                 = TEST_CONFIG_DEFAULT_KEY_SIZE,
+      .max_key_size             = TEST_CONFIG_DEFAULT_KEY_SIZE,
       .message_size             = TEST_CONFIG_DEFAULT_MESSAGE_SIZE,
       .num_inserts              = TEST_CONFIG_DEFAULT_NUM_INSERTS,
       .seed                     = TEST_CONFIG_DEFAULT_SEED,
@@ -105,6 +123,13 @@ config_usage()
    platform_error_log("\t--fanout (%d)\n", TEST_CONFIG_DEFAULT_FANOUT);
    platform_error_log("\t--max-branches-per-node (%d)\n",
                       TEST_CONFIG_DEFAULT_MAX_BRANCHES_PER_NODE);
+
+   platform_error_log("\t--num-normal-bg-threads (%d)\n",
+                      TEST_CONFIG_DEFAULT_NUM_NORMAL_BG_THREADS);
+
+   platform_error_log("\t--num-memtable-bg-threads (%d)\n",
+                      TEST_CONFIG_DEFAULT_NUM_MEMTABLE_BG_THREADS);
+
    platform_error_log("\t--stats\n");
    platform_error_log("\t--no-stats\n");
    platform_error_log("\t--log\n");
@@ -225,6 +250,15 @@ config_parse(master_config *cfg, const uint8 num_config, int argc, char *argv[])
          {}
          config_set_mib("reclaim-threshold", cfg, reclaim_threshold) {}
          config_set_gib("reclaim-threshold", cfg, reclaim_threshold) {}
+
+         /*
+          * These arguments will be passed through to Splinter initialization
+          * to setup Splinter task system to use background threads.
+          */
+         config_set_uint64("num-normal-bg-threads", cfg, num_normal_bg_threads);
+         config_set_uint64(
+            "num-memtable-bg-threads", cfg, num_memtable_bg_threads);
+
          config_has_option("stats")
          {
             for (uint8 cfg_idx = 0; cfg_idx < num_config; cfg_idx++) {
@@ -283,6 +317,8 @@ config_parse(master_config *cfg, const uint8 num_config, int argc, char *argv[])
             return STATUS_BAD_PARAM;
          }
       }
+
+      // Validate consistency of config parameters provided.
       for (uint8 cfg_idx = 0; cfg_idx < num_config; cfg_idx++) {
          if (cfg[cfg_idx].extent_size % cfg[cfg_idx].page_size != 0) {
             platform_error_log("Configured extent-size, %lu, is not a multiple "
@@ -314,6 +350,17 @@ config_parse(master_config *cfg, const uint8 num_config, int argc, char *argv[])
                                "experimental.\n",
                                cfg[cfg_idx].max_key_size,
                                TEST_CONFIG_MIN_KEY_SIZE);
+            return STATUS_BAD_PARAM;
+         }
+         if ((cfg[cfg_idx].num_normal_bg_threads == 0)
+             != (cfg[cfg_idx].num_memtable_bg_threads == 0))
+         {
+            platform_error_log("Both configuration parameters for background "
+                               "threads, --num-normal-bg-threads (%lu) "
+                               " and --num-memtable-bg-threads (%lu) "
+                               "must be zero or be non-zero.\n",
+                               cfg[cfg_idx].num_normal_bg_threads,
+                               cfg[cfg_idx].num_memtable_bg_threads);
             return STATUS_BAD_PARAM;
          }
       }

--- a/tests/config.h
+++ b/tests/config.h
@@ -71,13 +71,17 @@ typedef struct master_config {
    bool use_log;
 
    // splinter
-   uint64               memtable_capacity;
-   uint64               fanout;
-   uint64               max_branches_per_node;
-   uint64               use_stats;
-   uint64               reclaim_threshold;
-   bool                 verbose_logging_enabled;
-   bool                 verbose_progress;
+   uint64 memtable_capacity;
+   uint64 fanout;
+   uint64 max_branches_per_node;
+   uint64 use_stats;
+   uint64 reclaim_threshold;
+   uint64 num_normal_bg_threads;   // Both bg_threads fields have to be non-zero
+   uint64 num_memtable_bg_threads; // for background threads to be enabled
+
+   bool verbose_logging_enabled;
+   bool verbose_progress;
+
    platform_log_handle *log_handle;
 
    // data

--- a/tests/functional/btree_test.c
+++ b/tests/functional/btree_test.c
@@ -1471,7 +1471,7 @@ btree_test(int argc, char *argv[])
    bool                   run_perf_test;
    platform_status        rc;
    uint64                 seed;
-   task_system           *ts;
+   task_system           *ts = NULL;
    test_message_generator gen;
 
    if (argc > 1 && strncmp(argv[1], "--perf", sizeof("--perf")) == 0) {
@@ -1503,6 +1503,8 @@ btree_test(int argc, char *argv[])
    rc = platform_heap_create(platform_get_module_id(), 1 * GiB, &hh, &hid);
    platform_assert_status_ok(rc);
 
+   uint64 num_bg_threads[NUM_TASK_TYPES] = {0}; // no bg threads
+
    data_config  *data_cfg;
    trunk_config *cfg = TYPED_MALLOC(hid, cfg);
 
@@ -1514,6 +1516,8 @@ btree_test(int argc, char *argv[])
                         &log_cfg,
                         &seed,
                         &gen,
+                        &num_bg_threads[TASK_TYPE_MEMTABLE],
+                        &num_bg_threads[TASK_TYPE_NORMAL],
                         config_argc,
                         config_argv);
 
@@ -1556,10 +1560,7 @@ btree_test(int argc, char *argv[])
       goto free_iohandle;
    }
 
-   uint8 num_bg_threads[NUM_TASK_TYPES] = {0}; // no bg threads
-
-   rc = test_init_task_system(
-      hid, io, &ts, cfg->use_stats, FALSE, num_bg_threads);
+   rc = test_init_task_system(hid, io, &ts, cfg->use_stats, num_bg_threads);
    if (!SUCCESS(rc)) {
       platform_error_log("Failed to init splinter state: %s\n",
                          platform_status_to_string(rc));

--- a/tests/functional/cache_test.c
+++ b/tests/functional/cache_test.c
@@ -966,7 +966,7 @@ cache_test(int argc, char *argv[])
    int                    config_argc = argc - 1;
    char                 **config_argv = argv + 1;
    platform_status        rc;
-   task_system           *ts;
+   task_system           *ts        = NULL;
    bool                   benchmark = FALSE, async = FALSE;
    uint64                 seed;
    test_message_generator gen;
@@ -994,6 +994,7 @@ cache_test(int argc, char *argv[])
    rc = platform_heap_create(platform_get_module_id(), 1 * GiB, &hh, &hid);
    platform_assert_status_ok(rc);
 
+   uint64        num_bg_threads[NUM_TASK_TYPES] = {0}; // no bg threads
    trunk_config *splinter_cfg = TYPED_MALLOC(hid, splinter_cfg);
 
    rc = test_parse_args(splinter_cfg,
@@ -1004,6 +1005,8 @@ cache_test(int argc, char *argv[])
                         &log_cfg,
                         &seed,
                         &gen,
+                        &num_bg_threads[TASK_TYPE_MEMTABLE],
+                        &num_bg_threads[TASK_TYPE_NORMAL],
                         config_argc,
                         config_argv);
    if (!SUCCESS(rc)) {
@@ -1033,10 +1036,8 @@ cache_test(int argc, char *argv[])
       goto free_iohandle;
    }
 
-   uint8 num_bg_threads[NUM_TASK_TYPES] = {0}; // no bg threads
-
    rc = test_init_task_system(
-      hid, io, &ts, splinter_cfg->use_stats, FALSE, num_bg_threads);
+      hid, io, &ts, splinter_cfg->use_stats, num_bg_threads);
    if (!SUCCESS(rc)) {
       platform_error_log("Failed to init splinter state: %s\n",
                          platform_status_to_string(rc));

--- a/tests/functional/filter_test.c
+++ b/tests/functional/filter_test.c
@@ -318,6 +318,9 @@ filter_test(int argc, char *argv[])
    rc = platform_heap_create(platform_get_module_id(), 1 * GiB, &hh, &hid);
    platform_assert_status_ok(rc);
 
+   uint64 num_memtable_bg_threads_unused = 0;
+   uint64 num_normal_bg_threads_unused   = 0;
+
    trunk_config *cfg = TYPED_MALLOC(hid, cfg);
 
    rc = test_parse_args(cfg,
@@ -328,6 +331,8 @@ filter_test(int argc, char *argv[])
                         &log_cfg,
                         &seed,
                         &gen,
+                        &num_memtable_bg_threads_unused,
+                        &num_normal_bg_threads_unused,
                         config_argc,
                         config_argv);
    if (!SUCCESS(rc)) {

--- a/tests/functional/splinter_test.c
+++ b/tests/functional/splinter_test.c
@@ -2383,7 +2383,9 @@ usage(const char *argv0)
       "\t%s --cache-per-table\n"
       "\t%s --parallel-perf --max-async-inflight [num] --num-pthreads [num] "
       "--lookup-positive-percent [num] --seed [num]\n"
-      "\t%s --num-bg-threads (number of background threads)\n"
+      "\t%s --num-normal-bg-threads (number of normal background threads)\n"
+      "\t\t      --num-memtable-bg-threads (number of background threads for "
+      "memtables)\n"
       "\t%s --insert-rate (inserts_done_by_all_threads in a second)\n",
       argv0,
       argv0,
@@ -2498,15 +2500,13 @@ splinter_test(int argc, char *argv[])
    uint64              test_ops;
    uint64              correctness_check_frequency;
    // Max async IOs inflight per-thread
-   uint32 num_insert_threads, num_lookup_threads;
-   uint32 num_range_lookup_threads, max_async_inflight;
-   uint32 num_pthreads    = 0;
-   uint8  num_tables      = 1;
-   bool   cache_per_table = FALSE;
-   // no bg threads by default.
-   uint8                  num_bg_threads[NUM_TASK_TYPES] = {0};
-   uint64                 insert_rate = 0; // no rate throttling by default.
-   task_system           *ts;
+   uint32                 num_insert_threads, num_lookup_threads;
+   uint32                 num_range_lookup_threads, max_async_inflight;
+   uint32                 num_pthreads    = 0;
+   uint8                  num_tables      = 1;
+   bool                   cache_per_table = FALSE;
+   uint64                 insert_rate     = 0; // no rate throttling by default.
+   task_system           *ts              = NULL;
    uint8                  lookup_positive_pct = 0;
    test_message_generator gen;
    test_exec_config       test_exec_cfg;
@@ -2602,6 +2602,7 @@ splinter_test(int argc, char *argv[])
       config_argc -= 2;
       config_argv += 2;
    }
+
    if (config_argc > 0
        && strncmp(
              config_argv[0], "--cache-per-table", sizeof("--cache-per-table"))
@@ -2611,33 +2612,7 @@ splinter_test(int argc, char *argv[])
       config_argc -= 1;
       config_argv += 1;
    }
-   if (config_argc > 0
-       && strncmp(
-             config_argv[0], "--num-bg-threads", sizeof("--num-bg-threads"))
-             == 0)
-   {
-      if (!try_string_to_uint8(config_argv[1],
-                               &num_bg_threads[TASK_TYPE_NORMAL])) {
-         usage(argv[0]);
-         return -1;
-      }
-      config_argc -= 2;
-      config_argv += 2;
-   }
-   if (config_argc > 0
-       && strncmp(config_argv[0],
-                  "--num-memtable-bg-threads",
-                  sizeof("--num-bg-threads"))
-             == 0)
-   {
-      if (!try_string_to_uint8(config_argv[1],
-                               &num_bg_threads[TASK_TYPE_MEMTABLE])) {
-         usage(argv[0]);
-         return -1;
-      }
-      config_argc -= 2;
-      config_argv += 2;
-   }
+
    if (splinter_test_parse_perf_args(&config_argv,
                                      &config_argc,
                                      &max_async_inflight,
@@ -2718,6 +2693,9 @@ splinter_test(int argc, char *argv[])
    clockcache_config *cache_cfg =
       TYPED_ARRAY_MALLOC(hid, cache_cfg, num_tables);
 
+   // no bg threads by default.
+   uint64 num_bg_threads[NUM_TASK_TYPES] = {0};
+
    rc = test_parse_args_n(splinter_cfg,
                           &data_cfg,
                           &io_cfg,
@@ -2726,6 +2704,8 @@ splinter_test(int argc, char *argv[])
                           &log_cfg,
                           &test_exec_cfg,
                           &gen,
+                          &num_bg_threads[TASK_TYPE_MEMTABLE],
+                          &num_bg_threads[TASK_TYPE_NORMAL],
                           num_tables,
                           config_argc,
                           config_argv);
@@ -2788,7 +2768,7 @@ splinter_test(int argc, char *argv[])
    bool use_bg_threads = num_bg_threads[TASK_TYPE_NORMAL] != 0;
 
    rc = test_init_task_system(
-      hid, io, &ts, splinter_cfg->use_stats, use_bg_threads, num_bg_threads);
+      hid, io, &ts, splinter_cfg->use_stats, num_bg_threads);
    if (!SUCCESS(rc)) {
       platform_error_log("Failed to init splinter state: %s\n",
                          platform_status_to_string(rc));

--- a/tests/functional/ycsb_test.c
+++ b/tests/functional/ycsb_test.c
@@ -1154,7 +1154,7 @@ ycsb_test(int argc, char *argv[])
    char              **config_argv;
    platform_status     rc;
    uint64              seed;
-   task_system        *ts;
+   task_system        *ts = NULL;
 
    uint64                 nphases;
    bool                   use_existing = 0;
@@ -1188,6 +1188,7 @@ ycsb_test(int argc, char *argv[])
 
    data_config  *data_cfg;
    trunk_config *splinter_cfg = TYPED_MALLOC(hid, splinter_cfg);
+   uint64        num_bg_threads[NUM_TASK_TYPES] = {0}; // no bg threads
 
    rc = test_parse_args(splinter_cfg,
                         &data_cfg,
@@ -1197,6 +1198,8 @@ ycsb_test(int argc, char *argv[])
                         &log_cfg,
                         &seed,
                         &gen,
+                        &num_bg_threads[TASK_TYPE_MEMTABLE],
+                        &num_bg_threads[TASK_TYPE_NORMAL],
                         config_argc,
                         config_argv);
    if (!SUCCESS(rc)) {
@@ -1274,10 +1277,8 @@ ycsb_test(int argc, char *argv[])
       goto free_iohandle;
    }
 
-   uint8 num_bg_threads[NUM_TASK_TYPES] = {0}; // no bg threads
-
    rc = test_init_task_system(
-      hid, io, &ts, splinter_cfg->use_stats, FALSE, num_bg_threads);
+      hid, io, &ts, splinter_cfg->use_stats, num_bg_threads);
    if (!SUCCESS(rc)) {
       platform_error_log("Failed to init splinter state: %s\n",
                          platform_status_to_string(rc));

--- a/tests/unit/btree_stress_test.c
+++ b/tests/unit/btree_stress_test.c
@@ -104,7 +104,7 @@ CTEST_DATA(btree_stress)
 
    // Stuff needed to setup and exercise multiple threads.
    platform_io_handle io;
-   uint8              num_bg_threads[NUM_TASK_TYPES];
+   uint64             num_bg_threads[NUM_TASK_TYPES];
    task_system       *ts;
    rc_allocator       al;
    clockcache         cc;
@@ -142,12 +142,12 @@ CTEST_SETUP(btree_stress)
    }
    // Setup execution of concurrent threads
    ZERO_ARRAY(data->num_bg_threads);
+   data->ts = NULL;
    if (!SUCCESS(io_handle_init(&data->io, &data->io_cfg, data->hh, data->hid))
        || !SUCCESS(task_system_create(data->hid,
                                       &data->io,
                                       &data->ts,
                                       data->master_cfg.use_stats,
-                                      FALSE,
                                       data->num_bg_threads,
                                       sizeof(btree_scratch)))
        || !SUCCESS(rc_allocator_init(&data->al,

--- a/tests/unit/config_parse_test.c
+++ b/tests/unit/config_parse_test.c
@@ -79,6 +79,9 @@ CTEST2(config_parse, test_basic_parsing)
 
    cache_cfg = TYPED_ARRAY_MALLOC(data->hid, cache_cfg, num_tables);
 
+   uint64 num_memtable_bg_threads = 0;
+   uint64 num_normal_bg_threads   = 0;
+
    platform_status rc;
 
    rc = test_parse_args_n(splinter_cfg,
@@ -89,6 +92,8 @@ CTEST2(config_parse, test_basic_parsing)
                           &log_cfg,
                           &data->test_exec_cfg,
                           &gen,
+                          &num_memtable_bg_threads,
+                          &num_normal_bg_threads,
                           num_tables,
                           Ctest_argc, // argc/argv globals setup by CTests
                           (char **)Ctest_argv);

--- a/tests/unit/splinter_test.c
+++ b/tests/unit/splinter_test.c
@@ -85,7 +85,7 @@ CTEST_DATA(splinter)
    uint32 max_async_inflight;
    int    spl_num_tables;
 
-   uint8 num_bg_threads[NUM_TASK_TYPES];
+   uint64 num_bg_threads[NUM_TASK_TYPES];
 
    // Config structs required, as per splinter_test() setup work.
    io_config           io_cfg;
@@ -145,6 +145,10 @@ CTEST_SETUP(splinter)
    data->cache_cfg = TYPED_ARRAY_MALLOC(data->hid, data->cache_cfg, num_tables);
 
    ZERO_STRUCT(data->test_exec_cfg);
+   // no bg threads by default.
+   for (int idx = 0; idx < NUM_TASK_TYPES; idx++) {
+       data->num_bg_threads[idx] = 0;
+   }
 
    rc = test_parse_args_n(data->splinter_cfg,
                           &data->data_cfg,
@@ -154,6 +158,8 @@ CTEST_SETUP(splinter)
                           &data->log_cfg,
                           &data->test_exec_cfg,
                           &data->gen,
+                          &data->num_bg_threads[TASK_TYPE_MEMTABLE],
+                          &data->num_bg_threads[TASK_TYPE_NORMAL],
                           num_tables,
                           Ctest_argc,   // argc/argv globals setup by CTests
                           (char **)Ctest_argv);
@@ -183,15 +189,9 @@ CTEST_SETUP(splinter)
    ASSERT_TRUE((data->io != NULL));
    rc = io_handle_init(data->io, &data->io_cfg, data->hh, data->hid);
 
-   // no bg threads by default.
-   for (int idx = 0; idx < NUM_TASK_TYPES; idx++) {
-       data->num_bg_threads[idx] = 0;
-   }
-
-   bool use_bg_threads = data->num_bg_threads[TASK_TYPE_NORMAL] != 0;
-
+   data->tasks = NULL;
    rc = test_init_task_system(data->hid, data->io, &data->tasks, data->splinter_cfg->use_stats,
-                           use_bg_threads, data->num_bg_threads);
+                              data->num_bg_threads);
    ASSERT_TRUE(SUCCESS(rc),
               "Failed to init splinter state: %s\n",
               platform_status_to_string(rc));

--- a/tests/unit/splinterdb_quick_test.c
+++ b/tests/unit/splinterdb_quick_test.c
@@ -858,6 +858,56 @@ CTEST2(splinterdb_quick, test_iterator_init_bug)
 }
 
 /*
+ * ------------------------------------------------------------------------
+ * Test that SplinterDB can be created with the task system configured with
+ * background threads.
+ * ------------------------------------------------------------------------
+ */
+CTEST2(splinterdb_quick, test_splinterdb_create_w_background_threads)
+{
+   splinterdb       *kvsb;
+   splinterdb_config cfg;
+   data_config       default_data_cfg;
+
+   default_data_config_init(TEST_MAX_KEY_SIZE, &default_data_cfg);
+   create_default_cfg(&cfg, &default_data_cfg);
+
+   // Task system should be setup with background threads
+   cfg.num_normal_bg_threads   = 1;
+   cfg.num_memtable_bg_threads = 1;
+
+   int rv = splinterdb_create(&cfg, &kvsb);
+   ASSERT_EQUAL(0, rv);
+
+   splinterdb_close(&kvsb);
+}
+
+/*
+ * ------------------------------------------------------------------------
+ * Test that SplinterDB can be created even when background threads use
+ * up all the slots.
+ * ------------------------------------------------------------------------
+ */
+CTEST2(splinterdb_quick, test_splinterdb_create_w_all_background_threads)
+{
+   splinterdb       *kvsb;
+   splinterdb_config cfg;
+   data_config       default_data_cfg;
+
+   default_data_config_init(TEST_MAX_KEY_SIZE, &default_data_cfg);
+   create_default_cfg(&cfg, &default_data_cfg);
+
+   // Task system should be setup with all background threads
+   cfg.num_normal_bg_threads   = (MAX_THREADS - 2);
+   cfg.num_memtable_bg_threads = 1;
+
+   int rv = splinterdb_create(&cfg, &kvsb);
+   ASSERT_EQUAL(0, rv);
+
+   splinterdb_close(&kvsb);
+}
+
+/*
  * ********************************************************************************
  * Define minions and helper functions here, after all test cases are
  * enumerated.


### PR DESCRIPTION
This commit exercises use of background threads, a feature that has been implemented but hadn't been fully tested & engaged.

- Minor adjustments are done to task system initialization to manage the order in which background threads are started up.

- Fixed some checks in task_system_test to cope with the new variation that this test case could, optionally, be exercised with `--num-normal-bg-threads` | `--num-memtable-bg-threads` arguments.

- Enhanced config_parse() to recognize these two new options.
- Added a case to test.sh to exercise the task_system_test with background threads.

-  Stabilization fixes to get large inserts stress tests working. (New test withdrawn)

-  Add new test cases to test.sh, exercising background threads.

---------------
**NOTE**: Before you can run the `large_inserts_stress_test` that was leveraged to exercise background threads functionality,  you need to pull-in in-flight fix for issue https://github.com/vmware/splinterdb/issues/458; Otherwise you will run into that assertion first. 

The dev-branch were this repro has been constructed, `agurajada/478-Enable-bg-thread-feature`, pulls-in that commit already.