### PR TITLE
Fix Default Filter Config and Remove Superfluous Printing

### DIFF
--- a/src/rc_allocator.c
+++ b/src/rc_allocator.c
@@ -473,10 +473,6 @@ rc_allocator_mount(rc_allocator        *al,
          al->stats.curr_allocated++;
       }
    }
-   platform_default_log(
-      "Allocated %lu extents at mount: (%lu MiB)\n",
-      al->stats.curr_allocated,
-      B_TO_MiB(al->stats.curr_allocated * cfg->io_cfg->extent_size));
    return STATUS_OK;
 }
 
@@ -485,10 +481,6 @@ void
 rc_allocator_unmount(rc_allocator *al)
 {
    platform_status status;
-
-   platform_default_log(
-      "Allocated at unmount: %lu MiB\n",
-      B_TO_MiB(al->stats.curr_allocated * al->cfg->io_cfg->extent_size));
 
    // persist the ref counts upon unmount.
    uint32 io_size =

--- a/src/splinterdb.c
+++ b/src/splinterdb.c
@@ -88,7 +88,7 @@ splinterdb_config_set_defaults(splinterdb_config *cfg)
       cfg->filter_index_size = 256;
    }
    if (!cfg->filter_remainder_size) {
-      cfg->filter_remainder_size = 6;
+      cfg->filter_remainder_size = 4;
    }
 
    if (!cfg->memtable_capacity) {

--- a/src/trunk.c
+++ b/src/trunk.c
@@ -9041,8 +9041,6 @@ trunk_config_init(trunk_config        *trunk_cfg,
       filter_cfg->fingerprint_size = 32 - max_value_size;
    }
 
-   platform_default_log("fingerprint_size: %u\n", filter_cfg->fingerprint_size);
-
    /*
     * Set filter index size
     *

--- a/tests/unit/task_system_test.c
+++ b/tests/unit/task_system_test.c
@@ -162,7 +162,6 @@ CTEST2(task_system, test_basic_create_destroy)
 {
    threadid main_thread_idx = platform_get_tid();
    ASSERT_EQUAL(main_thread_idx, 0);
-   platform_default_log("platform_get_tid() = %lu\n", main_thread_idx);
 }
 
 /*
@@ -298,8 +297,10 @@ CTEST2(task_system, test_multiple_threads)
    platform_status rc          = STATUS_OK;
 
    ZERO_ARRAY(thread_cfg);
-   platform_default_log(" Before threads start, task_get_max_tid() = %lu\n",
-                        task_get_max_tid(data->tasks));
+   ASSERT_EQUAL(task_get_max_tid(data->tasks),
+                1,
+                "Before threads start, task_get_max_tid() = %lu",
+                task_get_max_tid(data->tasks));
 
    // Start-up n-threads, record their expected thread-IDs, which will be
    // validated by the thread's execution function below.
@@ -380,11 +381,6 @@ exec_one_thread_use_lower_apis(void *arg)
    platform_thread thread_id = platform_thread_id_self();
    ASSERT_TRUE((thread_cfg->this_thread_id == thread_id)
                || (thread_cfg->this_thread_id == 0));
-
-   platform_default_log("platform_get_tid() = %lu,"
-                        "new_thread_ID == platform_thread_id_self()=%lu\n",
-                        platform_get_tid(),
-                        thread_id);
 
    task_deregister_this_thread(thread_cfg->tasks);
 


### PR DESCRIPTION
Changes the default filter config so that the system doesn't print a warning.

Removes allocator, trunk, and task test printing.