### PR TITLE
tweak example running policy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ PLATFORM_DIR = platform_$(PLATFORM)
 
 help::
 	@echo 'Usage: make [<target>]'
-	@echo 'Supported targets: clean all libs all-tests run-tests test-results install'
+	@echo 'Supported targets: clean all libs all-tests run-tests test-results run-examples install'
 
 #*************************************************************#
 # SOURCE DIRECTORIES AND FILES

--- a/Makefile
+++ b/Makefile
@@ -484,6 +484,9 @@ run-tests: all-tests
 test-results: all-tests
 	INCLUDE_SLOW_TESTS=true BINDIR=$(BINDIR) ./test.sh 2>&1 | tee ./test-results
 
+run-examples: all-examples
+		for i in $(EXAMPLES_BINS); do $$i || exit; done
+
 INSTALL_PATH ?= /usr/local
 
 install: $(LIBDIR)/libsplinterdb.so $(LIBDIR)/libsplinterdb.a

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## What is SplinterDB?
 SplinterDB is a key-value store designed for high performance on fast storage devices.
 
-See
+See [this talk at the CMU Database Seminar](https://www.youtube.com/watch?v=1gOlXfbiT_Y) and this paper:
 > Alexander Conway, Abhishek Gupta, Vijay Chidambaram, Martin Farach-Colton, Richard P. Spillane, Amy Tai, Rob Johnson:
 [SplinterDB: Closing the Bandwidth Gap for NVMe Key-Value Stores](https://www.usenix.org/conference/atc20/presentation/conway). USENIX Annual Technical Conference 2020: 49-63
 

--- a/ci/steps.lib.yml
+++ b/ci/steps.lib.yml
@@ -130,7 +130,7 @@ config:
     dir: #@ input_name
     args:
     - "-c"
-    - "make $MAKE_HELP all run-tests"
+    - "make $MAKE_HELP all run-tests run-examples"
 #@ end
 
 ---

--- a/test.sh
+++ b/test.sh
@@ -507,17 +507,6 @@ function test_make_run_tests() {
 }
 
 # ##################################################################
-# Exercise example programs, to ensure that they don't fail.
-# ##################################################################
-function test_example_programs() {
-
-    "$BINDIR"/examples/splinterdb_intro_example
-    "$BINDIR"/examples/splinterdb_wide_values_example
-    "$BINDIR"/examples/splinterdb_iterators_example
-    "$BINDIR"/examples/splinterdb_custom_ipv4_addr_sortcmp_example
-}
-
-# ##################################################################
 # Smoke Tests: Run a small collection of fast-running unit-tests
 # ##################################################################
 function run_fast_unit_tests() {
@@ -709,8 +698,6 @@ if [ "$INCLUDE_SLOW_TESTS" != "true" ]; then
    start_seconds=$SECONDS
 
    run_with_timing "Smoke tests" run_fast_unit_tests
-
-   run_with_timing "Test example programs" test_example_programs
 
    if [ "$RUN_MAKE_TESTS" == "true" ]; then
       run_with_timing "Basic build-and-test tests" test_make_run_tests


### PR DESCRIPTION
Adds a new target, run-example, which runs as part of CI but not part of any version of "run-tests".