### PR TITLE
When file open fails, return error code instead of crashing

### DIFF
--- a/src/platform_linux/laio.c
+++ b/src/platform_linux/laio.c
@@ -97,7 +97,11 @@ io_handle_init(laio_handle         *io,
    } else {
       io->fd = open(cfg->filename, cfg->flags);
    }
-   platform_assert(io->fd != -1);
+   if (io->fd == -1) {
+      platform_error_log(
+         "open() '%s' failed: %s\n", cfg->filename, strerror(errno));
+      return CONST_STATUS(errno);
+   }
 
    req_size =
       sizeof(io_async_req) + cfg->async_max_pages * sizeof(struct iovec);

--- a/tests/unit/splinterdb_quick_test.c
+++ b/tests/unit/splinterdb_quick_test.c
@@ -112,7 +112,9 @@ CTEST_SETUP(splinterdb_quick)
 // Optional teardown function for suite, called after every test in suite
 CTEST_TEARDOWN(splinterdb_quick)
 {
-   splinterdb_close(&data->kvsb);
+   if (data->kvsb) {
+      splinterdb_close(&data->kvsb);
+   }
 }
 
 /*
@@ -851,6 +853,29 @@ CTEST2(splinterdb_quick, test_iterator_init_bug)
    ASSERT_EQUAL(num_inserts, i);
 
    splinterdb_iterator_deinit(it);
+}
+
+/*
+ * Check that errors on file-opening are returned, not asserted.
+ * Previously, a user error, e.g. bad file permissions, would
+ * just crash the program.
+ */
+CTEST2(splinterdb_quick, test_file_error_returns)
+{
+   // Tear down default instance, so we can try to create a new one.
+   splinterdb_close(&data->kvsb);
+
+   data->cfg.filename = "/dev/null/this-file-cannot-possibly-be-opened";
+
+   fprintf(Platform_error_log_handle,
+           "=== Testing an error condition, expect to see error messages "
+           "following this\n");
+   // this will fail, but shouldn't crash!
+   int rc = splinterdb_create(&data->cfg, &data->kvsb);
+   ASSERT_TRUE(0 != rc);
+   fprintf(Platform_error_log_handle, "^^^ Done testing an error condition\n");
+   // if we've made it this far, at least the application can report
+   // the error and recover!
 }
 
 /*


### PR DESCRIPTION
Fixes #482