### PR TITLE
Fix missing initialization of rc_allocator_in_use_virtual fn in rc_allocator_ops{} virtual functions table.

### DIFF
--- a/src/rc_allocator.c
+++ b/src/rc_allocator.c
@@ -177,6 +177,7 @@ const static allocator_ops rc_allocator_ops = {
    .get_super_addr    = rc_allocator_get_super_addr_virtual,
    .alloc_super_addr  = rc_allocator_alloc_super_addr_virtual,
    .remove_super_addr = rc_allocator_remove_super_addr_virtual,
+   .in_use            = rc_allocator_in_use_virtual,
    .get_capacity      = rc_allocator_get_capacity_virtual,
    .assert_noleaks    = rc_allocator_assert_noleaks_virtual,
    .print_stats       = rc_allocator_print_stats_virtual,


### PR DESCRIPTION
In a separate dev-effort, while running large inserts stress tests, I ran into a signal as reported in this issue.

It's a mystery why we are not seeing this signal in other performance benchmarking efforts.

Several efforts were made to develop `large_inserts_stress_tests` to reproduce this issue, but to no avail.

The missing virtual function pointer is a clear bug from code-inspection.

Hence, I am pushing this change to a PR for integration to /main.