### PR TITLE
(#481) Fix missing free for fingerprint array in trunk_compact_bundle()

### DIFF
--- a/src/trunk.c
+++ b/src/trunk.c
@@ -4988,6 +4988,7 @@ trunk_compact_bundle(void *arg, void *scratch_buf)
          spl->stats[tid].compaction_time_wasted_ns[height] +=
             platform_timestamp_elapsed(compaction_start);
       }
+      platform_free(spl->heap_id, req->fp_arr);
       platform_free(spl->heap_id, req);
    } else {
       if (spl->cfg.use_stats) {


### PR DESCRIPTION
This commit fixes a missing free for memory allocated to the fingerprint array. The problem was seen to occur in highly concurrent inserts stress workload developed as part of concurrent POC-development and is difficult to reproduce in standalone Splinter.

In trunk_compact_bundle(), for a specific code-flow when we found no newly split siblings to replace with a new branch, we release the memory allocated for the trunk_compact_bundle_req{} struct, and exit processing. But the memory allocated (elsewhere, previously) for the fingerprint array hanging off this req struct remains unfreed.

This fix was identified through trace diagnostics and code walk through. And has been independently verified to fix this memory leak in the stress workloads that were used to generate this error.