### PR TITLE
(#507) Change platform_buffer_create()/destroy() interfaces to platform_buffer_init() / deinit() methods.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -443,6 +443,9 @@ $(BINDIR)/$(UNITDIR)/task_system_test: $(UTIL_SYS)                              
                                        $(OBJDIR)/$(FUNCTIONAL_TESTSDIR)/test_async.o \
                                        $(LIBDIR)/libsplinterdb.so
 
+$(BINDIR)/$(UNITDIR)/platform_apis_test: $(UTIL_SYS)       \
+                                         $(PLATFORM_SYS)
+
 ########################################
 # Convenience mini unit-test targets
 unit/util_test:                    $(BINDIR)/$(UNITDIR)/util_test

--- a/src/clockcache.c
+++ b/src/clockcache.c
@@ -46,7 +46,7 @@
  *
  *      clockcache_log, etc. are used to write an output of cache operations to
  *      a log file for debugging purposes. If CC_LOG is set, then all output is
- *      written, if ADDR_TRACING is set, then only operations which affect
+ *      written. If ADDR_TRACING is set, then only operations which affect
  *      entries with either entry_number TRACE_ENTRY or address TRACE_ADDR are
  *      written.
  *
@@ -1761,14 +1761,13 @@ clockcache_config_init(clockcache_config *cache_cfg,
 }
 
 platform_status
-clockcache_init(clockcache          *cc,   // OUT
-                clockcache_config   *cfg,  // IN
-                io_handle           *io,   // IN
-                allocator           *al,   // IN
-                char                *name, // IN
-                platform_heap_handle hh,   // IN
-                platform_heap_id     hid,  // IN
-                platform_module_id   mid)    // IN
+clockcache_init(clockcache        *cc,   // OUT
+                clockcache_config *cfg,  // IN
+                io_handle         *io,   // IN
+                allocator         *al,   // IN
+                char              *name, // IN
+                platform_heap_id   hid,  // IN
+                platform_module_id mid)  // IN
 {
    int      i;
    threadid thr_i;
@@ -1803,10 +1802,9 @@ clockcache_init(clockcache          *cc,   // OUT
    clockcache_log(
       0, 0, "init: capacity %lu name %s\n", cc->cfg->capacity, name);
 
-   cc->al          = al;
-   cc->io          = io;
-   cc->heap_handle = hh;
-   cc->heap_id     = hid;
+   cc->al      = al;
+   cc->io      = io;
+   cc->heap_id = hid;
 
    /* lookup maps addrs to entries, entry contains the entries themselves */
    cc->lookup =
@@ -1824,12 +1822,14 @@ clockcache_init(clockcache          *cc,   // OUT
       goto alloc_error;
    }
 
+   platform_status rc = STATUS_NO_MEMORY;
+
    /* data must be aligned because of O_DIRECT */
-   cc->bh = platform_buffer_create(cc->cfg->capacity, cc->heap_handle, mid);
-   if (!cc->bh) {
+   rc = platform_buffer_init(&cc->bh, cc->cfg->capacity);
+   if (!SUCCESS(rc)) {
       goto alloc_error;
    }
-   cc->data = platform_buffer_getaddr(cc->bh);
+   cc->data = platform_buffer_getaddr(&cc->bh);
 
    /* Set up the entries */
    for (i = 0; i < cc->cfg->page_capacity; i++) {
@@ -1841,14 +1841,19 @@ clockcache_init(clockcache          *cc,   // OUT
 
    /* Entry per-thread ref counts */
    size_t refcount_size = cc->cfg->page_capacity * CC_RC_WIDTH * sizeof(uint8);
-   cc->rc_bh = platform_buffer_create(refcount_size, cc->heap_handle, mid);
-   if (!cc->rc_bh) {
+
+   rc = platform_buffer_init(&cc->rc_bh, refcount_size);
+   if (!SUCCESS(rc)) {
       goto alloc_error;
    }
-   cc->refcount = platform_buffer_getaddr(cc->rc_bh);
+   cc->refcount = platform_buffer_getaddr(&cc->rc_bh);
+
    /* Separate ref counts for pins */
    cc->pincount =
       TYPED_ARRAY_ZALLOC(cc->heap_id, cc->pincount, cc->cfg->page_capacity);
+   if (!cc->pincount) {
+      goto alloc_error;
+   }
 
    /* The hands and associated page */
    cc->free_hand  = 0;
@@ -1872,15 +1877,17 @@ alloc_error:
    return STATUS_NO_MEMORY;
 }
 
+/*
+ * De-init the resources allocated to initialize a clockcache.
+ * This function may be called to deal with error situations, or a failed
+ * clockcache_init(). So check for non-NULL handles before trying to release
+ * resources.
+ */
 void
 clockcache_deinit(clockcache *cc) // IN/OUT
 {
    platform_assert(cc != NULL);
 
-   /*
-    * Check for non-null cause this is also used to clean up a failed
-    * clockcache_init
-    */
    if (cc->logfile) {
       clockcache_log(0, 0, "deinit %s\n", "");
 #if defined(CC_LOG) || defined(ADDR_TRACING)
@@ -1888,19 +1895,34 @@ clockcache_deinit(clockcache *cc) // IN/OUT
 #endif
    }
 
-   if (cc->rc_bh) {
-      platform_buffer_destroy(cc->rc_bh);
+   if (cc->lookup) {
+      platform_free(cc->heap_id, cc->lookup);
+   }
+   if (cc->entry) {
+      platform_free(cc->heap_id, cc->entry);
    }
 
-   platform_free(cc->heap_id, cc->entry);
-   platform_free(cc->heap_id, cc->lookup);
-   if (cc->bh) {
-      platform_buffer_destroy(cc->bh);
+   debug_only platform_status rc = STATUS_TEST_FAILED;
+   if (cc->data) {
+      rc = platform_buffer_deinit(&cc->bh);
+
+      // We expect above to succeed. Anyway, we are in the process of
+      // dismantling the clockcache, hence, for now, can't do much by way
+      // of reporting errors further upstream.
+      debug_assert(SUCCESS(rc), "rc=%s", platform_status_to_string(rc));
+      cc->data = NULL;
    }
-   cc->data = NULL;
-   platform_free_volatile(cc->heap_id, cc->batch_busy);
+   if (cc->refcount) {
+      rc = platform_buffer_deinit(&cc->rc_bh);
+      debug_assert(SUCCESS(rc), "rc=%s", platform_status_to_string(rc));
+      cc->refcount = NULL;
+   }
+
    if (cc->pincount) {
       platform_free_volatile(cc->heap_id, cc->pincount);
+   }
+   if (cc->batch_busy) {
+      platform_free_volatile(cc->heap_id, cc->batch_busy);
    }
 }
 

--- a/src/clockcache.h
+++ b/src/clockcache.h
@@ -116,14 +116,13 @@ struct clockcache {
 
    uint32              *lookup;
    clockcache_entry    *entry;
-   buffer_handle       *bh;   // actual memory for pages
+   buffer_handle        bh;   // actual memory for pages
    char                *data; // convenience pointer for bh
    platform_log_handle *logfile;
-   platform_heap_handle heap_handle;
    platform_heap_id     heap_id;
 
    // Distributed locks (the write bit is in the status uint32 of the entry)
-   buffer_handle  *rc_bh;
+   buffer_handle   rc_bh;
    volatile uint8 *refcount;
    volatile uint8 *pincount;
 
@@ -157,14 +156,13 @@ clockcache_config_init(clockcache_config *cache_config,
                        uint64             use_stats);
 
 platform_status
-clockcache_init(clockcache          *cc,   // OUT
-                clockcache_config   *cfg,  // IN
-                io_handle           *io,   // IN
-                allocator           *al,   // IN
-                char                *name, // IN
-                platform_heap_handle hh,   // IN
-                platform_heap_id     hid,  // IN
-                platform_module_id   mid);   // IN
+clockcache_init(clockcache        *cc,   // OUT
+                clockcache_config *cfg,  // IN
+                io_handle         *io,   // IN
+                allocator         *al,   // IN
+                char              *name, // IN
+                platform_heap_id   hid,  // IN
+                platform_module_id mid); // IN
 
 void
 clockcache_deinit(clockcache *cc); // IN

--- a/src/platform_linux/platform.h
+++ b/src/platform_linux/platform.h
@@ -626,16 +626,14 @@ platform_heap_create(platform_module_id    module_id,
 void
 platform_heap_destroy(platform_heap_handle *heap_handle);
 
-buffer_handle *
-platform_buffer_create(size_t               length,
-                       platform_heap_handle heap_handle,
-                       platform_module_id   module_id);
+platform_status
+platform_buffer_init(buffer_handle *bh, size_t length);
 
 void *
 platform_buffer_getaddr(const buffer_handle *bh);
 
 platform_status
-platform_buffer_destroy(buffer_handle *bh);
+platform_buffer_deinit(buffer_handle *bh);
 
 platform_status
 platform_mutex_init(platform_mutex    *mu,

--- a/src/rc_allocator.h
+++ b/src/rc_allocator.h
@@ -58,7 +58,7 @@ typedef struct rc_allocator_stats {
 typedef struct rc_allocator {
    allocator               super;
    allocator_config       *cfg;
-   buffer_handle          *bh;
+   buffer_handle           bh;
    uint8                  *ref_count;
    uint64                  hand;
    io_handle              *io;
@@ -68,32 +68,29 @@ typedef struct rc_allocator {
     * mutex to synchronize updates to super block addresses of the splinter
     * tables in the meta page.
     */
-   platform_mutex       lock;
-   platform_heap_handle heap_handle;
-   platform_heap_id     heap_id;
+   platform_mutex   lock;
+   platform_heap_id heap_id;
 
    // Stats -- not distributed for now
    rc_allocator_stats stats;
 } rc_allocator;
 
 platform_status
-rc_allocator_init(rc_allocator        *al,
-                  allocator_config    *cfg,
-                  io_handle           *io,
-                  platform_heap_handle hh,
-                  platform_heap_id     hid,
-                  platform_module_id   mid);
+rc_allocator_init(rc_allocator      *al,
+                  allocator_config  *cfg,
+                  io_handle         *io,
+                  platform_heap_id   hid,
+                  platform_module_id mid);
 
 void
 rc_allocator_deinit(rc_allocator *al);
 
 platform_status
-rc_allocator_mount(rc_allocator        *al,
-                   allocator_config    *cfg,
-                   io_handle           *io,
-                   platform_heap_handle hh,
-                   platform_heap_id     hid,
-                   platform_module_id   mid);
+rc_allocator_mount(rc_allocator      *al,
+                   allocator_config  *cfg,
+                   io_handle         *io,
+                   platform_heap_id   hid,
+                   platform_module_id mid);
 
 void
 rc_allocator_unmount(rc_allocator *al);

--- a/src/splinterdb.c
+++ b/src/splinterdb.c
@@ -274,14 +274,12 @@ splinterdb_create_or_open(const splinterdb_config *kvs_cfg,      // IN
       status = rc_allocator_mount(&kvs->allocator_handle,
                                   &kvs->allocator_cfg,
                                   (io_handle *)&kvs->io_handle,
-                                  kvs->heap_handle,
                                   kvs->heap_id,
                                   platform_get_module_id());
    } else {
       status = rc_allocator_init(&kvs->allocator_handle,
                                  &kvs->allocator_cfg,
                                  (io_handle *)&kvs->io_handle,
-                                 kvs->heap_handle,
                                  kvs->heap_id,
                                  platform_get_module_id());
    }
@@ -296,7 +294,6 @@ splinterdb_create_or_open(const splinterdb_config *kvs_cfg,      // IN
                             (io_handle *)&kvs->io_handle,
                             (allocator *)&kvs->allocator_handle,
                             "splinterdb",
-                            kvs->heap_handle,
                             kvs->heap_id,
                             platform_get_module_id());
    if (!SUCCESS(status)) {

--- a/tests/functional/btree_test.c
+++ b/tests/functional/btree_test.c
@@ -1571,7 +1571,7 @@ btree_test(int argc, char *argv[])
 
    rc_allocator al;
    rc_allocator_init(
-      &al, &al_cfg, (io_handle *)io, hh, hid, platform_get_module_id());
+      &al, &al_cfg, (io_handle *)io, hid, platform_get_module_id());
 
    clockcache *cc = TYPED_MALLOC(hid, cc);
    rc             = clockcache_init(cc,
@@ -1579,7 +1579,6 @@ btree_test(int argc, char *argv[])
                         (io_handle *)io,
                         (allocator *)&al,
                         "test",
-                        hh,
                         hid,
                         platform_get_module_id());
    platform_assert_status_ok(rc);

--- a/tests/functional/cache_test.c
+++ b/tests/functional/cache_test.c
@@ -1047,7 +1047,7 @@ cache_test(int argc, char *argv[])
 
    rc_allocator al;
    rc_allocator_init(
-      &al, &al_cfg, (io_handle *)io, hh, hid, platform_get_module_id());
+      &al, &al_cfg, (io_handle *)io, hid, platform_get_module_id());
 
    clockcache *cc = TYPED_MALLOC(hid, cc);
    rc             = clockcache_init(cc,
@@ -1055,7 +1055,6 @@ cache_test(int argc, char *argv[])
                         (io_handle *)io,
                         (allocator *)&al,
                         "test",
-                        hh,
                         hid,
                         platform_get_module_id());
    platform_assert_status_ok(rc);

--- a/tests/functional/filter_test.c
+++ b/tests/functional/filter_test.c
@@ -360,7 +360,7 @@ filter_test(int argc, char *argv[])
    platform_assert_status_ok(rc);
 
    rc = rc_allocator_init(
-      &al, &allocator_cfg, (io_handle *)io, hh, hid, platform_get_module_id());
+      &al, &allocator_cfg, (io_handle *)io, hid, platform_get_module_id());
    platform_assert_status_ok(rc);
 
    cc = TYPED_MALLOC(hid, cc);
@@ -370,7 +370,6 @@ filter_test(int argc, char *argv[])
                         (io_handle *)io,
                         (allocator *)&al,
                         "test",
-                        hh,
                         hid,
                         platform_get_module_id());
    platform_assert_status_ok(rc);

--- a/tests/functional/log_test.c
+++ b/tests/functional/log_test.c
@@ -28,7 +28,6 @@ test_log_crash(clockcache             *cc,
                shard_log_config       *cfg,
                shard_log              *log,
                task_system            *ts,
-               platform_heap_handle    hh,
                platform_heap_id        hid,
                test_message_generator *gen,
                uint64                  num_entries,
@@ -75,7 +74,7 @@ test_log_crash(clockcache             *cc,
    if (crash) {
       clockcache_deinit(cc);
       rc = clockcache_init(
-         cc, cache_cfg, io, al, "crashed", hh, hid, platform_get_module_id());
+         cc, cache_cfg, io, al, "crashed", hid, platform_get_module_id());
       platform_assert_status_ok(rc);
    }
 
@@ -318,7 +317,7 @@ log_test(int argc, char *argv[])
    }
 
    status = rc_allocator_init(
-      &al, &al_cfg, (io_handle *)io, hh, hid, platform_get_module_id());
+      &al, &al_cfg, (io_handle *)io, hid, platform_get_module_id());
    platform_assert_status_ok(status);
 
    clockcache *cc = TYPED_MALLOC(hid, cc);
@@ -328,7 +327,6 @@ log_test(int argc, char *argv[])
                             (io_handle *)io,
                             (allocator *)&al,
                             "test",
-                            hh,
                             hid,
                             platform_get_module_id());
    platform_assert_status_ok(status);
@@ -348,7 +346,6 @@ log_test(int argc, char *argv[])
                           &log_cfg,
                           log,
                           ts,
-                          hh,
                           hid,
                           &gen,
                           500000,
@@ -362,11 +359,10 @@ log_test(int argc, char *argv[])
                           &log_cfg,
                           log,
                           ts,
-                          hh,
                           hid,
                           &gen,
                           500000,
-                          FALSE /* don't cash */);
+                          FALSE /* don't crash */);
       platform_assert(rc == 0);
    }
 

--- a/tests/functional/splinter_test.c
+++ b/tests/functional/splinter_test.c
@@ -2762,7 +2762,7 @@ splinter_test(int argc, char *argv[])
 
    rc_allocator al;
    rc_allocator_init(
-      &al, &al_cfg, (io_handle *)io, hh, hid, platform_get_module_id());
+      &al, &al_cfg, (io_handle *)io, hid, platform_get_module_id());
 
    platform_error_log("Running splinter_test with %d caches\n", num_caches);
    clockcache *cc = TYPED_ARRAY_MALLOC(hid, cc, num_caches);
@@ -2773,7 +2773,6 @@ splinter_test(int argc, char *argv[])
                            (io_handle *)io,
                            (allocator *)&al,
                            "test",
-                           hh,
                            hid,
                            platform_get_module_id());
       platform_assert_status_ok(rc);
@@ -2901,7 +2900,6 @@ splinter_test(int argc, char *argv[])
                                  test_ops,
                                  correctness_check_frequency,
                                  ts,
-                                 hh,
                                  hid,
                                  num_tables,
                                  num_caches,

--- a/tests/functional/test_functionality.c
+++ b/tests/functional/test_functionality.c
@@ -20,7 +20,7 @@
 void
 destroy_test_splinter_shadow_array(test_splinter_shadow_array *sharr)
 {
-   platform_buffer_destroy(sharr->buffer);
+   platform_buffer_deinit(&sharr->buffer);
    sharr->nkeys = 0;
 }
 
@@ -469,7 +469,6 @@ static platform_status
 validate_tree_against_shadow(trunk_handle              *spl,
                              random_state              *prg,
                              test_splinter_shadow_tree *shadow,
-                             platform_heap_handle       hh,
                              platform_heap_id           hid,
                              bool                       do_it,
                              test_async_lookup         *async_lookup)
@@ -485,7 +484,7 @@ validate_tree_against_shadow(trunk_handle              *spl,
 
    memset(&sharr, 0, sizeof(sharr));
    if (do_it) {
-      rc = test_splinter_build_shadow_array(shadow, &sharr, hh);
+      rc = test_splinter_build_shadow_array(shadow, &sharr);
       if (!SUCCESS(rc)) {
          // might need to cleanup a partially allocated shadow array.
          platform_error_log("Failed to build shadow array: %s\n",
@@ -631,19 +630,18 @@ cmp_ptrs(const void *a, const void *b)
  *-----------------------------------------------------------------------------
  */
 platform_status
-test_functionality(allocator           *al,
-                   io_handle           *io,
-                   cache               *cc[],
-                   trunk_config        *cfg,
-                   uint64               seed,
-                   uint64               num_inserts,
-                   uint64               correctness_check_frequency,
-                   task_system         *state,
-                   platform_heap_handle hh,
-                   platform_heap_id     hid,
-                   uint8                num_tables,
-                   uint8                num_caches,
-                   uint32               max_async_inflight)
+test_functionality(allocator       *al,
+                   io_handle       *io,
+                   cache           *cc[],
+                   trunk_config    *cfg,
+                   uint64           seed,
+                   uint64           num_inserts,
+                   uint64           correctness_check_frequency,
+                   task_system     *state,
+                   platform_heap_id hid,
+                   uint8            num_tables,
+                   uint8            num_caches,
+                   uint32           max_async_inflight)
 {
    platform_error_log("Functional test started with %d tables\n", num_tables);
    platform_assert(cc != NULL);
@@ -675,7 +673,7 @@ test_functionality(allocator           *al,
    // Initialize the splinter/shadow for each splinter table.
    for (uint8 idx = 0; idx < num_tables; idx++) {
       cache *cache_to_use = num_caches > 1 ? cc[idx] : *cc;
-      status = test_splinter_shadow_create(&shadows[idx], hh, hid, num_inserts);
+      status = test_splinter_shadow_create(&shadows[idx], hid, num_inserts);
       if (!SUCCESS(status)) {
          platform_error_log("Failed to init shadow for splinter: %s\n",
                             platform_status_to_string(status));
@@ -697,7 +695,7 @@ test_functionality(allocator           *al,
       trunk_handle              *spl    = spl_tables[idx];
       test_splinter_shadow_tree *shadow = shadows[idx];
       status                            = validate_tree_against_shadow(
-         spl, &prg, shadow, hh, hid, TRUE, async_lookup);
+         spl, &prg, shadow, hid, TRUE, async_lookup);
       if (!SUCCESS(status)) {
          platform_error_log("Failed to validate empty tree against shadow: \
                             %s\n",
@@ -793,7 +791,6 @@ test_functionality(allocator           *al,
             spl,
             &prg,
             shadow,
-            hh,
             hid,
             correctness_check_frequency
                && (i % correctness_check_frequency) == 0,
@@ -840,7 +837,6 @@ test_functionality(allocator           *al,
          spl,
          &prg,
          shadow,
-         hh,
          hid,
          correctness_check_frequency
             && ((i - 1) % correctness_check_frequency) != 0,

--- a/tests/functional/test_functionality.h
+++ b/tests/functional/test_functionality.h
@@ -7,16 +7,15 @@
 #include "platform.h"
 
 platform_status
-test_functionality(allocator           *al,
-                   io_handle           *io,
-                   cache               *cc[],
-                   trunk_config        *cfg,
-                   uint64               seed,
-                   uint64               num_inserts,
-                   uint64               correctness_check_frequency,
-                   task_system         *ts,
-                   platform_heap_handle hh,
-                   platform_heap_id     hid,
-                   uint8                num_tables,
-                   uint8                num_caches,
-                   uint32               max_async_inflight);
+test_functionality(allocator       *al,
+                   io_handle       *io,
+                   cache           *cc[],
+                   trunk_config    *cfg,
+                   uint64           seed,
+                   uint64           num_inserts,
+                   uint64           correctness_check_frequency,
+                   task_system     *ts,
+                   platform_heap_id hid,
+                   uint8            num_tables,
+                   uint8            num_caches,
+                   uint32           max_async_inflight);

--- a/tests/functional/test_splinter_shadow.h
+++ b/tests/functional/test_splinter_shadow.h
@@ -25,22 +25,21 @@ typedef struct test_splinter_shadow_tree {
    AvlTree                    tree;
    uint64                     numPreAllocatedNodes;
    uint64                     currentAllocIdx;
-   buffer_handle             *nodes_buffer;
+   buffer_handle              nodes_buffer;
    test_splinter_shadow_node *nodes;
 } test_splinter_shadow_tree;
 
 
 typedef struct test_splinter_shadow_array {
-   uint64         nkeys;
-   buffer_handle *buffer;
-   uint64        *keys;
-   int8          *ref_counts;
+   uint64        nkeys;
+   buffer_handle buffer;
+   uint64       *keys;
+   int8         *ref_counts;
 } test_splinter_shadow_array;
 
 
 platform_status
 test_splinter_shadow_create(test_splinter_shadow_tree **tree,
-                            platform_heap_handle        hh,
                             platform_heap_id            hid,
                             uint64                      max_operations);
 
@@ -81,7 +80,6 @@ test_splinter_shadow_destroy(platform_heap_id           hid,
 
 platform_status
 test_splinter_build_shadow_array(test_splinter_shadow_tree  *tree,
-                                 test_splinter_shadow_array *shadow_array,
-                                 platform_heap_handle        hh);
+                                 test_splinter_shadow_array *shadow_array);
 
 #endif

--- a/tests/functional/ycsb_test.c
+++ b/tests/functional/ycsb_test.c
@@ -1291,18 +1291,13 @@ ycsb_test(int argc, char *argv[])
    trunk_handle *spl;
 
    if (use_existing) {
-      rc_allocator_mount(&al,
-                         &allocator_cfg,
-                         (io_handle *)io,
-                         hh,
-                         hid,
-                         platform_get_module_id());
+      rc_allocator_mount(
+         &al, &allocator_cfg, (io_handle *)io, hid, platform_get_module_id());
       rc = clockcache_init(cc,
                            &cache_cfg,
                            (io_handle *)io,
                            (allocator *)&al,
                            "test",
-                           hh,
                            hid,
                            platform_get_module_id());
       platform_assert_status_ok(rc);
@@ -1314,18 +1309,13 @@ ycsb_test(int argc, char *argv[])
                         hid);
       platform_assert(spl);
    } else {
-      rc_allocator_init(&al,
-                        &allocator_cfg,
-                        (io_handle *)io,
-                        hh,
-                        hid,
-                        platform_get_module_id());
+      rc_allocator_init(
+         &al, &allocator_cfg, (io_handle *)io, hid, platform_get_module_id());
       rc = clockcache_init(cc,
                            &cache_cfg,
                            (io_handle *)io,
                            (allocator *)&al,
                            "test",
-                           hh,
                            hid,
                            platform_get_module_id());
       platform_assert_status_ok(rc);

--- a/tests/unit/btree_stress_test.c
+++ b/tests/unit/btree_stress_test.c
@@ -150,7 +150,6 @@ CTEST_SETUP(btree_stress)
        || !SUCCESS(rc_allocator_init(&data->al,
                                      &data->allocator_cfg,
                                      (io_handle *)&data->io,
-                                     data->hh,
                                      data->hid,
                                      platform_get_module_id()))
        || !SUCCESS(clockcache_init(&data->cc,
@@ -158,7 +157,6 @@ CTEST_SETUP(btree_stress)
                                    (io_handle *)&data->io,
                                    (allocator *)&data->al,
                                    "test",
-                                   data->hh,
                                    data->hid,
                                    platform_get_module_id())))
    {
@@ -174,6 +172,7 @@ CTEST_TEARDOWN(btree_stress)
    clockcache_deinit(&data->cc);
    rc_allocator_deinit(&data->al);
    task_system_destroy(data->hid, &data->ts);
+   platform_heap_destroy(&data->hh);
 }
 
 /*

--- a/tests/unit/platform_apis_test.c
+++ b/tests/unit/platform_apis_test.c
@@ -1,0 +1,104 @@
+// Copyright 2023 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+ * -----------------------------------------------------------------------------
+ * platform_apis_test.c
+ *
+ *  Exercise some of the interfaces in platform.c
+ * -----------------------------------------------------------------------------
+ */
+#include <sys/mman.h>
+
+#include "ctest.h" // This is required for all test-case files.
+#include "platform.h"
+
+/*
+ * Global data declaration macro:
+ */
+CTEST_DATA(platform_api)
+{
+   // Declare heap handles for platform heap memory.
+   platform_heap_handle hh;
+   platform_heap_id     hid;
+   platform_module_id   mid;
+};
+
+CTEST_SETUP(platform_api)
+{
+   // This test exercises error cases, so even when everything succeeds
+   // it generates lots of "error" messages.
+   // By default, that would go to stderr, which would pollute test output.
+   // Here we ensure those expected error messages are only printed
+   // when the caller sets the VERBOSE env var to opt-in.
+   if (Ctest_verbose) {
+      platform_set_log_streams(stdout, stderr);
+      CTEST_LOG_INFO("\nVerbose mode on.  This test exercises an error case, "
+                     "so on sucess it "
+                     "will print a message that appears to be an error.\n");
+   } else {
+      FILE *dev_null = fopen("/dev/null", "w");
+      ASSERT_NOT_NULL(dev_null);
+      platform_set_log_streams(dev_null, dev_null);
+   }
+
+   platform_status rc = STATUS_OK;
+
+   uint64 heap_capacity = (256 * MiB); // small heap is sufficient.
+   data->mid            = platform_get_module_id();
+   rc = platform_heap_create(data->mid, heap_capacity, &data->hh, &data->hid);
+   platform_assert_status_ok(rc);
+}
+
+CTEST_TEARDOWN(platform_api)
+{
+   platform_heap_destroy(&data->hh);
+}
+
+/*
+ * Test platform_buffer_init() and platform_buffer_deinit().
+ */
+CTEST2(platform_api, test_platform_buffer_init)
+{
+   platform_status rc = STATUS_NO_MEMORY;
+
+   buffer_handle bh;
+   ZERO_CONTENTS(&bh);
+
+   rc = platform_buffer_init(&bh, KiB);
+   ASSERT_TRUE(SUCCESS(rc));
+   ASSERT_TRUE(bh.addr != NULL);
+   ASSERT_TRUE(bh.addr == platform_buffer_getaddr(&bh));
+   ASSERT_TRUE(bh.length == KiB);
+
+   rc = platform_buffer_deinit(&bh);
+   ASSERT_TRUE(SUCCESS(rc));
+   ASSERT_TRUE(bh.addr == NULL);
+   ASSERT_TRUE(bh.length == 0);
+}
+
+/*
+ * Test failure to mmap() a very large buffer_init().
+ */
+CTEST2(platform_api, test_platform_buffer_init_fails_for_very_large_length)
+{
+   platform_status rc = STATUS_NO_MEMORY;
+
+   buffer_handle bh;
+   ZERO_CONTENTS(&bh);
+
+   size_t length = (1024 * KiB * GiB);
+
+   // On most test machines we use, this is expected to fail as mmap() under
+   // here will fail for very large lengths. (If this test case ever fails,
+   // check the 'length' here and the machine's configuration to see why
+   // mmap() unexpectedly succeeded.)
+   rc = platform_buffer_init(&bh, length);
+   ASSERT_FALSE(SUCCESS(rc));
+   ASSERT_TRUE(bh.addr == NULL);
+   ASSERT_TRUE(bh.length == 0);
+
+   // deinit() would fail horribly when nothing was successfully mmap()'ed
+   rc = platform_buffer_deinit(&bh);
+   ASSERT_FALSE(SUCCESS(rc));
+}

--- a/tests/unit/splinter_test.c
+++ b/tests/unit/splinter_test.c
@@ -189,7 +189,7 @@ CTEST_SETUP(splinter)
               "Failed to init splinter state: %s\n",
               platform_status_to_string(rc));
 
-   rc_allocator_init(&data->al, &data->al_cfg, (io_handle *)data->io, data->hh, data->hid,
+   rc_allocator_init(&data->al, &data->al_cfg, (io_handle *)data->io, data->hid,
                      platform_get_module_id());
 
    data->clock_cache = TYPED_ARRAY_MALLOC(data->hid, data->clock_cache, num_caches);
@@ -201,7 +201,6 @@ CTEST_SETUP(splinter)
                            (io_handle *)data->io,
                            (allocator *)&data->al,
                            "test",
-                           data->hh,
                            data->hid,
                            platform_get_module_id());
 


### PR DESCRIPTION
This commit reworks the interfaces of `platform_buffer_create()` and `platform_buffer_destroy()` to now become `platform_buffer_init()` and `platform_buffer_deinit()` interfaces.

This removes a dependency on `platform_heap_id` or `platform_heap_handle` arg. 

This change does not functionally change anything in these methods. Also, this (indirectly) fixes a minor bug in the create function to deal with the (very rare) case of failing to allocate memory from the heap for `buffer_handle *bh` . Added small unit-test, platform_apis_test, to exercise these changes.

---
NOTE: This is some common infra-code built in a prototype dev branch for supporting different memory handles.

I'm pulling this piece out on its own for integration to /main, so that this ground work can be laid for integrating future dev-efforts (w/ little less pain).