### PR TITLE
use pragma once in preference to matched ifndef blocks

### DIFF
--- a/include/splinterdb/data.h
+++ b/include/splinterdb/data.h
@@ -17,8 +17,7 @@
  *
  */
 
-#ifndef __DATA_H
-#define __DATA_H
+#pragma once
 
 #include "splinterdb/public_platform.h"
 #include "splinterdb/public_util.h"
@@ -170,5 +169,3 @@ struct data_config {
    key_to_str_fn        key_to_string;
    message_to_str_fn    message_to_string;
 };
-
-#endif // __DATA_H

--- a/include/splinterdb/platform_linux/public_platform.h
+++ b/include/splinterdb/platform_linux/public_platform.h
@@ -8,8 +8,7 @@
  *     for internal use.
  */
 
-#ifndef __PUBLIC_PLATFORM_H
-#define __PUBLIC_PLATFORM_H
+#pragma once
 
 #include <stdio.h>
 
@@ -79,5 +78,3 @@ typedef FILE platform_log_handle;
 void
 platform_set_log_streams(platform_log_handle *info_stream,
                          platform_log_handle *error_stream);
-
-#endif // __PUBLIC_PLATFORM_H

--- a/include/splinterdb/public_platform.h
+++ b/include/splinterdb/public_platform.h
@@ -22,8 +22,7 @@ compile time for the linux platform, you might
 
 */
 
-#ifndef __SPLINTERDB_PUBLIC_PLATFORM_H
-#define __SPLINTERDB_PUBLIC_PLATFORM_H
+#pragma once
 
 #ifndef SPLINTERDB_PLATFORM_DIR
 #   error Define SPLINTERDB_PLATFORM_DIR for your target, e.g. compile with flag -DSPLINTERDB_PLATFORM_DIR=platform_linux
@@ -42,5 +41,3 @@ compile time for the linux platform, you might
 #undef PUBLIC_PLATFORM_H
 #undef TEMP_STRINGIFY
 #undef TEMP_XSTRINGIFY
-
-#endif // __SPLINTERDB_PUBLIC_PLATFORM_H

--- a/include/splinterdb/public_util.h
+++ b/include/splinterdb/public_util.h
@@ -1,8 +1,7 @@
 // Copyright 2018-2021 VMware, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef __PUBLIC_UTIL_H__
-#define __PUBLIC_UTIL_H__
+#pragma once
 
 #include "splinterdb/public_platform.h"
 
@@ -51,5 +50,3 @@ slice_data(const slice b)
 {
    return b.data;
 }
-
-#endif /* __PUBLIC_UTIL_H__ */

--- a/src/allocator.h
+++ b/src/allocator.h
@@ -7,8 +7,7 @@
  *     This file contains the abstract interface for an allocator.
  */
 
-#ifndef __ALLOCATOR_H
-#define __ALLOCATOR_H
+#pragma once
 
 #include "platform.h"
 
@@ -199,5 +198,3 @@ allocator_print_allocated(allocator *al)
 {
    return al->ops->print_allocated(al);
 }
-
-#endif // __ALLOCATOR_H

--- a/src/btree.h
+++ b/src/btree.h
@@ -7,8 +7,7 @@
  *     This file contains the public interfaces for dynamic b-trees/memtables.
  */
 
-#ifndef __BTREE_H__
-#define __BTREE_H__
+#pragma once
 
 #include "mini_allocator.h"
 #include "iterator.h"
@@ -452,5 +451,3 @@ btree_message_to_string(btree_config *cfg, message data, char str[static 128])
 {
    return data_message_to_string(cfg->data_cfg, data, str, 128);
 }
-
-#endif // __BTREE_H__

--- a/src/btree_private.h
+++ b/src/btree_private.h
@@ -8,8 +8,7 @@
  * These definitions are provided here so that they can be shared by the
  * source and test modules.
  */
-#ifndef __BTREE_PRIVATE_H__
-#define __BTREE_PRIVATE_H__
+#pragma once
 
 #include "splinterdb/public_platform.h"
 #include "splinterdb/data.h"
@@ -306,5 +305,3 @@ btree_get_child_addr(const btree_config *cfg,
 {
    return index_entry_child_addr(btree_get_index_entry(cfg, hdr, k));
 }
-
-#endif // __BTREE_PRIVATE_H__

--- a/src/cache.h
+++ b/src/cache.h
@@ -7,8 +7,7 @@
  *     This file contains the abstract interface for a cache.
  */
 
-#ifndef __CACHE_H
-#define __CACHE_H
+#pragma once
 
 #include "platform.h"
 #include "allocator.h"
@@ -481,5 +480,3 @@ cache_pages_share_extent(const cache *cc, uint64 addr1, uint64 addr2)
    cache_config *cfg = cache_get_config(cc);
    return cache_config_pages_share_extent(cfg, addr1, addr2);
 }
-
-#endif // __CACHE_H

--- a/src/clockcache.h
+++ b/src/clockcache.h
@@ -7,8 +7,7 @@
  *     This file contains interface for a concurrent clock cache.
  */
 
-#ifndef __CLOCKCACHE_H
-#define __CLOCKCACHE_H
+#pragma once
 
 #include "allocator.h"
 #include "cache.h"
@@ -170,5 +169,3 @@ clockcache_init(clockcache          *cc,   // OUT
 
 void
 clockcache_deinit(clockcache *cc); // IN
-
-#endif // __CLOCKCACHE_H

--- a/src/data_internal.h
+++ b/src/data_internal.h
@@ -7,8 +7,7 @@
  *     A slice-based interface to the datatype definitions
  */
 
-#ifndef __DATA_INTERNAL_H
-#define __DATA_INTERNAL_H
+#pragma once
 
 #include "splinterdb/data.h"
 #include "util.h"
@@ -639,5 +638,3 @@ data_message_to_string(const data_config *cfg,
        data_message_to_string((cfg), (msg), b.buffer, 128);                    \
        b;                                                                      \
     }).buffer)
-
-#endif // __DATA_INTERNAL_H

--- a/src/io.h
+++ b/src/io.h
@@ -7,8 +7,7 @@
  *     This file contains the abstract interface for IO.
  */
 
-#ifndef __IO_H
-#define __IO_H
+#pragma once
 
 #include "platform.h"
 
@@ -204,5 +203,3 @@ io_config_init(io_config  *io_cfg,
    io_cfg->kernel_queue_size = async_queue_depth;
    io_cfg->async_max_pages   = extent_size / page_size;
 }
-
-#endif //__IO_H

--- a/src/iterator.h
+++ b/src/iterator.h
@@ -1,8 +1,7 @@
 // Copyright 2018-2021 VMware, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef __ITERATOR_H
-#define __ITERATOR_H
+#pragma once
 
 #include "data_internal.h"
 #include "util.h"
@@ -52,5 +51,3 @@ iterator_print(iterator *itor)
 {
    return itor->ops->print(itor);
 }
-
-#endif // __ITERATOR_H

--- a/src/log.h
+++ b/src/log.h
@@ -7,8 +7,7 @@
  *     This file contains the abstract interface for a write-ahead log.
  */
 
-#ifndef __LOG_H
-#define __LOG_H
+#pragma once
 
 #include "platform.h"
 #include "cache.h"
@@ -72,5 +71,3 @@ log_magic(log_handle *log)
 
 log_handle *
 log_create(cache *cc, log_config *cfg, platform_heap_id hid);
-
-#endif //__LOG_H

--- a/src/memtable.h
+++ b/src/memtable.h
@@ -7,8 +7,7 @@
  *     This file contains the interface for the splinter memtable.
  */
 
-#ifndef __MEMTABLE_H
-#define __MEMTABLE_H
+#pragma once
 
 #include "platform.h"
 #include "task.h"
@@ -295,5 +294,3 @@ memtable_print_stats(platform_log_handle *log_handle, cache *cc, memtable *mt)
 {
    btree_print_tree_stats(log_handle, cc, mt->cfg, mt->root_addr);
 };
-
-#endif // __MEMTABLE_H

--- a/src/merge.h
+++ b/src/merge.h
@@ -7,8 +7,7 @@
  *    Merging functionality, notably merge iterators.
  */
 
-#ifndef __MERGE_H
-#define __MERGE_H
+#pragma once
 
 #include "data_internal.h"
 #include "iterator.h"
@@ -105,5 +104,3 @@ merge_iterator_destroy(platform_heap_id hid, merge_iterator **merge_itor);
 
 void
 merge_iterator_print(merge_iterator *merge_itor);
-
-#endif // __BTREE_MERGE_H

--- a/src/mini_allocator.h
+++ b/src/mini_allocator.h
@@ -14,8 +14,7 @@
  *     operations can be restricted to given key ranges.
  */
 
-#ifndef __MINI_ALLOCATOR_H
-#define __MINI_ALLOCATOR_H
+#pragma once
 
 #include "platform.h"
 #include "allocator.h"
@@ -130,5 +129,3 @@ mini_num_extents(mini_allocator *mini)
 {
    return mini->num_extents;
 }
-
-#endif // __MINI_ALLOCATOR_H

--- a/src/pcq.h
+++ b/src/pcq.h
@@ -8,8 +8,7 @@
  *     number of maximum elements.
  */
 
-#ifndef __PCQ_H_
-#define __PCQ_H_
+#pragma once
 
 #include "platform.h"
 
@@ -122,5 +121,3 @@ pcq_dequeue(pcq   *q,    // IN
 
    return STATUS_OK;
 }
-
-#endif // __PCQ_H_

--- a/src/platform_linux/laio.h
+++ b/src/platform_linux/laio.h
@@ -7,8 +7,7 @@
  *     This file contains the interface for a libaio wrapper.
  */
 
-#ifndef __LAIO_H
-#define __LAIO_H
+#pragma once
 
 #include "io.h"
 #include "task.h"
@@ -53,5 +52,3 @@ typedef struct laio_handle {
 
 platform_status
 laio_config_valid(io_config *cfg);
-
-#endif //__LAIO_H

--- a/src/rc_allocator.h
+++ b/src/rc_allocator.h
@@ -7,8 +7,7 @@
  * This file contains the interface for the ref count allocator.
  */
 
-#ifndef __RC_ALLOCATOR_H
-#define __RC_ALLOCATOR_H
+#pragma once
 
 #include "allocator.h"
 #include "platform.h"
@@ -113,5 +112,3 @@ rc_allocator_mount(rc_allocator        *al,
 
 void
 rc_allocator_unmount(rc_allocator *al);
-
-#endif /* __RC_ALLOCATOR_H */

--- a/src/routing_filter.h
+++ b/src/routing_filter.h
@@ -7,8 +7,7 @@
  *     This file contains the routing_filter interface.
  */
 
-#ifndef __ROUTING_FILTER_H
-#define __ROUTING_FILTER_H
+#pragma once
 
 #include "cache.h"
 #include "iterator.h"
@@ -187,5 +186,3 @@ routing_filter_verify(cache          *cc,
 
 void
 routing_filter_print(cache *cc, routing_config *cfg, routing_filter *filter);
-
-#endif // __ROUTING_FILTER_H

--- a/src/shard_log.h
+++ b/src/shard_log.h
@@ -7,8 +7,7 @@
  *     This file contains the interface for a sharded write-ahead log.
  */
 
-#ifndef __SHARD_LOG_H
-#define __SHARD_LOG_H
+#pragma once
 
 #include "log.h"
 #include "cache.h"
@@ -93,5 +92,3 @@ shard_log_config_init(shard_log_config *log_cfg,
                       data_config      *data_cfg);
 void
 shard_log_print(shard_log *log);
-
-#endif //__SHARD_LOG_H

--- a/src/srq.h
+++ b/src/srq.h
@@ -8,8 +8,7 @@
  *     to identify potential compactions to perform to reclaim space.
  */
 
-#ifndef __SRQ_H
-#define __SRQ_H
+#pragma once
 
 #include "platform.h"
 
@@ -355,5 +354,3 @@ out:
    }
    return ret;
 }
-
-#endif //__SRQ_H

--- a/src/task.h
+++ b/src/task.h
@@ -1,8 +1,7 @@
 // Copyright 2018-2021 VMware, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef __TASK_H
-#define __TASK_H
+#pragma once
 
 #include "platform.h"
 
@@ -191,5 +190,3 @@ task_active_tasks_mask(task_system *ts);
 
 void
 task_print_stats(task_system *ts);
-
-#endif // __TASK_H

--- a/src/trunk.h
+++ b/src/trunk.h
@@ -7,8 +7,7 @@
  *     This file contains the interface for SplinterDB.
  */
 
-#ifndef __TRUNK_H
-#define __TRUNK_H
+#pragma once
 
 #include "splinterdb/data.h"
 #include "btree.h"
@@ -468,5 +467,3 @@ trunk_config_init(trunk_config        *trunk_cfg,
                   platform_log_handle *log_handle);
 size_t
 trunk_get_scratch_size();
-
-#endif // __TRUNK_H

--- a/tests/config.h
+++ b/tests/config.h
@@ -7,8 +7,7 @@
  *     This file contains functions for config parsing.
  */
 
-#ifndef __CONFIG_H
-#define __CONFIG_H
+#pragma once
 
 #include "clockcache.h"
 #include "splinterdb/data.h"
@@ -236,6 +235,3 @@ config_parse(master_config *cfg,
 #define config_set_else                                                        \
    }                                                                           \
    else
-
-
-#endif // __CONFIG_H

--- a/tests/functional/test.h
+++ b/tests/functional/test.h
@@ -7,8 +7,7 @@
  *     This file contains constants and functions that pertain to tests.
  */
 
-#ifndef __TEST_H
-#define __TEST_H
+#pragma once
 
 #include "cache.h"
 #include "clockcache.h"
@@ -386,5 +385,3 @@ test_generate_allocator_root_id()
 {
    return __sync_fetch_and_add(&counter, 1);
 }
-
-#endif

--- a/tests/functional/test_async.h
+++ b/tests/functional/test_async.h
@@ -7,8 +7,7 @@
  *     This file contains interfaces for a toy per-thread ctxt manager.
  */
 
-#ifndef __TEST_ASYNC_H_
-#define __TEST_ASYNC_H_
+#pragma once
 
 #include "platform.h"
 
@@ -69,5 +68,3 @@ async_ctxt_process_ready(trunk_handle         *spl,
                          timestamp            *latency_max,
                          async_ctxt_process_cb process_cb,
                          void                 *process_arg);
-
-#endif // __TEST_ASYNC_H_

--- a/tests/test_common.h
+++ b/tests/test_common.h
@@ -9,8 +9,7 @@
  * in test_common.c, that are shared between functional/ and unit/ test sources.
  * -----------------------------------------------------------------------------
  */
-#ifndef __TEST_COMMON_H__
-#define __TEST_COMMON_H__
+#pragma once
 
 #include "trunk.h"
 #include "functional/test.h"
@@ -56,6 +55,3 @@ test_show_verbose_progress(test_exec_config *test_exec_cfg)
 {
    return (test_exec_cfg->verbose_progress);
 }
-
-
-#endif /* __TEST_COMMON_H__ */

--- a/tests/test_data.h
+++ b/tests/test_data.h
@@ -1,8 +1,7 @@
 // Copyright 2018-2021 VMware, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef __TEST_DATA_H
-#define __TEST_DATA_H
+#pragma once
 
 #include "splinterdb/data.h"
 #include "util.h"
@@ -30,5 +29,3 @@ test_data_print_key(const void *key, platform_log_handle *log_handle)
                 key_p[1],
                 key_p[2]);
 }
-
-#endif

--- a/tests/unit/btree_test_common.h
+++ b/tests/unit/btree_test_common.h
@@ -5,8 +5,7 @@
  * by different BTree unit-test modules.
  */
 
-#ifndef __BTREE_TEST_COMMON_H__
-#define __BTREE_TEST_COMMON_H__
+#pragma once
 
 #include "../config.h"
 #include "io.h"
@@ -37,5 +36,3 @@ init_btree_config_from_master_config(btree_config  *dbtree_cfg,
                                      master_config *master_cfg,
                                      cache_config  *cache_cfg,
                                      data_config   *data_cfg);
-
-#endif /* __BTREE_TEST_COMMON_H__ */


### PR DESCRIPTION
Switch from matched-ifndef blocks to the "nonstandard but widely supported" #pragma once. This has the nice benefit that there's no possibility of name collision, no need to rename the ifndef if you rename a file later, and just generally less boilerplate clutter to sift through.