### PR TITLE
Copy-on-write Trunk

### DIFF
--- a/src/allocator.h
+++ b/src/allocator.h
@@ -54,7 +54,6 @@ typedef enum page_type {
    PAGE_TYPE_LOG,
    PAGE_TYPE_SUPERBLOCK,
    PAGE_TYPE_MISC, // Used mainly as a testing hook, for cache access testing.
-   PAGE_TYPE_LOCK_NO_DATA,
    NUM_PAGE_TYPES,
 } page_type;
 
@@ -65,8 +64,7 @@ static const char *const page_type_str[] = {"invalid",
                                             "filter",
                                             "log",
                                             "superblock",
-                                            "misc",
-                                            "lock"};
+                                            "misc"};
 
 // Ensure that the page-type lookup array is adequately sized.
 _Static_assert(

--- a/src/clockcache.c
+++ b/src/clockcache.c
@@ -2263,8 +2263,7 @@ clockcache_get(clockcache *cc, uint64 addr, bool blocking, page_type type)
    page_handle *handle;
 
    debug_assert(cc->per_thread[platform_get_tid()].enable_sync_get
-                || type == PAGE_TYPE_MEMTABLE
-                || type == PAGE_TYPE_LOCK_NO_DATA);
+                || type == PAGE_TYPE_MEMTABLE);
    while (1) {
       retry = clockcache_get_internal(cc, addr, blocking, type, &handle);
       if (!retry) {

--- a/src/data_internal.c
+++ b/src/data_internal.c
@@ -1,4 +1,3 @@
-
 #include "data_internal.h"
 
 message_type

--- a/src/memtable.c
+++ b/src/memtable.c
@@ -16,6 +16,9 @@
 
 #define MEMTABLE_COUNT_GRANULARITY 128
 
+#define MEMTABLE_INSERT_LOCK_IDX 0
+#define MEMTABLE_LOOKUP_LOCK_IDX 1
+
 bool
 memtable_is_full(const memtable_config *cfg, memtable *mt)
 {
@@ -40,46 +43,106 @@ memtable_process(memtable_context *ctxt, uint64 generation)
    ctxt->process(ctxt->process_ctxt, generation);
 }
 
+void
+memtable_get_insert_lock(memtable_context *ctxt)
+{
+   platform_batch_rwlock_get(ctxt->rwlock, MEMTABLE_INSERT_LOCK_IDX);
+}
+
+void
+memtable_unget_insert_lock(memtable_context *ctxt)
+{
+   platform_batch_rwlock_unget(ctxt->rwlock, MEMTABLE_INSERT_LOCK_IDX);
+}
+
+bool
+memtable_try_lock_insert_lock(memtable_context *ctxt)
+{
+   if (!platform_batch_rwlock_try_claim(ctxt->rwlock, MEMTABLE_INSERT_LOCK_IDX))
+   {
+      return FALSE;
+   }
+   platform_batch_rwlock_lock(ctxt->rwlock, MEMTABLE_INSERT_LOCK_IDX);
+   return TRUE;
+}
+
+void
+memtable_lock_insert_lock(memtable_context *ctxt)
+{
+   platform_batch_rwlock_claim(ctxt->rwlock, MEMTABLE_INSERT_LOCK_IDX);
+   platform_batch_rwlock_lock(ctxt->rwlock, MEMTABLE_INSERT_LOCK_IDX);
+}
+
+void
+memtable_unlock_insert_lock(memtable_context *ctxt)
+{
+   platform_batch_rwlock_unclaim(ctxt->rwlock, MEMTABLE_INSERT_LOCK_IDX);
+   platform_batch_rwlock_unlock(ctxt->rwlock, MEMTABLE_INSERT_LOCK_IDX);
+}
+
+void
+memtable_get_lookup_lock(memtable_context *ctxt)
+{
+   platform_batch_rwlock_get(ctxt->rwlock, MEMTABLE_LOOKUP_LOCK_IDX);
+}
+
+void
+memtable_unget_lookup_lock(memtable_context *ctxt)
+{
+   platform_batch_rwlock_unget(ctxt->rwlock, MEMTABLE_LOOKUP_LOCK_IDX);
+}
+
+void
+memtable_lock_lookup_lock(memtable_context *ctxt)
+{
+   platform_batch_rwlock_claim(ctxt->rwlock, MEMTABLE_LOOKUP_LOCK_IDX);
+   platform_batch_rwlock_lock(ctxt->rwlock, MEMTABLE_LOOKUP_LOCK_IDX);
+}
+
+void
+memtable_unlock_lookup_lock(memtable_context *ctxt)
+{
+   platform_batch_rwlock_unclaim(ctxt->rwlock, MEMTABLE_LOOKUP_LOCK_IDX);
+   platform_batch_rwlock_unlock(ctxt->rwlock, MEMTABLE_LOOKUP_LOCK_IDX);
+}
+
 
 platform_status
 memtable_maybe_rotate_and_get_insert_lock(memtable_context *ctxt,
-                                          uint64           *generation,
-                                          page_handle     **lock_page)
+                                          uint64           *generation)
 {
-   cache *cc        = ctxt->cc;
-   uint64 lock_addr = ctxt->insert_lock_addr;
-   uint64 wait      = 100;
+   uint64 wait = 100;
    while (TRUE) {
-      *lock_page      = cache_get(cc, lock_addr, TRUE, PAGE_TYPE_LOCK_NO_DATA);
+      memtable_get_insert_lock(ctxt);
       *generation     = ctxt->generation;
       uint64    mt_no = *generation % ctxt->cfg.max_memtables;
       memtable *mt    = &ctxt->mt[mt_no];
       if (mt->state != MEMTABLE_STATE_READY) {
          // The next memtable is not ready yet, back off and wait.
-         cache_unget(cc, *lock_page);
+         memtable_unget_insert_lock(ctxt);
          platform_sleep_ns(wait);
          wait = wait > 2048 ? wait : 2 * wait;
          continue;
       }
+      wait = 100;
 
       if (memtable_is_full(&ctxt->cfg, &ctxt->mt[mt_no])) {
          // If the current memtable is full, try to retire it.
-         if (cache_try_claim(cc, *lock_page)) {
-            // We successfully got the claim, so we do the finalization
-            cache_lock(cc, *lock_page);
+         memtable_unget_insert_lock(ctxt);
+         if (memtable_try_lock_insert_lock(ctxt)) {
+            // We successfully got the lock, so we do the finalization
             memtable_transition(
                mt, MEMTABLE_STATE_READY, MEMTABLE_STATE_FINALIZED);
 
+            // Safe to increment non-atomically because we have a lock on
+            // the insert lock
             uint64 process_generation = ctxt->generation++;
             memtable_mark_empty(ctxt);
-            cache_unlock(cc, *lock_page);
-            cache_unclaim(cc, *lock_page);
-            cache_unget(cc, *lock_page);
+            memtable_unlock_insert_lock(ctxt);
             memtable_process(ctxt, process_generation);
          } else {
-            cache_unget(cc, *lock_page);
             platform_sleep_ns(wait);
-            wait *= 2;
+            wait = wait > 2048 ? wait : 2 * wait;
          }
          continue;
       }
@@ -144,46 +207,6 @@ memtable_insert(memtable_context *ctxt,
    return rc;
 }
 
-void
-memtable_unget_insert_lock(memtable_context *ctxt, page_handle *lock_page)
-{
-   cache_unget(ctxt->cc, lock_page);
-}
-
-page_handle *
-memtable_get_lookup_lock(memtable_context *ctxt)
-{
-   return cache_get(
-      ctxt->cc, ctxt->lookup_lock_addr, TRUE, PAGE_TYPE_LOCK_NO_DATA);
-}
-
-void
-memtable_unget_lookup_lock(memtable_context *ctxt, page_handle *lock_page)
-{
-   cache_unget(ctxt->cc, lock_page);
-}
-
-page_handle *
-memtable_uncontended_get_claim_lock_lookup_lock(memtable_context *ctxt)
-{
-   page_handle *lock_page = memtable_get_lookup_lock(ctxt);
-   cache       *cc        = ctxt->cc;
-   bool         claimed   = cache_try_claim(cc, lock_page);
-   platform_assert(claimed);
-   cache_lock(cc, lock_page);
-   return lock_page;
-}
-
-void
-memtable_unlock_unclaim_unget_lookup_lock(memtable_context *ctxt,
-                                          page_handle      *lock_page)
-{
-   cache *cc = ctxt->cc;
-   cache_unlock(cc, lock_page);
-   cache_unclaim(cc, lock_page);
-   cache_unget(cc, lock_page);
-}
-
 /*
  * if there are no outstanding refs, then destroy and reinit memtable and
  * transition to READY
@@ -209,18 +232,7 @@ memtable_dec_ref_maybe_recycle(memtable_context *ctxt, memtable *mt)
 uint64
 memtable_force_finalize(memtable_context *ctxt)
 {
-   uint64       lock_addr = ctxt->insert_lock_addr;
-   cache       *cc        = ctxt->cc;
-   page_handle *lock_page =
-      cache_get(cc, lock_addr, TRUE, PAGE_TYPE_LOCK_NO_DATA);
-   uint64 wait = 100;
-   while (!cache_try_claim(cc, lock_page)) {
-      cache_unget(cc, lock_page);
-      platform_sleep_ns(wait);
-      wait *= 2;
-      lock_page = cache_get(cc, lock_addr, TRUE, PAGE_TYPE_LOCK_NO_DATA);
-   }
-   cache_lock(cc, lock_page);
+   memtable_lock_insert_lock(ctxt);
 
    uint64    generation = ctxt->generation;
    uint64    mt_no      = generation % ctxt->cfg.max_memtables;
@@ -229,10 +241,7 @@ memtable_force_finalize(memtable_context *ctxt)
    uint64 process_generation = ctxt->generation++;
    memtable_mark_empty(ctxt);
 
-   cache_unlock(cc, lock_page);
-   cache_unclaim(cc, lock_page);
-   cache_unget(cc, lock_page);
-
+   memtable_unlock_insert_lock(ctxt);
    return process_generation;
 }
 
@@ -268,29 +277,10 @@ memtable_context_create(platform_heap_id hid,
    ctxt->cc = cc;
    memmove(&ctxt->cfg, cfg, sizeof(ctxt->cfg));
 
-   uint64          base_addr;
-   allocator      *al = cache_get_allocator(cc);
-   platform_status rc = allocator_alloc(al, &base_addr, PAGE_TYPE_LOCK_NO_DATA);
-   platform_assert_status_ok(rc);
-
-   ctxt->insert_lock_addr = base_addr;
-   ctxt->lookup_lock_addr = base_addr + cache_page_size(cc);
-
-   page_handle *lock_page =
-      cache_alloc(cc, ctxt->insert_lock_addr, PAGE_TYPE_LOCK_NO_DATA);
-   cache_pin(cc, lock_page);
-   cache_unlock(cc, lock_page);
-   cache_unclaim(cc, lock_page);
-   cache_unget(cc, lock_page);
-
-   lock_page = cache_alloc(cc, ctxt->lookup_lock_addr, PAGE_TYPE_LOCK_NO_DATA);
-   cache_pin(cc, lock_page);
-   cache_unlock(cc, lock_page);
-   cache_unclaim(cc, lock_page);
-   cache_unget(cc, lock_page);
-
-   platform_spinlock_init(
-      &ctxt->incorporation_lock, platform_get_module_id(), hid);
+   platform_mutex_init(
+      &ctxt->incorporation_mutex, platform_get_module_id(), hid);
+   ctxt->rwlock = TYPED_MALLOC(hid, ctxt->rwlock);
+   platform_batch_rwlock_init(ctxt->rwlock);
 
    for (uint64 mt_no = 0; mt_no < cfg->max_memtables; mt_no++) {
       uint64 generation = mt_no;
@@ -317,19 +307,8 @@ memtable_context_destroy(platform_heap_id hid, memtable_context *ctxt)
       memtable_deinit(cc, &ctxt->mt[mt_no]);
    }
 
-   platform_spinlock_destroy(&ctxt->incorporation_lock);
-
-   /*
-    * lookup lock and insert lock share extents but not pages.
-    * this deallocs both.
-    */
-   allocator *al = cache_get_allocator(cc);
-   uint8      ref =
-      allocator_dec_ref(al, ctxt->insert_lock_addr, PAGE_TYPE_LOCK_NO_DATA);
-   platform_assert(ref == AL_NO_REFS);
-   cache_extent_discard(cc, ctxt->insert_lock_addr, PAGE_TYPE_LOCK_NO_DATA);
-   ref = allocator_dec_ref(al, ctxt->insert_lock_addr, PAGE_TYPE_LOCK_NO_DATA);
-   platform_assert(ref == AL_FREE);
+   platform_mutex_destroy(&ctxt->incorporation_mutex);
+   platform_free(hid, ctxt->rwlock);
 
    platform_free(hid, ctxt);
 }

--- a/src/platform_linux/platform.c
+++ b/src/platform_linux/platform.c
@@ -219,6 +219,140 @@ platform_spinlock_destroy(platform_spinlock *lock)
    return CONST_STATUS(ret);
 }
 
+/*
+ *-----------------------------------------------------------------------------
+ * Batch Read/Write Locks
+ *
+ * These are generic distributed reader/writer locks with an intermediate claim
+ * state. These offer similar semantics to the locks in the clockcache, but in
+ * these locks read locks cannot be held with write locks.
+ *
+ * These locks are allocated in batches of PLATFORM_CACHELINE_SIZE / 2, so that
+ * the write lock and claim bits, as well as the distributed read counters, can
+ * be colocated across the batch.
+ *-----------------------------------------------------------------------------
+ */
+
+void
+platform_batch_rwlock_init(platform_batch_rwlock *lock)
+{
+   ZERO_CONTENTS(lock);
+}
+
+/*
+ *-----------------------------------------------------------------------------
+ * lock/unlock
+ *
+ * Drains and blocks all gets (read locks)
+ *
+ * Caller must hold a claim
+ * Caller cannot hold a get (read lock)
+ *-----------------------------------------------------------------------------
+ */
+
+void
+platform_batch_rwlock_lock(platform_batch_rwlock *lock, uint64 lock_idx)
+{
+   platform_assert(lock->write_lock[lock_idx].claim);
+   debug_only uint8 was_locked =
+      __sync_lock_test_and_set(&lock->write_lock[lock_idx].lock, 1);
+   debug_assert(!was_locked,
+                "platform_batch_rwlock_lock: Attempt to lock a locked page.\n");
+
+   uint64 wait = 1;
+   for (uint64 i = 0; i < MAX_THREADS; i++) {
+      while (lock->read_counter[i][lock_idx] != 0) {
+         platform_sleep_ns(wait);
+         wait = wait > 2048 ? wait : 2 * wait;
+      }
+      wait = 1;
+   }
+}
+
+void
+platform_batch_rwlock_unlock(platform_batch_rwlock *lock, uint64 lock_idx)
+{
+   __sync_lock_release(&lock->write_lock[lock_idx].lock);
+}
+
+/*
+ *-----------------------------------------------------------------------------
+ * try_claim/claim/unlock
+ *
+ * A claim blocks all other claimants (and therefore all other writelocks,
+ * because writelocks are required to hold a claim during the writelock).
+ *
+ * Cannot hold a get (read lock)
+ *
+ * try_claim returns whether the claim succeeded
+ *-----------------------------------------------------------------------------
+ */
+
+bool
+platform_batch_rwlock_try_claim(platform_batch_rwlock *lock, uint64 lock_idx)
+{
+   if (__sync_lock_test_and_set(&lock->write_lock[lock_idx].claim, 1)) {
+      return FALSE;
+   }
+   return TRUE;
+}
+
+void
+platform_batch_rwlock_claim(platform_batch_rwlock *lock, uint64 lock_idx)
+{
+   uint64 wait = 1;
+   while (!platform_batch_rwlock_try_claim(lock, lock_idx)) {
+      platform_sleep_ns(wait);
+      wait = wait > 2048 ? wait : 2 * wait;
+   }
+}
+
+void
+platform_batch_rwlock_unclaim(platform_batch_rwlock *lock, uint64 lock_idx)
+{
+   __sync_lock_release(&lock->write_lock[lock_idx].claim);
+}
+
+/*
+ *-----------------------------------------------------------------------------
+ * get/unget
+ *
+ * Acquire a read lock
+ *-----------------------------------------------------------------------------
+ */
+
+void
+platform_batch_rwlock_get(platform_batch_rwlock *lock, uint64 lock_idx)
+{
+   threadid tid = platform_get_tid();
+   while (1) {
+      uint64 wait = 1;
+      while (lock->write_lock[lock_idx].lock) {
+         platform_sleep_ns(wait);
+         wait = wait > 2048 ? wait : 2 * wait;
+      }
+      debug_only uint8 old_counter =
+         __sync_fetch_and_add(&lock->read_counter[tid][lock_idx], 1);
+      debug_assert(old_counter == 0);
+      if (!lock->write_lock[lock_idx].lock) {
+         return;
+      }
+      old_counter = __sync_fetch_and_sub(&lock->read_counter[tid][lock_idx], 1);
+      debug_assert(old_counter == 1);
+   }
+   platform_assert(0);
+}
+
+void
+platform_batch_rwlock_unget(platform_batch_rwlock *lock, uint64 lock_idx)
+{
+   threadid         tid = platform_get_tid();
+   debug_only uint8 old_counter =
+      __sync_fetch_and_sub(&lock->read_counter[tid][lock_idx], 1);
+   debug_assert(old_counter == 1);
+}
+
+
 platform_status
 platform_histo_create(platform_heap_id       heap_id,
                       uint32                 num_buckets,

--- a/src/trunk.c
+++ b/src/trunk.c
@@ -90,6 +90,11 @@ static const int64 latency_histo_buckets[LATENCYHISTO_SIZE] = {
 #define TRUNK_SINGLE_LEAF_THRESHOLD_PCT (75)
 
 /*
+ * Index of the trunk_root_lock batch rwlock used.
+ */
+#define TRUNK_ROOT_LOCK_IDX 0
+
+/*
  * During Splinter configuration, the fanout parameter is provided by the user.
  * SplinterDB defers internal node splitting in order to use hand-over-hand
  * locking. As a result, index nodes may temporarily have more pivots than the
@@ -99,6 +104,7 @@ static const int64 latency_histo_buckets[LATENCYHISTO_SIZE] = {
 #define TRUNK_EXTRA_PIVOT_KEYS (6)
 
 #define TRUNK_INVALID_PIVOT_NO (UINT16_MAX)
+
 /*
  * Trunk logging functions.
  *
@@ -523,8 +529,6 @@ typedef struct ONDISK trunk_bundle {
 typedef struct ONDISK trunk_hdr {
    uint16 num_pivot_keys;   // number of used pivot keys (== num_children + 1)
    uint16 height;           // height of the node
-   uint64 next_addr;        // PBN of the node's successor (0 if no successor)
-   uint64 generation;       // counter incremented on a node split
    uint64 pivot_generation; // counter incremented when new pivots are added
 
    uint16 start_branch;      // first live branch
@@ -571,7 +575,6 @@ typedef struct ONDISK trunk_pivot_data {
 } trunk_pivot_data;
 
 /*
- *
  *-----------------------------------------------------------------------------
  * Trunk Node Access Wrappers
  *-----------------------------------------------------------------------------
@@ -654,33 +657,21 @@ trunk_node_async_done(trunk_handle *spl, trunk_async_ctxt *ctxt)
  */
 
 static inline uint16
-trunk_height(trunk_node *node)
+trunk_node_height(trunk_node *node)
 {
    return node->hdr->height;
 }
 
 static inline bool
-trunk_is_leaf(trunk_node *node)
+trunk_node_is_leaf(trunk_node *node)
 {
-   return trunk_height(node) == 0;
+   return trunk_node_height(node) == 0;
 }
 
 static inline bool
-trunk_is_index(trunk_node *node)
+trunk_node_is_index(trunk_node *node)
 {
-   return !trunk_is_leaf(node);
-}
-
-static inline uint64
-trunk_next_addr(trunk_node *node)
-{
-   return node->hdr->next_addr;
-}
-
-static inline void
-trunk_set_next_addr(trunk_node *node, uint64 addr)
-{
-   node->hdr->next_addr = addr;
+   return !trunk_node_is_leaf(node);
 }
 
 /*
@@ -703,23 +694,38 @@ typedef enum trunk_compaction_type {
    NUM_TRUNK_COMPACTION_TYPES,
 } trunk_compaction_type;
 
-// arguments to a compact_bundle job
+/*
+ *-----------------------------------------------------------------------------
+ * Compact Bundle Requests
+ *
+ * Arguments and scratch space to compact bundle number <bundle_no> in the
+ * node[s] at height <height> spanning the range [start_key, end_key). <addr>
+ * is the address of the node where the bundle was initially created, and is
+ * used to revisit the node to create the iterators which become inputs to the
+ * compaction.
+ *-----------------------------------------------------------------------------
+ */
 struct trunk_compact_bundle_req {
+
+   // Inputs
    trunk_handle         *spl;
    uint64                addr;
+   key_buffer            start_key;
+   key_buffer            end_key;
    uint16                height;
    uint16                bundle_no;
    trunk_compaction_type type;
-   uint64                generation; // node generation
-   uint64                pivot_generation[TRUNK_MAX_PIVOTS];
-   uint64                max_pivot_generation;
-   uint64                input_pivot_tuple_count[TRUNK_MAX_PIVOTS];
-   uint64                output_pivot_tuple_count[TRUNK_MAX_PIVOTS];
-   uint64                input_pivot_kv_byte_count[TRUNK_MAX_PIVOTS];
-   uint64                output_pivot_kv_byte_count[TRUNK_MAX_PIVOTS];
-   uint64                tuples_reclaimed;
-   uint64                kv_bytes_reclaimed;
-   uint32               *fp_arr;
+
+   // Computed as part of the compaction process
+   uint64  pivot_generation[TRUNK_MAX_PIVOTS];
+   uint64  max_pivot_generation;
+   uint64  input_pivot_tuple_count[TRUNK_MAX_PIVOTS];
+   uint64  output_pivot_tuple_count[TRUNK_MAX_PIVOTS];
+   uint64  input_pivot_kv_byte_count[TRUNK_MAX_PIVOTS];
+   uint64  output_pivot_kv_byte_count[TRUNK_MAX_PIVOTS];
+   uint64  tuples_reclaimed;
+   uint64  kv_bytes_reclaimed;
+   uint32 *fp_arr;
 };
 
 // an iterator which skips masked pivots
@@ -786,11 +792,12 @@ static inline uint16               trunk_num_pivot_keys            (trunk_handle
 static inline void                 trunk_set_num_pivot_keys        (trunk_handle *spl, trunk_node *node, uint16 num_pivot_keys);
 static inline void                 trunk_inc_num_pivot_keys        (trunk_handle *spl, trunk_node *node);
 static inline key                  trunk_max_key                   (trunk_handle *spl, trunk_node *node);
+static inline key                  trunk_min_key                   (trunk_handle *spl, trunk_node *node);
 static inline uint64               trunk_pivot_num_tuples          (trunk_handle *spl, trunk_node *node, uint16 pivot_no);
 static inline uint64               trunk_pivot_kv_bytes            (trunk_handle *spl, trunk_node *node, uint16 pivot_no);
 static inline void                 trunk_pivot_branch_tuple_counts (trunk_handle *spl, trunk_node  *node, uint16 pivot_no, uint16 branch_no, uint64 *num_tuples, uint64 *num_kv_bytes);
 void                               trunk_pivot_recount_num_tuples_and_kv_bytes  (trunk_handle *spl, trunk_node *node, uint64 pivot_no);
-//static inline bool                 trunk_has_vacancy               (trunk_handle *spl, trunk_node *node, uint16 num_new_branches);
+static inline bool                 trunk_has_vacancy               (trunk_handle *spl, trunk_node *node, uint16 num_new_branches);
 static inline uint16               trunk_add_bundle_number         (trunk_handle *spl, uint16 start, uint16 end);
 static inline uint16               trunk_subtract_bundle_number    (trunk_handle *spl, uint16 start, uint16 end);
 static inline trunk_bundle        *trunk_get_bundle                (trunk_handle *spl, trunk_node *node, uint16 bundle_no);
@@ -831,9 +838,9 @@ void                               trunk_compact_bundle            (void *arg, v
 platform_status                    trunk_flush                     (trunk_handle *spl, trunk_node *parent, trunk_pivot_data *pdata, bool is_space_rec);
 platform_status                    trunk_flush_fullest             (trunk_handle *spl, trunk_node *node);
 static inline bool                 trunk_needs_split               (trunk_handle *spl, trunk_node *node);
-int                                trunk_split_index               (trunk_handle *spl, trunk_node *parent, trunk_node *child, uint64 pivot_no);
 void                               trunk_split_leaf                (trunk_handle *spl, trunk_node *parent, trunk_node *leaf, uint16 child_idx);
-int                                trunk_split_root                (trunk_handle *spl, trunk_node     *root);
+void                               trunk_split_index               (trunk_handle *spl, trunk_node *parent, trunk_node *child, uint16 pivot_no, trunk_compact_bundle_req *req);
+int                                trunk_split_root                (trunk_handle *spl, trunk_node *root);
 void                               trunk_print                     (platform_log_handle *log_handle, trunk_handle *spl);
 void                               trunk_print_node                (platform_log_handle *log_handle, trunk_handle *spl, uint64 addr);
 static void                        trunk_print_pivots              (platform_log_handle *log_handle, trunk_handle *spl, trunk_node *node);
@@ -854,6 +861,12 @@ const static iterator_ops trunk_btree_skiperator_ops = {
 };
 
 // clang-format on
+
+static inline data_config *
+trunk_data_config(trunk_handle *spl)
+{
+   return spl->cfg.data_cfg;
+}
 
 static inline uint64
 trunk_page_size(const trunk_config *cfg)
@@ -878,7 +891,7 @@ trunk_tree_height(trunk_handle *spl)
 {
    trunk_node root;
    trunk_node_get(spl->cc, spl->root_addr, &root);
-   uint16 tree_height = trunk_height(&root);
+   uint16 tree_height = trunk_node_height(&root);
    trunk_node_unget(spl->cc, &root);
    return tree_height;
 }
@@ -1012,6 +1025,31 @@ trunk_node_is_full(trunk_handle *spl, trunk_node *node)
    return num_kv_bytes > spl->cfg.max_kv_bytes_per_node;
 }
 
+bool
+trunk_for_each_subtree(trunk_handle *spl, uint64 addr, node_fn func, void *arg)
+{
+   // func may be deallocation, so first apply to subtree
+   trunk_node node;
+   trunk_node_get(spl->cc, addr, &node);
+   if (!trunk_node_is_leaf(&node)) {
+      uint16 num_children = trunk_num_children(spl, &node);
+      for (uint16 pivot_no = 0; pivot_no < num_children; pivot_no++) {
+         trunk_pivot_data *pdata = trunk_get_pivot_data(spl, &node, pivot_no);
+         bool              succeeded_on_subtree =
+            trunk_for_each_subtree(spl, pdata->addr, func, arg);
+         if (!succeeded_on_subtree) {
+            goto failed_on_subtree;
+         }
+      }
+   }
+   trunk_node_unget(spl->cc, &node);
+   return func(spl, addr, arg);
+
+failed_on_subtree:
+   trunk_node_unget(spl->cc, &node);
+   return FALSE;
+}
+
 /*
  * trunk_for_each_node() is an iterator driver function to walk through all
  * nodes in a Splinter tree, and to execute the work-horse 'func' function on
@@ -1022,36 +1060,273 @@ trunk_node_is_full(trunk_handle *spl, trunk_node *node)
 bool
 trunk_for_each_node(trunk_handle *spl, node_fn func, void *arg)
 {
-   uint16 tree_height     = trunk_tree_height(spl);
-   uint64 next_level_addr = spl->root_addr;
-   for (uint64 i = 0; i <= tree_height; i++) {
-      trunk_node node;
-      trunk_node_get(spl->cc, next_level_addr, &node);
-      uint64            addr  = next_level_addr;
-      trunk_pivot_data *pdata = trunk_get_pivot_data(spl, &node, 0);
-      next_level_addr         = pdata->addr;
-      trunk_node_unget(spl->cc, &node);
-      while (addr != 0) {
-         // first get the next_addr, then apply func, in case func
-         // deletes the node for example
-         trunk_node node;
-         trunk_node_get(spl->cc, addr, &node);
-         uint64 next_addr = trunk_next_addr(&node);
-         trunk_node_unget(spl->cc, &node);
-         bool rc = func(spl, addr, arg);
-         if (rc != TRUE) {
-            return rc;
-         }
-         addr = next_addr;
-      }
-   }
-   return TRUE;
+   return trunk_for_each_subtree(spl, spl->root_addr, func, arg);
 }
 
 static inline btree_config *
 trunk_btree_config(trunk_handle *spl)
 {
    return &spl->cfg.btree_cfg;
+}
+
+/*
+ * Copies <node> into a newly allocated node <node_copy>.
+ */
+static inline void
+trunk_node_copy(trunk_handle *spl, trunk_node *node, trunk_node *node_copy)
+{
+   trunk_alloc(spl->cc, &spl->mini, trunk_node_height(node), node_copy);
+   memmove(node_copy->hdr, node->hdr, trunk_page_size(&spl->cfg));
+   trunk_default_log_if_enabled(
+      spl, "Node copy %lu -> %lu\n", node->addr, node_copy->addr);
+}
+
+/*
+ * Makes a copy of the child indicated by pdata and replaces the parent's
+ * pointer with one to the new child. Returns the new child's page_handle *.
+ */
+static inline void
+trunk_copy_node_and_add_to_parent(trunk_handle     *spl,    // IN
+                                  trunk_node       *parent, // IN
+                                  trunk_pivot_data *pdata,  // IN
+                                  trunk_node       *new_child)    // OUT
+{
+   trunk_node old_child;
+   trunk_node_get(spl->cc, pdata->addr, &old_child);
+   trunk_node_copy(spl, &old_child, new_child);
+   trunk_node_unget(spl->cc, &old_child);
+   pdata->addr = new_child->addr;
+}
+
+/*
+ *-----------------------------------------------------------------------------
+ * Trunk Root Access
+ *
+ * The root node must be accessed using trunk_root_get,
+ * trunk_root_get_by_key_and_height, trunk_claim_and_copy_root or
+ * trunk_copy_path_by_key_and_height
+ *-----------------------------------------------------------------------------
+ */
+
+/*
+ *-----------------------------------------------------------------------------
+ * Fetch the latest copy of the root
+ *
+ * The copy is guaranteed to be the latest at some time during the call
+ * duration, but may be out of date after return.
+ */
+static inline void
+trunk_root_get(trunk_handle *spl, trunk_node *root)
+{
+   platform_batch_rwlock_get(&spl->trunk_root_lock, TRUNK_ROOT_LOCK_IDX);
+   trunk_node_get(spl->cc, spl->root_addr, root);
+   platform_batch_rwlock_unget(&spl->trunk_root_lock, TRUNK_ROOT_LOCK_IDX);
+}
+
+/*
+ *-----------------------------------------------------------------------------
+ * Fetch Trunk Nodes By Key and Height
+ *
+ * Returns the node whose key range contains key at height height. Returns an
+ * error if no such node exists, which should only happen when height >
+ * height(root);
+ *-----------------------------------------------------------------------------
+ */
+
+platform_status
+trunk_node_get_by_key_and_height_from_root(trunk_handle *spl,    // IN
+                                           key           target, // IN
+                                           uint16        height, // IN
+                                           trunk_node   *root,   // IN
+                                           trunk_node   *out_node) // OUT
+{
+   trunk_node node        = *root;
+   uint16     root_height = trunk_node_height(root);
+   if (root_height < height) {
+      goto error;
+   }
+   for (uint16 h = root_height; h > height; h--) {
+      debug_assert(trunk_node_height(&node) == h);
+      uint16 pivot_no =
+         trunk_find_pivot(spl, &node, target, less_than_or_equal);
+      debug_assert(pivot_no < trunk_num_children(spl, &node));
+      trunk_pivot_data *pdata = trunk_get_pivot_data(spl, &node, pivot_no);
+      trunk_node        child;
+      trunk_node_get(spl->cc, pdata->addr, &child);
+      trunk_node_unget(spl->cc, &node);
+      node = child;
+   }
+
+   debug_assert(trunk_node_height(&node) == height);
+   debug_assert(trunk_key_compare(spl, trunk_min_key(spl, &node), target) <= 0);
+   debug_assert(trunk_key_compare(spl, target, trunk_max_key(spl, &node)) < 0);
+
+   *out_node = node;
+   return STATUS_OK;
+
+error:
+   return STATUS_BAD_PARAM;
+}
+
+platform_status
+trunk_node_get_by_key_and_height(trunk_handle *spl,    // IN
+                                 key           target, // IN
+                                 uint16        height, // IN
+                                 trunk_node   *out_node) // OUT
+{
+   trunk_node root;
+   trunk_root_get(spl, &root);
+   uint16 root_height = trunk_node_height(&root);
+   if (height > root_height) {
+      goto error;
+   }
+
+   return trunk_node_get_by_key_and_height_from_root(
+      spl, target, height, &root, out_node);
+
+error:
+   trunk_node_unget(spl->cc, &root);
+   return STATUS_BAD_PARAM;
+}
+
+/*
+ *-----------------------------------------------------------------------------
+ * Helper functions to control the root lock
+ *-----------------------------------------------------------------------------
+ */
+
+static inline void
+trunk_root_claim(trunk_handle *spl)
+{
+   platform_batch_rwlock_claim(&spl->trunk_root_lock, TRUNK_ROOT_LOCK_IDX);
+}
+
+
+static inline void
+trunk_root_lock(trunk_handle *spl)
+{
+   platform_batch_rwlock_lock(&spl->trunk_root_lock, TRUNK_ROOT_LOCK_IDX);
+}
+
+static inline void
+trunk_root_unlock(trunk_handle *spl)
+{
+   platform_batch_rwlock_unlock(&spl->trunk_root_lock, TRUNK_ROOT_LOCK_IDX);
+}
+
+static inline void
+trunk_root_unclaim(trunk_handle *spl)
+{
+   platform_batch_rwlock_unclaim(&spl->trunk_root_lock, TRUNK_ROOT_LOCK_IDX);
+}
+
+/*
+ *-----------------------------------------------------------------------------
+ * Returns a copy of the root node with a *claim*
+ *
+ * Must be followed by a call to trunk_update_claimed_root, which makes the
+ * copy the new root and releases all locks.
+ *-----------------------------------------------------------------------------
+ */
+void
+trunk_claim_and_copy_root(trunk_handle *spl,      // IN
+                          trunk_node   *new_root, // OUT
+                          uint64       *old_root_addr)  // OUT
+{
+   trunk_root_claim(spl);
+   trunk_node root;
+   // Safe because we have the claim
+   trunk_node_get(spl->cc, spl->root_addr, &root);
+   *old_root_addr = spl->root_addr;
+   trunk_node_copy(spl, &root, new_root);
+   trunk_node_unget(spl->cc, &root);
+}
+
+/*
+ *-----------------------------------------------------------------------------
+ * Update claimed root
+ *
+ * Switches in the given new root and releases the trunk root lock.
+ *
+ * Must be preceded with a call to trunk_claim_and_copy_root.
+ *-----------------------------------------------------------------------------
+ */
+void
+trunk_update_claimed_root(trunk_handle *spl,    // IN
+                          trunk_node   *new_root) // IN
+{
+   trunk_root_lock(spl);
+   spl->root_addr = new_root->addr;
+   trunk_root_unlock(spl);
+   trunk_root_unclaim(spl);
+}
+
+/*
+ *-----------------------------------------------------------------------------
+ * Update claimed root and release locks.
+ *
+ * Switches in the given new root and releases all locks (root lock and the
+ * node locks on the root).
+ *
+ * Must be preceded with a call to trunk_claim_and_copy_root.
+ *-----------------------------------------------------------------------------
+ */
+void
+trunk_update_claimed_root_and_unlock(trunk_handle *spl,    // IN
+                                     trunk_node   *new_root) // IN
+{
+   trunk_update_claimed_root(spl, new_root);
+
+   trunk_node_unlock(spl->cc, new_root);
+   trunk_node_unclaim(spl->cc, new_root);
+   trunk_node_unget(spl->cc, new_root);
+}
+
+
+/*
+ *-----------------------------------------------------------------------------
+ * Copy the path from the root to the node at given height whose key range
+ * contains key.
+ *
+ * Returns the address of the new root in out_root_addr.
+ *
+ * Switches in the new root and releases all locks except for a write lock on
+ * the output node.
+ *-----------------------------------------------------------------------------
+ */
+void
+trunk_copy_path_by_key_and_height(trunk_handle *spl,      // IN
+                                  key           target,   // IN
+                                  uint16        height,   // IN
+                                  trunk_node   *out_node, // OUT
+                                  uint64       *old_root_addr)  // OUT
+{
+   trunk_node node;
+   trunk_claim_and_copy_root(spl, &node, old_root_addr);
+   // Note we still hold a writelock on the new root
+   trunk_update_claimed_root(spl, &node);
+   uint16 root_height = trunk_node_height(&node);
+
+   for (uint16 h = root_height; h > height; h--) {
+      debug_assert(trunk_node_height(&node) == h);
+      uint16 pivot_no =
+         trunk_find_pivot(spl, &node, target, less_than_or_equal);
+      debug_assert(pivot_no < trunk_num_children(spl, &node));
+      trunk_pivot_data *pdata = trunk_get_pivot_data(spl, &node, pivot_no);
+      trunk_node        child;
+      trunk_copy_node_and_add_to_parent(spl, &node, pdata, &child);
+      // Hold a writelock on the child
+      trunk_node_unlock(spl->cc, &node);
+      trunk_node_unclaim(spl->cc, &node);
+      trunk_node_unget(spl->cc, &node);
+      node = child;
+   }
+
+   debug_assert(trunk_node_height(&node) == height);
+   debug_assert(trunk_key_compare(spl, trunk_min_key(spl, &node), target) <= 0);
+   debug_assert(trunk_key_compare(spl, target, trunk_max_key(spl, &node)) < 0);
+
+   *out_node = node;
 }
 
 /*
@@ -1209,7 +1484,7 @@ trunk_set_initial_pivots(trunk_handle *spl, trunk_node *node)
    copy_key_to_ondisk_key(&pdata->pivot, POSITIVE_INFINITY_KEY);
 }
 
-debug_only static inline key
+static inline key
 trunk_min_key(trunk_handle *spl, trunk_node *node)
 {
    return trunk_get_pivot(spl, node, 0);
@@ -1238,7 +1513,7 @@ trunk_set_pivot_data_new_root(trunk_handle *spl,
                               trunk_node   *node,
                               uint64        child_addr)
 {
-   debug_assert(trunk_height(node) != 0);
+   debug_assert(trunk_node_height(node) != 0);
    trunk_pivot_data *pdata = trunk_get_pivot_data(spl, node, 0);
 
    pdata->addr                = child_addr;
@@ -1258,7 +1533,7 @@ trunk_init_pivot_data_from_pred(trunk_handle *spl,
                                 uint64        child_addr,
                                 key           new_pivot)
 {
-   debug_assert(trunk_height(node) != 0);
+   debug_assert(trunk_node_height(node) != 0);
    debug_assert(pivot_no != 0);
    trunk_pivot_data *pdata      = trunk_get_pivot_data(spl, node, pivot_no);
    trunk_pivot_data *pred_pdata = trunk_get_pivot_data(spl, node, pivot_no - 1);
@@ -1283,23 +1558,11 @@ trunk_pivot_start_branch(trunk_handle *spl, trunk_node *node, uint16 pivot_no)
    return pdata->start_branch;
 }
 
-static inline uint64
-trunk_generation(trunk_handle *spl, trunk_node *node)
-{
-   return node->hdr->generation;
-}
-
 static inline uint16
 trunk_pivot_start_bundle(trunk_handle *spl, trunk_node *node, uint16 pivot_no)
 {
    trunk_pivot_data *pdata = trunk_get_pivot_data(spl, node, pivot_no);
    return pdata->start_bundle;
-}
-
-static inline void
-trunk_inc_generation(trunk_handle *spl, trunk_node *node)
-{
-   node->hdr->generation++;
 }
 
 /*
@@ -1437,7 +1700,7 @@ trunk_shift_pivots(trunk_handle *spl,
                    uint16        pivot_no,
                    uint16        shift)
 {
-   debug_assert(trunk_height(node) != 0);
+   debug_assert(trunk_node_height(node) != 0);
    debug_assert(trunk_num_pivot_keys(spl, node) + shift
                 < spl->cfg.max_pivot_keys);
    debug_assert(pivot_no < trunk_num_pivot_keys(spl, node));
@@ -1491,6 +1754,7 @@ trunk_add_pivot_new_root(trunk_handle *spl,
    uint64 child_addr = child->addr;
    trunk_set_pivot_data_new_root(spl, parent, child_addr);
 }
+
 
 /*
  * pivot_recount_num_tuples recounts num_tuples for the pivot at position
@@ -1899,37 +2163,6 @@ trunk_inc_num_pivot_keys(trunk_handle *spl, trunk_node *node)
 
 
 /*
- * Returns the PBN of the node at height height whose key range contains key.
- *
- * Used to locate the parent of a leaf which has finished splitting in the case
- * where the parent might have changed as a result of a internal node split or
- * root split.
- */
-uint64
-trunk_find_node(trunk_handle *spl, key target, uint64 height)
-{
-   trunk_node node;
-   trunk_node_get(spl->cc, spl->root_addr, &node);
-   uint16 tree_height = trunk_height(&node);
-   for (uint16 h = tree_height; h > height + 1; h--) {
-      uint32 pivot_no =
-         trunk_find_pivot(spl, &node, target, less_than_or_equal);
-      debug_assert(pivot_no < trunk_num_children(spl, &node));
-      trunk_pivot_data *pdata = trunk_get_pivot_data(spl, &node, pivot_no);
-      trunk_node        child;
-      trunk_node_get(spl->cc, pdata->addr, &child);
-      trunk_node_unget(spl->cc, &node);
-      node = child;
-   }
-   uint32 pivot_no = trunk_find_pivot(spl, &node, target, less_than_or_equal);
-   debug_assert(pivot_no < trunk_num_children(spl, &node));
-   trunk_pivot_data *pdata    = trunk_get_pivot_data(spl, &node, pivot_no);
-   uint64            ret_addr = pdata->addr;
-   trunk_node_unget(spl->cc, &node);
-   return ret_addr;
-}
-
-/*
  *-----------------------------------------------------------------------------
  * Bundle functions
  *-----------------------------------------------------------------------------
@@ -2197,7 +2430,7 @@ trunk_leaf_remove_bundles_except(trunk_handle *spl,
                                  trunk_node   *node,
                                  uint16        bundle_no)
 {
-   debug_assert(trunk_height(node) == 0);
+   debug_assert(trunk_node_height(node) == 0);
    uint16 last_bundle_no = trunk_end_bundle(spl, node);
    last_bundle_no        = trunk_subtract_bundle_number(spl, last_bundle_no, 1);
    debug_assert(bundle_no == last_bundle_no);
@@ -2218,7 +2451,7 @@ trunk_leaf_rebundle_all_branches(trunk_handle *spl,
                                  uint64        target_kv_bytes,
                                  bool          is_space_rec)
 {
-   debug_assert(trunk_height(node) == 0);
+   debug_assert(trunk_node_height(node) == 0);
    uint16 bundle_no = trunk_get_new_bundle(spl, node);
    if (trunk_branch_is_whole(spl, node, trunk_start_branch(spl, node))) {
       trunk_subbundle *sb = trunk_leaf_get_new_subbundle_at_head(spl, node);
@@ -2587,16 +2820,113 @@ trunk_process_generation_to_pos(trunk_handle             *spl,
 }
 
 /*
+ * trunk_garbage_collect_node_get fetches the node at the
+ * given height containing the given key from the snapshot with root given by
+ * old_root_addr. It performs hand-over-hand write-locking to drain readers
+ * along the path.
+ *
+ * Returns the node with a write lock.
+ */
+static inline void
+trunk_garbage_collect_node_get(trunk_handle             *spl,
+                               uint64                    old_root_addr,
+                               trunk_compact_bundle_req *req,
+                               trunk_node               *out_node)
+{
+   uint16 height    = req->height;
+   key    start_key = key_buffer_key(&req->start_key);
+   /*
+    * Note: don't need to acquire the trunk_root_lock here, since this is an
+    * old snapshot
+    */
+   trunk_node node;
+   trunk_node_get(spl->cc, old_root_addr, &node);
+   uint16 root_height = trunk_node_height(&node);
+   trunk_node_claim(spl->cc, &node);
+   trunk_node_lock(spl->cc, &node);
+   platform_assert(height <= root_height);
+
+   for (uint16 h = root_height; h > height; h--) {
+      debug_assert(trunk_node_height(&node) == h);
+      uint16 pivot_no =
+         trunk_find_pivot(spl, &node, start_key, less_than_or_equal);
+      debug_assert(pivot_no < trunk_num_children(spl, &node));
+      trunk_pivot_data *pdata = trunk_get_pivot_data(spl, &node, pivot_no);
+      trunk_node        child;
+      trunk_node_get(spl->cc, pdata->addr, &child);
+      // Here is where we would deallocate the trunk node
+      trunk_node_claim(spl->cc, &child);
+      trunk_node_lock(spl->cc, &child);
+      trunk_node_unlock(spl->cc, &node);
+      trunk_node_unclaim(spl->cc, &node);
+      trunk_node_unget(spl->cc, &node);
+      node = child;
+   }
+
+   debug_assert(trunk_node_height(&node) == height);
+   debug_assert(trunk_key_compare(spl, trunk_min_key(spl, &node), start_key)
+                <= 0);
+   debug_assert(trunk_key_compare(spl, start_key, trunk_max_key(spl, &node))
+                < 0);
+
+   *out_node = node;
+}
+
+/*
+ * garbage_collect_bundle dereferences the branches for the specified bundle
+ */
+static inline void
+trunk_garbage_collect_bundle(trunk_handle             *spl,
+                             uint64                    old_root_addr,
+                             trunk_compact_bundle_req *req)
+{
+   trunk_node node;
+   trunk_garbage_collect_node_get(spl, old_root_addr, req, &node);
+
+   uint16        bundle_no    = req->bundle_no;
+   trunk_bundle *bundle       = trunk_get_bundle(spl, &node, bundle_no);
+   uint16 bundle_start_branch = trunk_bundle_start_branch(spl, &node, bundle);
+   uint16 bundle_end_branch   = trunk_bundle_end_branch(spl, &node, bundle);
+
+   trunk_default_log_if_enabled(
+      spl,
+      "compact_bundle gc: addr %lu, range %s-%s, height %u, bundle %u\n",
+      node.addr,
+      key_string(trunk_data_config(spl), key_buffer_key(&req->start_key)),
+      key_string(trunk_data_config(spl), key_buffer_key(&req->end_key)),
+      req->height,
+      req->bundle_no);
+
+   uint16 num_children = trunk_num_children(spl, &node);
+   for (uint16 branch_no = bundle_start_branch; branch_no != bundle_end_branch;
+        branch_no        = trunk_add_branch_number(spl, branch_no, 1))
+   {
+      trunk_branch *branch = trunk_get_branch(spl, &node, branch_no);
+      for (uint16 pivot_no = 0; pivot_no < num_children; pivot_no++) {
+         if (trunk_bundle_live_for_pivot(spl, &node, bundle_no, pivot_no)) {
+            key start_key = trunk_get_pivot(spl, &node, pivot_no);
+            key end_key   = trunk_get_pivot(spl, &node, pivot_no + 1);
+            trunk_zap_branch_range(
+               spl, branch, start_key, end_key, PAGE_TYPE_BRANCH);
+         }
+      }
+   }
+
+   trunk_node_unlock(spl->cc, &node);
+   trunk_node_unclaim(spl->cc, &node);
+   trunk_node_unget(spl->cc, &node);
+}
+
+/*
  * replace_bundle_branches replaces the branches of an uncompacted bundle with
  * a newly compacted branch.
  *
  * This process is:
- * 1. de-ref the old branches of the bundle
- * 2. add the new branch (unless replacement_branch == NULL)
- * 3. move any remaining branches to maintain a contiguous array
- * 4. adjust pivot start branches if necessary
- * 5. mark bundle as compacted and remove all by its first subbundle
- * 6. move any remaining subbundles to maintain a contiguous array (and adjust
+ * 1. add the new branch (unless replacement_branch == NULL)
+ * 2. move any remaining branches to maintain a contiguous array
+ * 3. adjust pivot start branches if necessary
+ * 4. mark bundle as compacted and remove all by its first subbundle
+ * 5. move any remaining subbundles to maintain a contiguous array (and adjust
  *    any remaining bundles to account)
  */
 void
@@ -2605,29 +2935,14 @@ trunk_replace_bundle_branches(trunk_handle             *spl,
                               trunk_branch             *repl_branch,
                               trunk_compact_bundle_req *req)
 {
-   debug_assert(req->height == trunk_height(node));
+   debug_assert(req->height == trunk_node_height(node));
 
    uint16        bundle_no    = req->bundle_no;
    trunk_bundle *bundle       = trunk_get_bundle(spl, node, bundle_no);
    uint16 bundle_start_branch = trunk_bundle_start_branch(spl, node, bundle);
    uint16 bundle_end_branch   = trunk_bundle_end_branch(spl, node, bundle);
    uint16 branch_diff         = trunk_bundle_branch_count(spl, node, bundle);
-
-   // de-ref the dead branches
-   uint16 num_children = trunk_num_children(spl, node);
-   for (uint16 branch_no = bundle_start_branch; branch_no != bundle_end_branch;
-        branch_no        = trunk_add_branch_number(spl, branch_no, 1))
-   {
-      trunk_branch *branch = trunk_get_branch(spl, node, branch_no);
-      for (uint16 pivot_no = 0; pivot_no < num_children; pivot_no++) {
-         if (trunk_bundle_live_for_pivot(spl, node, bundle_no, pivot_no)) {
-            key start_key = trunk_get_pivot(spl, node, pivot_no);
-            key end_key   = trunk_get_pivot(spl, node, pivot_no + 1);
-            trunk_zap_branch_range(
-               spl, branch, start_key, end_key, PAGE_TYPE_BRANCH);
-         }
-      }
-   }
+   uint16 num_children        = trunk_num_children(spl, node);
 
    // add new branch
    uint16 new_branch_no = UINT16_MAX;
@@ -3050,10 +3365,9 @@ trunk_memtable_iterator_deinit(trunk_handle   *spl,
 platform_status
 trunk_memtable_insert(trunk_handle *spl, key tuple_key, message msg)
 {
-   page_handle    *lock_page;
    uint64          generation;
-   platform_status rc = memtable_maybe_rotate_and_get_insert_lock(
-      spl->mt_ctxt, &generation, &lock_page);
+   platform_status rc =
+      memtable_maybe_rotate_and_get_insert_lock(spl->mt_ctxt, &generation);
    if (!SUCCESS(rc)) {
       goto out;
    }
@@ -3075,7 +3389,7 @@ trunk_memtable_insert(trunk_handle *spl, key tuple_key, message msg)
    }
 
 unlock_insert_lock:
-   memtable_unget_insert_lock(spl->mt_ctxt, lock_page);
+   memtable_unget_insert_lock(spl->mt_ctxt);
 out:
    return rc;
 }
@@ -3241,80 +3555,37 @@ unlock_incorp_lock:
    return should_continue;
 }
 
-/*
- * Function to incorporate the memtable to the root.
- * Carries out the following steps :
- *  4. Lock root (block lookups -- lookups obtain a read lock on the root
- *     before performing lookup on memtable)
- *  5. Add the memtable to the root as a new compacted bundle
- *  6. If root is full, flush until it is no longer full
- *  7. If necessary, split the root
- *  8. Create a new empty memtable in the memtable array at position
- *     curr_memtable.
- *  9. Unlock the root
- *
- * This functions has some preconditions prior to being called.
- *  --> Trunk root node should be write locked.
- *  --> The memtable should have inserts blocked (can_insert == FALSE)
- */
-static void
-trunk_memtable_incorporate(trunk_handle  *spl,
-                           uint64         generation,
-                           const threadid tid)
+static inline void
+trunk_install_new_compacted_subbundle(trunk_handle             *spl,
+                                      trunk_node               *node,
+                                      trunk_branch             *new_branch,
+                                      routing_filter           *new_filter,
+                                      trunk_compact_bundle_req *req)
 {
-   // X. Get, claim and lock the lookup lock
-   page_handle *mt_lookup_lock_page =
-      memtable_uncontended_get_claim_lock_lookup_lock(spl->mt_ctxt);
+   req->spl                  = spl;
+   req->height               = trunk_node_height(node);
+   req->max_pivot_generation = trunk_pivot_generation(spl, node);
+   key_buffer_init_from_key(
+      &req->start_key, spl->heap_id, trunk_min_key(spl, node));
+   key_buffer_init_from_key(
+      &req->end_key, spl->heap_id, trunk_max_key(spl, node));
+   req->bundle_no = trunk_get_new_bundle(spl, node);
 
-   memtable_increment_to_generation_retired(spl->mt_ctxt, generation);
+   trunk_bundle    *bundle = trunk_get_bundle(spl, node, req->bundle_no);
+   trunk_subbundle *sb     = trunk_get_new_subbundle(spl, node, 1);
+   trunk_branch    *branch = trunk_get_new_branch(spl, node);
+   *branch                 = *new_branch;
+   bundle->start_subbundle = trunk_subbundle_no(spl, node, sb);
+   bundle->end_subbundle   = trunk_end_subbundle(spl, node);
+   sb->start_branch        = trunk_branch_no(spl, node, branch);
+   sb->end_branch          = trunk_end_branch(spl, node);
+   sb->state               = SB_STATE_COMPACTED;
+   routing_filter *filter  = trunk_subbundle_filter(spl, node, sb, 0);
+   *filter                 = *new_filter;
 
-   // X. Get, claim and lock the root
-   trunk_node root;
-   trunk_node_get(spl->cc, spl->root_addr, &root);
-   trunk_node_claim(spl->cc, &root);
-   platform_assert(trunk_has_vacancy(spl, &root, 1));
-   trunk_node_lock(spl->cc, &root);
-
-   platform_stream_handle stream;
-   platform_status        rc = trunk_open_log_stream_if_enabled(spl, &stream);
-   platform_assert_status_ok(rc);
-   trunk_log_stream_if_enabled(spl,
-                               &stream,
-                               "incorporate memtable gen %lu into root %lu\n",
-                               generation,
-                               spl->root_addr);
-   trunk_log_node_if_enabled(&stream, spl, &root);
-   trunk_log_stream_if_enabled(
-      spl, &stream, "----------------------------------------\n");
-
-   // X. Release lookup lock
-   memtable_unlock_unclaim_unget_lookup_lock(spl->mt_ctxt, mt_lookup_lock_page);
-
-   /*
-    * X. Get a new branch in a bundle for the memtable
-    */
-   trunk_compacted_memtable *cmt =
-      trunk_get_compacted_memtable(spl, generation);
-   trunk_compact_bundle_req *req = cmt->req;
-   req->bundle_no                = trunk_get_new_bundle(spl, &root);
-   trunk_bundle    *bundle       = trunk_get_bundle(spl, &root, req->bundle_no);
-   trunk_subbundle *sb           = trunk_get_new_subbundle(spl, &root, 1);
-   trunk_branch    *branch       = trunk_get_new_branch(spl, &root);
-   *branch                       = cmt->branch;
-   bundle->start_subbundle       = trunk_subbundle_no(spl, &root, sb);
-   bundle->end_subbundle         = trunk_end_subbundle(spl, &root);
-   sb->start_branch              = trunk_branch_no(spl, &root, branch);
-   sb->end_branch                = trunk_end_branch(spl, &root);
-   sb->state                     = SB_STATE_COMPACTED;
-   routing_filter *filter        = trunk_subbundle_filter(spl, &root, sb, 0);
-   *filter                       = cmt->filter;
-   req->spl                      = spl;
-   req->addr                     = spl->root_addr;
-   req->height                   = trunk_height(&root);
-   req->generation               = trunk_generation(spl, &root);
-   req->max_pivot_generation     = trunk_pivot_generation(spl, &root);
+   // count tuples for both the req and the pivot counts in the node
    trunk_tuples_in_bundle(spl,
-                          &root,
+                          node,
                           bundle,
                           req->output_pivot_tuple_count,
                           req->output_pivot_kv_byte_count);
@@ -3325,78 +3596,138 @@ trunk_memtable_incorporate(trunk_handle  *spl,
            req->output_pivot_kv_byte_count,
            sizeof(req->input_pivot_kv_byte_count));
    trunk_pivot_add_bundle_tuple_counts(spl,
-                                       &root,
+                                       node,
                                        bundle,
-                                       req->output_pivot_tuple_count,
-                                       req->output_pivot_kv_byte_count);
-   uint16 num_children = trunk_num_children(spl, &root);
+                                       req->input_pivot_tuple_count,
+                                       req->input_pivot_kv_byte_count);
+
+   // record the pivot generations and increment the boundaries
+   uint16 num_children = trunk_num_children(spl, node);
    for (uint16 pivot_no = 0; pivot_no < num_children; pivot_no++) {
       if (pivot_no != 0) {
-         key pivot_key = trunk_get_pivot(spl, &root, pivot_no);
-         trunk_inc_intersection(spl, branch, pivot_key, FALSE);
+         key pivot = trunk_get_pivot(spl, node, pivot_no);
+         trunk_inc_intersection(spl, branch, pivot, FALSE);
       }
-      trunk_pivot_data *pdata = trunk_get_pivot_data(spl, &root, pivot_no);
+      trunk_pivot_data *pdata = trunk_get_pivot_data(spl, node, pivot_no);
       req->pivot_generation[pivot_no] = pdata->generation;
    }
-   debug_assert(trunk_subbundle_branch_count(spl, &root, sb) != 0);
-   trunk_log_stream_if_enabled(spl,
-                               &stream,
-                               "enqueuing build filter %lu-%u\n",
-                               req->addr,
-                               req->bundle_no);
-   task_enqueue(
-      spl->ts, TASK_TYPE_NORMAL, trunk_bundle_build_filters, req, TRUE);
+   debug_assert(trunk_subbundle_branch_count(spl, node, sb) != 0);
+}
 
-   // X. Incorporate new memtable into the bundle
+/*
+ * Function to incorporate the memtable to the root.
+ * Carries out the following steps :
+ *  1. Claim and copy the root.
+ *  2. Add the memtable to the new root as a new compacted bundle.
+ *  3. If the new root is full, flush until it is no longer full. Also flushes
+ *     any full descendents.
+ *  4. If necessary, split the new root.
+ *  5. Lock lookup lock (blocks lookups, which must obtain a read lock on the
+ *     lookup lock).
+ *  6. Transition memtable state and increment generation_retired.
+ *  7. Update root to new_root and unlock all locks (root lock, lookup lock,
+ *     new root lock).
+ *  8. Enqueue the filter building task.
+ *  9. Decrement the now-incorporated memtable ref count and recycle if no
+ *     references.
+ *
+ * This functions has some preconditions prior to being called.
+ *  --> Trunk root node should be write locked.
+ *  --> The memtable should have inserts blocked (can_insert == FALSE)
+ */
+static void
+trunk_memtable_incorporate_and_flush(trunk_handle  *spl,
+                                     uint64         generation,
+                                     const threadid tid)
+{
+   trunk_node new_root;
+   uint64     old_root_addr; // unused
+   trunk_claim_and_copy_root(spl, &new_root, &old_root_addr);
+   platform_assert(trunk_has_vacancy(spl, &new_root, 1));
+
+   platform_stream_handle stream;
+   platform_status        rc = trunk_open_log_stream_if_enabled(spl, &stream);
+   platform_assert_status_ok(rc);
+   trunk_log_stream_if_enabled(
+      spl,
+      &stream,
+      "incorporate memtable gen %lu into new root %lu\n",
+      generation,
+      new_root.addr);
+   trunk_log_node_if_enabled(&stream, spl, &new_root);
+   trunk_log_stream_if_enabled(
+      spl, &stream, "----------------------------------------\n");
+
+   // Add the memtable to the new root as a new compacted bundle
+   trunk_compacted_memtable *cmt =
+      trunk_get_compacted_memtable(spl, generation);
+   trunk_compact_bundle_req *req = cmt->req;
+   trunk_install_new_compacted_subbundle(
+      spl, &new_root, &cmt->branch, &cmt->filter, req);
+   if (spl->cfg.use_stats) {
+      spl->stats[tid].memtable_flush_wait_time_ns +=
+         platform_timestamp_elapsed(cmt->wait_start);
+   }
+
+   trunk_log_node_if_enabled(&stream, spl, &new_root);
+   trunk_log_stream_if_enabled(
+      spl, &stream, "----------------------------------------\n");
+   trunk_log_stream_if_enabled(spl, &stream, "\n");
+
+   /*
+    * If root is full, flush until it is no longer full. Also flushes any full
+    * descendents.
+    */
+   uint64 flush_start;
+   if (spl->cfg.use_stats) {
+      flush_start = platform_get_timestamp();
+   }
+   while (trunk_node_is_full(spl, &new_root)) {
+      trunk_flush_fullest(spl, &new_root);
+   }
+
+   // If necessary, split the root
+   if (trunk_needs_split(spl, &new_root)) {
+      trunk_split_root(spl, &new_root);
+   }
+
+   /*
+    * Lock the lookup lock, blocking lookups.
+    * Transition memtable state and increment memtable generation (blocks
+    * lookups from accessing the memtable that's being incorporated).
+    */
+   memtable_lock_lookup_lock(spl->mt_ctxt);
    memtable *mt = trunk_get_memtable(spl, generation);
    // Normally need to hold incorp_mutex, but debug code and also guaranteed no
    // one is changing gen_to_incorp (we are the only thread that would try)
    debug_assert(generation == memtable_generation_to_incorporate(spl->mt_ctxt));
    memtable_transition(
       mt, MEMTABLE_STATE_INCORPORATION_ASSIGNED, MEMTABLE_STATE_INCORPORATING);
-   *branch = cmt->branch;
-   *filter = cmt->filter;
-   if (spl->cfg.use_stats) {
-      spl->stats[tid].memtable_flush_wait_time_ns +=
-         platform_timestamp_elapsed(cmt->wait_start);
-   }
-
    memtable_transition(
       mt, MEMTABLE_STATE_INCORPORATING, MEMTABLE_STATE_INCORPORATED);
-   trunk_log_node_if_enabled(&stream, spl, &root);
+   memtable_increment_to_generation_retired(spl->mt_ctxt, generation);
+
+   // Switch in the new root and release all locks
+   trunk_update_claimed_root_and_unlock(spl, &new_root);
+   memtable_unlock_lookup_lock(spl->mt_ctxt);
+
+   // Enqueue the filter building task.
    trunk_log_stream_if_enabled(
-      spl, &stream, "----------------------------------------\n");
-   trunk_log_stream_if_enabled(spl, &stream, "\n");
+      spl,
+      &stream,
+      "enqueuing build filter: range %s-%s, height %u, bundle %u\n",
+      key_string(trunk_data_config(spl), key_buffer_key(&req->start_key)),
+      key_string(trunk_data_config(spl), key_buffer_key(&req->end_key)),
+      req->height,
+      req->bundle_no);
    trunk_close_log_stream_if_enabled(spl, &stream);
+   task_enqueue(
+      spl->ts, TASK_TYPE_NORMAL, trunk_bundle_build_filters, req, TRUE);
 
-   // X. If root is full, flush until it is no longer full
-   uint64 flush_start;
-   if (spl->cfg.use_stats) {
-      flush_start = platform_get_timestamp();
-   }
-
-   uint64 wait = 1;
-   while (trunk_node_is_full(spl, &root)) {
-      platform_status rc = trunk_flush_fullest(spl, &root);
-      if (!SUCCESS(rc)) {
-         trunk_node_unlock(spl->cc, &root);
-         platform_sleep_ns(wait);
-         wait = wait > 2048 ? 2048 : 2 * wait;
-         trunk_node_lock(spl->cc, &root);
-      }
-   }
-
-   // X. If necessary, split the &root
-   if (trunk_needs_split(spl, &root)) {
-      trunk_split_root(spl, &root);
-   }
-
-   // X. Unlock the &root
-   trunk_node_unlock(spl->cc, &root);
-   trunk_node_unclaim(spl->cc, &root);
-   trunk_node_unget(spl->cc, &root);
-
-   // X. Dec-ref the now-incorporated memtable
+   /*
+    * Decrement the now-incorporated memtable ref count and recycle if no
+    * references
+    */
    memtable_dec_ref_maybe_recycle(spl->mt_ctxt, mt);
 
    if (spl->cfg.use_stats) {
@@ -3429,7 +3760,7 @@ trunk_memtable_flush_internal(trunk_handle *spl, uint64 generation)
       goto out;
    }
    do {
-      trunk_memtable_incorporate(spl, generation, tid);
+      trunk_memtable_incorporate_and_flush(spl, generation, tid);
       generation++;
    } while (trunk_try_continue_incorporate(spl, generation));
 out:
@@ -3558,80 +3889,70 @@ trunk_dec_filter(trunk_handle *spl, routing_filter *filter)
  * Scratch space used for filter building.
  */
 typedef struct trunk_filter_scratch {
+   key_buffer     start_key;
+   key_buffer     end_key;
+   uint16         height;
    bool           should_build[TRUNK_MAX_PIVOTS];
    routing_filter old_filter[TRUNK_MAX_PIVOTS];
    uint16         value[TRUNK_MAX_PIVOTS];
    routing_filter filter[TRUNK_MAX_PIVOTS];
    uint32        *fp_arr;
-} trunk_filter_req;
+} trunk_filter_scratch;
 
 static inline void
-trunk_filter_req_init(trunk_compact_bundle_req *compact_req,
-                      trunk_filter_req         *filter_req)
+trunk_filter_scratch_init(trunk_compact_bundle_req *compact_req,
+                          trunk_filter_scratch     *filter_scratch)
 {
-   ZERO_CONTENTS(filter_req);
-   filter_req->fp_arr = compact_req->fp_arr;
+   ZERO_CONTENTS(filter_scratch);
+   filter_scratch->fp_arr = compact_req->fp_arr;
+}
+static inline bool
+trunk_compact_bundle_node_has_split(trunk_handle             *spl,
+                                    trunk_compact_bundle_req *req,
+                                    trunk_node               *node)
+{
+   return trunk_key_compare(
+      spl, key_buffer_key(&req->end_key), trunk_max_key(spl, node));
+}
+
+static inline platform_status
+trunk_compact_bundle_node_get(trunk_handle             *spl,
+                              trunk_compact_bundle_req *req,
+                              trunk_node               *node)
+{
+   return trunk_node_get_by_key_and_height(
+      spl, key_buffer_key(&req->start_key), req->height, node);
 }
 
 static inline void
-trunk_node_get_maybe_descend(trunk_handle             *spl,
-                             trunk_compact_bundle_req *req,
-                             trunk_node               *node)
+trunk_compact_bundle_node_copy_path(trunk_handle             *spl,
+                                    trunk_compact_bundle_req *req,
+                                    trunk_node               *out_node,
+                                    uint64                   *old_root_addr)
 {
-   trunk_node_get(spl->cc, req->addr, node);
-   while (trunk_height(node) != req->height) {
-      debug_assert(trunk_height(node) > req->height);
-      debug_assert(req->height != 0);
-      trunk_pivot_data *pdata = trunk_get_pivot_data(spl, node, 0);
-      req->addr               = pdata->addr;
-      platform_stream_handle stream;
-      platform_status rc = trunk_open_log_stream_if_enabled(spl, &stream);
-      platform_assert_status_ok(rc);
-      trunk_log_stream_if_enabled(
-         spl, &stream, "build_filter descending from root\n");
-      trunk_log_stream_if_enabled(spl,
-                                  &stream,
-                                  "enqueuing build filter %lu-%u\n",
-                                  req->addr,
-                                  req->bundle_no);
-      trunk_log_node_if_enabled(&stream, spl, node);
-      trunk_node_unget(spl->cc, node);
-      // Load the node at new req->addr into node
-      trunk_node_get(spl->cc, req->addr, node);
-   }
-}
-
-static inline void
-trunk_node_get_claim_maybe_descend(trunk_handle             *spl,
-                                   trunk_compact_bundle_req *req,
-                                   trunk_node               *node)
-{
-   uint64 wait = 1;
-   while (1) {
-      trunk_node_get_maybe_descend(spl, req, node);
-      if (cache_try_claim(spl->cc, node->page)) {
-         break;
-      }
-      trunk_node_unget(spl->cc, node);
-      platform_sleep_ns(wait);
-      wait = wait > 2048 ? wait : 2 * wait;
-   }
+   key start_key = key_buffer_key(&req->start_key);
+   trunk_copy_path_by_key_and_height(
+      spl, start_key, req->height, out_node, old_root_addr);
 }
 
 static inline bool
 trunk_build_filter_should_abort(trunk_compact_bundle_req *req, trunk_node *node)
 {
-   trunk_handle *spl    = req->spl;
-   uint16        height = trunk_height(node);
-   if (height == 0 && req->generation < trunk_generation(spl, node)) {
+   trunk_handle *spl = req->spl;
+   if (trunk_node_is_leaf(node)
+       && trunk_compact_bundle_node_has_split(spl, req, node))
+   {
       platform_stream_handle stream;
       platform_status rc = trunk_open_log_stream_if_enabled(spl, &stream);
       platform_assert_status_ok(rc);
-      trunk_log_stream_if_enabled(spl,
-                                  &stream,
-                                  "build_filter leaf abort %lu-%u\n",
-                                  req->addr,
-                                  req->bundle_no);
+      trunk_log_stream_if_enabled(
+         spl,
+         &stream,
+         "build_filter leaf abort: range %s-%s, height %u, bundle %u\n",
+         key_string(trunk_data_config(spl), key_buffer_key(&req->start_key)),
+         key_string(trunk_data_config(spl), key_buffer_key(&req->end_key)),
+         req->height,
+         req->bundle_no);
       trunk_log_node_if_enabled(&stream, spl, node);
       trunk_close_log_stream_if_enabled(spl, &stream);
       return TRUE;
@@ -3647,12 +3968,14 @@ trunk_build_filter_should_skip(trunk_compact_bundle_req *req, trunk_node *node)
       platform_stream_handle stream;
       platform_status rc = trunk_open_log_stream_if_enabled(spl, &stream);
       platform_assert_status_ok(rc);
-      trunk_log_stream_if_enabled(spl,
-                                  &stream,
-                                  "build_filter flush abort %lu-%u (%u)\n",
-                                  req->addr,
-                                  req->bundle_no,
-                                  req->height);
+      trunk_log_stream_if_enabled(
+         spl,
+         &stream,
+         "build_filter flush abort: range %s-%s, height %u, bundle %u\n",
+         key_string(trunk_data_config(spl), key_buffer_key(&req->start_key)),
+         key_string(trunk_data_config(spl), key_buffer_key(&req->end_key)),
+         req->height,
+         req->bundle_no);
       trunk_log_node_if_enabled(&stream, spl, node);
       trunk_close_log_stream_if_enabled(spl, &stream);
       return TRUE;
@@ -3669,17 +3992,15 @@ trunk_build_filter_should_reenqueue(trunk_compact_bundle_req *req,
       platform_stream_handle stream;
       platform_status rc = trunk_open_log_stream_if_enabled(spl, &stream);
       platform_assert_status_ok(rc);
-      trunk_log_stream_if_enabled(spl,
-                                  &stream,
-                                  "build filter for %lu bundle %u\n",
-                                  req->addr,
-                                  req->bundle_no);
+      trunk_log_stream_if_enabled(
+         spl,
+         &stream,
+         "build_filter reenqueuing: range %s-%s, height %u, bundle %u\n",
+         key_string(trunk_data_config(spl), key_buffer_key(&req->start_key)),
+         key_string(trunk_data_config(spl), key_buffer_key(&req->end_key)),
+         req->height,
+         req->bundle_no);
       trunk_log_node_if_enabled(&stream, spl, node);
-      trunk_log_stream_if_enabled(spl,
-                                  &stream,
-                                  "reenqueuing build filter %lu-%u\n",
-                                  req->addr,
-                                  req->bundle_no);
       trunk_close_log_stream_if_enabled(spl, &stream);
       return TRUE;
    }
@@ -3689,14 +4010,14 @@ trunk_build_filter_should_reenqueue(trunk_compact_bundle_req *req,
 static inline void
 trunk_prepare_build_filter(trunk_handle             *spl,
                            trunk_compact_bundle_req *compact_req,
-                           trunk_filter_req         *filter_req,
+                           trunk_filter_scratch     *filter_scratch,
                            trunk_node               *node)
 {
-   uint16 height = trunk_height(node);
+   uint16 height = trunk_node_height(node);
    platform_assert(compact_req->height == height);
    platform_assert(compact_req->bundle_no == trunk_start_bundle(spl, node));
 
-   trunk_filter_req_init(compact_req, filter_req);
+   trunk_filter_scratch_init(compact_req, filter_scratch);
 
    uint16 num_children = trunk_num_children(spl, node);
    for (uint16 pivot_no = 0; pivot_no < num_children; pivot_no++) {
@@ -3706,12 +4027,20 @@ trunk_prepare_build_filter(trunk_handle             *spl,
          uint64 pos = trunk_process_generation_to_pos(
             spl, compact_req, pdata->generation);
          platform_assert(pos != TRUNK_MAX_PIVOTS);
-         filter_req->old_filter[pos] = pdata->filter;
-         filter_req->value[pos] =
+         filter_scratch->old_filter[pos] = pdata->filter;
+         filter_scratch->value[pos] =
             trunk_pivot_whole_branch_count(spl, node, pdata);
-         filter_req->should_build[pos] = TRUE;
+         filter_scratch->should_build[pos] = TRUE;
       }
    }
+
+   // copy the node's start and end key so that replacement can determine when
+   // to stop
+   key_buffer_init_from_key(
+      &filter_scratch->start_key, spl->heap_id, trunk_min_key(spl, node));
+   key_buffer_init_from_key(
+      &filter_scratch->end_key, spl->heap_id, trunk_max_key(spl, node));
+   filter_scratch->height = height;
 }
 
 static inline void
@@ -3736,7 +4065,7 @@ trunk_process_generation_to_fp_bounds(trunk_handle             *spl,
 static inline void
 trunk_build_filters(trunk_handle             *spl,
                     trunk_compact_bundle_req *compact_req,
-                    trunk_filter_req         *filter_req)
+                    trunk_filter_scratch     *filter_scratch)
 {
    threadid tid;
    uint64   filter_build_start;
@@ -3748,26 +4077,26 @@ trunk_build_filters(trunk_handle             *spl,
    }
 
    for (uint64 pos = 0; pos < TRUNK_MAX_PIVOTS; pos++) {
-      if (!filter_req->should_build[pos]) {
+      if (!filter_scratch->should_build[pos]) {
          continue;
       }
-      routing_filter old_filter = filter_req->old_filter[pos];
+      routing_filter old_filter = filter_scratch->old_filter[pos];
       uint32         fp_start, fp_end;
       uint64         generation = compact_req->pivot_generation[pos];
       trunk_process_generation_to_fp_bounds(
          spl, compact_req, generation, &fp_start, &fp_end);
-      uint32 *fp_arr           = filter_req->fp_arr + fp_start;
+      uint32 *fp_arr           = filter_scratch->fp_arr + fp_start;
       uint32  num_fingerprints = fp_end - fp_start;
       if (num_fingerprints == 0) {
          if (old_filter.addr != 0) {
             trunk_inc_filter(spl, &old_filter);
          }
-         filter_req->filter[pos] = old_filter;
+         filter_scratch->filter[pos] = old_filter;
          continue;
       }
       routing_filter  new_filter;
       routing_config *filter_cfg = &spl->cfg.filter_cfg;
-      uint16          value      = filter_req->value[pos];
+      uint16          value      = filter_scratch->value[pos];
       platform_status rc         = routing_filter_add(spl->cc,
                                               filter_cfg,
                                               spl->heap_id,
@@ -3778,8 +4107,8 @@ trunk_build_filters(trunk_handle             *spl,
                                               value);
       platform_assert(SUCCESS(rc));
 
-      filter_req->filter[pos]       = new_filter;
-      filter_req->should_build[pos] = FALSE;
+      filter_scratch->filter[pos]       = new_filter;
+      filter_scratch->should_build[pos] = FALSE;
       if (spl->cfg.use_stats) {
          spl->stats[tid].filters_built[height]++;
          spl->stats[tid].filter_tuples[height] += num_fingerprints;
@@ -3795,7 +4124,7 @@ trunk_build_filters(trunk_handle             *spl,
 static inline void
 trunk_replace_routing_filter(trunk_handle             *spl,
                              trunk_compact_bundle_req *compact_req,
-                             trunk_filter_req         *filter_req,
+                             trunk_filter_scratch     *filter_scratch,
                              trunk_node               *node)
 {
    uint16 num_children = trunk_num_children(spl, node);
@@ -3805,21 +4134,21 @@ trunk_replace_routing_filter(trunk_handle             *spl,
          trunk_process_generation_to_pos(spl, compact_req, pdata->generation);
       if (!trunk_bundle_live_for_pivot(
              spl, node, compact_req->bundle_no, pivot_no)) {
-         if (pos != TRUNK_MAX_PIVOTS && filter_req->filter[pos].addr != 0) {
-            trunk_dec_filter(spl, &filter_req->filter[pos]);
-            ZERO_CONTENTS(&filter_req->filter[pos]);
+         if (pos != TRUNK_MAX_PIVOTS && filter_scratch->filter[pos].addr != 0) {
+            trunk_dec_filter(spl, &filter_scratch->filter[pos]);
+            ZERO_CONTENTS(&filter_scratch->filter[pos]);
          }
          continue;
       }
       platform_assert(pos != TRUNK_MAX_PIVOTS);
       debug_assert(pdata->generation < compact_req->max_pivot_generation);
-      trunk_dec_filter(spl, &pdata->filter);
-      pdata->filter = filter_req->filter[pos];
-      ZERO_CONTENTS(&filter_req->filter[pos]);
+      pdata->filter = filter_scratch->filter[pos];
+      ZERO_CONTENTS(&filter_scratch->filter[pos]);
 
       // Move the tuples count from the bundle to whole branch
       uint64 bundle_num_tuples = compact_req->output_pivot_tuple_count[pos];
       debug_assert(pdata->num_tuples_bundle >= bundle_num_tuples);
+      debug_assert((bundle_num_tuples == 0) == (pdata->filter.addr == 0));
       pdata->num_tuples_bundle -= bundle_num_tuples;
       pdata->num_tuples_whole += bundle_num_tuples;
 
@@ -3845,6 +4174,28 @@ trunk_replace_routing_filter(trunk_handle             *spl,
    }
 }
 
+static inline void
+trunk_garbage_collect_filters(trunk_handle             *spl,
+                              uint64                    old_root_addr,
+                              trunk_compact_bundle_req *req)
+{
+   trunk_node node;
+   trunk_garbage_collect_node_get(spl, old_root_addr, req, &node);
+
+   uint16 num_children = trunk_num_children(spl, &node);
+   for (uint16 pivot_no = 0; pivot_no < num_children; pivot_no++) {
+      trunk_pivot_data *pdata = trunk_get_pivot_data(spl, &node, pivot_no);
+      if (!trunk_bundle_live_for_pivot(spl, &node, req->bundle_no, pivot_no)) {
+         continue;
+      }
+      debug_assert(pdata->generation < req->max_pivot_generation);
+      trunk_dec_filter(spl, &pdata->filter);
+   }
+   trunk_node_unlock(spl->cc, &node);
+   trunk_node_unclaim(spl->cc, &node);
+   trunk_node_unget(spl->cc, &node);
+}
+
 
 /*
  * Asynchronous task function which builds routing filters for a compacted
@@ -3856,20 +4207,25 @@ trunk_bundle_build_filters(void *arg, void *scratch)
    trunk_compact_bundle_req *compact_req = (trunk_compact_bundle_req *)arg;
    trunk_handle             *spl         = compact_req->spl;
 
-   uint64 generation;
-   do {
-      trunk_node node;
-      trunk_node_get_maybe_descend(spl, compact_req, &node);
+   bool should_continue_build_filters = TRUE;
+   while (should_continue_build_filters) {
+      trunk_node      node;
+      platform_status rc =
+         trunk_compact_bundle_node_get(spl, compact_req, &node);
+      platform_assert_status_ok(rc);
 
       platform_stream_handle stream;
       trunk_open_log_stream_if_enabled(spl, &stream);
       trunk_log_stream_if_enabled(
          spl,
          &stream,
-         "build filter for %lu bundle %u pivot_gen %lu\n",
-         compact_req->addr,
-         compact_req->bundle_no,
-         compact_req->max_pivot_generation);
+         "build_filter: range %s-%s, height %u, bundle %u\n",
+         key_string(trunk_data_config(spl),
+                    key_buffer_key(&compact_req->start_key)),
+         key_string(trunk_data_config(spl),
+                    key_buffer_key(&compact_req->end_key)),
+         compact_req->height,
+         compact_req->bundle_no);
       trunk_log_node_if_enabled(&stream, spl, &node);
       if (trunk_build_filter_should_abort(compact_req, &node)) {
          trunk_log_stream_if_enabled(spl, &stream, "leaf split, aborting\n");
@@ -3896,77 +4252,129 @@ trunk_bundle_build_filters(void *arg, void *scratch)
       }
 
       debug_assert(trunk_verify_node(spl, &node));
-      trunk_filter_req filter_req = {0};
-      trunk_prepare_build_filter(spl, compact_req, &filter_req, &node);
-      uint64 filter_generation = trunk_generation(spl, &node);
+      trunk_filter_scratch filter_scratch = {0};
+      trunk_prepare_build_filter(spl, compact_req, &filter_scratch, &node);
       trunk_node_unget(spl->cc, &node);
 
-      trunk_build_filters(spl, compact_req, &filter_req);
+      trunk_build_filters(spl, compact_req, &filter_scratch);
 
-      trunk_log_stream_if_enabled(
-         spl, &stream, "----------------------------------------\n");
+      trunk_log_stream_if_enabled(spl, &stream, "Filters built\n");
 
-      do {
-         trunk_node_get_claim_maybe_descend(spl, compact_req, &node);
+      bool should_continue_replacing_filters = TRUE;
+      while (should_continue_replacing_filters) {
+         uint64 old_root_addr;
+         key    start_key = key_buffer_key(&filter_scratch.start_key);
+         uint16 height    = filter_scratch.height;
+         trunk_copy_path_by_key_and_height(
+            spl, start_key, height, &node, &old_root_addr);
+         platform_assert_status_ok(rc);
+
          if (trunk_build_filter_should_abort(compact_req, &node)) {
             trunk_log_stream_if_enabled(
-               spl,
-               &stream,
-               "replace_filter abort leaf split (%lu)\n",
-               compact_req->addr);
+               spl, &stream, "replace_filter abort leaf split\n");
+            trunk_root_unclaim(spl);
+            trunk_node_unlock(spl->cc, &node);
             trunk_node_unclaim(spl->cc, &node);
             trunk_node_unget(spl->cc, &node);
             for (uint64 pos = 0; pos < TRUNK_MAX_PIVOTS; pos++) {
-               trunk_dec_filter(spl, &filter_req.filter[pos]);
+               trunk_dec_filter(spl, &filter_scratch.filter[pos]);
             }
+            // cleanup filter_scratch
+            key_buffer_deinit(&filter_scratch.start_key);
+            key_buffer_deinit(&filter_scratch.end_key);
             goto out;
          }
-         trunk_node_lock(spl->cc, &node);
-         trunk_replace_routing_filter(spl, compact_req, &filter_req, &node);
+
+         trunk_replace_routing_filter(spl, compact_req, &filter_scratch, &node);
+
          if (trunk_bundle_live(spl, &node, compact_req->bundle_no)) {
             trunk_clear_bundle(spl, &node, compact_req->bundle_no);
          }
+
          trunk_node_unlock(spl->cc, &node);
          trunk_node_unclaim(spl->cc, &node);
-         compact_req->addr = trunk_next_addr(&node);
-         generation        = trunk_generation(spl, &node);
          debug_assert(trunk_verify_node(spl, &node));
-         if (generation != filter_generation) {
-            trunk_log_stream_if_enabled(spl,
-                                        &stream,
-                                        "replace_filter split to %lu\n",
-                                        compact_req->addr);
+
+         trunk_log_node_if_enabled(&stream, spl, &node);
+         trunk_log_stream_if_enabled(
+            spl, &stream, "Filters replaced in &node:\n");
+         trunk_log_stream_if_enabled(spl,
+                                     &stream,
+                                     "addr: %lu, height: %u\n",
+                                     node.addr,
+                                     trunk_node_height(&node));
+         trunk_log_stream_if_enabled(
+            spl,
+            &stream,
+            "range: %s-%s\n",
+            key_string(trunk_data_config(spl),
+                       key_buffer_key(&compact_req->start_key)),
+            key_string(trunk_data_config(spl),
+                       key_buffer_key(&compact_req->end_key)));
+
+         key_buffer_copy_key(&filter_scratch.start_key,
+                             trunk_max_key(spl, &node));
+         should_continue_replacing_filters =
+            trunk_key_compare(spl,
+                              key_buffer_key(&filter_scratch.start_key),
+                              key_buffer_key(&filter_scratch.end_key));
+
+         trunk_garbage_collect_filters(spl, old_root_addr, compact_req);
+
+         if (should_continue_replacing_filters) {
+            trunk_log_stream_if_enabled(
+               spl,
+               &stream,
+               "replace_filter split: range %s-%s, height %u, bundle %u\n",
+               key_string(trunk_data_config(spl),
+                          key_buffer_key(&compact_req->start_key)),
+               key_string(trunk_data_config(spl),
+                          key_buffer_key(&compact_req->end_key)),
+               compact_req->height,
+               compact_req->bundle_no);
             debug_assert(compact_req->height != 0);
-            debug_assert(compact_req->addr != 0);
             trunk_node_unget(spl->cc, &node);
          }
-      } while (generation != filter_generation);
+      }
 
       for (uint64 pos = 0; pos < TRUNK_MAX_PIVOTS; pos++) {
-         trunk_dec_filter(spl, &filter_req.filter[pos]);
+         trunk_dec_filter(spl, &filter_scratch.filter[pos]);
       }
 
-      trunk_log_node_if_enabled(&stream, spl, &node);
-      trunk_log_stream_if_enabled(
-         spl, &stream, "----------------------------------------\n");
-      trunk_log_stream_if_enabled(spl, &stream, "\n");
+      // cleanup filter_scratch
+      key_buffer_deinit(&filter_scratch.start_key);
+      key_buffer_deinit(&filter_scratch.end_key);
 
    next_node:
-      compact_req->addr = trunk_next_addr(&node);
-      generation        = trunk_generation(spl, &node);
       debug_assert(trunk_verify_node(spl, &node));
+      key_buffer_copy_key(&compact_req->start_key, trunk_max_key(spl, &node));
       trunk_node_unget(spl->cc, &node);
-      if (compact_req->generation != generation) {
+      should_continue_build_filters =
+         trunk_key_compare(spl,
+                           key_buffer_key(&compact_req->start_key),
+                           key_buffer_key(&compact_req->end_key));
+      if (should_continue_build_filters) {
          trunk_log_stream_if_enabled(
-            spl, &stream, "build_filter split to %lu\n", compact_req->addr);
+            spl,
+            &stream,
+            "build_filter split: range %s-%s, height %u, bundle %u\n",
+            key_string(trunk_data_config(spl),
+                       key_buffer_key(&compact_req->start_key)),
+            key_string(trunk_data_config(spl),
+                       key_buffer_key(&compact_req->end_key)),
+            compact_req->height,
+            compact_req->bundle_no);
          debug_assert(compact_req->height != 0);
-         debug_assert(compact_req->addr != 0);
       }
       trunk_close_log_stream_if_enabled(spl, &stream);
-   } while (compact_req->generation != generation);
+   }
+   while (should_continue_build_filters)
+      ;
 
 out:
    platform_free(spl->heap_id, compact_req->fp_arr);
+   key_buffer_deinit(&compact_req->start_key);
+   key_buffer_deinit(&compact_req->end_key);
    platform_free(spl->heap_id, compact_req);
    trunk_maybe_reclaim_space(spl);
    return;
@@ -4016,11 +4424,15 @@ trunk_flush_into_bundle(trunk_handle             *spl,    // IN
 
    req->spl    = spl;
    req->addr   = child->addr;
-   req->height = trunk_height(child);
+   req->height = trunk_node_height(child);
    debug_assert(req->addr != 0);
    req->bundle_no            = trunk_get_new_bundle(spl, child);
-   req->generation           = trunk_generation(spl, child);
    req->max_pivot_generation = trunk_pivot_generation(spl, child);
+
+   key_buffer_init_from_key(
+      &req->start_key, spl->heap_id, trunk_min_key(spl, child));
+   key_buffer_init_from_key(
+      &req->end_key, spl->heap_id, trunk_max_key(spl, child));
 
    uint16 num_children = trunk_num_children(spl, child);
    for (uint16 pivot_no = 0; pivot_no < num_children; pivot_no++) {
@@ -4147,11 +4559,39 @@ trunk_room_to_flush(trunk_handle     *spl,
 }
 
 /*
+ * trunk_compact_bundle_enqueue enqueues a compact bundle task
+ */
+
+static inline platform_status
+trunk_compact_bundle_enqueue(trunk_handle             *spl,
+                             const char               *msg,
+                             trunk_compact_bundle_req *req)
+{
+   trunk_default_log_if_enabled(
+      spl,
+      "compact_bundle %s: addr %lu, height %u, bundle %u\n"
+      "range %s-%s\n",
+      msg,
+      req->addr,
+      req->height,
+      req->bundle_no,
+      key_string(trunk_data_config(spl), key_buffer_key(&req->start_key)),
+      key_string(trunk_data_config(spl), key_buffer_key(&req->end_key)));
+   key start_key = key_buffer_key(&req->start_key);
+   key end_key   = key_buffer_key(&req->end_key);
+   platform_assert(trunk_key_compare(spl, start_key, end_key) < 0);
+   return task_enqueue(
+      spl->ts, TASK_TYPE_NORMAL, trunk_compact_bundle, req, FALSE);
+}
+
+/*
  * flush flushes from parent to the child indicated by pdata.
  *
+ * FLUSH FAILURE DISABLED TEMPORARILY (WILL ASSERT)
  * Failure can occur if there is not enough space in the child.
  *
- * NOTE: parent must be write locked
+ * NOTE: parent must be write locked and a claim on the trunk root lock must be
+ * held.
  */
 platform_status
 trunk_flush(trunk_handle     *spl,
@@ -4168,23 +4608,13 @@ trunk_flush(trunk_handle     *spl,
       wait_start = platform_get_timestamp();
    }
 
-   trunk_node child;
-   trunk_node_get(spl->cc, pdata->addr, &child);
-   trunk_node_claim(spl->cc, &child);
+   trunk_node new_child;
+   trunk_copy_node_and_add_to_parent(spl, parent, pdata, &new_child);
 
-   if (!trunk_room_to_flush(spl, parent, &child, pdata)) {
-      platform_error_log("Flush failed: %lu %lu\n", parent->addr, child.addr);
-      if (spl->cfg.use_stats) {
-         if (parent->addr == spl->root_addr) {
-            spl->stats[tid].root_failed_flushes++;
-         } else {
-            spl->stats[tid].failed_flushes[trunk_height(parent)]++;
-         }
-      }
-      trunk_node_unclaim(spl->cc, &child);
-      trunk_node_unget(spl->cc, &child);
-      return STATUS_INVALID_STATE;
-   }
+   platform_assert(trunk_room_to_flush(spl, parent, &new_child, pdata),
+                   "Flush failed: %lu %lu\n",
+                   parent->addr,
+                   new_child.addr);
 
    if ((!is_space_rec && pdata->srq_idx != -1)
        && spl->cfg.reclaim_threshold != UINT64_MAX)
@@ -4195,14 +4625,13 @@ trunk_flush(trunk_handle     *spl,
       srq_print(&spl->srq);
       pdata->srq_idx = -1;
    }
-   trunk_node_lock(spl->cc, &child);
 
    if (spl->cfg.use_stats) {
       if (parent->addr == spl->root_addr) {
          spl->stats[tid].root_flush_wait_time_ns +=
             platform_timestamp_elapsed(wait_start);
       } else {
-         spl->stats[tid].flush_wait_time_ns[trunk_height(parent)] +=
+         spl->stats[tid].flush_wait_time_ns[trunk_node_height(parent)] +=
             platform_timestamp_elapsed(wait_start);
       }
       flush_start = platform_get_timestamp();
@@ -4211,44 +4640,49 @@ trunk_flush(trunk_handle     *spl,
    // flush the branch references into a new bundle in the child
    trunk_compact_bundle_req *req = TYPED_ZALLOC(spl->heap_id, req);
    trunk_bundle             *bundle =
-      trunk_flush_into_bundle(spl, parent, &child, pdata, req);
+      trunk_flush_into_bundle(spl, parent, &new_child, pdata, req);
    trunk_tuples_in_bundle(spl,
-                          &child,
+                          &new_child,
                           bundle,
                           req->input_pivot_tuple_count,
                           req->input_pivot_kv_byte_count);
    trunk_pivot_add_bundle_tuple_counts(spl,
-                                       &child,
+                                       &new_child,
                                        bundle,
                                        req->input_pivot_tuple_count,
                                        req->input_pivot_kv_byte_count);
-   trunk_bundle_inc_pivot_rc(spl, &child, bundle);
+   trunk_bundle_inc_pivot_rc(spl, &new_child, bundle);
    debug_assert(allocator_page_valid(spl->al, req->addr));
    req->type = is_space_rec ? TRUNK_COMPACTION_TYPE_FLUSH
                             : TRUNK_COMPACTION_TYPE_SPACE_REC;
 
    // split child if necessary
-   if (trunk_needs_split(spl, &child)) {
-      if (trunk_is_leaf(&child)) {
+   if (trunk_needs_split(spl, &new_child)) {
+      if (trunk_node_is_leaf(&new_child)) {
          platform_free(spl->heap_id, req);
          uint16 child_idx = trunk_pdata_to_pivot_index(spl, parent, pdata);
-         trunk_split_leaf(spl, parent, &child, child_idx);
+         trunk_split_leaf(spl, parent, &new_child, child_idx);
          return STATUS_OK;
       } else {
          uint64 child_idx = trunk_pdata_to_pivot_index(spl, parent, pdata);
-         trunk_split_index(spl, parent, &child, child_idx);
+         trunk_split_index(spl, parent, &new_child, child_idx, req);
       }
    }
 
-   debug_assert(trunk_verify_node(spl, &child));
-   trunk_node_unlock(spl->cc, &child);
-   trunk_node_unclaim(spl->cc, &child);
-   trunk_node_unget(spl->cc, &child);
+   debug_assert(trunk_verify_node(spl, &new_child));
 
-   trunk_default_log_if_enabled(
-      spl, "enqueuing compact_bundle %lu-%u\n", req->addr, req->bundle_no);
-   rc =
-      task_enqueue(spl->ts, TASK_TYPE_NORMAL, trunk_compact_bundle, req, FALSE);
+   // flush the child if full
+   while (trunk_node_is_full(spl, &new_child)) {
+      platform_assert(!trunk_node_is_leaf(&new_child),
+                      "Full leaf after leaf split\n");
+      trunk_flush_fullest(spl, &new_child);
+   }
+
+   trunk_node_unlock(spl->cc, &new_child);
+   trunk_node_unclaim(spl->cc, &new_child);
+   trunk_node_unget(spl->cc, &new_child);
+
+   rc = trunk_compact_bundle_enqueue(spl, "enqueue", req);
    platform_assert_status_ok(rc);
    if (spl->cfg.use_stats) {
       flush_start = platform_timestamp_elapsed(flush_start);
@@ -4258,7 +4692,7 @@ trunk_flush(trunk_handle     *spl,
             spl->stats[tid].root_flush_time_max_ns = flush_start;
          }
       } else {
-         const uint32 h = trunk_height(parent);
+         const uint32 h = trunk_node_height(parent);
          spl->stats[tid].flush_time_ns[h] += flush_start;
          if (flush_start > spl->stats[tid].flush_time_max_ns[h]) {
             spl->stats[tid].flush_time_max_ns[h] = flush_start;
@@ -4300,7 +4734,7 @@ trunk_flush_fullest(trunk_handle *spl, trunk_node *node)
             if (node->addr == spl->root_addr) {
                spl->stats[tid].root_count_flushes++;
             } else {
-               spl->stats[tid].count_flushes[trunk_height(node)]++;
+               spl->stats[tid].count_flushes[trunk_node_height(node)]++;
             }
          }
       } else if (fullest_pivot_no == TRUNK_INVALID_PIVOT_NO
@@ -4315,7 +4749,7 @@ trunk_flush_fullest(trunk_handle *spl, trunk_node *node)
          if (node->addr == spl->root_addr) {
             spl->stats[tid].root_full_flushes++;
          } else {
-            spl->stats[tid].full_flushes[trunk_height(node)]++;
+            spl->stats[tid].full_flushes[trunk_node_height(node)]++;
          }
       }
       platform_assert(fullest_pivot_no != TRUNK_INVALID_PIVOT_NO);
@@ -4598,19 +5032,18 @@ trunk_compact_bundle_cleanup_iterators(trunk_handle           *spl,
  *
  * Algorithm:
  * 1.  Acquire node read lock
- * 2.  Flush if node is full (acquires write lock)
- * 3.  If the node has split before this call (interaction 4), this
+ * 2.  If the node has split before this call (interaction 4), this
  *     bundle exists in the new split siblings, so issue compact_bundles
  *     for those nodes
- * 4.  Abort if node is a leaf and started splitting (interaction 6)
- * 5.  The bundle may have been completely flushed by step 2, if so abort
- * 6.  Build iterators
- * 7.  Release read lock
- * 8.  Perform compaction
- * 9.  Build filter
- * 10. Clean up
- * 11. Reacquire read lock
- * 12. For each newly split sibling replace bundle with new branch unless
+ * 3.  Abort if node is a leaf and started splitting (interaction 6)
+ * 4.  The bundle may have been completely flushed by step 2, if so abort
+ * 5.  Build iterators
+ * 6.  Release read lock
+ * 7.  Perform compaction
+ * 8.  Build filter
+ * 9. Clean up
+ * 10. Reacquire read lock
+ * 11. For each newly split sibling replace bundle with new branch unless
  *        a. node if leaf which has split, in which case discard (interaction 6)
  *        b. node is internal and bundle has been flushed
  */
@@ -4630,84 +5063,43 @@ trunk_compact_bundle(void *arg, void *scratch_buf)
    trunk_node node;
    trunk_node_get(spl->cc, req->addr, &node);
 
-   /*
-    * 2. Flush if node is full (acquires write lock)
-    */
-   uint16 height = trunk_height(&node);
-   if (height != 0 && trunk_node_is_full(spl, &node)) {
-      trunk_node_claim(spl->cc, &node);
-      trunk_node_lock(spl->cc, &node);
-      rc = STATUS_OK;
-      while (SUCCESS(rc) && trunk_node_is_full(spl, &node)) {
-         rc = trunk_flush_fullest(spl, &node);
-      }
-      trunk_node_unlock(spl->cc, &node);
-      trunk_node_unclaim(spl->cc, &node);
-   }
-
    // timers for stats if enabled
    uint64 compaction_start, pack_start;
-
+   uint16 height = trunk_node_height(&node);
    if (spl->cfg.use_stats) {
       tid              = platform_get_tid();
       compaction_start = platform_get_timestamp();
       spl->stats[tid].compactions[height]++;
    }
 
-   /*
-    * 3. If the node has split before this call (interaction 4), this
-    *    bundle was copied to the new sibling[s], so issue compact_bundles for
-    *    those nodes
-    */
-   if (req->generation < trunk_generation(spl, &node)) {
-      if (height != 0) {
-         debug_assert(trunk_next_addr(&node) != 0);
-         trunk_compact_bundle_req *next_req =
-            TYPED_MALLOC(spl->heap_id, next_req);
-         memmove(next_req, req, sizeof(trunk_compact_bundle_req));
-         next_req->addr = trunk_next_addr(&node);
-         debug_assert(next_req->addr != 0);
-
-         req->generation = trunk_generation(spl, &node);
-
-         trunk_default_log_if_enabled(spl,
-                                      "compact_bundle split from %lu to %lu\n",
-                                      req->addr,
-                                      next_req->addr);
-         rc = task_enqueue(
-            spl->ts, TASK_TYPE_NORMAL, trunk_compact_bundle, next_req, FALSE);
-         platform_assert_status_ok(rc);
-      } else {
-         /*
-          * 4. Abort if node is a splitting leaf (interaction 6)
-          */
-         trunk_node_unget(spl->cc, &node);
-         trunk_default_log_if_enabled(
-            spl, "compact_bundle abort leaf split %lu\n", req->addr);
-         platform_free(spl->heap_id, req);
-         if (spl->cfg.use_stats) {
-            spl->stats[tid].compactions_aborted_leaf_split[height]++;
-            spl->stats[tid].compaction_time_wasted_ns[height] +=
-               platform_timestamp_elapsed(compaction_start);
-         }
-         return;
-      }
-   }
-
-   // store the generation of the node so we can detect splits after compaction
-   uint64 start_generation = trunk_generation(spl, &node);
+   platform_assert(
+      !trunk_compact_bundle_node_has_split(spl, req, &node),
+      "compact_bundle unexpected node split\n"
+      "addr: %lu\n"
+      "node range: %s-%s\n"
+      "req range:  %s-%s\n"
+      "key compare: %d\n",
+      node.addr,
+      key_string(trunk_data_config(spl), trunk_min_key(spl, &node)),
+      key_string(trunk_data_config(spl), trunk_max_key(spl, &node)),
+      key_string(trunk_data_config(spl), key_buffer_key(&req->start_key)),
+      key_string(trunk_data_config(spl), key_buffer_key(&req->end_key)),
+      trunk_key_compare(
+         spl, trunk_max_key(spl, &node), key_buffer_key(&req->end_key)));
 
    /*
-    * 5. The bundle may have been completely flushed by 2., if so abort
-    *       -- note this cannot happen in leaves (if the bundle isn't live, the
-    *          generation number would change and it would be caught by step 4
-    *          above).
+    * 2. The bundle may have been completely flushed, if so abort
     */
    if (!trunk_bundle_live(spl, &node, req->bundle_no)) {
       debug_assert(height != 0);
       trunk_node_unget(spl->cc, &node);
       trunk_default_log_if_enabled(
-         spl, "compact_bundle abort flushed %lu\n", req->addr);
+         spl,
+         "compact_bundle abort flushed: range %s-%s, height %u, bundle %u\n",
+         key_string(trunk_data_config(spl), key_buffer_key(&req->start_key)),
+         key_string(trunk_data_config(spl), key_buffer_key(&req->end_key)),
+         req->height,
+         req->bundle_no);
       platform_free(spl->heap_id, req);
       if (spl->cfg.use_stats) {
          spl->stats[tid].compactions_aborted_flushed[height]++;
@@ -4739,14 +5131,18 @@ trunk_compact_bundle(void *arg, void *scratch_buf)
    platform_stream_handle stream;
    rc = trunk_open_log_stream_if_enabled(spl, &stream);
    platform_assert_status_ok(rc);
-   trunk_log_stream_if_enabled(spl,
-                               &stream,
-                               "compact_bundle addr %lu bundle %hu\n",
-                               req->addr,
-                               req->bundle_no);
+   trunk_log_stream_if_enabled(
+      spl,
+      &stream,
+      "compact_bundle starting: addr %lu, range %s-%s, height %u, bundle %u\n",
+      node.addr,
+      key_string(trunk_data_config(spl), key_buffer_key(&req->start_key)),
+      key_string(trunk_data_config(spl), key_buffer_key(&req->end_key)),
+      req->height,
+      req->bundle_no);
 
    /*
-    * 6. Build iterators
+    * 5. Build iterators
     */
    platform_assert(num_branches <= ARRAY_SIZE(scratch->skip_itor));
    trunk_btree_skiperator *skip_itor_arr = scratch->skip_itor;
@@ -4772,12 +5168,12 @@ trunk_compact_bundle(void *arg, void *scratch_buf)
    trunk_log_node_if_enabled(&stream, spl, &node);
 
    /*
-    * 7. Release read lock
+    * 6. Release read lock
     */
    trunk_node_unget(spl->cc, &node);
 
    /*
-    * 8. Perform compaction
+    * 7. Perform compaction
     */
    merge_iterator *merge_itor;
    rc = merge_iterator_create(spl->heap_id,
@@ -4831,7 +5227,7 @@ trunk_compact_bundle(void *arg, void *scratch_buf)
    }
 
    /*
-    * 10. Clean up
+    * 9. Clean up
     */
    trunk_compact_bundle_cleanup_iterators(
       spl, &merge_itor, num_branches, skip_itor_arr);
@@ -4839,33 +5235,34 @@ trunk_compact_bundle(void *arg, void *scratch_buf)
    deinit_saved_pivots_in_scratch(scratch);
 
    /*
-    * 11. Reacquire read lock
+    * 11. For each newly split sibling replace bundle with new branch
     */
-   trunk_node_get(spl->cc, req->addr, &node);
-
-   /*
-    * 12. For each newly split sibling replace bundle with new branch
-    */
-   uint64 addr             = req->addr;
    uint64 num_replacements = 0;
-   uint64 generation;
-   do {
-      trunk_node_claim(spl->cc, &node);
-      trunk_node_lock(spl->cc, &node);
-
+   bool   should_continue  = TRUE;
+   while (should_continue) {
+      uint64 old_root_addr;
+      trunk_compact_bundle_node_copy_path(spl, req, &node, &old_root_addr);
       trunk_log_node_if_enabled(&stream, spl, &node);
 
       /*
-       * 12a. ...unless node is a leaf which has split, in which case discard
+       * 11a. ...unless node is a leaf which has split, in which case discard
        *      (interaction 6)
        *
        *      For leaves, the split will cover the compaction and we do not
        *      need to look for the bundle in the split siblings, so simply
        *      exit.
        */
-      if (height == 0 && req->generation < trunk_generation(spl, &node)) {
+      if (trunk_node_is_leaf(&node)
+          && trunk_compact_bundle_node_has_split(spl, req, &node))
+      {
          trunk_log_stream_if_enabled(
-            spl, &stream, "compact_bundle discard split %lu\n", req->addr);
+            spl,
+            &stream,
+            "compact_bundle discard split: range %s-%s, height %u, bundle %u\n",
+            key_string(trunk_data_config(spl), key_buffer_key(&req->start_key)),
+            key_string(trunk_data_config(spl), key_buffer_key(&req->end_key)),
+            req->height,
+            req->bundle_no);
          if (spl->cfg.use_stats) {
             spl->stats[tid].compactions_discarded_leaf_split[height]++;
             spl->stats[tid].compaction_time_wasted_ns[height] +=
@@ -4874,6 +5271,8 @@ trunk_compact_bundle(void *arg, void *scratch_buf)
          trunk_node_unlock(spl->cc, &node);
          trunk_node_unclaim(spl->cc, &node);
          trunk_node_unget(spl->cc, &node);
+
+         // Here is where we would garbage collect the old path
 
          if (num_tuples != 0) {
             trunk_dec_ref(spl, &new_branch, FALSE);
@@ -4891,42 +5290,51 @@ trunk_compact_bundle(void *arg, void *scratch_buf)
                                         &stream,
                                         "inserted %lu into %lu\n",
                                         new_branch.root_addr,
-                                        addr);
+                                        node.addr);
          } else {
             trunk_replace_bundle_branches(spl, &node, NULL, req);
             trunk_log_stream_if_enabled(
-               spl, &stream, "compact_bundle empty %lu\n", addr);
+               spl, &stream, "compact_bundle empty %lu\n", node.addr);
          }
+
       } else {
          /*
-          * 12b. ...unless node is internal and bundle has been flushed
+          * 11b. ...unless node is internal and bundle has been flushed
           */
          platform_assert(height != 0);
          trunk_log_stream_if_enabled(
-            spl, &stream, "compact_bundle discarded flushed %lu\n", addr);
+            spl, &stream, "compact_bundle discarded flushed %lu\n", node.addr);
       }
-
-      addr       = trunk_next_addr(&node);
-      generation = trunk_generation(spl, &node);
       trunk_log_node_if_enabled(&stream, spl, &node);
-      debug_assert(trunk_verify_node(spl, &node));
 
-      if (num_replacements != 0 && num_tuples != 0
-          && start_generation == generation) {
+      should_continue = trunk_compact_bundle_node_has_split(spl, req, &node);
+      if (!should_continue && num_replacements != 0 && pack_req.num_tuples != 0)
+      {
          key max_key = trunk_max_key(spl, &node);
          trunk_zap_branch_range(
             spl, &new_branch, max_key, max_key, PAGE_TYPE_BRANCH);
       }
 
+      debug_assert(trunk_verify_node(spl, &node));
+
+      if (should_continue) {
+         debug_assert(height != 0);
+         key_buffer_copy_key(&req->start_key, trunk_max_key(spl, &node));
+      }
+
+      // garbage collect the old path and bundle
+      trunk_garbage_collect_bundle(spl, old_root_addr, req);
+
+      // only release locks on node after the garbage collection is complete
       trunk_node_unlock(spl->cc, &node);
       trunk_node_unclaim(spl->cc, &node);
       trunk_node_unget(spl->cc, &node);
-      if (start_generation != generation) {
-         debug_assert(height != 0);
-         debug_assert(addr != 0);
-         trunk_node_get(spl->cc, addr, &node);
+
+      if (should_continue) {
+         rc = trunk_compact_bundle_node_get(spl, req, &node);
+         platform_assert_status_ok(rc);
       }
-   } while (start_generation != generation);
+   }
 
    if (spl->cfg.use_stats) {
       if (req->type == TRUNK_COMPACTION_TYPE_SPACE_REC) {
@@ -4960,11 +5368,14 @@ trunk_compact_bundle(void *arg, void *scratch_buf)
             spl->stats[tid].compaction_time_max_ns[height] = compaction_start;
          }
       }
-      trunk_log_stream_if_enabled(spl,
-                                  &stream,
-                                  "enqueuing build filter %lu-%u\n",
-                                  req->addr,
-                                  req->bundle_no);
+      trunk_log_stream_if_enabled(
+         spl,
+         &stream,
+         "build_filter enqueue: range %s-%s, height %u, bundle %u\n",
+         key_string(trunk_data_config(spl), key_buffer_key(&req->start_key)),
+         key_string(trunk_data_config(spl), key_buffer_key(&req->end_key)),
+         req->height,
+         req->bundle_no);
       task_enqueue(
          spl->ts, TASK_TYPE_NORMAL, trunk_bundle_build_filters, req, TRUE);
    }
@@ -4972,73 +5383,6 @@ out:
    trunk_log_stream_if_enabled(spl, &stream, "\n");
    trunk_close_log_stream_if_enabled(spl, &stream);
 }
-
-
-bool
-trunk_flush_node(trunk_handle *spl, uint64 addr, void *arg)
-{
-   trunk_node node;
-   trunk_node_get(spl->cc, addr, &node);
-   trunk_node_claim(spl->cc, &node);
-   trunk_node_lock(spl->cc, &node);
-
-   if (trunk_height(&node) != 0) {
-      for (uint16 pivot_no = 0; pivot_no < trunk_num_children(spl, &node);
-           pivot_no++) {
-         trunk_pivot_data *pdata = trunk_get_pivot_data(spl, &node, pivot_no);
-         if (trunk_pivot_branch_count(spl, &node, pdata) != 0) {
-            platform_status rc = trunk_flush(spl, &node, pdata, FALSE);
-            platform_assert_status_ok(rc);
-         }
-      }
-   }
-
-   trunk_node_unlock(spl->cc, &node);
-   trunk_node_unclaim(spl->cc, &node);
-   trunk_node_unget(spl->cc, &node);
-
-   task_perform_all(spl->ts);
-
-   trunk_node_get(spl->cc, addr, &node);
-   trunk_node_claim(spl->cc, &node);
-   trunk_node_lock(spl->cc, &node);
-
-   if (trunk_height(&node) == 1) {
-      for (uint16 pivot_no = 0; pivot_no < trunk_num_children(spl, &node);
-           pivot_no++) {
-         trunk_pivot_data *pdata = trunk_get_pivot_data(spl, &node, pivot_no);
-         trunk_node        leaf;
-         trunk_node_get(spl->cc, pdata->addr, &leaf);
-         trunk_node_claim(spl->cc, &leaf);
-         trunk_node_lock(spl->cc, &leaf);
-         trunk_split_leaf(spl, &node, &leaf, pivot_no);
-      }
-   }
-
-   trunk_node_unlock(spl->cc, &node);
-   trunk_node_unclaim(spl->cc, &node);
-   trunk_node_unget(spl->cc, &node);
-
-   task_perform_all(spl->ts);
-
-   return TRUE;
-}
-
-
-void
-trunk_force_flush(trunk_handle *spl)
-{
-   page_handle    *lock_page;
-   uint64          generation;
-   platform_status rc = memtable_maybe_rotate_and_get_insert_lock(
-      spl->mt_ctxt, &generation, &lock_page);
-   platform_assert_status_ok(rc);
-   task_perform_all(spl->ts);
-   memtable_unget_insert_lock(spl->mt_ctxt, lock_page);
-   task_perform_all(spl->ts);
-   trunk_for_each_node(spl, trunk_flush_node, NULL);
-}
-
 
 /*
  *-----------------------------------------------------------------------------
@@ -5049,7 +5393,7 @@ trunk_force_flush(trunk_handle *spl)
 static inline bool
 trunk_needs_split(trunk_handle *spl, trunk_node *node)
 {
-   if (trunk_is_leaf(node)) {
+   if (trunk_node_is_leaf(node)) {
       uint64 num_tuples = trunk_pivot_num_tuples(spl, node, 0);
       uint64 kv_bytes   = trunk_pivot_kv_bytes(spl, node, 0);
       return num_tuples > spl->cfg.max_tuples_per_node
@@ -5060,11 +5404,12 @@ trunk_needs_split(trunk_handle *spl, trunk_node *node)
    return trunk_num_children(spl, node) > spl->cfg.fanout;
 }
 
-int
-trunk_split_index(trunk_handle *spl,
-                  trunk_node   *parent,
-                  trunk_node   *child,
-                  uint64        pivot_no)
+void
+trunk_split_index(trunk_handle             *spl,
+                  trunk_node               *parent,
+                  trunk_node               *child,
+                  uint16                    pivot_no,
+                  trunk_compact_bundle_req *req)
 {
    platform_stream_handle stream;
    platform_status        rc = trunk_open_log_stream_if_enabled(spl, &stream);
@@ -5078,12 +5423,12 @@ trunk_split_index(trunk_handle *spl,
    trunk_log_node_if_enabled(&stream, spl, child);
    trunk_node *left_node           = child;
    uint16      target_num_children = trunk_num_children(spl, left_node) / 2;
-   uint16      height              = trunk_height(left_node);
+   uint16      height              = trunk_node_height(left_node);
 
    if (spl->cfg.use_stats)
       spl->stats[platform_get_tid()].index_splits++;
 
-   // allocate right node and write lock it
+   // allocate right node
    trunk_node right_node;
    trunk_alloc(spl->cc, &spl->mini, height, &right_node);
    uint64 right_addr = right_node.addr;
@@ -5113,10 +5458,6 @@ trunk_split_index(trunk_handle *spl,
       left_node->hdr->num_pivot_keys - target_num_children;
    left_node->hdr->num_pivot_keys = target_num_children + 1;
 
-   right_node.hdr->next_addr = left_node->hdr->next_addr;
-   left_node->hdr->next_addr = right_addr;
-
-   left_node->hdr->generation++;
    trunk_reset_start_branch(spl, &right_node);
    trunk_reset_start_branch(spl, left_node);
 
@@ -5149,11 +5490,26 @@ trunk_split_index(trunk_handle *spl,
    trunk_log_node_if_enabled(&stream, spl, &right_node);
    trunk_close_log_stream_if_enabled(spl, &stream);
 
+   if (req != NULL) {
+      trunk_compact_bundle_req *next_req = TYPED_MALLOC(spl->heap_id, next_req);
+      memmove(next_req, req, sizeof(trunk_compact_bundle_req));
+      next_req->addr = right_node.addr;
+      key_buffer_init_from_key(
+         &next_req->start_key, spl->heap_id, trunk_min_key(spl, &right_node));
+      key_buffer_init_from_key(
+         &next_req->end_key, spl->heap_id, trunk_max_key(spl, &right_node));
+
+      platform_assert(!trunk_key_compare(
+         spl, key_buffer_key(&req->start_key), trunk_min_key(spl, left_node)));
+      key_buffer_copy_key(&req->end_key, trunk_max_key(spl, left_node));
+
+      rc = trunk_compact_bundle_enqueue(spl, "split to", req);
+      platform_assert_status_ok(rc);
+   }
+
    trunk_node_unlock(spl->cc, &right_node);
    trunk_node_unclaim(spl->cc, &right_node);
    trunk_node_unget(spl->cc, &right_node);
-
-   return 0;
 }
 
 /*
@@ -5439,8 +5795,6 @@ trunk_split_leaf(trunk_handle *spl,
 
    uint16 bundle_no = trunk_leaf_rebundle_all_branches(
       spl, leaf, leaf0_num_tuples, leaf0_kv_bytes, FALSE);
-   trunk_inc_generation(spl, leaf);
-   uint64 last_next_addr = trunk_next_addr(leaf);
 
    for (uint16 leaf_no = 0; leaf_no < num_leaves; leaf_no++) {
       /*
@@ -5490,9 +5844,6 @@ trunk_split_leaf(trunk_handle *spl,
          spl, &new_leaf, 0, new_leaf_num_tuples[0], new_leaf_kv_bytes[0]);
 
       if (leaf_no != 0) {
-         // set next_addr of leaf
-         trunk_set_next_addr(leaf, new_leaf.addr);
-
          // inc the refs of all the branches
          for (uint16 branch_no = trunk_start_branch(spl, &new_leaf);
               branch_no != trunk_end_branch(spl, &new_leaf);
@@ -5531,19 +5882,17 @@ trunk_split_leaf(trunk_handle *spl,
          req->addr                     = leaf->addr;
          req->type                     = comp_type;
          req->bundle_no                = bundle_no;
-         req->generation               = trunk_generation(spl, leaf);
          req->max_pivot_generation     = trunk_pivot_generation(spl, leaf);
          req->pivot_generation[0]      = trunk_pivot_generation(spl, leaf) - 1;
          req->input_pivot_tuple_count[0] = trunk_pivot_num_tuples(spl, leaf, 0);
          req->input_pivot_kv_byte_count[0] = trunk_pivot_kv_bytes(spl, leaf, 0);
+         key_buffer_init_from_key(
+            &req->start_key, spl->heap_id, trunk_min_key(spl, leaf));
+         key_buffer_init_from_key(
+            &req->end_key, spl->heap_id, trunk_max_key(spl, leaf));
 
-         trunk_default_log_if_enabled(spl,
-                                      "enqueuing compact_bundle %lu-%u\n",
-                                      req->addr,
-                                      req->bundle_no);
-         rc = task_enqueue(
-            spl->ts, TASK_TYPE_NORMAL, trunk_compact_bundle, req, FALSE);
-         platform_assert(SUCCESS(rc));
+         rc = trunk_compact_bundle_enqueue(spl, "enqueue", req);
+         platform_assert_status_ok(rc);
 
          trunk_log_node_if_enabled(&stream, spl, leaf);
 
@@ -5561,25 +5910,24 @@ trunk_split_leaf(trunk_handle *spl,
    }
 
    // set next_addr of leaf (from last iteration)
-   trunk_set_next_addr(leaf, last_next_addr);
    trunk_compact_bundle_req *req = TYPED_ZALLOC(spl->heap_id, req);
    req->spl                      = spl;
    req->addr                     = leaf->addr;
    // req->height already 0
    req->bundle_no                    = bundle_no;
-   req->generation                   = trunk_generation(spl, leaf);
    req->max_pivot_generation         = trunk_pivot_generation(spl, leaf);
    req->pivot_generation[0]          = trunk_pivot_generation(spl, leaf) - 1;
    req->input_pivot_tuple_count[0]   = trunk_pivot_num_tuples(spl, leaf, 0);
    req->input_pivot_kv_byte_count[0] = trunk_pivot_kv_bytes(spl, leaf, 0);
    req->type                         = comp_type;
+   key_buffer_init_from_key(
+      &req->start_key, spl->heap_id, trunk_min_key(spl, leaf));
+   key_buffer_init_from_key(
+      &req->end_key, spl->heap_id, trunk_max_key(spl, leaf));
 
    // issue compact_bundle for leaf and release
-   trunk_default_log_if_enabled(
-      spl, "enqueuing compact_bundle %lu-%u\n", req->addr, req->bundle_no);
-   rc =
-      task_enqueue(spl->ts, TASK_TYPE_NORMAL, trunk_compact_bundle, req, FALSE);
-   platform_assert(SUCCESS(rc));
+   rc = trunk_compact_bundle_enqueue(spl, "enqueue", req);
+   platform_assert_status_ok(rc);
 
    trunk_log_node_if_enabled(&stream, spl, parent);
    trunk_log_node_if_enabled(&stream, spl, leaf);
@@ -5618,7 +5966,6 @@ trunk_split_root(trunk_handle *spl, trunk_node *root)
    memmove(child.hdr, root->hdr, trunk_page_size(&spl->cfg));
    // num_pivot_keys is changed by add_pivot_new_root below
    root->hdr->height++;
-   debug_assert(root->hdr->next_addr == 0);
    // leave generation and pivot_generation
    root->hdr->start_branch      = 0;
    root->hdr->start_frac_branch = 0;
@@ -5632,7 +5979,7 @@ trunk_split_root(trunk_handle *spl, trunk_node *root)
 
    trunk_add_pivot_new_root(spl, root, &child);
 
-   trunk_split_index(spl, root, &child, 0);
+   trunk_split_index(spl, root, &child, 0, NULL);
 
    trunk_node_unlock(spl->cc, &child);
    trunk_node_unclaim(spl->cc, &child);
@@ -5692,7 +6039,7 @@ trunk_range_iterator_init(trunk_handle         *spl,
    ZERO_ARRAY(range_itor->compacted);
 
    // grab the lookup lock
-   page_handle *mt_lookup_lock_page = memtable_get_lookup_lock(spl->mt_ctxt);
+   memtable_get_lookup_lock(spl->mt_ctxt);
 
    // memtables
    ZERO_ARRAY(range_itor->branch);
@@ -5730,10 +6077,10 @@ trunk_range_iterator_init(trunk_handle         *spl,
 
    trunk_node node;
    trunk_node_get(spl->cc, spl->root_addr, &node);
-   memtable_unget_lookup_lock(spl->mt_ctxt, mt_lookup_lock_page);
+   memtable_unget_lookup_lock(spl->mt_ctxt);
 
    // index btrees
-   uint16 height = trunk_height(&node);
+   uint16 height = trunk_node_height(&node);
    for (uint16 h = height; h > 0; h--) {
       uint16 pivot_no = trunk_find_pivot(
          spl, &node, key_buffer_key(&range_itor->min_key), less_than_or_equal);
@@ -6017,7 +6364,6 @@ trunk_compact_leaf(trunk_handle *spl, trunk_node *leaf)
    uint64 kv_bytes   = trunk_pivot_kv_bytes(spl, leaf, 0);
    uint16 bundle_no =
       trunk_leaf_rebundle_all_branches(spl, leaf, num_tuples, kv_bytes, TRUE);
-   trunk_inc_generation(spl, leaf);
 
    // Issue compact_bundle for leaf and release
    trunk_compact_bundle_req *req = TYPED_ZALLOC(spl->heap_id, req);
@@ -6025,18 +6371,18 @@ trunk_compact_leaf(trunk_handle *spl, trunk_node *leaf)
    req->addr                     = leaf->addr;
    // req->height already 0
    req->bundle_no                    = bundle_no;
-   req->generation                   = trunk_generation(spl, leaf);
    req->max_pivot_generation         = trunk_pivot_generation(spl, leaf);
    req->pivot_generation[0]          = trunk_pivot_generation(spl, leaf) - 1;
    req->input_pivot_tuple_count[0]   = trunk_pivot_num_tuples(spl, leaf, 0);
    req->input_pivot_kv_byte_count[0] = trunk_pivot_kv_bytes(spl, leaf, 0);
    req->type                         = TRUNK_COMPACTION_TYPE_SPACE_REC;
+   key_buffer_init_from_key(
+      &req->start_key, spl->heap_id, trunk_min_key(spl, leaf));
+   key_buffer_init_from_key(
+      &req->end_key, spl->heap_id, trunk_max_key(spl, leaf));
 
-   trunk_default_log_if_enabled(
-      spl, "enqueuing compact_bundle %lu-%u\n", req->addr, req->bundle_no);
-   rc =
-      task_enqueue(spl->ts, TASK_TYPE_NORMAL, trunk_compact_bundle, req, FALSE);
-   platform_assert(SUCCESS(rc));
+   rc = trunk_compact_bundle_enqueue(spl, "enqueue", req);
+   platform_assert_status_ok(rc);
 
    trunk_log_node_if_enabled(&stream, spl, leaf);
 
@@ -6080,7 +6426,6 @@ trunk_reclaim_space(trunk_handle *spl)
 {
    platform_assert(spl->cfg.reclaim_threshold != UINT64_MAX);
    while (TRUE) {
-      // platform_default_log("Extract from SRQ\n");
       srq_data space_rec = srq_extract_max(&spl->srq);
       if (!srq_data_found(&space_rec)) {
          return STATUS_NOT_FOUND;
@@ -6097,12 +6442,8 @@ trunk_reclaim_space(trunk_handle *spl)
       }
       pdata->srq_idx = -1;
 
-      // platform_default_log("Space rec: %lu-%u\n",
-      //       node->disk_addr, trunk_pdata_to_pivot_index(spl, node,
-      //       pdata));
-
       trunk_node_lock(spl->cc, &node);
-      if (trunk_is_leaf(&node)) {
+      if (trunk_node_is_leaf(&node)) {
          trunk_compact_leaf(spl, &node);
       } else {
          uint64 sr_start;
@@ -6112,7 +6453,7 @@ trunk_reclaim_space(trunk_handle *spl)
          platform_status rc = trunk_flush(spl, &node, pdata, TRUE);
          if (spl->cfg.use_stats) {
             const threadid tid    = platform_get_tid();
-            uint16         height = trunk_height(&node);
+            uint16         height = trunk_node_height(&node);
             spl->stats[tid].space_recs[height]++;
             spl->stats[tid].space_rec_time_ns[height] +=
                platform_timestamp_elapsed(sr_start);
@@ -6215,7 +6556,7 @@ trunk_filter_lookup(trunk_handle      *spl,
    threadid tid;
    if (spl->cfg.use_stats) {
       tid    = platform_get_tid();
-      height = trunk_height(node);
+      height = trunk_node_height(node);
    }
 
    uint64          found_values;
@@ -6264,7 +6605,7 @@ trunk_compacted_subbundle_lookup(trunk_handle      *spl,
    threadid tid;
    if (spl->cfg.use_stats) {
       tid    = platform_get_tid();
-      height = trunk_height(node);
+      height = trunk_node_height(node);
    }
 
    uint16 filter_count = trunk_subbundle_filter_count(spl, node, sb);
@@ -6373,10 +6714,10 @@ trunk_lookup(trunk_handle *spl, key target, merge_accumulator *result)
 
    merge_accumulator_set_to_null(result);
 
-   bool         found_in_memtable   = FALSE;
-   page_handle *mt_lookup_lock_page = memtable_get_lookup_lock(spl->mt_ctxt);
-   uint64       mt_gen_start        = memtable_generation(spl->mt_ctxt);
-   uint64       mt_gen_end          = memtable_generation_retired(spl->mt_ctxt);
+   bool found_in_memtable = FALSE;
+   memtable_get_lookup_lock(spl->mt_ctxt);
+   uint64 mt_gen_start = memtable_generation(spl->mt_ctxt);
+   uint64 mt_gen_end   = memtable_generation_retired(spl->mt_ctxt);
    for (uint64 mt_gen = mt_gen_start; mt_gen != mt_gen_end; mt_gen--) {
       platform_status rc;
       rc = trunk_memtable_lookup(spl, mt_gen, target, result);
@@ -6387,15 +6728,14 @@ trunk_lookup(trunk_handle *spl, key target, merge_accumulator *result)
       }
    }
 
-   // hold root read lock to prevent memtable flush
    trunk_node node;
-   trunk_node_get(spl->cc, spl->root_addr, &node);
+   trunk_root_get(spl, &node);
 
    // release memtable lookup lock
-   memtable_unget_lookup_lock(spl->mt_ctxt, mt_lookup_lock_page);
+   memtable_unget_lookup_lock(spl->mt_ctxt);
 
    // look in index nodes
-   uint16 height = trunk_height(&node);
+   uint16 height = trunk_node_height(&node);
    for (uint16 h = height; h > 0; h--) {
       uint16 pivot_no =
          trunk_find_pivot(spl, &node, target, less_than_or_equal);
@@ -6429,7 +6769,7 @@ found_final_answer_early:
 
    if (found_in_memtable) {
       // release memtable lookup lock
-      memtable_unget_lookup_lock(spl->mt_ctxt, mt_lookup_lock_page);
+      memtable_unget_lookup_lock(spl->mt_ctxt);
    } else {
       trunk_node_unget(spl->cc, &node);
    }
@@ -6593,7 +6933,7 @@ trunk_lookup_async(trunk_handle      *spl,    // IN
          }
          case async_state_lookup_memtable:
          {
-            ctxt->mt_lock_page  = memtable_get_lookup_lock(spl->mt_ctxt);
+            memtable_get_lookup_lock(spl->mt_ctxt);
             uint64 mt_gen_start = memtable_generation(spl->mt_ctxt);
             uint64 mt_gen_end   = memtable_generation_retired(spl->mt_ctxt);
             for (uint64 mt_gen = mt_gen_start; mt_gen != mt_gen_end; mt_gen--) {
@@ -6603,8 +6943,12 @@ trunk_lookup_async(trunk_handle      *spl,    // IN
                if (merge_accumulator_is_definitive(result)) {
                   trunk_async_set_state(ctxt,
                                         async_state_found_final_answer_early);
+                  memtable_unget_lookup_lock(spl->mt_ctxt);
                   break;
                }
+            }
+            if (ctxt->state == async_state_found_final_answer_early) {
+               break;
             }
             // fallthrough
          }
@@ -6641,8 +6985,7 @@ trunk_lookup_async(trunk_handle      *spl,    // IN
                   ctxt->trunk_node.page = ctxt->cache_ctxt.page;
                   ctxt->trunk_node.hdr =
                      (trunk_hdr *)(ctxt->cache_ctxt.page->data);
-                  memtable_unget_lookup_lock(spl->mt_ctxt, ctxt->mt_lock_page);
-                  ctxt->mt_lock_page = NULL;
+                  memtable_unget_lookup_lock(spl->mt_ctxt);
                   break;
                default:
                   platform_assert(0);
@@ -6651,7 +6994,7 @@ trunk_lookup_async(trunk_handle      *spl,    // IN
          }
          case async_state_trunk_node_lookup:
          {
-            ctxt->height = trunk_height(node);
+            ctxt->height = trunk_node_height(node);
             uint16 pivot_no =
                trunk_find_pivot(spl, node, target, less_than_or_equal);
             debug_assert(pivot_no < trunk_num_children(spl, node));
@@ -6844,9 +7187,11 @@ trunk_lookup_async(trunk_handle      *spl,    // IN
                   if (merge_accumulator_is_definitive(result)) {
                      trunk_async_set_state(
                         ctxt, async_state_found_final_answer_early);
+                     trunk_node_unget(spl->cc, &ctxt->trunk_node);
+                     ZERO_CONTENTS(&ctxt->trunk_node);
                      break;
                   } else if (spl->cfg.use_stats) {
-                     const uint16 height = trunk_height(node);
+                     const uint16 height = trunk_node_height(node);
                      spl->stats[tid].filter_false_positives[height]++;
                   }
                   trunk_async_set_state(ctxt, async_state_next_in_node);
@@ -6915,6 +7260,8 @@ trunk_lookup_async(trunk_handle      *spl,    // IN
                   data_merge_tuples_final(spl->cfg.data_cfg, target, result);
                }
                trunk_async_set_state(ctxt, async_state_end);
+               trunk_node_unget(spl->cc, &ctxt->trunk_node);
+               ZERO_CONTENTS(&ctxt->trunk_node);
                break;
             } else {
                trunk_async_set_state(
@@ -6979,13 +7326,6 @@ trunk_lookup_async(trunk_handle      *spl,    // IN
          }
          case async_state_end:
          {
-            if (ctxt->mt_lock_page != NULL) {
-               memtable_unget_lookup_lock(spl->mt_ctxt, ctxt->mt_lock_page);
-               ctxt->mt_lock_page = NULL;
-            } else {
-               trunk_node_unget(spl->cc, node);
-            }
-            ZERO_CONTENTS(&ctxt->trunk_node);
             if (spl->cfg.use_stats) {
                if (!merge_accumulator_is_null(result)) {
                   spl->stats[tid].lookups_found++;
@@ -7078,13 +7418,16 @@ trunk_create(trunk_config     *cfg,
    spl->heap_id = hid;
    spl->ts      = ts;
 
+   platform_batch_rwlock_init(&spl->trunk_root_lock);
+
    srq_init(&spl->srq, platform_get_module_id(), hid);
 
    // get a free node for the root
    //    we don't use the mini allocator for this, since the root doesn't
    //    maintain constant height
-   platform_status rc =
-      allocator_alloc(spl->al, &spl->root_addr, PAGE_TYPE_TRUNK);
+   uint64          root_addr;
+   platform_status rc = allocator_alloc(spl->al, &root_addr, PAGE_TYPE_TRUNK);
+   spl->root_addr     = root_addr;
    platform_assert_status_ok(rc);
    trunk_node root;
    root.addr = spl->root_addr;
@@ -7126,7 +7469,7 @@ trunk_create(trunk_config     *cfg,
    trunk_set_initial_pivots(spl, &leaf);
    trunk_inc_pivot_generation(spl, &leaf);
 
-   // add &leaf to root and fix up root
+   // add leaf to root and fix up root
    root.hdr->height = 1;
    trunk_add_pivot_new_root(spl, &root, &leaf);
    trunk_inc_pivot_generation(spl, &root);
@@ -7189,6 +7532,8 @@ trunk_mount(trunk_config     *cfg,
 
    srq_init(&spl->srq, platform_get_module_id(), hid);
 
+   platform_batch_rwlock_init(&spl->trunk_root_lock);
+
    // find the unmounted super block
    spl->root_addr                      = 0;
    uint64             meta_tail        = 0;
@@ -7208,10 +7553,6 @@ trunk_mount(trunk_config     *cfg,
       return (trunk_handle *)NULL;
    }
    uint64 meta_head = spl->root_addr + trunk_page_size(&spl->cfg);
-
-   // get a free node for the root
-   // we don't use the next_addr arr for this, since the root doesn't
-   // maintain constant height
 
    memtable_config *mt_cfg = &spl->cfg.mt_cfg;
    spl->mt_ctxt            = memtable_context_create(
@@ -7341,13 +7682,9 @@ void
 trunk_destroy(trunk_handle *spl)
 {
    srq_deinit(&spl->srq);
-
    trunk_prepare_for_shutdown(spl);
-
    trunk_for_each_node(spl, trunk_node_destroy, NULL);
-
    mini_unkeyed_dec_ref(spl->cc, spl->mini.meta_head, PAGE_TYPE_TRUNK, FALSE);
-
    // clear out this splinter table from the meta page.
    allocator_remove_super_addr(spl->al, spl->id);
 
@@ -7374,8 +7711,8 @@ trunk_unmount(trunk_handle **spl_in)
 {
    trunk_handle *spl = *spl_in;
    srq_deinit(&spl->srq);
-   trunk_set_super_block(spl, FALSE, TRUE, FALSE);
    trunk_prepare_for_shutdown(spl);
+   trunk_set_super_block(spl, FALSE, TRUE, FALSE);
    if (spl->cfg.use_stats) {
       for (uint64 i = 0; i < MAX_THREADS; i++) {
          platform_histo_destroy(spl->heap_id,
@@ -7724,7 +8061,7 @@ trunk_verify_node(trunk_handle *spl, trunk_node *node)
 
 
    // check that leaves only have a single pivot
-   if (trunk_height(node) == 0) {
+   if (trunk_node_height(node) == 0) {
       if (trunk_num_children(spl, node) != 1) {
          platform_error_log("trunk_verify: leaf with multiple children\n");
          platform_error_log("addr: %lu\n", addr);
@@ -7740,35 +8077,48 @@ out:
    return is_valid;
 }
 
+
+/*
+ * Scratch space used with trunk_verify_node_with_neighbors to verify that
+ * pivots are coherent across neighboring nodes
+ */
+typedef struct trunk_verify_scratch {
+   key_buffer last_key_seen[TRUNK_MAX_HEIGHT];
+} trunk_verify_scratch;
+
 /*
  * verify_node_with_neighbors checks that the node has:
  * 1. coherent max key with successor's min key
  * 2. coherent pivots with children's min/max keys
  */
 bool
-trunk_verify_node_with_neighbors(trunk_handle *spl, trunk_node *node)
+trunk_verify_node_with_neighbors(trunk_handle         *spl,
+                                 trunk_node           *node,
+                                 trunk_verify_scratch *scratch)
 {
    bool   is_valid = FALSE;
    uint64 addr     = node->addr;
 
-   // check node and successor have coherent pivots
-   uint64 succ_addr = trunk_next_addr(node);
-   if (succ_addr != 0) {
-      trunk_node succ;
-      trunk_node_get(spl->cc, succ_addr, &succ);
-      key ube      = trunk_max_key(spl, node);
-      key succ_lbi = trunk_min_key(spl, &succ);
-      if (trunk_key_compare(spl, ube, succ_lbi) != 0) {
-         platform_default_log("trunk_verify_node_with_neighbors: "
-                              "mismatched pivots with successor\n");
-         platform_default_log("addr: %lu\n", addr);
-         trunk_node_unget(spl->cc, &succ);
-         goto out;
-      }
-      trunk_node_unget(spl->cc, &succ);
+   uint16 height = trunk_node_height(node);
+   // check node and predescessor have coherent pivots
+   if (trunk_key_compare(spl,
+                         key_buffer_key(&scratch->last_key_seen[height]),
+                         trunk_min_key(spl, node)))
+   {
+      platform_default_log("trunk_verify_node_with_neighbors: mismatched "
+                           "pivots with predescessor\n");
+      platform_default_log(
+         "predescessor max key: %s\n",
+         key_string(trunk_data_config(spl),
+                    key_buffer_key(&scratch->last_key_seen[height])));
+      goto out;
    }
+   // set last key seen in scratch
+   key_buffer_copy_key(&scratch->last_key_seen[height],
+                       trunk_max_key(spl, node));
 
-   if (trunk_height(node) == 0) {
+   // don't need to verify coherence with children if node is a leaf
+   if (trunk_node_is_leaf(node)) {
       is_valid = TRUE;
       goto out;
    }
@@ -7829,7 +8179,8 @@ trunk_verify_node_and_neighbors(trunk_handle *spl, uint64 addr, void *arg)
    if (!is_valid) {
       goto out;
    }
-   is_valid = trunk_verify_node_with_neighbors(spl, &node);
+   trunk_verify_scratch *scratch = (trunk_verify_scratch *)arg;
+   is_valid = trunk_verify_node_with_neighbors(spl, &node, scratch);
 
 out:
    trunk_node_unget(spl->cc, &node);
@@ -7842,7 +8193,17 @@ out:
 bool
 trunk_verify_tree(trunk_handle *spl)
 {
-   return trunk_for_each_node(spl, trunk_verify_node_and_neighbors, NULL);
+   trunk_verify_scratch scratch = {0};
+   for (uint64 h = 0; h < TRUNK_MAX_HEIGHT; h++) {
+      key_buffer_init_from_key(
+         &scratch.last_key_seen[h], spl->heap_id, NEGATIVE_INFINITY_KEY);
+   }
+   bool success =
+      trunk_for_each_node(spl, trunk_verify_node_and_neighbors, &scratch);
+   for (uint64 h = 0; h < TRUNK_MAX_HEIGHT; h++) {
+      key_buffer_deinit(&scratch.last_key_seen[h]);
+   }
+   return success;
 }
 
 /*
@@ -7889,7 +8250,7 @@ trunk_node_space_use(trunk_handle *spl, uint64 addr, void *arg)
       }
    }
 
-   uint16 height = trunk_height(&node);
+   uint16 height = trunk_node_height(&node);
    bytes_used_on_level[height] += bytes_used_in_node;
    trunk_node_unget(spl->cc, &node);
    return TRUE;
@@ -7914,12 +8275,13 @@ trunk_print_space_use(platform_log_handle *log_handle, trunk_handle *spl)
    platform_log(log_handle, "\n");
 }
 
+// clang-format off
 void
 trunk_print_locked_node(platform_log_handle *log_handle,
                         trunk_handle        *spl,
                         trunk_node          *node)
 {
-   uint16 height = trunk_height(node);
+   uint16 height = trunk_node_height(node);
 
    platform_log(log_handle,
                 "\nPage type: %s, Node addr=%lu\n{\n",
@@ -7927,14 +8289,12 @@ trunk_print_locked_node(platform_log_handle *log_handle,
                 node->addr);
 
    // clang-format off
-   platform_log(log_handle, "----------------------------------------------------------------------------------------------------\n");
-   platform_log(log_handle, "|          |     addr     |   next addr  | height |   gen   | pvt gen |                            |\n");
-   platform_log(log_handle, "|  HEADER  |--------------|--------------|--------|---------|---------|----------------------------|\n");
-   platform_log(log_handle, "|          | %12lu | %12lu | %6u | %7lu | %7lu |                            |\n",
+   platform_log(log_handle, "---------------------------------------------------------------------------------------\n");
+   platform_log(log_handle, "|          |     addr      | height | pvt gen |                                       |\n");
+   platform_log(log_handle, "|  HEADER  |---------------|--------|---------|---------|-----------------------------|\n");
+   platform_log(log_handle, "|          | %12lu^ | %6u | %7lu |                                       |\n",
       node->addr,
-      trunk_next_addr(node),
       height,
-      trunk_generation(spl, node),
       trunk_pivot_generation(spl, node));
    // clang-format on
 
@@ -8140,7 +8500,7 @@ trunk_print_subtree(platform_log_handle *log_handle,
    trunk_node node;
    trunk_node_get(spl->cc, addr, &node);
 
-   if (trunk_is_index(&node)) {
+   if (trunk_node_is_index(&node)) {
       for (uint32 i = 0; i < trunk_num_children(spl, &node); i++) {
          trunk_pivot_data *data = trunk_get_pivot_data(spl, &node, i);
          trunk_print_subtree(log_handle, spl, data->addr);
@@ -8240,7 +8600,7 @@ trunk_print_insertion_stats(platform_log_handle *log_handle, trunk_handle *spl)
    threadid thr_i;
    trunk_node node;
    trunk_node_get(spl->cc, spl->root_addr, &node);
-   uint32 height = trunk_height(&node);
+   uint32 height = trunk_node_height(&node);
    trunk_node_unget(spl->cc, &node);
 
    trunk_stats *global;
@@ -8557,7 +8917,7 @@ trunk_print_lookup_stats(platform_log_handle *log_handle, trunk_handle *spl)
    fraction avg_filter_lookups, avg_filter_false_positives, avg_branch_lookups;
    trunk_node node;
    trunk_node_get(spl->cc, spl->root_addr, &node);
-   uint32 height = trunk_height(&node);
+   uint32 height = trunk_node_height(&node);
    trunk_node_unget(spl->cc, &node);
 
    trunk_stats *global;
@@ -8684,7 +9044,7 @@ trunk_print_lookup(trunk_handle        *spl,
 
    trunk_node node;
    trunk_node_get(spl->cc, spl->root_addr, &node);
-   uint16 height = trunk_height(&node);
+   uint16 height = trunk_node_height(&node);
    for (uint16 h = height; h > 0; h--) {
       trunk_print_locked_node(Platform_default_log_handle, spl, &node);
       uint16 pivot_no =
@@ -8834,11 +9194,10 @@ trunk_node_print_branches(trunk_handle *spl, uint64 addr, void *arg)
       log_handle,
       "------------------------------------------------------------------\n");
    platform_log(log_handle,
-                "| Page type: %s, Node addr=%lu height=%u next_addr=%lu\n",
+                "| Page type: %s, Node addr=%lu height=%u\n",
                 page_type_str[PAGE_TYPE_TRUNK],
                 addr,
-                trunk_height(&node),
-                trunk_next_addr(&node));
+                trunk_node_height(&node));
    platform_log(
       log_handle,
       "------------------------------------------------------------------\n");

--- a/src/trunk.h
+++ b/src/trunk.h
@@ -178,10 +178,11 @@ typedef struct trunk_compacted_memtable {
 } trunk_compacted_memtable;
 
 struct trunk_handle {
-   uint64           root_addr;
-   uint64           super_block_idx;
-   trunk_config     cfg;
-   platform_heap_id heap_id;
+   volatile uint64       root_addr;
+   uint64                super_block_idx;
+   trunk_config          cfg;
+   platform_heap_id      heap_id;
+   platform_batch_rwlock trunk_root_lock;
 
    // space reclamation
    uint64 est_tuples_in_compaction;
@@ -289,11 +290,10 @@ typedef struct trunk_async_ctxt {
    trunk_async_cb cb; // IN: callback (requeues ctxt
                       // for dispatch)
    // These fields are internal
-   trunk_async_state prev_state;   // state machine's previous state
-   trunk_async_state state;        // state machine's current state
-   page_handle      *mt_lock_page; // Memtable lock page
-   trunk_node        trunk_node;   // Current trunk node
-   uint16            height;       // height of trunk_node
+   trunk_async_state prev_state; // state machine's previous state
+   trunk_async_state state;      // state machine's current state
+   trunk_node        trunk_node; // Current trunk node
+   uint16            height;     // height of trunk_node
 
    uint16 sb_no;     // subbundle number (newest)
    uint16 end_sb_no; // subbundle number (oldest,
@@ -385,8 +385,6 @@ trunk_unmount(trunk_handle **spl);
 void
 trunk_perform_tasks(trunk_handle *spl);
 
-void
-trunk_force_flush(trunk_handle *spl);
 void
 trunk_print_insertion_stats(platform_log_handle *log_handle, trunk_handle *spl);
 void

--- a/tests/config.c
+++ b/tests/config.c
@@ -68,7 +68,7 @@ config_set_defaults(master_config *cfg)
       .allocator_capacity       = GiB_TO_B(TEST_CONFIG_DEFAULT_DISK_SIZE_GB),
       .cache_capacity           = GiB_TO_B(TEST_CONFIG_DEFAULT_CACHE_SIZE_GB),
       .btree_rough_count_height = 1,
-      .filter_remainder_size    = 6,
+      .filter_remainder_size    = 4,
       .filter_index_size        = TEST_CONFIG_DEFAULT_FILTER_INDEX_SIZE,
       .use_log                  = FALSE,
       .num_normal_bg_threads    = TEST_CONFIG_DEFAULT_NUM_NORMAL_BG_THREADS,

--- a/tests/functional/btree_test.c
+++ b/tests/functional/btree_test.c
@@ -80,9 +80,8 @@ platform_status
 test_btree_insert(test_memtable_context *ctxt, key tuple_key, message data)
 {
    uint64          generation;
-   page_handle    *lock_page = NULL;
-   platform_status rc        = memtable_maybe_rotate_and_get_insert_lock(
-      ctxt->mt_ctxt, &generation, &lock_page);
+   platform_status rc =
+      memtable_maybe_rotate_and_get_insert_lock(ctxt->mt_ctxt, &generation);
    if (!SUCCESS(rc)) {
       return rc;
    }
@@ -102,7 +101,7 @@ test_btree_insert(test_memtable_context *ctxt, key tuple_key, message data)
                         &dummy_leaf_generation);
 
 out:
-   memtable_unget_insert_lock(ctxt->mt_ctxt, lock_page);
+   memtable_unget_insert_lock(ctxt->mt_ctxt);
    return rc;
 }
 

--- a/tests/functional/splinter_test.c
+++ b/tests/functional/splinter_test.c
@@ -2272,14 +2272,6 @@ test_splinter_delete(trunk_config    *cfg,
       cache_print_stats(Platform_default_log_handle, spl->cc);
    }
 
-   for (uint8 spl_idx = 0; spl_idx < num_tables; spl_idx++) {
-      trunk_handle *spl = spl_tables[spl_idx];
-      trunk_force_flush(spl);
-      platform_default_log("After flushing table %d:\n", spl_idx);
-      trunk_print_insertion_stats(Platform_default_log_handle, spl);
-      cache_print_stats(Platform_default_log_handle, spl->cc);
-   }
-
    for (uint64 i = 0; i < num_insert_threads; i++) {
       if (!SUCCESS(params[i].rc)) {
          rc = params[i].rc;


### PR DESCRIPTION
This changeset implements copy-on-write for trunk nodes, which includes several high-level changes. This PR still needs to be rebased onto main, but the the purpose is to discuss high- and low-level design decisions.

Changes in this PR:

1. Trunk root lock. A distributed RW lock is used to access/change the current root.

2. Flush from root. Flushes proceed from the root and cascade immediately rather than being triggered at the beginning of `trunk_compact_bundle`.

3. Copy-on-write. Trunk nodes cannot be modified directly, and instead are change via a copy-on-write of the root-to-node path together with a change of the root node.

4. Garbage Collection for unlinked branches and filters. After a copy-on-write, the nodes on the old path will be unreferenced. This PR does not GC the trunk nodes themselves, but it includes a GC path to dereference the replaced branches and filters.

5. `platform_batch_rwlock`. Replaces distributed locks using dummy cache pages with a batched distributed RW lock implementation in `platform.[ch]`.