### PR TITLE
make compaction failures carry on

### DIFF
--- a/src/btree.c
+++ b/src/btree.c
@@ -2947,6 +2947,9 @@ btree_pack_abort(btree_pack_req *req)
  *
  *      Packs a btree from an iterator source. Dec_Refs the
  *      output tree if it's empty.
+ *
+ * Returns STATUS_LIMIT_EXCEEDED if the pack results in too many kv pairs.
+ * Otherwise, returns standard errors, e.g. STATUS_NO_MEMORY, etc.
  *-----------------------------------------------------------------------------
  */
 platform_status

--- a/src/trunk.c
+++ b/src/trunk.c
@@ -4627,6 +4627,7 @@ trunk_compact_bundle_cleanup_iterators(trunk_handle           *spl,
    for (uint64 i = 0; i < num_branches; i++) {
       trunk_btree_skiperator_deinit(spl, &skip_itor_arr[i]);
    }
+   debug_only(memset(skip_itor_arr, 0, num_branches * sizeof(*skip_itor_arr)));
 }
 
 /*
@@ -4852,9 +4853,12 @@ trunk_compact_bundle(void *arg, void *scratch_buf)
 
    platform_status pack_status = btree_pack(&pack_req);
    if (!SUCCESS(pack_status)) {
-      platform_default_log("btree_pack failed: %d\n", pack_status.r);
+      platform_default_log("btree_pack failed: %s\n",
+                           platform_status_to_string(pack_status));
       trunk_compact_bundle_cleanup_iterators(
          spl, &merge_itor, num_branches, skip_itor_arr);
+      btree_pack_req_deinit(&pack_req, spl->heap_id);
+      platform_free(spl->heap_id, req);
       goto out;
    }
 


### PR DESCRIPTION
I'd be happy to extend this to also add a flag in trunk nodes to record when a node needs a split (due to a prior failure) so that a split will be forced next time we flush to it.

I _think_ the current splitting policy will already cause the node to split on the next flush, but it would be reasonable to add some mechanism to force that to happen no matter what the splitting policy is.
