### PR TITLE
(#505) Enhance platform_error_log() to prepend source code & OS-pid/tid-info

### DIFF
--- a/src/platform_linux/platform.c
+++ b/src/platform_linux/platform.c
@@ -372,7 +372,7 @@ platform_assert_msg(platform_log_handle *log_handle,
                     const char          *message,
                     va_list              varargs)
 {
-   static char assert_msg_fmt[] = "OS-pid=%d, OS-tid=%lu, Thread-ID=%lu, "
+   static char assert_msg_fmt[] = "OS-pid=%d, OS-tid=%d, Thread-ID=%lu, "
                                   "Assertion failed at %s:%d:%s(): \"%s\". ";
    platform_log(log_handle,
                 assert_msg_fmt,

--- a/src/platform_linux/platform_inline.h
+++ b/src/platform_linux/platform_inline.h
@@ -4,6 +4,7 @@
 #ifndef PLATFORM_LINUX_INLINE_H
 #define PLATFORM_LINUX_INLINE_H
 
+#include <unistd.h>
 #include <laio.h>
 #include <string.h> // for memcpy, strerror
 #include <time.h>   // for nanosecond sleep api.
@@ -288,9 +289,20 @@ platform_log_stream_to_string(platform_stream_handle *stream)
       platform_log(Platform_default_log_handle, __VA_ARGS__);                  \
    } while (0)
 
-#define platform_error_log(...)                                                \
+/*
+ * For improved debugging-ability, prepend the user-supplied message string,
+ * 'msgfmt' with source-code location info.
+ */
+#define platform_error_log(msgfmt, ...)                                        \
    do {                                                                        \
-      platform_log(Platform_error_log_handle, __VA_ARGS__);                    \
+      platform_log(Platform_error_log_handle,                                  \
+                   "%s:%d:%s(): OS-pid=%d, OS-tid=%d, Thread-ID=%lu, " msgfmt, \
+                   __FILE__,                                                   \
+                   __LINE__,                                                   \
+                   __FUNCTION__,                                               \
+                   getpid(),                                                   \
+                   gettid(),                                                   \
+                   platform_get_tid() __VA_OPT__(, ) __VA_ARGS__);             \
    } while (0)
 
 #define platform_log_stream(stream, ...)                                       \

--- a/tests/unit/misc_test.c
+++ b/tests/unit/misc_test.c
@@ -67,12 +67,14 @@ CTEST_SETUP(misc)
    // So lets send those messages to /dev/null unless VERBOSE=1.
    if (Ctest_verbose) {
       data->log_output = stdout;
+      platform_set_log_streams(stdout, stderr);
       CTEST_LOG_INFO("\nVerbose mode on.  This test exercises error-reporting "
                      "logic, so on success it will print a message "
                      "that appears to be an error.\n");
    } else {
-      data->log_output = fopen("/dev/null", "w");
+      FILE *dev_null = data->log_output = fopen("/dev/null", "w");
       ASSERT_NOT_NULL(data->log_output);
+      platform_set_log_streams(dev_null, dev_null);
    }
 }
 
@@ -181,6 +183,22 @@ CTEST2(misc, test_ctest_assert_prints_user_msg_with_params)
                  expmsg_len,
                  assert_str);
    platform_close_log_stream(&stream, data->log_output);
+}
+
+/*
+ * Test case to exercise platform_error_log() w/ and w/o arguments to msg.
+ */
+CTEST2(misc, test_platform_error_log_wo_args)
+{
+   platform_error_log("This is a test message without arguments\n");
+}
+
+CTEST2(misc, test_platform_error_log_w_args)
+{
+   platform_error_log("This is a test message with arguments: "
+                      "sizeof(pid_t)=%lu, '%s'\n",
+                      sizeof(pid_t),
+                      "String arg to test msg.");
 }
 
 /* Helper functions follow all test case methods */


### PR DESCRIPTION
This commit enhances platform_error_log() to prepend source-code location triplet (file, line, function-name) and OS-pid/tid and thread-ID to the message being printed. This extra info makes it easier to quickly find out where-from the code-base a particular error is raised and affecting which OS process / Splinter thread.

---

NOTE: This was a diagnostic enhancement I had used during on-going prototype integration code. I found it very useful to have this extra-info printed for an error.

Rather than applying these few extra fields to every call to `platform_error_log()` that wants to gain this new functionality, I think it will be better to do this generically. That way, in all instances of an error message we will get this extra diagnostic info reliably.