### PR TITLE
(#511) Add fns to print 'size' as human-readable string w/ unit-specifiers.

### DIFF
--- a/src/btree.c
+++ b/src/btree.c
@@ -3083,6 +3083,10 @@ btree_print_offset_table(platform_log_handle *log_handle, btree_hdr *hdr)
    platform_log(log_handle, "\n");
 }
 
+// Macro to deal with printing Pivot stats 'sz' bytes as uninitialized
+#define PIVOT_STATS_BYTES_AS_STR(sz)                                           \
+   (((sz) == BTREE_UNKNOWN_COUNTER) ? "BTREE_UNKNOWN_COUNTER" : size_str((sz)))
+
 static void
 btree_print_btree_pivot_stats(platform_log_handle *log_handle,
                               btree_pivot_stats   *pivot_stats)
@@ -3099,11 +3103,13 @@ btree_print_btree_pivot_stats(platform_log_handle *log_handle,
    // Indentation is dictated by outer caller
    platform_log(log_handle,
                 "   (num_kvs=%u\n"
-                "    key_bytes=%u\n"
-                "    message_bytes=%u)\n",
+                "    key_bytes=%u (%s)\n"
+                "    message_bytes=%u (%s))\n",
                 pivot_stats->num_kvs,
                 pivot_stats->key_bytes,
-                pivot_stats->message_bytes);
+                PIVOT_STATS_BYTES_AS_STR(pivot_stats->key_bytes),
+                pivot_stats->message_bytes,
+                PIVOT_STATS_BYTES_AS_STR(pivot_stats->message_bytes));
 }
 
 static void
@@ -3255,6 +3261,7 @@ btree_print_subtree(platform_log_handle *log_handle,
    node.addr = addr;
    btree_print_node(log_handle, cc, cfg, &node);
    if (!allocator_page_valid(cache_get_allocator(cc), node.addr)) {
+      platform_log(log_handle, "Unallocated BTree node addr=%lu\n", addr);
       return;
    }
    btree_node_get(cc, cfg, &node, PAGE_TYPE_BRANCH);

--- a/src/platform_linux/platform.h
+++ b/src/platform_linux/platform.h
@@ -88,14 +88,27 @@
 
 // Data unit constants
 #define KiB (1024UL)
-#define MiB (KiB * KiB)
-#define GiB (MiB * KiB)
+#define MiB (KiB * 1024)
+#define GiB (MiB * 1024)
+#define TiB (GiB * 1024)
 
+// Convert 'x' in unit-specifiers to bytes
 #define KiB_TO_B(x) ((x)*KiB)
 #define MiB_TO_B(x) ((x)*MiB)
 #define GiB_TO_B(x) ((x)*GiB)
+#define TiB_TO_B(x) ((x)*TiB)
+
+// Convert 'x' in bytes to 'int'-value with unit-specifiers
+#define B_TO_KiB(x) ((x) / KiB)
 #define B_TO_MiB(x) ((x) / MiB)
 #define B_TO_GiB(x) ((x) / GiB)
+#define B_TO_TiB(x) ((x) / TiB)
+
+// For x bytes, returns as int the fractional portion modulo a unit-specifier
+#define B_TO_KiB_FRACT(x) ((100 * ((x) % KiB)) / KiB)
+#define B_TO_MiB_FRACT(x) ((100 * ((x) % MiB)) / MiB)
+#define B_TO_GiB_FRACT(x) ((100 * ((x) % GiB)) / GiB)
+#define B_TO_TiB_FRACT(x) ((100 * ((x) % TiB)) / TiB)
 
 // Time unit constants
 #define THOUSAND (1000UL)

--- a/src/rc_allocator.h
+++ b/src/rc_allocator.h
@@ -44,8 +44,8 @@ _Static_assert(offsetof(rc_allocator_meta_page, splinters) == 0,
  *----------------------------------------------------------------------
  */
 typedef struct rc_allocator_stats {
-   int64 curr_allocated;
-   int64 max_allocated;
+   int64 curr_allocated; // # of extents allocated
+   int64 max_allocated;  // # of extents allocated high-water mark
    int64 extent_allocs[NUM_PAGE_TYPES];
    int64 extent_deallocs[NUM_PAGE_TYPES];
 } rc_allocator_stats;

--- a/src/trunk.c
+++ b/src/trunk.c
@@ -7905,8 +7905,11 @@ trunk_print_space_use(platform_log_handle *log_handle, trunk_handle *spl)
                 "Space used by level: trunk_tree_height=%d\n",
                 trunk_tree_height(spl));
    for (uint16 i = 0; i <= trunk_tree_height(spl); i++) {
-      platform_log(
-         log_handle, "%u: %8lu MiB\n", i, B_TO_MiB(bytes_used_by_level[i]));
+      platform_log(log_handle,
+                   "%u: %lu bytes (%s)\n",
+                   i,
+                   bytes_used_by_level[i],
+                   size_str(bytes_used_by_level[i]));
    }
    platform_log(log_handle, "\n");
 }
@@ -8851,7 +8854,7 @@ trunk_node_print_branches(trunk_handle *spl, uint64 addr, void *arg)
          spl, &node, branch_no, &num_tuples_in_branch, &kv_bytes_in_branch);
       uint64 kib_in_branch = 0;
       // trunk_branch_extent_count(spl, &node, branch_no);
-      kib_in_branch *= trunk_extent_size(&spl->cfg) / 1024;
+      kib_in_branch *= B_TO_KiB(trunk_extent_size(&spl->cfg));
       fraction space_amp =
          init_fraction(kib_in_branch * 1024, kv_bytes_in_branch);
       platform_log(
@@ -8861,7 +8864,7 @@ trunk_node_print_branches(trunk_handle *spl, uint64 addr, void *arg)
          branch_no,
          addr,
          num_tuples_in_branch,
-         kv_bytes_in_branch / 1024,
+         B_TO_KiB(kv_bytes_in_branch),
          kib_in_branch,
          FRACTION_ARGS(space_amp));
    }

--- a/src/util.h
+++ b/src/util.h
@@ -382,4 +382,40 @@ debug_hex_dump_slice(platform_log_handle *, uint64 grouping, slice data);
     : ((intval) < 1000) ? "3d"                                                 \
                         : "4d")
 
+// Length of output buffer to snprintf()-into size as string w/ unit specifier
+#define SIZE_TO_STR_LEN 20
+
+// Format a size value with unit-specifiers, in an output buffer.
+char *
+size_to_str(char *outbuf, size_t outbuflen, size_t size);
+
+char *
+size_to_fmtstr(char *outbuf, size_t outbuflen, const char *fmtstr, size_t size);
+
+/*
+ * Convenience caller macros to convert 'sz' bytes to return a string,
+ * formatting the input size as human-readable value with unit-specifiers.
+ */
+// char *size_str(size_t sz)
+#define size_str(sz)                                                           \
+   (({                                                                         \
+       struct {                                                                \
+          char buffer[SIZE_TO_STR_LEN];                                        \
+       } onstack_chartmp;                                                      \
+       size_to_str(                                                            \
+          onstack_chartmp.buffer, sizeof(onstack_chartmp.buffer), sz);         \
+       onstack_chartmp;                                                        \
+    }).buffer)
+
+// char *size_fmtstr(const char *fmtstr, size_t sz)
+#define size_fmtstr(fmtstr, sz)                                                \
+   (({                                                                         \
+       struct {                                                                \
+          char buffer[SIZE_TO_STR_LEN];                                        \
+       } onstack_chartmp;                                                      \
+       size_to_fmtstr(                                                         \
+          onstack_chartmp.buffer, sizeof(onstack_chartmp.buffer), fmtstr, sz); \
+       onstack_chartmp;                                                        \
+    }).buffer)
+
 #endif // _SPLINTER_UTIL_H_

--- a/tests/unit/btree_stress_test.c
+++ b/tests/unit/btree_stress_test.c
@@ -113,6 +113,16 @@ CTEST_DATA(btree_stress)
 // Setup function for suite, called before every test in suite
 CTEST_SETUP(btree_stress)
 {
+   if (Ctest_verbose) {
+      platform_set_log_streams(stdout, stderr);
+      CTEST_LOG_INFO("\nVerbose mode on.  This test exercises an error case, "
+                     "so on sucess it "
+                     "will print a message that appears to be an error.\n");
+   } else {
+      FILE *dev_null = fopen("/dev/null", "w");
+      ASSERT_NOT_NULL(dev_null);
+      platform_set_log_streams(dev_null, dev_null);
+   }
    config_set_defaults(&data->master_cfg);
    data->master_cfg.cache_capacity = GiB_TO_B(5);
    data->data_cfg                  = test_data_config;
@@ -255,6 +265,12 @@ CTEST2(btree_stress, test_random_inserts_concurrent)
    rc = iterator_tests(
       (cache *)&data->cc, &data->dbtree_cfg, packed_root_addr, nkvs, data->hid);
    ASSERT_NOT_EQUAL(0, rc, "Invalid ranges in packed tree\n");
+
+   // Exercise print method to verify that it basically continues to work.
+   btree_print_tree(Platform_default_log_handle,
+                    (cache *)&data->cc,
+                    &data->dbtree_cfg,
+                    packed_root_addr);
 
    // Release memory allocated in this test case
    for (uint64 i = 0; i < nthreads; i++) {


### PR DESCRIPTION
This commit adds couple of utility functions to convert 'size' unit to a human-readable string with unit-specifiers, in an output buffer.

- size_to_str() - Convert 'size' to a string in an output buffer
- size_to_fmtstr() - Same as above, using user-specified format-string. Useful to generate output enclosed in '(%s)'.

Add utility bytes to Units conversion macros. Add test cases to exercise these interfaces. Apply these utility fns in couple of stats-printing methods, to display values in units of bytes as a string.

---
NOTE: This work was done in an in-flight integration development branch, to closely track memory usage (free / allocation metrics). The utility methods have been formalized, productized with new unit-tests. 

This commit applies the conversion functions to couple of existing print functions. These helper conversion functions can become useful in other places, too.

---- Updated (28.Dec.2021) ---- this work has now been rebased on top of another in-flight PR #521 . And the new changes to print with unit-specifiers has been applied to `btree_print_btree_pivot_stats()`. See the sample outputs shown in the diff block associated with this file.