### PR TITLE
Enable application to silence info logs

### DIFF
--- a/include/splinterdb/platform_linux/public_platform.h
+++ b/include/splinterdb/platform_linux/public_platform.h
@@ -67,9 +67,22 @@ typedef int32 bool;
 #endif
 typedef uint8 bool8;
 
-// See platform.c
+// By default, platform_default_log() messages are sent to /dev/null
+// and platform_error_log() messages go to stderr.
+//
+// Use platform_set_log_streams() to send the log messages elsewhere.
 typedef FILE                platform_log_handle;
-extern platform_log_handle *Platform_default_log_handle; // stdout FILE handle
-extern platform_log_handle *Platform_error_log_handle;   // stderr FILE handle
+extern platform_log_handle *Platform_default_log_handle;
+extern platform_log_handle *Platform_error_log_handle;
+
+// Set the streams where informational and error messages will be printed.
+//
+// These default to /dev/null and stderr, respectively.
+//
+// For example, to send info messages to stdout and errors to stderr, run:
+//    platform_set_log_streams(stdout, stderr);
+void
+platform_set_log_streams(platform_log_handle *info_stream,
+                         platform_log_handle *error_stream);
 
 #endif // __PUBLIC_PLATFORM_H

--- a/src/merge.c
+++ b/src/merge.c
@@ -408,12 +408,12 @@ merge_iterator_create(platform_heap_id hid,
    if (!out_itor || !itor_arr || !cfg || num_trees < 0
        || num_trees >= ARRAY_SIZE(merge_itor->ordered_iterator_stored))
    {
-      platform_default_log("merge_iterator_create: bad parameter merge_itor %p"
-                           " num_trees %d itor_arr %p cfg %p\n",
-                           out_itor,
-                           num_trees,
-                           itor_arr,
-                           cfg);
+      platform_error_log("merge_iterator_create: bad parameter merge_itor %p"
+                         " num_trees %d itor_arr %p cfg %p\n",
+                         out_itor,
+                         num_trees,
+                         itor_arr,
+                         cfg);
       return STATUS_BAD_PARAM;
    }
 

--- a/src/platform_linux/platform.c
+++ b/src/platform_linux/platform.c
@@ -12,17 +12,32 @@ __thread threadid xxxtid;
 bool platform_use_hugetlb = FALSE;
 bool platform_use_mlock   = FALSE;
 
-// By default, platform_default_log() messages go to stdout, and
-// platform_error_log() messages go to stderr. These can be changed to module-
-// or test-specific log files, by overriding these settings.
+// By default, platform_default_log() messages are sent to /dev/null
+// and platform_error_log() messages go to stderr (see below).
+//
+// Use platform_set_log_streams() to send the log messages elsewhere.
 platform_log_handle *Platform_default_log_handle = NULL;
 platform_log_handle *Platform_error_log_handle   = NULL;
 
 // This function is run automatically at library-load time
 void __attribute__((constructor)) platform_init_log_file_handles(void)
 {
-   Platform_default_log_handle = stdout;
+   FILE *dev_null_file = fopen("/dev/null", "w");
+   platform_assert(dev_null_file != NULL);
+
+   Platform_default_log_handle = dev_null_file;
    Platform_error_log_handle   = stderr;
+}
+
+// Set the streams where informational and error messages will be printed.
+void
+platform_set_log_streams(platform_log_handle *info_stream,
+                         platform_log_handle *error_stream)
+{
+   platform_assert(info_stream != NULL);
+   platform_assert(error_stream != NULL);
+   Platform_default_log_handle = info_stream;
+   Platform_error_log_handle   = error_stream;
 }
 
 platform_status

--- a/src/trunk.c
+++ b/src/trunk.c
@@ -9032,7 +9032,7 @@ trunk_config_init(trunk_config        *trunk_cfg,
    size_t max_value_size        = 64 - __builtin_clzll(max_value);
 
    if (filter_fingerprint_size > 32 - max_value_size) {
-      platform_error_log(
+      platform_default_log(
          "Fingerprint size %lu too large, max value size is %lu, "
          "setting to %lu\n",
          filter_fingerprint_size,
@@ -9069,10 +9069,10 @@ trunk_config_init(trunk_config        *trunk_cfg,
    while (filter_cfg->index_size <= (trunk_cfg->max_tuples_per_node
                                      / (addrs_per_page * pages_per_extent)))
    {
-      platform_error_log("filter-index-size: %u is too small, "
-                         "setting to %u\n",
-                         filter_cfg->index_size,
-                         filter_cfg->index_size * 2);
+      platform_default_log("filter-index-size: %u is too small, "
+                           "setting to %u\n",
+                           filter_cfg->index_size,
+                           filter_cfg->index_size * 2);
       filter_cfg->index_size *= 2;
       filter_cfg->log_index_size++;
    }

--- a/tests/functional/test_dispatcher.c
+++ b/tests/functional/test_dispatcher.c
@@ -26,6 +26,8 @@ usage(void)
 int
 test_dispatcher(int argc, char *argv[])
 {
+   platform_set_log_streams(stdout, stderr);
+
    platform_default_log("%s: %s\n", argv[0], BUILD_VERSION);
    // check first arg and call the appropriate test
    if (argc > 1) {

--- a/tests/functional/test_functionality.c
+++ b/tests/functional/test_functionality.c
@@ -48,7 +48,7 @@ search_for_key_via_iterator(trunk_handle *spl, key target)
       iterator_advance((iterator *)&iter);
       count++;
    }
-   platform_error_log("Saw a total of %lu keys\n", count);
+   platform_default_log("Saw a total of %lu keys\n", count);
 }
 
 


### PR DESCRIPTION
Fixes #441 , mostly.

Info messages now default to `/dev/null`.  Error messages still go to stderr.

The app may customize that by calling a new function `splinterdb_logs_set_streams()`.

A future PR could provide command-line or env-var control over _test_ output.