### PR TITLE
Jonh move extent funcs to allocator

### DIFF
--- a/src/allocator.h
+++ b/src/allocator.h
@@ -74,7 +74,7 @@ _Static_assert(
    "Lookup array page_type_str[] is incorrectly sized for NUM_PAGE_TYPES");
 
 /*
- * Configuration structure to set up the Ref Count Allocation sub-system.
+ * Configuration structure to set up the Allocation sub-system.
  */
 typedef struct allocator_config {
    io_config *io_cfg;
@@ -209,6 +209,7 @@ allocator_dec_ref(allocator *al, uint64 addr, page_type type)
    return al->ops->dec_ref(al, addr, type);
 }
 
+// TODO rename get_refcount
 static inline uint8
 allocator_get_ref(allocator *al, uint64 addr)
 {

--- a/src/btree.c
+++ b/src/btree.c
@@ -1141,7 +1141,7 @@ btree_create(cache              *cc,
    // get a free node for the root
    // we don't use the next_addr arr for this, since the root doesn't
    // maintain constant height
-   allocator      *al = cache_allocator(cc);
+   allocator      *al = cache_get_allocator(cc);
    uint64          base_addr;
    platform_status rc = allocator_alloc(al, &base_addr, type);
    platform_assert_status_ok(rc);

--- a/src/btree.c
+++ b/src/btree.c
@@ -1109,11 +1109,9 @@ btree_node_get_from_cache_ctxt(const btree_config *cfg,  // IN
 
 
 static inline bool
-btree_addrs_share_extent(cache *cc,
-                         uint64              left_addr,
-                         uint64              right_addr)
+btree_addrs_share_extent(cache *cc, uint64 left_addr, uint64 right_addr)
 {
-   allocator* al = cache_get_allocator(cc);
+   allocator *al = cache_get_allocator(cc);
    return allocator_config_pages_share_extent(
       allocator_get_config(al), right_addr, left_addr);
 }
@@ -1848,7 +1846,8 @@ start_over:
       debug_assert(parent_entry->pivot_data.stats.message_bytes
                    == BTREE_UNKNOWN_COUNTER);
       child_node.addr = index_entry_child_addr(parent_entry);
-      debug_assert(allocator_page_valid(cache_get_allocator(cc), child_node.addr));
+      debug_assert(
+         allocator_page_valid(cache_get_allocator(cc), child_node.addr));
       btree_node_get(cc, cfg, &child_node, PAGE_TYPE_MEMTABLE);
       height--;
    }

--- a/src/cache.h
+++ b/src/cache.h
@@ -203,7 +203,7 @@ typedef struct cache_ops {
    count_dirty_fn       count_dirty;
    page_get_read_ref_fn page_get_read_ref;
    enable_sync_get_fn   enable_sync_get;
-   get_allocator_fn get_allocator;
+   get_allocator_fn     get_allocator;
    cache_config_fn      get_config;
 } cache_ops;
 

--- a/src/clockcache.c
+++ b/src/clockcache.c
@@ -132,9 +132,6 @@ clockcache_config_page_size(const clockcache_config *cfg);
 static uint64
 clockcache_config_extent_size(const clockcache_config *cfg);
 
-static uint64
-clockcache_config_extent_base_addr(const clockcache_config *cfg, uint64 addr);
-
 page_handle *
 clockcache_alloc(clockcache *cc, uint64 addr, page_type type);
 
@@ -216,9 +213,6 @@ clockcache_assert_no_locks_held(clockcache *cc);
 void
 clockcache_print(platform_log_handle *log_handle, clockcache *cc);
 
-bool
-clockcache_page_valid(clockcache *cc, uint64 addr);
-
 void
 clockcache_validate_page(clockcache *cc, page_handle *page, uint64 addr);
 
@@ -246,9 +240,6 @@ clockcache_enable_sync_get(clockcache *cc, bool enabled);
 allocator *
 clockcache_allocator(const clockcache *cc);
 
-uint64
-clockcache_extent_base_addr(const clockcache *cc, uint64 addr);
-
 /*
  *-----------------------------------------------------------------------------
  *
@@ -273,17 +264,9 @@ clockcache_config_extent_size_virtual(const cache_config *cfg)
    return clockcache_config_extent_size(ccfg);
 }
 
-uint64
-clockcache_config_extent_base_addr_virtual(const cache_config *cfg, uint64 addr)
-{
-   clockcache_config *ccfg = (clockcache_config *)cfg;
-   return clockcache_config_extent_base_addr(ccfg, addr);
-}
-
 cache_config_ops clockcache_config_ops = {
-   .page_size        = clockcache_config_page_size_virtual,
-   .extent_size      = clockcache_config_extent_size_virtual,
-   .extent_base_addr = clockcache_config_extent_base_addr_virtual,
+   .page_size   = clockcache_config_page_size_virtual,
+   .extent_size = clockcache_config_extent_size_virtual,
 };
 
 page_handle *
@@ -298,13 +281,6 @@ clockcache_hard_evict_extent_virtual(cache *c, uint64 addr, page_type type)
 {
    clockcache *cc = (clockcache *)c;
    return clockcache_hard_evict_extent(cc, addr, type);
-}
-
-uint8
-clockcache_get_allocator_ref_virtual(cache *c, uint64 addr)
-{
-   clockcache *cc = (clockcache *)c;
-   return clockcache_get_allocator_ref(cc, addr);
 }
 
 page_handle *
@@ -453,13 +429,6 @@ clockcache_print_virtual(platform_log_handle *log_handle, cache *c)
    clockcache_print(log_handle, cc);
 }
 
-bool
-clockcache_page_valid_virtual(cache *c, uint64 addr)
-{
-   clockcache *cc = (clockcache *)c;
-   return clockcache_page_valid(cc, addr);
-}
-
 void
 clockcache_validate_page_virtual(cache *c, page_handle *page, uint64 addr)
 {
@@ -516,20 +485,6 @@ clockcache_enable_sync_get_virtual(cache *c, bool enabled)
    clockcache_enable_sync_get(cc, enabled);
 }
 
-allocator *
-clockcache_allocator_virtual(const cache *c)
-{
-   clockcache *cc = (clockcache *)c;
-   return clockcache_allocator(cc);
-}
-
-uint64
-clockcache_extent_base_addr_virtual(const cache *c, uint64 addr)
-{
-   clockcache *cc = (clockcache *)c;
-   return clockcache_extent_base_addr(cc, addr);
-}
-
 cache_config *
 clockcache_get_config_virtual(const cache *c)
 {
@@ -540,7 +495,6 @@ clockcache_get_config_virtual(const cache *c)
 static cache_ops clockcache_ops = {
    .page_alloc        = clockcache_alloc_virtual,
    .extent_hard_evict = clockcache_hard_evict_extent_virtual,
-   .page_get_ref      = clockcache_get_allocator_ref_virtual,
    .page_get          = clockcache_get_virtual,
    .page_get_async    = clockcache_get_async_virtual,
    .page_async_done   = clockcache_async_done_virtual,
@@ -564,13 +518,11 @@ static cache_ops clockcache_ops = {
    .print_stats       = clockcache_print_stats_virtual,
    .io_stats          = clockcache_io_stats_virtual,
    .reset_stats       = clockcache_reset_stats_virtual,
-   .page_valid        = clockcache_page_valid_virtual,
    .validate_page     = clockcache_validate_page_virtual,
    .count_dirty       = clockcache_count_dirty_virtual,
    .page_get_read_ref = clockcache_get_read_ref_virtual,
    .cache_present     = clockcache_present_virtual,
    .enable_sync_get   = clockcache_enable_sync_get_virtual,
-   .cache_allocator   = clockcache_allocator_virtual,
    .get_config        = clockcache_get_config_virtual,
 };
 
@@ -730,12 +682,6 @@ clockcache_divide_by_page_size(const clockcache *cc, uint64 addr)
    return addr >> cc->cfg->log_page_size;
 }
 
-static inline uint64
-clockcache_config_extent_base_addr(const clockcache_config *cfg, uint64 addr)
-{
-   return addr & cfg->extent_mask;
-}
-
 static inline uint32
 clockcache_lookup(const clockcache *cc, uint64 addr)
 {
@@ -756,15 +702,6 @@ static inline clockcache_entry *
 clockcache_lookup_entry(const clockcache *cc, uint64 addr)
 {
    return &cc->entry[clockcache_lookup(cc, addr)];
-}
-
-static inline bool
-clockcache_pages_share_extent(const clockcache *cc,
-                              uint64            left_addr,
-                              uint64            right_addr)
-{
-   return clockcache_config_extent_base_addr(cc->cfg, left_addr)
-          == clockcache_config_extent_base_addr(cc->cfg, right_addr);
 }
 
 static inline clockcache_entry *
@@ -1379,7 +1316,8 @@ clockcache_batch_start_writeback(clockcache *cc, uint64 batch, bool is_urgent)
          // walk backwards through extent to find first cleanable entry
          do {
             first_addr -= clockcache_page_size(cc);
-            if (clockcache_pages_share_extent(cc, first_addr, addr))
+            if (allocator_config_pages_share_extent(
+                   cc->cfg->allocator_cfg, first_addr, addr))
                next_entry_no = clockcache_lookup(cc, first_addr);
             else
                next_entry_no = CC_UNMAPPED_ENTRY;
@@ -1391,7 +1329,8 @@ clockcache_batch_start_writeback(clockcache *cc, uint64 batch, bool is_urgent)
          // walk forwards through extent to find last cleanable entry
          do {
             end_addr += clockcache_page_size(cc);
-            if (clockcache_pages_share_extent(cc, end_addr, addr))
+            if (allocator_config_pages_share_extent(
+                   cc->cfg->allocator_cfg, end_addr, addr))
                next_entry_no = clockcache_lookup(cc, end_addr);
             else
                next_entry_no = CC_UNMAPPED_ENTRY;
@@ -1788,8 +1727,6 @@ clockcache_config_init(clockcache_config *cache_cfg,
    cache_cfg->io_cfg        = io_cfg;
    cache_cfg->capacity      = capacity;
    cache_cfg->log_page_size = 63 - __builtin_clzll(io_cfg->page_size);
-   uint64 log_extent_size   = 63 - __builtin_clzll(io_cfg->extent_size);
-   cache_cfg->extent_mask   = ~((1ULL << log_extent_size) - 1);
    cache_cfg->page_capacity = capacity / io_cfg->page_size;
    cache_cfg->use_stats     = use_stats;
 
@@ -1840,7 +1777,7 @@ clockcache_init(clockcache          *cc,   // OUT
    clockcache_log(
       0, 0, "init: capacity %lu name %s\n", cc->cfg->capacity, name);
 
-   cc->al          = al;
+   cc->debug_al    = al;
    cc->io          = io;
    cc->heap_handle = hh;
    cc->heap_id     = hid;
@@ -2072,27 +2009,13 @@ void
 clockcache_hard_evict_extent(clockcache *cc, uint64 addr, page_type type)
 {
    debug_assert(addr % clockcache_extent_size(cc) == 0);
-   debug_code(allocator *al = cc->al);
-   debug_assert(allocator_get_ref(al, addr) == 1);
+   debug_assert(allocator_get_ref(cc->debug_al, addr) == 1);
 
    clockcache_log(addr, 0, "hard evict extent: addr %lu\n", addr);
    for (uint64 i = 0; i < cc->cfg->pages_per_extent; i++) {
       uint64 page_addr = addr + clockcache_multiply_by_page_size(cc, i);
       clockcache_try_hard_evict(cc, page_addr);
    }
-}
-
-/*
- *----------------------------------------------------------------------
- * clockcache_get_allocator_ref --
- *
- *      Returns the allocator ref count of the addr.
- *----------------------------------------------------------------------
- */
-uint8
-clockcache_get_allocator_ref(clockcache *cc, uint64 addr)
-{
-   return allocator_get_ref(cc->al, addr);
 }
 
 /*
@@ -2120,18 +2043,19 @@ clockcache_get_internal(clockcache   *cc,       // IN
    debug_assert(addr % clockcache_page_size(cc) == 0);
    uint32            entry_number = CC_UNMAPPED_ENTRY;
    uint64            lookup_no    = clockcache_divide_by_page_size(cc, addr);
-   debug_only uint64 base_addr    = clockcache_extent_base_addr(cc, addr);
-   const threadid    tid          = platform_get_tid();
+   debug_only uint64 base_addr =
+      allocator_config_extent_base_addr(cc->cfg->allocator_cfg, addr);
+   const threadid    tid = platform_get_tid();
    clockcache_entry *entry;
    platform_status   status;
    uint64            start, elapsed;
 
 #if SPLINTER_DEBUG
-   uint8 extent_ref_count = allocator_get_ref(cc->al, base_addr);
+   uint8 extent_ref_count = allocator_get_ref(cc->debug_al, base_addr);
 
    // Dump allocated extents info for deeper debugging.
    if (extent_ref_count <= 1) {
-      allocator_print_allocated(cc->al);
+      allocator_print_allocated(cc->debug_al);
    }
    debug_assert((extent_ref_count > 1),
                 "Attempt to get a buffer for page addr=%lu"
@@ -2384,12 +2308,13 @@ clockcache_get_async(clockcache       *cc,   // IN
    debug_assert((cache *)cc == ctxt->cc);
    uint32            entry_number = CC_UNMAPPED_ENTRY;
    uint64            lookup_no    = clockcache_divide_by_page_size(cc, addr);
-   debug_only uint64 base_addr    = clockcache_extent_base_addr(cc, addr);
-   const threadid    tid          = platform_get_tid();
+   debug_only uint64 base_addr =
+      allocator_config_extent_base_addr(cc->cfg->allocator_cfg, addr);
+   const threadid    tid = platform_get_tid();
    clockcache_entry *entry;
    platform_status   status;
 
-   debug_assert(allocator_get_ref(cc->al, base_addr) > 1);
+   debug_assert(allocator_get_ref(cc->debug_al, base_addr) > 1);
 
    ctxt->page   = NULL;
    entry_number = clockcache_lookup(cc, addr);
@@ -3051,19 +2976,6 @@ clockcache_print(platform_log_handle *log_handle, clockcache *cc)
    return;
 }
 
-bool
-clockcache_page_valid(clockcache *cc, uint64 addr)
-{
-   if (addr % clockcache_page_size(cc) != 0)
-      return FALSE;
-   uint64 base_addr = clockcache_extent_base_addr(cc, addr);
-   if (addr < allocator_get_capacity(cc->al)) {
-      return base_addr != 0 && allocator_get_ref(cc->al, base_addr) != 0;
-   } else {
-      return FALSE;
-   }
-}
-
 void
 clockcache_validate_page(clockcache *cc, page_handle *page, uint64 addr)
 {
@@ -3209,7 +3121,7 @@ clockcache_print_stats(platform_log_handle *log_handle, clockcache *cc)
                 FRACTION_ARGS(avg_write_pages));
    // clang-format on
 
-   allocator_print_stats(cc->al);
+   allocator_print_stats(cc->debug_al);
 }
 
 void
@@ -3272,16 +3184,4 @@ static void
 clockcache_enable_sync_get(clockcache *cc, bool enabled)
 {
    cc->per_thread[platform_get_tid()].enable_sync_get = enabled;
-}
-
-allocator *
-clockcache_allocator(const clockcache *cc)
-{
-   return cc->al;
-}
-
-uint64
-clockcache_extent_base_addr(const clockcache *cc, uint64 addr)
-{
-   return clockcache_config_extent_base_addr(cc->cfg, addr);
 }

--- a/src/clockcache.c
+++ b/src/clockcache.c
@@ -530,7 +530,7 @@ static cache_ops clockcache_ops = {
    .page_get_read_ref = clockcache_get_read_ref_virtual,
    .cache_present     = clockcache_present_virtual,
    .enable_sync_get   = clockcache_enable_sync_get_virtual,
-   .get_allocator   = clockcache_get_allocator_virtual,
+   .get_allocator     = clockcache_get_allocator_virtual,
    .get_config        = clockcache_get_config_virtual,
 };
 
@@ -1326,7 +1326,7 @@ clockcache_batch_start_writeback(clockcache *cc, uint64 batch, bool is_urgent)
          do {
             first_addr -= clockcache_page_size(cc);
             if (allocator_config_pages_share_extent(
-                  allocator_cfg, first_addr, addr))
+                   allocator_cfg, first_addr, addr))
                next_entry_no = clockcache_lookup(cc, first_addr);
             else
                next_entry_no = CC_UNMAPPED_ENTRY;
@@ -1786,7 +1786,7 @@ clockcache_init(clockcache          *cc,   // OUT
    clockcache_log(
       0, 0, "init: capacity %lu name %s\n", cc->cfg->capacity, name);
 
-   cc->al    = al;
+   cc->al          = al;
    cc->io          = io;
    cc->heap_handle = hh;
    cc->heap_id     = hid;
@@ -3198,5 +3198,5 @@ clockcache_enable_sync_get(clockcache *cc, bool enabled)
 static allocator *
 clockcache_get_allocator(const clockcache *cc)
 {
-    return cc->al;
+   return cc->al;
 }

--- a/src/io.h
+++ b/src/io.h
@@ -20,12 +20,14 @@ typedef struct io_async_req io_async_req;
 typedef struct io_config {
    uint64 async_queue_size;
    uint64 kernel_queue_size;
-   uint64 async_max_pages;
    uint64 page_size;
    uint64 extent_size;
    char   filename[MAX_STRING_LENGTH];
    int    flags;
    uint32 perms;
+
+   // computed
+   uint64 async_max_pages;
 } io_config;
 
 typedef void (*io_callback_fn)(void           *metadata,
@@ -201,5 +203,7 @@ io_config_init(io_config  *io_cfg,
    io_cfg->perms             = perms;
    io_cfg->async_queue_size  = async_queue_depth;
    io_cfg->kernel_queue_size = async_queue_depth;
-   io_cfg->async_max_pages   = extent_size / page_size;
+
+   // computed values
+   io_cfg->async_max_pages = extent_size / page_size;
 }

--- a/src/memtable.c
+++ b/src/memtable.c
@@ -269,7 +269,7 @@ memtable_context_create(platform_heap_id hid,
    memmove(&ctxt->cfg, cfg, sizeof(ctxt->cfg));
 
    uint64          base_addr;
-   allocator      *al = cache_allocator(cc);
+   allocator      *al = cache_get_allocator(cc);
    platform_status rc = allocator_alloc(al, &base_addr, PAGE_TYPE_LOCK_NO_DATA);
    platform_assert_status_ok(rc);
 
@@ -323,7 +323,7 @@ memtable_context_destroy(platform_heap_id hid, memtable_context *ctxt)
     * lookup lock and insert lock share extents but not pages.
     * this deallocs both.
     */
-   allocator *al = cache_allocator(cc);
+   allocator *al = cache_get_allocator(cc);
    uint8      ref =
       allocator_dec_ref(al, ctxt->insert_lock_addr, PAGE_TYPE_LOCK_NO_DATA);
    platform_assert(ref == AL_NO_REFS);

--- a/src/mini_allocator.c
+++ b/src/mini_allocator.c
@@ -237,9 +237,11 @@ mini_allocator_get_new_extent(mini_allocator *mini, uint64 *addr)
    return rc;
 }
 
-static uint64 base_addr(cache          *cc, uint64          addr)
+static uint64
+base_addr(cache *cc, uint64 addr)
 {
-    return allocator_config_extent_base_addr(allocator_get_config(cache_get_allocator(cc)), addr);
+   return allocator_config_extent_base_addr(
+      allocator_get_config(cache_get_allocator(cc)), addr);
 }
 
 /*
@@ -299,7 +301,8 @@ mini_init(mini_allocator *mini,
 
       if (!keyed) {
          // meta_page gets an extra ref
-         uint8  ref       = allocator_inc_ref(mini->al, base_addr(cc, mini->meta_head));
+         uint8 ref =
+            allocator_inc_ref(mini->al, base_addr(cc, mini->meta_head));
          platform_assert(ref == MINI_NO_REFS + 1);
       }
 
@@ -671,10 +674,13 @@ mini_deinit(cache *cc, uint64 meta_head, page_type type, bool pinned)
       meta_addr                   = mini_get_next_meta_addr(meta_page);
       cache_unget(cc, meta_page);
 
-      allocator_config* allocator_cfg = allocator_get_config(cache_get_allocator(cc));
-      if (!allocator_config_pages_share_extent(allocator_cfg, last_meta_addr, meta_addr)) {
+      allocator_config *allocator_cfg =
+         allocator_get_config(cache_get_allocator(cc));
+      if (!allocator_config_pages_share_extent(
+             allocator_cfg, last_meta_addr, meta_addr))
+      {
          uint64 last_meta_base_addr = base_addr(cc, last_meta_addr);
-         uint8 ref = allocator_dec_ref(al, last_meta_base_addr, type);
+         uint8  ref = allocator_dec_ref(al, last_meta_base_addr, type);
          platform_assert(ref == AL_NO_REFS);
          cache_hard_evict_extent(cc, last_meta_base_addr, type);
          ref = allocator_dec_ref(al, last_meta_base_addr, type);
@@ -994,8 +1000,8 @@ mini_keyed_for_each_self_exclusive(cache           *cc,
 uint8
 mini_unkeyed_inc_ref(cache *cc, uint64 meta_head)
 {
-   allocator *al        = cache_get_allocator(cc);
-   uint8      ref       = allocator_inc_ref(al, base_addr(cc, meta_head));
+   allocator *al  = cache_get_allocator(cc);
+   uint8      ref = allocator_inc_ref(al, base_addr(cc, meta_head));
    platform_assert(ref > MINI_NO_REFS);
    return ref - MINI_NO_REFS;
 }
@@ -1021,8 +1027,8 @@ mini_unkeyed_dec_ref(cache *cc, uint64 meta_head, page_type type, bool pinned)
       platform_assert(!pinned);
    }
 
-   allocator *al        = cache_get_allocator(cc);
-   uint8      ref       = allocator_dec_ref(al, base_addr(cc, meta_head), type);
+   allocator *al  = cache_get_allocator(cc);
+   uint8      ref = allocator_dec_ref(al, base_addr(cc, meta_head), type);
    if (ref != MINI_NO_REFS) {
       debug_assert(ref != AL_NO_REFS);
       debug_assert(ref != AL_FREE);
@@ -1116,8 +1122,8 @@ mini_keyed_dec_ref_extent(cache    *cc,
 static void
 mini_wait_for_blockers(cache *cc, uint64 meta_head)
 {
-   allocator *al        = cache_get_allocator(cc);
-   uint64     wait      = 1;
+   allocator *al   = cache_get_allocator(cc);
+   uint64     wait = 1;
    while (allocator_get_ref(al, base_addr(cc, meta_head)) != AL_ONE_REF) {
       platform_sleep(wait);
       wait = wait > 1024 ? wait : 2 * wait;
@@ -1143,8 +1149,8 @@ mini_keyed_dec_ref(cache       *cc,
                                          mini_keyed_dec_ref_extent,
                                          NULL);
    if (should_cleanup) {
-      allocator *al        = cache_get_allocator(cc);
-      uint8      ref       = allocator_get_ref(al, base_addr(cc, meta_head));
+      allocator *al  = cache_get_allocator(cc);
+      uint8      ref = allocator_get_ref(al, base_addr(cc, meta_head));
       platform_assert(ref == AL_ONE_REF);
       mini_deinit(cc, meta_head, type, FALSE);
    }
@@ -1168,16 +1174,17 @@ mini_keyed_dec_ref(cache       *cc,
 void
 mini_block_dec_ref(cache *cc, uint64 meta_head)
 {
-   allocator *al        = cache_get_allocator(cc);
-   uint8      ref       = allocator_inc_ref(al, base_addr(cc, meta_head));
+   allocator *al  = cache_get_allocator(cc);
+   uint8      ref = allocator_inc_ref(al, base_addr(cc, meta_head));
    platform_assert(ref > AL_ONE_REF);
 }
 
 void
 mini_unblock_dec_ref(cache *cc, uint64 meta_head)
 {
-   allocator *al        = cache_get_allocator(cc);
-   uint8      ref       = allocator_dec_ref(al, base_addr(cc, meta_head), PAGE_TYPE_INVALID);
+   allocator *al = cache_get_allocator(cc);
+   uint8      ref =
+      allocator_dec_ref(al, base_addr(cc, meta_head), PAGE_TYPE_INVALID);
    platform_assert(ref >= AL_ONE_REF);
 }
 

--- a/src/mini_allocator.c
+++ b/src/mini_allocator.c
@@ -237,6 +237,11 @@ mini_allocator_get_new_extent(mini_allocator *mini, uint64 *addr)
    return rc;
 }
 
+static uint64 base_addr(cache          *cc, uint64          addr)
+{
+    return allocator_config_extent_base_addr(allocator_get_config(cache_get_allocator(cc)), addr);
+}
+
 /*
  *-----------------------------------------------------------------------------
  * mini_init --
@@ -276,7 +281,7 @@ mini_init(mini_allocator *mini,
 
    ZERO_CONTENTS(mini);
    mini->cc          = cc;
-   mini->al          = cache_allocator(cc);
+   mini->al          = cache_get_allocator(cc);
    mini->data_cfg    = cfg;
    mini->keyed       = keyed;
    mini->meta_head   = meta_head;
@@ -294,8 +299,7 @@ mini_init(mini_allocator *mini,
 
       if (!keyed) {
          // meta_page gets an extra ref
-         uint64 base_addr = cache_extent_base_addr(cc, mini->meta_head);
-         uint8  ref       = allocator_inc_ref(mini->al, base_addr);
+         uint8  ref       = allocator_inc_ref(mini->al, base_addr(cc, mini->meta_head));
          platform_assert(ref == MINI_NO_REFS + 1);
       }
 
@@ -659,7 +663,7 @@ mini_release(mini_allocator *mini, key end_key)
 void
 mini_deinit(cache *cc, uint64 meta_head, page_type type, bool pinned)
 {
-   allocator *al        = cache_allocator(cc);
+   allocator *al        = cache_get_allocator(cc);
    uint64     meta_addr = meta_head;
    do {
       page_handle *meta_page      = cache_get(cc, meta_addr, TRUE, type);
@@ -668,8 +672,7 @@ mini_deinit(cache *cc, uint64 meta_head, page_type type, bool pinned)
       cache_unget(cc, meta_page);
 
       if (!cache_pages_share_extent(cc, last_meta_addr, meta_addr)) {
-         uint64 last_meta_base_addr =
-            cache_extent_base_addr(cc, last_meta_addr);
+         uint64 last_meta_base_addr = base_addr(cc, last_meta_addr);
          uint8 ref = allocator_dec_ref(al, last_meta_base_addr, type);
          platform_assert(ref == AL_NO_REFS);
          cache_hard_evict_extent(cc, last_meta_base_addr, type);
@@ -990,9 +993,8 @@ mini_keyed_for_each_self_exclusive(cache           *cc,
 uint8
 mini_unkeyed_inc_ref(cache *cc, uint64 meta_head)
 {
-   allocator *al        = cache_allocator(cc);
-   uint64     base_addr = cache_extent_base_addr(cc, meta_head);
-   uint8      ref       = allocator_inc_ref(al, base_addr);
+   allocator *al        = cache_get_allocator(cc);
+   uint8      ref       = allocator_inc_ref(al, base_addr(cc, meta_addr));
    platform_assert(ref > MINI_NO_REFS);
    return ref - MINI_NO_REFS;
 }
@@ -1000,7 +1002,7 @@ mini_unkeyed_inc_ref(cache *cc, uint64 meta_head)
 static bool
 mini_dealloc_extent(cache *cc, page_type type, uint64 base_addr, void *out)
 {
-   allocator *al  = cache_allocator(cc);
+   allocator *al  = cache_get_allocator(cc);
    uint8      ref = allocator_dec_ref(al, base_addr, type);
    platform_assert(ref == AL_NO_REFS);
    cache_hard_evict_extent(cc, base_addr, type);
@@ -1018,9 +1020,8 @@ mini_unkeyed_dec_ref(cache *cc, uint64 meta_head, page_type type, bool pinned)
       platform_assert(!pinned);
    }
 
-   allocator *al        = cache_allocator(cc);
-   uint64     base_addr = cache_extent_base_addr(cc, meta_head);
-   uint8      ref       = allocator_dec_ref(al, base_addr, type);
+   allocator *al        = cache_get_allocator(cc);
+   uint8      ref       = allocator_dec_ref(al, base_addr(cc, meta_head), type);
    if (ref != MINI_NO_REFS) {
       debug_assert(ref != AL_NO_REFS);
       debug_assert(ref != AL_FREE);
@@ -1071,7 +1072,7 @@ mini_keyed_inc_ref_extent(cache    *cc,
                           uint64    base_addr,
                           void     *out)
 {
-   allocator *al = cache_allocator(cc);
+   allocator *al = cache_get_allocator(cc);
    allocator_inc_ref(al, base_addr);
    return FALSE;
 }
@@ -1100,7 +1101,7 @@ mini_keyed_dec_ref_extent(cache    *cc,
                           uint64    base_addr,
                           void     *out)
 {
-   allocator *al  = cache_allocator(cc);
+   allocator *al  = cache_get_allocator(cc);
    uint8      ref = allocator_dec_ref(al, base_addr, type);
    if (ref == AL_NO_REFS) {
       cache_hard_evict_extent(cc, base_addr, type);
@@ -1114,10 +1115,9 @@ mini_keyed_dec_ref_extent(cache    *cc,
 static void
 mini_wait_for_blockers(cache *cc, uint64 meta_head)
 {
-   allocator *al        = cache_allocator(cc);
-   uint64     base_addr = cache_extent_base_addr(cc, meta_head);
+   allocator *al        = cache_get_allocator(cc);
    uint64     wait      = 1;
-   while (allocator_get_ref(al, base_addr) != AL_ONE_REF) {
+   while (allocator_get_ref(al, base_addr(cc, meta_head)) != AL_ONE_REF) {
       platform_sleep(wait);
       wait = wait > 1024 ? wait : 2 * wait;
    }
@@ -1142,9 +1142,8 @@ mini_keyed_dec_ref(cache       *cc,
                                          mini_keyed_dec_ref_extent,
                                          NULL);
    if (should_cleanup) {
-      allocator *al        = cache_allocator(cc);
-      uint64     base_addr = cache_extent_base_addr(cc, meta_head);
-      uint8      ref       = allocator_get_ref(al, base_addr);
+      allocator *al        = cache_get_allocator(cc);
+      uint8      ref       = allocator_get_ref(al, base_addr(cc, meta_head));
       platform_assert(ref == AL_ONE_REF);
       mini_deinit(cc, meta_head, type, FALSE);
    }
@@ -1168,18 +1167,16 @@ mini_keyed_dec_ref(cache       *cc,
 void
 mini_block_dec_ref(cache *cc, uint64 meta_head)
 {
-   allocator *al        = cache_allocator(cc);
-   uint64     base_addr = cache_extent_base_addr(cc, meta_head);
-   uint8      ref       = allocator_inc_ref(al, base_addr);
+   allocator *al        = cache_get_allocator(cc);
+   uint8      ref       = allocator_inc_ref(al, base_addr(cc, meta_head));
    platform_assert(ref > AL_ONE_REF);
 }
 
 void
 mini_unblock_dec_ref(cache *cc, uint64 meta_head)
 {
-   allocator *al        = cache_allocator(cc);
-   uint64     base_addr = cache_extent_base_addr(cc, meta_head);
-   uint8      ref       = allocator_dec_ref(al, base_addr, PAGE_TYPE_INVALID);
+   allocator *al        = cache_get_allocator(cc);
+   uint8      ref       = allocator_dec_ref(al, base_addr(cc, meta_head), PAGE_TYPE_INVALID);
    platform_assert(ref >= AL_ONE_REF);
 }
 
@@ -1306,7 +1303,7 @@ mini_keyed_print(cache       *cc,
                  uint64       meta_head,
                  page_type    type)
 {
-   allocator *al             = cache_allocator(cc);
+   allocator *al             = cache_get_allocator(cc);
    uint64     next_meta_addr = meta_head;
 
    platform_default_log("------------------------------------------------------"
@@ -1327,11 +1324,10 @@ mini_keyed_print(cache       *cc,
    do {
       page_handle *meta_page = cache_get(cc, next_meta_addr, TRUE, type);
 
-      uint64 base_meta_addr = cache_extent_base_addr(cc, next_meta_addr);
       platform_default_log(
          "| meta addr: %12lu (%u)                                       |\n",
          next_meta_addr,
-         allocator_get_ref(al, base_meta_addr));
+         allocator_get_ref(al, base_addr(cc, next_meta_addr)));
       platform_default_log("|--------------------------------------------------"
                            "-----------------|\n");
 

--- a/src/mini_allocator.c
+++ b/src/mini_allocator.c
@@ -671,7 +671,8 @@ mini_deinit(cache *cc, uint64 meta_head, page_type type, bool pinned)
       meta_addr                   = mini_get_next_meta_addr(meta_page);
       cache_unget(cc, meta_page);
 
-      if (!cache_pages_share_extent(cc, last_meta_addr, meta_addr)) {
+      allocator_config* allocator_cfg = allocator_get_config(cache_get_allocator(cc));
+      if (!allocator_config_pages_share_extent(allocator_cfg, last_meta_addr, meta_addr)) {
          uint64 last_meta_base_addr = base_addr(cc, last_meta_addr);
          uint8 ref = allocator_dec_ref(al, last_meta_base_addr, type);
          platform_assert(ref == AL_NO_REFS);
@@ -994,7 +995,7 @@ uint8
 mini_unkeyed_inc_ref(cache *cc, uint64 meta_head)
 {
    allocator *al        = cache_get_allocator(cc);
-   uint8      ref       = allocator_inc_ref(al, base_addr(cc, meta_addr));
+   uint8      ref       = allocator_inc_ref(al, base_addr(cc, meta_head));
    platform_assert(ref > MINI_NO_REFS);
    return ref - MINI_NO_REFS;
 }

--- a/src/rc_allocator.h
+++ b/src/rc_allocator.h
@@ -22,16 +22,6 @@
 #define RC_ALLOCATOR_MAX_ROOT_IDS (30)
 
 /*
- * Configuration structure to set up the Ref Count Allocation sub-system.
- */
-typedef struct rc_allocator_config {
-   io_config *io_cfg;
-   uint64     capacity;
-   uint64     page_capacity;
-   uint64     extent_capacity;
-} rc_allocator_config;
-
-/*
  *----------------------------------------------------------------------
  * rc_allocator_meta_page -- Disk-resident structure.
  *
@@ -67,7 +57,7 @@ typedef struct rc_allocator_stats {
  */
 typedef struct rc_allocator {
    allocator               super;
-   rc_allocator_config    *cfg;
+   allocator_config       *cfg;
    buffer_handle          *bh;
    uint8                  *ref_count;
    uint64                  hand;
@@ -86,14 +76,9 @@ typedef struct rc_allocator {
    rc_allocator_stats stats;
 } rc_allocator;
 
-void
-rc_allocator_config_init(rc_allocator_config *allocator_cfg,
-                         io_config           *io_cfg,
-                         uint64               capacity);
-
 platform_status
 rc_allocator_init(rc_allocator        *al,
-                  rc_allocator_config *cfg,
+                  allocator_config    *cfg,
                   io_handle           *io,
                   platform_heap_handle hh,
                   platform_heap_id     hid,
@@ -104,7 +89,7 @@ rc_allocator_deinit(rc_allocator *al);
 
 platform_status
 rc_allocator_mount(rc_allocator        *al,
-                   rc_allocator_config *cfg,
+                   allocator_config    *cfg,
                    io_handle           *io,
                    platform_heap_handle hh,
                    platform_heap_id     hid,

--- a/src/routing_filter.c
+++ b/src/routing_filter.c
@@ -410,7 +410,7 @@ routing_filter_add(cache           *cc,
    memset(encoding_buffer, 0xff, ROUTING_FPS_PER_PAGE / 32 * sizeof(uint32));
 
    // we use a mini_allocator to obtain pages
-   allocator      *al = cache_allocator(cc);
+   allocator      *al = cache_get_allocator(cc);
    uint64          meta_head;
    platform_status rc = allocator_alloc(al, &meta_head, PAGE_TYPE_FILTER);
    platform_assert_status_ok(rc);

--- a/src/shard_log.c
+++ b/src/shard_log.c
@@ -94,7 +94,7 @@ shard_log_init(shard_log *log, cache *cc, shard_log_config *cfg)
    uint64 magic_idx = __sync_fetch_and_add(&shard_log_magic_idx, 1);
    log->magic = platform_checksum64(&magic_idx, sizeof(uint64), cfg->seed);
 
-   allocator      *al = cache_allocator(cc);
+   allocator      *al = cache_get_allocator(cc);
    platform_status rc = allocator_alloc(al, &log->meta_head, PAGE_TYPE_LOG);
    platform_assert_status_ok(rc);
 

--- a/src/shard_log.c
+++ b/src/shard_log.c
@@ -348,7 +348,7 @@ shard_log_iterator_init(cache              *cc,
    memset(itor, 0, sizeof(shard_log_iterator));
    itor->super.ops = &shard_log_iterator_ops;
    itor->cfg       = cfg;
-   allocator* al = cache_get_allocator(cc);
+   allocator *al   = cache_get_allocator(cc);
 
    // traverse the log extents and calculate the required space
    extent_addr = addr;
@@ -479,7 +479,7 @@ shard_log_print(shard_log *log)
    uint64            magic            = log->magic;
    data_config      *dcfg             = cfg->data_cfg;
    uint64            pages_per_extent = shard_log_pages_per_extent(cfg);
-   allocator* al = cache_get_allocator(cc);
+   allocator        *al               = cache_get_allocator(cc);
 
    while (extent_addr != 0 && allocator_get_ref(al, extent_addr) > 0) {
       cache_prefetch(cc, extent_addr, PAGE_TYPE_LOG);

--- a/src/shard_log.c
+++ b/src/shard_log.c
@@ -348,10 +348,11 @@ shard_log_iterator_init(cache              *cc,
    memset(itor, 0, sizeof(shard_log_iterator));
    itor->super.ops = &shard_log_iterator_ops;
    itor->cfg       = cfg;
+   allocator* al = cache_get_allocator(cc);
 
    // traverse the log extents and calculate the required space
    extent_addr = addr;
-   while (extent_addr != 0 && cache_get_ref(cc, extent_addr) > 0) {
+   while (extent_addr != 0 && allocator_get_ref(al, extent_addr) > 0) {
       cache_prefetch(cc, extent_addr, PAGE_TYPE_LOG);
       next_extent_addr = 0;
       for (i = 0; i < pages_per_extent; i++) {
@@ -379,7 +380,7 @@ finished_first_pass:
    log_entry *cursor    = (log_entry *)itor->contents;
    uint64     entry_idx = 0;
    extent_addr          = addr;
-   while (extent_addr != 0 && cache_get_ref(cc, extent_addr) > 0) {
+   while (extent_addr != 0 && allocator_get_ref(al, extent_addr) > 0) {
       cache_prefetch(cc, extent_addr, PAGE_TYPE_LOG);
       next_extent_addr = 0;
       for (i = 0; i < pages_per_extent; i++) {
@@ -478,8 +479,9 @@ shard_log_print(shard_log *log)
    uint64            magic            = log->magic;
    data_config      *dcfg             = cfg->data_cfg;
    uint64            pages_per_extent = shard_log_pages_per_extent(cfg);
+   allocator* al = cache_get_allocator(cc);
 
-   while (extent_addr != 0 && cache_get_ref(cc, extent_addr) > 0) {
+   while (extent_addr != 0 && allocator_get_ref(al, extent_addr) > 0) {
       cache_prefetch(cc, extent_addr, PAGE_TYPE_LOG);
       uint64 next_extent_addr = 0;
       for (uint64 i = 0; i < pages_per_extent; i++) {

--- a/src/splinterdb.c
+++ b/src/splinterdb.c
@@ -33,7 +33,7 @@ typedef struct splinterdb {
    task_system         *task_sys;
    io_config            io_cfg;
    platform_io_handle   io_handle;
-   rc_allocator_config  allocator_cfg;
+   allocator_config  allocator_cfg;
    rc_allocator         allocator_handle;
    clockcache_config    cache_cfg;
    clockcache           cache_handle;

--- a/src/splinterdb.c
+++ b/src/splinterdb.c
@@ -178,7 +178,7 @@ splinterdb_init_config(const splinterdb_config *kvs_cfg, // IN
       return rc;
    }
 
-   rc_allocator_config_init(&kvs->allocator_cfg, &kvs->io_cfg, cfg.disk_size);
+   allocator_config_init(&kvs->allocator_cfg, &kvs->io_cfg, cfg.disk_size);
 
    clockcache_config_init(&kvs->cache_cfg,
                           &kvs->io_cfg,

--- a/src/splinterdb.c
+++ b/src/splinterdb.c
@@ -33,7 +33,7 @@ typedef struct splinterdb {
    task_system         *task_sys;
    io_config            io_cfg;
    platform_io_handle   io_handle;
-   allocator_config  allocator_cfg;
+   allocator_config     allocator_cfg;
    rc_allocator         allocator_handle;
    clockcache_config    cache_cfg;
    clockcache           cache_handle;

--- a/src/trunk.c
+++ b/src/trunk.c
@@ -4223,7 +4223,7 @@ trunk_flush(trunk_handle     *spl,
                                        req->input_pivot_tuple_count,
                                        req->input_pivot_kv_byte_count);
    trunk_bundle_inc_pivot_rc(spl, &child, bundle);
-   debug_assert(cache_page_valid(spl->cc, req->addr));
+   debug_assert(allocator_page_valid(spl->al, req->addr));
    req->type = is_space_rec ? TRUNK_COMPACTION_TYPE_FLUSH
                             : TRUNK_COMPACTION_TYPE_SPACE_REC;
 
@@ -8097,7 +8097,7 @@ trunk_print_node(platform_log_handle *log_handle,
                  trunk_handle        *spl,
                  uint64               addr)
 {
-   if (!cache_page_valid(spl->cc, addr)) {
+   if (!allocator_page_valid(cache_get_allocator(spl->cc), addr)) {
       platform_log(log_handle, "*******************\n");
       platform_log(log_handle, "** INVALID NODE \n");
       platform_log(log_handle, "** addr: %lu \n", addr);

--- a/tests/functional/btree_test.c
+++ b/tests/functional/btree_test.c
@@ -1463,7 +1463,7 @@ int
 btree_test(int argc, char *argv[])
 {
    io_config              io_cfg;
-   rc_allocator_config    al_cfg;
+   allocator_config    al_cfg;
    clockcache_config      cache_cfg;
    shard_log_config       log_cfg;
    int                    config_argc;

--- a/tests/functional/btree_test.c
+++ b/tests/functional/btree_test.c
@@ -1463,7 +1463,7 @@ int
 btree_test(int argc, char *argv[])
 {
    io_config              io_cfg;
-   allocator_config    al_cfg;
+   allocator_config       al_cfg;
    clockcache_config      cache_cfg;
    shard_log_config       log_cfg;
    int                    config_argc;

--- a/tests/functional/cache_test.c
+++ b/tests/functional/cache_test.c
@@ -65,7 +65,7 @@ cache_test_alloc_extents(cache             *cc,
                          uint64             addr_arr[],
                          uint32             extents_to_allocate)
 {
-   allocator *al               = cache_allocator(cc);
+   allocator *al               = cache_get_allocator(cc);
    uint64     page_size        = cache_config_page_size(&cfg->super);
    uint64     pages_per_extent = cache_config_pages_per_extent(&cfg->super);
    platform_status rc;
@@ -268,7 +268,7 @@ test_cache_basic(cache *cc, clockcache_config *cfg, platform_heap_id hid)
     */
    for (uint32 i = 0; i < extents_to_allocate; i++) {
       uint64     addr = addr_arr[i * pages_per_extent];
-      allocator *al   = cache_allocator(cc);
+      allocator *al   = cache_get_allocator(cc);
       uint8      ref  = allocator_dec_ref(al, addr, PAGE_TYPE_MISC);
       platform_assert(ref == AL_NO_REFS);
       cache_hard_evict_extent(cc, addr, PAGE_TYPE_MISC);
@@ -545,7 +545,7 @@ test_cache_flush(cache             *cc,
     */
    for (uint32 i = 0; i < extents_to_allocate; i++) {
       uint64     addr = addr_arr[i * pages_per_extent];
-      allocator *al   = cache_allocator(cc);
+      allocator *al   = cache_get_allocator(cc);
       uint8      ref  = allocator_dec_ref(al, addr, PAGE_TYPE_MISC);
       platform_assert(ref == AL_NO_REFS);
       cache_hard_evict_extent(cc, addr, PAGE_TYPE_MISC);
@@ -931,7 +931,7 @@ test_cache_async(cache             *cc,
    // Deallocate all the entries.
    for (uint32 i = 0; i < extents_to_allocate; i++) {
       uint64     addr = addr_arr[i * pages_per_extent];
-      allocator *al   = cache_allocator(cc);
+      allocator *al   = cache_get_allocator(cc);
       uint8      ref  = allocator_dec_ref(al, addr, PAGE_TYPE_MISC);
       platform_assert(ref == AL_NO_REFS);
       cache_hard_evict_extent(cc, addr, PAGE_TYPE_MISC);

--- a/tests/functional/cache_test.c
+++ b/tests/functional/cache_test.c
@@ -960,7 +960,7 @@ cache_test(int argc, char *argv[])
 {
    data_config           *data_cfg;
    io_config              io_cfg;
-   allocator_config    al_cfg;
+   allocator_config       al_cfg;
    clockcache_config      cache_cfg;
    shard_log_config       log_cfg;
    int                    config_argc = argc - 1;

--- a/tests/functional/cache_test.c
+++ b/tests/functional/cache_test.c
@@ -960,7 +960,7 @@ cache_test(int argc, char *argv[])
 {
    data_config           *data_cfg;
    io_config              io_cfg;
-   rc_allocator_config    al_cfg;
+   allocator_config    al_cfg;
    clockcache_config      cache_cfg;
    shard_log_config       log_cfg;
    int                    config_argc = argc - 1;

--- a/tests/functional/filter_test.c
+++ b/tests/functional/filter_test.c
@@ -290,7 +290,7 @@ filter_test(int argc, char *argv[])
    int                    r;
    data_config           *data_cfg;
    io_config              io_cfg;
-   allocator_config    allocator_cfg;
+   allocator_config       allocator_cfg;
    clockcache_config      cache_cfg;
    shard_log_config       log_cfg;
    rc_allocator           al;

--- a/tests/functional/filter_test.c
+++ b/tests/functional/filter_test.c
@@ -290,7 +290,7 @@ filter_test(int argc, char *argv[])
    int                    r;
    data_config           *data_cfg;
    io_config              io_cfg;
-   rc_allocator_config    allocator_cfg;
+   allocator_config    allocator_cfg;
    clockcache_config      cache_cfg;
    shard_log_config       log_cfg;
    rc_allocator           al;

--- a/tests/functional/log_test.c
+++ b/tests/functional/log_test.c
@@ -233,7 +233,7 @@ log_test(int argc, char *argv[])
    platform_status        status;
    data_config           *data_cfg;
    io_config              io_cfg;
-   allocator_config    al_cfg;
+   allocator_config       al_cfg;
    clockcache_config      cache_cfg;
    shard_log_config       log_cfg;
    rc_allocator           al;

--- a/tests/functional/log_test.c
+++ b/tests/functional/log_test.c
@@ -233,7 +233,7 @@ log_test(int argc, char *argv[])
    platform_status        status;
    data_config           *data_cfg;
    io_config              io_cfg;
-   rc_allocator_config    al_cfg;
+   allocator_config    al_cfg;
    clockcache_config      cache_cfg;
    shard_log_config       log_cfg;
    rc_allocator           al;

--- a/tests/functional/splinter_test.c
+++ b/tests/functional/splinter_test.c
@@ -2488,7 +2488,7 @@ int
 splinter_test(int argc, char *argv[])
 {
    io_config           io_cfg;
-   rc_allocator_config al_cfg;
+   allocator_config al_cfg;
    shard_log_config    log_cfg;
    int                 config_argc;
    char              **config_argv;

--- a/tests/functional/splinter_test.c
+++ b/tests/functional/splinter_test.c
@@ -2487,16 +2487,16 @@ splinter_test_parse_perf_args(char ***argv,
 int
 splinter_test(int argc, char *argv[])
 {
-   io_config           io_cfg;
+   io_config        io_cfg;
    allocator_config al_cfg;
-   shard_log_config    log_cfg;
-   int                 config_argc;
-   char              **config_argv;
-   test_type           test;
-   platform_status     rc;
-   uint64              seed = 0;
-   uint64              test_ops;
-   uint64              correctness_check_frequency;
+   shard_log_config log_cfg;
+   int              config_argc;
+   char           **config_argv;
+   test_type        test;
+   platform_status  rc;
+   uint64           seed = 0;
+   uint64           test_ops;
+   uint64           correctness_check_frequency;
    // Max async IOs inflight per-thread
    uint32 num_insert_threads, num_lookup_threads;
    uint32 num_range_lookup_threads, max_async_inflight;

--- a/tests/functional/test.h
+++ b/tests/functional/test.h
@@ -213,7 +213,7 @@ test_config_init(trunk_config           *splinter_cfg,  // OUT
                  data_config           **data_cfg,      // OUT
                  shard_log_config       *log_cfg,       // OUT
                  clockcache_config      *cache_cfg,     // OUT
-                 rc_allocator_config    *allocator_cfg, // OUT
+                 allocator_config    *allocator_cfg, // OUT
                  io_config              *io_cfg,        // OUT
                  test_message_generator *gen,
                  master_config          *master_cfg // IN

--- a/tests/functional/test.h
+++ b/tests/functional/test.h
@@ -283,7 +283,7 @@ static inline platform_status
 test_parse_args_n(trunk_config           *splinter_cfg,            // OUT
                   data_config           **data_cfg,                // OUT
                   io_config              *io_cfg,                  // OUT
-                  allocator_config    *allocator_cfg,           // OUT
+                  allocator_config       *allocator_cfg,           // OUT
                   clockcache_config      *cache_cfg,               // OUT
                   shard_log_config       *log_cfg,                 // OUT
                   test_exec_config       *test_exec_cfg,           // OUT

--- a/tests/functional/test.h
+++ b/tests/functional/test.h
@@ -213,7 +213,7 @@ test_config_init(trunk_config           *splinter_cfg,  // OUT
                  data_config           **data_cfg,      // OUT
                  shard_log_config       *log_cfg,       // OUT
                  clockcache_config      *cache_cfg,     // OUT
-                 allocator_config    *allocator_cfg, // OUT
+                 allocator_config       *allocator_cfg, // OUT
                  io_config              *io_cfg,        // OUT
                  test_message_generator *gen,
                  master_config          *master_cfg // IN
@@ -230,8 +230,7 @@ test_config_init(trunk_config           *splinter_cfg,  // OUT
                   master_cfg->io_async_queue_depth,
                   master_cfg->io_filename);
 
-   allocator_config_init(
-      allocator_cfg, io_cfg, master_cfg->allocator_capacity);
+   allocator_config_init(allocator_cfg, io_cfg, master_cfg->allocator_capacity);
 
    clockcache_config_init(cache_cfg,
                           io_cfg,
@@ -287,7 +286,7 @@ static inline platform_status
 test_parse_args_n(trunk_config           *splinter_cfg,  // OUT
                   data_config           **data_cfg,      // OUT
                   io_config              *io_cfg,        // OUT
-                  allocator_config    *allocator_cfg, // OUT
+                  allocator_config       *allocator_cfg, // OUT
                   clockcache_config      *cache_cfg,     // OUT
                   shard_log_config       *log_cfg,       // OUT
                   test_exec_config       *test_exec_cfg, // OUT
@@ -346,7 +345,7 @@ static inline platform_status
 test_parse_args(trunk_config           *splinter_cfg,
                 data_config           **data_cfg,
                 io_config              *io_cfg,
-                allocator_config    *allocator_cfg,
+                allocator_config       *allocator_cfg,
                 clockcache_config      *cache_cfg,
                 shard_log_config       *log_cfg,
                 uint64                 *seed,

--- a/tests/functional/test.h
+++ b/tests/functional/test.h
@@ -230,7 +230,7 @@ test_config_init(trunk_config           *splinter_cfg,  // OUT
                   master_cfg->io_async_queue_depth,
                   master_cfg->io_filename);
 
-   rc_allocator_config_init(
+   allocator_config_init(
       allocator_cfg, io_cfg, master_cfg->allocator_capacity);
 
    clockcache_config_init(cache_cfg,
@@ -287,7 +287,7 @@ static inline platform_status
 test_parse_args_n(trunk_config           *splinter_cfg,  // OUT
                   data_config           **data_cfg,      // OUT
                   io_config              *io_cfg,        // OUT
-                  rc_allocator_config    *allocator_cfg, // OUT
+                  allocator_config    *allocator_cfg, // OUT
                   clockcache_config      *cache_cfg,     // OUT
                   shard_log_config       *log_cfg,       // OUT
                   test_exec_config       *test_exec_cfg, // OUT
@@ -346,7 +346,7 @@ static inline platform_status
 test_parse_args(trunk_config           *splinter_cfg,
                 data_config           **data_cfg,
                 io_config              *io_cfg,
-                rc_allocator_config    *allocator_cfg,
+                allocator_config    *allocator_cfg,
                 clockcache_config      *cache_cfg,
                 shard_log_config       *log_cfg,
                 uint64                 *seed,

--- a/tests/functional/test_functionality.c
+++ b/tests/functional/test_functionality.c
@@ -808,7 +808,7 @@ test_functionality(allocator           *al,
          /*     (i % correctness_check_frequency) == 0) { */
          /*    platform_assert(trunk_verify_tree(spl)); */
          /*    platform_default_log("Dismount and remount\n"); */
-         /*    rc_allocator_config *al_cfg  = ((rc_allocator *)al)->cfg; */
+         /*    allocator_config *al_cfg  = ((rc_allocator *)al)->cfg; */
          /*    uint64 prev_root_addr = spl->root_addr; */
          /*    trunk_dismount(spl); */
          /*    rc_allocator_dismount((rc_allocator *)al); */

--- a/tests/functional/ycsb_test.c
+++ b/tests/functional/ycsb_test.c
@@ -1146,15 +1146,15 @@ write_all_reports(ycsb_phase *phases, int num_phases)
 int
 ycsb_test(int argc, char *argv[])
 {
-   io_config           io_cfg;
-   allocator_config allocator_cfg;
-   clockcache_config   cache_cfg;
-   shard_log_config    log_cfg;
-   int                 config_argc;
-   char              **config_argv;
-   platform_status     rc;
-   uint64              seed;
-   task_system        *ts = NULL;
+   io_config         io_cfg;
+   allocator_config  allocator_cfg;
+   clockcache_config cache_cfg;
+   shard_log_config  log_cfg;
+   int               config_argc;
+   char            **config_argv;
+   platform_status   rc;
+   uint64            seed;
+   task_system      *ts = NULL;
 
    uint64                 nphases;
    bool                   use_existing = 0;

--- a/tests/functional/ycsb_test.c
+++ b/tests/functional/ycsb_test.c
@@ -1147,7 +1147,7 @@ int
 ycsb_test(int argc, char *argv[])
 {
    io_config           io_cfg;
-   rc_allocator_config allocator_cfg;
+   allocator_config allocator_cfg;
    clockcache_config   cache_cfg;
    shard_log_config    log_cfg;
    int                 config_argc;

--- a/tests/functional/ycsb_test.c
+++ b/tests/functional/ycsb_test.c
@@ -1146,15 +1146,15 @@ write_all_reports(ycsb_phase *phases, int num_phases)
 int
 ycsb_test(int argc, char *argv[])
 {
-   io_config           io_cfg;
-   allocator_config allocator_cfg;
-   clockcache_config   cache_cfg;
-   shard_log_config    log_cfg;
-   int                 config_argc;
-   char              **config_argv;
-   platform_status     rc;
-   uint64              seed;
-   task_system        *ts;
+   io_config         io_cfg;
+   allocator_config  allocator_cfg;
+   clockcache_config cache_cfg;
+   shard_log_config  log_cfg;
+   int               config_argc;
+   char            **config_argv;
+   platform_status   rc;
+   uint64            seed;
+   task_system      *ts;
 
    uint64                 nphases;
    bool                   use_existing = 0;

--- a/tests/unit/btree_stress_test.c
+++ b/tests/unit/btree_stress_test.c
@@ -93,7 +93,7 @@ CTEST_DATA(btree_stress)
    master_config       master_cfg;
    data_config        *data_cfg;
    io_config           io_cfg;
-   rc_allocator_config allocator_cfg;
+   allocator_config allocator_cfg;
    clockcache_config   cache_cfg;
    btree_scratch       test_scratch;
    btree_config        dbtree_cfg;

--- a/tests/unit/btree_stress_test.c
+++ b/tests/unit/btree_stress_test.c
@@ -90,13 +90,13 @@ CTEST_DATA(btree_stress)
    // This part of the data structures is common to what we need
    // to set up a Splinter instance, as is done in
    // btree_test.c
-   master_config       master_cfg;
-   data_config        *data_cfg;
-   io_config           io_cfg;
-   allocator_config allocator_cfg;
-   clockcache_config   cache_cfg;
-   btree_scratch       test_scratch;
-   btree_config        dbtree_cfg;
+   master_config     master_cfg;
+   data_config      *data_cfg;
+   io_config         io_cfg;
+   allocator_config  allocator_cfg;
+   clockcache_config cache_cfg;
+   btree_scratch     test_scratch;
+   btree_config      dbtree_cfg;
 
    // To create a heap for io, allocator, cache and splinter
    platform_heap_handle hh;

--- a/tests/unit/btree_test.c
+++ b/tests/unit/btree_test.c
@@ -65,7 +65,7 @@ CTEST_DATA(btree)
    master_config       master_cfg;
    data_config        *data_cfg;
    io_config           io_cfg;
-   rc_allocator_config allocator_cfg;
+   allocator_config allocator_cfg;
    clockcache_config   cache_cfg;
    btree_scratch       test_scratch;
    btree_config        dbtree_cfg;

--- a/tests/unit/btree_test.c
+++ b/tests/unit/btree_test.c
@@ -62,14 +62,14 @@ btree_leaf_incorporate_tuple(const btree_config    *cfg,
  */
 CTEST_DATA(btree)
 {
-   master_config       master_cfg;
-   data_config        *data_cfg;
-   io_config           io_cfg;
-   allocator_config allocator_cfg;
-   clockcache_config   cache_cfg;
-   btree_scratch       test_scratch;
-   btree_config        dbtree_cfg;
-   platform_heap_id    hid;
+   master_config     master_cfg;
+   data_config      *data_cfg;
+   io_config         io_cfg;
+   allocator_config  allocator_cfg;
+   clockcache_config cache_cfg;
+   btree_scratch     test_scratch;
+   btree_config      dbtree_cfg;
+   platform_heap_id  hid;
 };
 
 // Optional setup function for suite, called before every test in suite

--- a/tests/unit/btree_test_common.c
+++ b/tests/unit/btree_test_common.c
@@ -28,11 +28,11 @@ init_io_config_from_master_config(io_config *io_cfg, master_config *master_cfg)
 }
 
 int
-init_rc_allocator_config_from_master_config(rc_allocator_config *allocator_cfg,
+init_rc_allocator_config_from_master_config(allocator_config *allocator_cfg,
                                             master_config       *master_cfg,
                                             io_config           *io_cfg)
 {
-   rc_allocator_config_init(
+   allocator_config_init(
       allocator_cfg, io_cfg, master_cfg->allocator_capacity);
    return 1;
 }

--- a/tests/unit/btree_test_common.c
+++ b/tests/unit/btree_test_common.c
@@ -29,11 +29,10 @@ init_io_config_from_master_config(io_config *io_cfg, master_config *master_cfg)
 
 int
 init_rc_allocator_config_from_master_config(allocator_config *allocator_cfg,
-                                            master_config       *master_cfg,
-                                            io_config           *io_cfg)
+                                            master_config    *master_cfg,
+                                            io_config        *io_cfg)
 {
-   allocator_config_init(
-      allocator_cfg, io_cfg, master_cfg->allocator_capacity);
+   allocator_config_init(allocator_cfg, io_cfg, master_cfg->allocator_capacity);
    return 1;
 }
 

--- a/tests/unit/btree_test_common.h
+++ b/tests/unit/btree_test_common.h
@@ -22,7 +22,7 @@ init_io_config_from_master_config(io_config *io_cfg, master_config *master_cfg);
 
 
 int
-init_rc_allocator_config_from_master_config(rc_allocator_config *allocator_cfg,
+init_rc_allocator_config_from_master_config(allocator_config *allocator_cfg,
                                             master_config       *master_cfg,
                                             io_config           *io_cfg);
 

--- a/tests/unit/btree_test_common.h
+++ b/tests/unit/btree_test_common.h
@@ -23,8 +23,8 @@ init_io_config_from_master_config(io_config *io_cfg, master_config *master_cfg);
 
 int
 init_rc_allocator_config_from_master_config(allocator_config *allocator_cfg,
-                                            master_config       *master_cfg,
-                                            io_config           *io_cfg);
+                                            master_config    *master_cfg,
+                                            io_config        *io_cfg);
 
 int
 init_clockcache_config_from_master_config(clockcache_config *cache_cfg,

--- a/tests/unit/config_parse_test.c
+++ b/tests/unit/config_parse_test.c
@@ -63,7 +63,7 @@ CTEST2(config_parse, test_basic_parsing)
 {
    // Config structs required, as per splinter_test() setup work.
    io_config           io_cfg;
-   rc_allocator_config al_cfg;
+   allocator_config al_cfg;
    shard_log_config    log_cfg;
 
    // Following get setup pointing to allocated memory

--- a/tests/unit/config_parse_test.c
+++ b/tests/unit/config_parse_test.c
@@ -62,9 +62,9 @@ CTEST_TEARDOWN(config_parse)
 CTEST2(config_parse, test_basic_parsing)
 {
    // Config structs required, as per splinter_test() setup work.
-   io_config           io_cfg;
+   io_config        io_cfg;
    allocator_config al_cfg;
-   shard_log_config    log_cfg;
+   shard_log_config log_cfg;
 
    // Following get setup pointing to allocated memory
    trunk_config          *splinter_cfg = NULL;

--- a/tests/unit/limitations_test.c
+++ b/tests/unit/limitations_test.c
@@ -39,7 +39,7 @@ CTEST_DATA(limitations)
 
    // Config structs required, as per splinter_test() setup work.
    io_config           io_cfg;
-   rc_allocator_config al_cfg;
+   allocator_config al_cfg;
    shard_log_config    log_cfg;
 
    rc_allocator al;

--- a/tests/unit/limitations_test.c
+++ b/tests/unit/limitations_test.c
@@ -38,9 +38,9 @@ CTEST_DATA(limitations)
    platform_heap_id     hid;
 
    // Config structs required, as per splinter_test() setup work.
-   io_config           io_cfg;
+   io_config        io_cfg;
    allocator_config al_cfg;
-   shard_log_config    log_cfg;
+   shard_log_config log_cfg;
 
    rc_allocator al;
 

--- a/tests/unit/splinter_test.c
+++ b/tests/unit/splinter_test.c
@@ -89,7 +89,7 @@ CTEST_DATA(splinter)
 
    // Config structs required, as per splinter_test() setup work.
    io_config           io_cfg;
-   rc_allocator_config al_cfg;
+   allocator_config al_cfg;
    shard_log_config    log_cfg;
 
    rc_allocator al;

--- a/tests/unit/splinter_test.c
+++ b/tests/unit/splinter_test.c
@@ -88,9 +88,9 @@ CTEST_DATA(splinter)
    uint8 num_bg_threads[NUM_TASK_TYPES];
 
    // Config structs required, as per splinter_test() setup work.
-   io_config           io_cfg;
+   io_config        io_cfg;
    allocator_config al_cfg;
-   shard_log_config    log_cfg;
+   shard_log_config log_cfg;
 
    rc_allocator al;
 


### PR DESCRIPTION
This change reduces the width of the polymorphic cache interface by moving things that only depend on the allocator to the allocator.