### PR TITLE
(#513) Refactor into set_log_streams_for_tests() to manage unit-test outputs.

### DIFF
--- a/tests/unit/btree_stress_test.c
+++ b/tests/unit/btree_stress_test.c
@@ -113,16 +113,8 @@ CTEST_DATA(btree_stress)
 // Setup function for suite, called before every test in suite
 CTEST_SETUP(btree_stress)
 {
-   if (Ctest_verbose) {
-      platform_set_log_streams(stdout, stderr);
-      CTEST_LOG_INFO("\nVerbose mode on.  This test exercises an error case, "
-                     "so on sucess it "
-                     "will print a message that appears to be an error.\n");
-   } else {
-      FILE *dev_null = fopen("/dev/null", "w");
-      ASSERT_NOT_NULL(dev_null);
-      platform_set_log_streams(dev_null, dev_null);
-   }
+   set_log_streams_for_error_tests(NULL, NULL);
+
    config_set_defaults(&data->master_cfg);
    data->master_cfg.cache_capacity = GiB_TO_B(5);
    data->data_cfg                  = test_data_config;

--- a/tests/unit/limitations_test.c
+++ b/tests/unit/limitations_test.c
@@ -67,21 +67,7 @@ CTEST_DATA(limitations)
  */
 CTEST_SETUP(limitations)
 {
-   // This test exercises error cases, so even when everything succeeds
-   // it generates lots of "error" messages.
-   // By default, that would go to stderr, which would pollute test output.
-   // Here we ensure those expected error messages are only printed
-   // when the caller sets the VERBOSE env var to opt-in.
-   if (Ctest_verbose) {
-      platform_set_log_streams(stdout, stderr);
-      CTEST_LOG_INFO("\nVerbose mode on.  This test exercises an error case, "
-                     "so on sucess it "
-                     "will print a message that appears to be an error.\n");
-   } else {
-      FILE *dev_null = fopen("/dev/null", "w");
-      ASSERT_NOT_NULL(dev_null);
-      platform_set_log_streams(dev_null, dev_null);
-   }
+   set_log_streams_for_error_tests(NULL, NULL);
 
    uint64 heap_capacity = (1 * GiB);
 

--- a/tests/unit/misc_test.c
+++ b/tests/unit/misc_test.c
@@ -63,24 +63,12 @@ test_streqn(char *expstr, char *actstr, int caseno);
  */
 CTEST_DATA(misc)
 {
-   FILE *log_output;
+   platform_log_handle *log_output;
 };
 
 CTEST_SETUP(misc)
 {
-   // It can be surprising to see errors printed from a successful test run.
-   // So lets send those messages to /dev/null unless VERBOSE=1.
-   if (Ctest_verbose) {
-      data->log_output = stdout;
-      platform_set_log_streams(stdout, stderr);
-      CTEST_LOG_INFO("\nVerbose mode on.  This test exercises error-reporting "
-                     "logic, so on success it will print a message "
-                     "that appears to be an error.\n");
-   } else {
-      FILE *dev_null = data->log_output = fopen("/dev/null", "w");
-      ASSERT_NOT_NULL(data->log_output);
-      platform_set_log_streams(dev_null, dev_null);
-   }
+   set_log_streams_for_error_tests(&data->log_output, NULL);
 }
 
 // Optional teardown function for suite, called after every test in suite

--- a/tests/unit/platform_apis_test.c
+++ b/tests/unit/platform_apis_test.c
@@ -12,6 +12,7 @@
 
 #include "ctest.h" // This is required for all test-case files.
 #include "platform.h"
+#include "unit_tests.h"
 
 /*
  * Global data declaration macro:
@@ -26,21 +27,7 @@ CTEST_DATA(platform_api)
 
 CTEST_SETUP(platform_api)
 {
-   // This test exercises error cases, so even when everything succeeds
-   // it generates lots of "error" messages.
-   // By default, that would go to stderr, which would pollute test output.
-   // Here we ensure those expected error messages are only printed
-   // when the caller sets the VERBOSE env var to opt-in.
-   if (Ctest_verbose) {
-      platform_set_log_streams(stdout, stderr);
-      CTEST_LOG_INFO("\nVerbose mode on.  This test exercises an error case, "
-                     "so on sucess it "
-                     "will print a message that appears to be an error.\n");
-   } else {
-      FILE *dev_null = fopen("/dev/null", "w");
-      ASSERT_NOT_NULL(dev_null);
-      platform_set_log_streams(dev_null, dev_null);
-   }
+   set_log_streams_for_error_tests(NULL, NULL);
 
    platform_status rc = STATUS_OK;
 

--- a/tests/unit/splinter_test.c
+++ b/tests/unit/splinter_test.c
@@ -114,9 +114,8 @@ CTEST_DATA(splinter)
 // clang-format off
 CTEST_SETUP(splinter)
 {
-   if (Ctest_verbose) {
-      platform_set_log_streams(stdout, stderr);
-   }
+   set_log_streams_for_tests();
+
    // Defaults: For basic unit-tests, use single threads
    data->num_insert_threads = 1;
    data->num_lookup_threads = 1;

--- a/tests/unit/splinterdb_quick_test.c
+++ b/tests/unit/splinterdb_quick_test.c
@@ -98,9 +98,7 @@ CTEST_DATA(splinterdb_quick)
 // Optional setup function for suite, called before every test in suite
 CTEST_SETUP(splinterdb_quick)
 {
-   if (Ctest_verbose) {
-      platform_set_log_streams(stdout, stderr);
-   }
+   set_log_streams_for_tests();
 
    default_data_config_init(TEST_MAX_KEY_SIZE, &data->default_data_cfg.super);
    create_default_cfg(&data->cfg, &data->default_data_cfg.super);

--- a/tests/unit/splinterdb_stress_test.c
+++ b/tests/unit/splinterdb_stress_test.c
@@ -48,9 +48,7 @@ CTEST_DATA(splinterdb_stress)
 // Setup function for suite, called before every test in suite
 CTEST_SETUP(splinterdb_stress)
 {
-   if (Ctest_verbose) {
-      platform_set_log_streams(stdout, stderr);
-   }
+   set_log_streams_for_tests();
 
    data->cfg           = (splinterdb_config){.filename   = TEST_DB_NAME,
                                              .cache_size = 1000 * Mega,

--- a/tests/unit/task_system_test.c
+++ b/tests/unit/task_system_test.c
@@ -104,21 +104,7 @@ CTEST_DATA(task_system)
 CTEST_SETUP(task_system)
 {
    platform_status rc = STATUS_OK;
-   // This test exercises error cases, so even when everything succeeds
-   // it generates lots of "error" messages.
-   // By default, that would go to stderr, which would pollute test output.
-   // Here we ensure those expected error messages are only printed
-   // when the caller sets the VERBOSE env var to opt-in.
-   if (Ctest_verbose) {
-      platform_set_log_streams(stdout, stderr);
-      CTEST_LOG_INFO("\nVerbose mode on.  This test exercises an error case, "
-                     "so on sucess it "
-                     "will print a message that appears to be an error.\n");
-   } else {
-      FILE *dev_null = fopen("/dev/null", "w");
-      ASSERT_NOT_NULL(dev_null);
-      platform_set_log_streams(dev_null, dev_null);
-   }
+   set_log_streams_for_error_tests(NULL, NULL);
 
    uint64 heap_capacity = (256 * MiB); // small heap is sufficient.
    // Create a heap for io and task system to use.

--- a/tests/unit/unit_tests.h
+++ b/tests/unit/unit_tests.h
@@ -5,9 +5,18 @@
  *  Define things in here that are going to be needed across most unit tests.
  */
 
+#include "splinterdb/public_platform.h"
+
 /* Name of SplinterDB device created for unit-tests */
-#define TEST_DB_NAME "unit_tests_db"
+#define TEST_DB_NAME "splinterdb_unit_tests_db"
 
 #define Kilo (1024UL)
 #define Mega (1024UL * Kilo)
 #define Giga (1024UL * Mega)
+
+void
+set_log_streams_for_tests();
+
+void
+set_log_streams_for_error_tests(platform_log_handle **log_stdout,
+                                platform_log_handle **log_stderr);

--- a/tests/unit/unit_tests_common.c
+++ b/tests/unit/unit_tests_common.c
@@ -1,0 +1,70 @@
+// Copyright 2023 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+ * -----------------------------------------------------------------------------
+ * unit_tests_common.c
+ *
+ * Common functions shared across unit test sources.
+ * -----------------------------------------------------------------------------
+ */
+#include "ctest.h" // This is required for all test-case files.
+#include "unit_tests.h"
+
+/*
+ * Setup function to manage output log streams from most (unit) tests.
+ * By default, there will be no output. Info / error messages are only printed
+ * when the caller sets the VERBOSE env var to opt-in.
+ */
+void
+set_log_streams_for_tests()
+{
+   if (Ctest_verbose) {
+      platform_set_log_streams(stdout, stderr);
+   }
+}
+
+/*
+ * Setup function is provided to manage output log streams from (unit) tests
+ * that are induce error conditions and check that error messages are raised
+ * as expected.
+ *
+ * Some unit tests exercise error cases, so even when everything succeeds, they
+ * generate lots of "error" messages. By default, that would go to stderr, which
+ * would pollute the test output. This function sets up output file handles such
+ * that those expected error messages are only printed when the caller sets the
+ * VERBOSE env var to opt-in. By default, execution from unit-tests will be
+ * silent, redirecting output handles to /dev/null.
+ *
+ * Returns: Output file handles (out/error) if caller has requested for them.
+ */
+void
+set_log_streams_for_error_tests(platform_log_handle **log_stdout,
+                                platform_log_handle **log_stderr)
+{
+   // Here we ensure those expected error messages are only printed
+   // when the caller sets the VERBOSE env var to opt-in.
+   if (Ctest_verbose) {
+      platform_set_log_streams(stdout, stderr);
+      if (log_stdout) {
+         *log_stdout = stdout;
+      }
+      if (log_stderr) {
+         *log_stderr = stderr;
+      }
+      CTEST_LOG_INFO("\nVerbose mode on. This test may exercise an error case, "
+                     "so on success it will print a message that appears to "
+                     "be an error. "
+                     "Or, the test may exercise print-diagnostic code.\n");
+   } else {
+      FILE *dev_null = fopen("/dev/null", "w");
+      ASSERT_NOT_NULL(dev_null);
+      platform_set_log_streams(dev_null, dev_null);
+      if (log_stdout) {
+         *log_stdout = dev_null;
+      }
+      if (log_stderr) {
+         *log_stderr = dev_null;
+      }
+   }
+}


### PR DESCRIPTION
This commit refactors existing chunks of code that exists in different unit- test sources to manage output file handles to a common function, now defined in new file `unit/unit_tests_common.c` ; `set_log_streams_for_tests()`.

Tests that check error-raising behaviour will now need to call `set_log_streams_for_neg_tests()`, to manage output streams.

Minor correction to `TEST_DB_NAME`; change it to conform to the r.e. defined in .gitignore to suppress listing this in 'git status' output.

----
NOTE: I did not try to make this even more generic beyond unit-tests to have `functional/ tests` also call into these interfaces. That's why this new file `unit_tests_common.c` is in `tests/unit` sub-dir and not in top-level `tests/` dir.

I think, let's see how this settles down and if we ever find the need to make functional tests also get this capability, we can consider relocating this new file to `tests/` sub-dir.