### PR TITLE
Rename allocator_get_ref to _get_refcount

### DIFF
--- a/src/allocator.h
+++ b/src/allocator.h
@@ -209,9 +209,8 @@ allocator_dec_ref(allocator *al, uint64 addr, page_type type)
    return al->ops->dec_ref(al, addr, type);
 }
 
-// TODO rename get_refcount
 static inline uint8
-allocator_get_ref(allocator *al, uint64 addr)
+allocator_get_refcount(allocator *al, uint64 addr)
 {
    return al->ops->get_ref(al, addr);
 }
@@ -284,11 +283,11 @@ allocator_page_valid(allocator *al, uint64 addr)
 
    uint64 base_addr = allocator_config_extent_base_addr(allocator_cfg, addr);
    if ((base_addr != 0) && (addr < allocator_cfg->capacity)) {
-      uint8 refcount = allocator_get_ref(al, base_addr);
+      uint8 refcount = allocator_get_refcount(al, base_addr);
       if (refcount == 0) {
          platform_error_log(
             "%s():%d: Trying to access an unreferenced extent."
-            " base_addr=%lu, addr=%lu, allocator_get_ref()=%d\n",
+            " base_addr=%lu, addr=%lu, allocator_get_refcount()=%d\n",
             __FUNCTION__,
             __LINE__,
             base_addr,

--- a/src/clockcache.c
+++ b/src/clockcache.c
@@ -2018,7 +2018,7 @@ void
 clockcache_hard_evict_extent(clockcache *cc, uint64 addr, page_type type)
 {
    debug_assert(addr % clockcache_extent_size(cc) == 0);
-   debug_assert(allocator_get_ref(cc->al, addr) == 1);
+   debug_assert(allocator_get_refcount(cc->al, addr) == 1);
 
    clockcache_log(addr, 0, "hard evict extent: addr %lu\n", addr);
    for (uint64 i = 0; i < cc->cfg->pages_per_extent; i++) {
@@ -2060,7 +2060,7 @@ clockcache_get_internal(clockcache   *cc,       // IN
    uint64            start, elapsed;
 
 #if SPLINTER_DEBUG
-   uint8 extent_ref_count = allocator_get_ref(cc->al, base_addr);
+   uint8 extent_ref_count = allocator_get_refcount(cc->al, base_addr);
 
    // Dump allocated extents info for deeper debugging.
    if (extent_ref_count <= 1) {
@@ -2323,7 +2323,7 @@ clockcache_get_async(clockcache       *cc,   // IN
    clockcache_entry *entry;
    platform_status   status;
 
-   debug_assert(allocator_get_ref(cc->al, base_addr) > 1);
+   debug_assert(allocator_get_refcount(cc->al, base_addr) > 1);
 
    ctxt->page   = NULL;
    entry_number = clockcache_lookup(cc, addr);

--- a/src/mini_allocator.c
+++ b/src/mini_allocator.c
@@ -1124,7 +1124,7 @@ mini_wait_for_blockers(cache *cc, uint64 meta_head)
 {
    allocator *al   = cache_get_allocator(cc);
    uint64     wait = 1;
-   while (allocator_get_ref(al, base_addr(cc, meta_head)) != AL_ONE_REF) {
+   while (allocator_get_refcount(al, base_addr(cc, meta_head)) != AL_ONE_REF) {
       platform_sleep(wait);
       wait = wait > 1024 ? wait : 2 * wait;
    }
@@ -1150,7 +1150,7 @@ mini_keyed_dec_ref(cache       *cc,
                                          NULL);
    if (should_cleanup) {
       allocator *al  = cache_get_allocator(cc);
-      uint8      ref = allocator_get_ref(al, base_addr(cc, meta_head));
+      uint8      ref = allocator_get_refcount(al, base_addr(cc, meta_head));
       platform_assert(ref == AL_ONE_REF);
       mini_deinit(cc, meta_head, type, FALSE);
    }
@@ -1335,7 +1335,7 @@ mini_keyed_print(cache       *cc,
       platform_default_log(
          "| meta addr: %12lu (%u)                                       |\n",
          next_meta_addr,
-         allocator_get_ref(al, base_addr(cc, next_meta_addr)));
+         allocator_get_refcount(al, base_addr(cc, next_meta_addr)));
       platform_default_log("|--------------------------------------------------"
                            "-----------------|\n");
 
@@ -1354,7 +1354,7 @@ mini_keyed_print(cache       *cc,
          if (entry->extent_addr == TERMINAL_EXTENT_ADDR) {
             snprintf(ref_str, 4, "n/a");
          } else {
-            uint8 ref = allocator_get_ref(al, entry->extent_addr);
+            uint8 ref = allocator_get_refcount(al, entry->extent_addr);
             snprintf(ref_str, 4, "%3u", ref);
          }
          platform_default_log("| %3lu | %5u | %14s | %18.18s | %3s |\n",

--- a/src/shard_log.c
+++ b/src/shard_log.c
@@ -352,7 +352,7 @@ shard_log_iterator_init(cache              *cc,
 
    // traverse the log extents and calculate the required space
    extent_addr = addr;
-   while (extent_addr != 0 && allocator_get_ref(al, extent_addr) > 0) {
+   while (extent_addr != 0 && allocator_get_refcount(al, extent_addr) > 0) {
       cache_prefetch(cc, extent_addr, PAGE_TYPE_LOG);
       next_extent_addr = 0;
       for (i = 0; i < pages_per_extent; i++) {
@@ -380,7 +380,7 @@ finished_first_pass:
    log_entry *cursor    = (log_entry *)itor->contents;
    uint64     entry_idx = 0;
    extent_addr          = addr;
-   while (extent_addr != 0 && allocator_get_ref(al, extent_addr) > 0) {
+   while (extent_addr != 0 && allocator_get_refcount(al, extent_addr) > 0) {
       cache_prefetch(cc, extent_addr, PAGE_TYPE_LOG);
       next_extent_addr = 0;
       for (i = 0; i < pages_per_extent; i++) {
@@ -481,7 +481,7 @@ shard_log_print(shard_log *log)
    uint64            pages_per_extent = shard_log_pages_per_extent(cfg);
    allocator        *al               = cache_get_allocator(cc);
 
-   while (extent_addr != 0 && allocator_get_ref(al, extent_addr) > 0) {
+   while (extent_addr != 0 && allocator_get_refcount(al, extent_addr) > 0) {
       cache_prefetch(cc, extent_addr, PAGE_TYPE_LOG);
       uint64 next_extent_addr = 0;
       for (uint64 i = 0; i < pages_per_extent; i++) {

--- a/src/trunk.c
+++ b/src/trunk.c
@@ -8160,7 +8160,7 @@ trunk_print_memtable(platform_log_handle *log_handle, trunk_handle *spl)
                    "Memtable root_addr=%lu: gen %lu ref_count %u state %d\n",
                    mt_gen,
                    mt->root_addr,
-                   allocator_get_ref(spl->al, mt->root_addr),
+                   allocator_get_refcount(spl->al, mt->root_addr),
                    mt->state);
 
       memtable_print(log_handle, spl->cc, mt);


### PR DESCRIPTION
The function returns a count of references, not a reference.
Fixes #517.
