### PR TITLE
(#509) Fix off-by-1 issues re. MAX_THREADS in clockcache.c

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -270,6 +270,21 @@ function nightly_sync_perf_tests() {
                                                 --db-capacity-gib 60 \
                                                 --db-location ${dbname}
     rm ${dbname}
+
+    # Exercise a case with max # of insert-threads which tripped an assertion
+    # This isn't really a 'perf' test but a regression / stability test exec
+    nins_t=63
+    nrange_lookup_t=0
+    test_descr="${nins_t} insert threads"
+    dbname="splinter_test.max_threads.db"
+
+    run_with_timing "Performance with max-threads ${test_descr}" \
+            "$BINDIR"/driver_test splinter_test --perf \
+                                                --num-insert-threads ${nins_t} \
+                                                --num-range-lookup-threads ${nrange_lookup_t} \
+                                                --tree-size-gib 1 \
+                                                --db-location ${dbname}
+    rm ${dbname}
 }
 
 # #############################################################################


### PR DESCRIPTION
This commit fixes off-by-1 issues checking MAX_THREADS value in assertions in `clockcache.c` . These problems are easily reproduced with `driver_test splinter_test ` with max # of threads. A new test execution with --num-insert-threads 63 is added to nightly runs, in test.sh .

----

The issue #509 fully describes the repro and assertions seen.

These problems were discovered during an in-flight integration while exercising `MAX_THREADS` threads. These fixes were applied to the dev-branch and allowed testing to continue.

Integrating these to /main will help improve overall stability.