### PR TITLE
(#342) Fix checks in trunk_config_init() to report correct arg-values.

### DIFF
--- a/src/splinterdb.c
+++ b/src/splinterdb.c
@@ -199,22 +199,26 @@ splinterdb_init_config(const splinterdb_config *kvs_cfg, // IN
       return rc;
    }
 
-   trunk_config_init(&kvs->trunk_cfg,
-                     &kvs->cache_cfg.super,
-                     kvs->data_cfg,
-                     (log_config *)&kvs->log_cfg,
-                     cfg.memtable_capacity,
-                     cfg.fanout,
-                     cfg.max_branches_per_node,
-                     cfg.btree_rough_count_height,
-                     cfg.filter_remainder_size,
-                     cfg.filter_index_size,
-                     cfg.reclaim_threshold,
-                     cfg.queue_scale_percent,
-                     cfg.use_log,
-                     cfg.use_stats,
-                     FALSE,
-                     NULL);
+   rc = trunk_config_init(&kvs->trunk_cfg,
+                          &kvs->cache_cfg.super,
+                          kvs->data_cfg,
+                          (log_config *)&kvs->log_cfg,
+                          cfg.memtable_capacity,
+                          cfg.fanout,
+                          cfg.max_branches_per_node,
+                          cfg.btree_rough_count_height,
+                          cfg.filter_remainder_size,
+                          cfg.filter_index_size,
+                          cfg.reclaim_threshold,
+                          cfg.queue_scale_percent,
+                          cfg.use_log,
+                          cfg.use_stats,
+                          FALSE,
+                          NULL);
+   if (!SUCCESS(rc)) {
+      return rc;
+   }
+
    return STATUS_OK;
 }
 

--- a/src/trunk.c
+++ b/src/trunk.c
@@ -8923,7 +8923,7 @@ trunk_validate_data_config(const data_config *cfg)
  *       This function calls btree_config_init
  *-----------------------------------------------------------------------------
  */
-void
+platform_status
 trunk_config_init(trunk_config        *trunk_cfg,
                   cache_config        *cache_cfg,
                   data_config         *data_cfg,
@@ -8944,6 +8944,7 @@ trunk_config_init(trunk_config        *trunk_cfg,
 {
    trunk_validate_data_config(data_cfg);
 
+   platform_status rc = STATUS_BAD_PARAM;
    uint64          trunk_pivot_size;
    uint64          bytes_for_branches;
    routing_config *filter_cfg = &trunk_cfg->filter_cfg;
@@ -8965,7 +8966,7 @@ trunk_config_init(trunk_config        *trunk_cfg,
    // Inline what we would get from trunk_pivot_size(trunk_handle *).
    trunk_pivot_size = data_cfg->max_key_size + sizeof(trunk_pivot_data);
 
-   // Setting hard limit and over overprovisioning
+   // Setting hard limit and check configuration for over-provisioning
    trunk_cfg->max_pivot_keys = trunk_cfg->fanout + TRUNK_EXTRA_PIVOT_KEYS;
    uint64 header_bytes       = sizeof(trunk_hdr);
 
@@ -8973,31 +8974,44 @@ trunk_config_init(trunk_config        *trunk_cfg,
                          * (data_cfg->max_key_size + sizeof(trunk_pivot_data)));
    uint64 branch_bytes =
       trunk_cfg->max_branches_per_node * sizeof(trunk_branch);
-   uint64 trunk_node_min_size = header_bytes + pivot_bytes + branch_bytes;
-   uint64 available_pivot_bytes =
-      cache_config_page_size(cache_cfg) - header_bytes - branch_bytes;
+   uint64 trunk_node_min_size   = header_bytes + pivot_bytes + branch_bytes;
+   uint64 page_size             = cache_config_page_size(cache_cfg);
+   uint64 available_pivot_bytes = page_size - header_bytes - branch_bytes;
    uint64 available_bytes_per_pivot =
       available_pivot_bytes / trunk_cfg->max_pivot_keys;
-   uint64 available_bytes_per_pivot_key =
-      available_bytes_per_pivot - sizeof(trunk_pivot_data);
-   platform_assert(trunk_node_min_size < cache_config_page_size(cache_cfg),
-                   "\nTrunk node does not fit in page size as configured.\n"
-                   "node->hdr: %luB\n"
-                   "pivots: %luB (max_pivot=%lu x %luB)\n"
-                   "branches %luB (max_branches=%lu x %luB).\n"
-                   "Maximum key size supported with current config: %luB.\n",
-                   header_bytes,
-                   pivot_bytes,
-                   trunk_cfg->max_pivot_keys,
-                   data_cfg->max_key_size + sizeof(trunk_pivot_data),
-                   branch_bytes,
-                   max_branches_per_node,
-                   sizeof(trunk_branch),
-                   available_bytes_per_pivot_key);
+
+   // Deal with mis-configurations where we don't have available bytes per
+   // pivot key
+   uint64 available_bytes_per_pivot_key = 0;
+   if (available_bytes_per_pivot > sizeof(trunk_pivot_data)) {
+      available_bytes_per_pivot_key =
+         available_bytes_per_pivot - sizeof(trunk_pivot_data);
+   }
+
+   if (trunk_node_min_size >= page_size) {
+      platform_error_log("Trunk node min size=%lu bytes "
+                         "does not fit in page size=%lu bytes as configured.\n"
+                         "node->hdr: %lu bytes, "
+                         "pivots: %lu bytes (max_pivot=%lu x %lu bytes),\n"
+                         "branches %lu bytes (max_branches=%lu x %lu bytes).\n"
+                         "Maximum key size supported with current "
+                         "configuration: %lu bytes.\n",
+                         trunk_node_min_size,
+                         page_size,
+                         header_bytes,
+                         pivot_bytes,
+                         trunk_cfg->max_pivot_keys,
+                         trunk_pivot_size,
+                         branch_bytes,
+                         max_branches_per_node,
+                         sizeof(trunk_branch),
+                         available_bytes_per_pivot_key);
+      return rc;
+   }
 
    // Space left for branches past end of pivot array of [max_pivot_keys]
-   bytes_for_branches = (trunk_page_size(trunk_cfg) - trunk_hdr_size()
-                         - trunk_cfg->max_pivot_keys * trunk_pivot_size);
+   bytes_for_branches = (page_size - trunk_hdr_size()
+                         - (trunk_cfg->max_pivot_keys * trunk_pivot_size));
 
    // Internally determined hard-limit, which effectively depends on the
    // - configured page size and trunk header size
@@ -9086,6 +9100,8 @@ trunk_config_init(trunk_config        *trunk_cfg,
       filter_cfg->index_size *= 2;
       filter_cfg->log_index_size++;
    }
+   // When everything succeeds, return success.
+   return STATUS_OK;
 }
 
 size_t

--- a/src/trunk.h
+++ b/src/trunk.h
@@ -451,7 +451,7 @@ trunk_pivot_message_size();
 uint64
 trunk_hdr_size();
 
-void
+platform_status
 trunk_config_init(trunk_config        *trunk_cfg,
                   cache_config        *cache_cfg,
                   data_config         *data_cfg,

--- a/tests/unit/limitations_test.c
+++ b/tests/unit/limitations_test.c
@@ -28,6 +28,9 @@
 static void
 create_default_cfg(splinterdb_config *out_cfg, data_config *default_data_cfg);
 
+static platform_status
+parse_cmdline_args(void *datap, int unit_test_argc, char **unit_test_argv);
+
 /*
  * Global data declaration macro:
  */
@@ -387,6 +390,55 @@ CTEST2(limitations, test_disk_size_not_integral_multiple_of_extents)
    ASSERT_NOT_EQUAL(0, rc);
 }
 
+/*
+ * **************************************************************************
+ * Test that an invalid configuration that makes trunk node configuration
+ * impractical fails correctly with an error message. We try out few diff
+ * config params that go into error checks in trunk_config_init().
+ * **************************************************************************
+ */
+CTEST2(limitations, test_trunk_config_init_fails_for_invalid_configs)
+{
+   platform_status rc;
+   uint64          num_tables = 1;
+
+   // Allocate memory for global config structures
+   data->splinter_cfg =
+      TYPED_ARRAY_MALLOC(data->hid, data->splinter_cfg, num_tables);
+
+   data->cache_cfg = TYPED_ARRAY_MALLOC(data->hid, data->cache_cfg, num_tables);
+
+   char *unit_test_argv0[] = {"--key-size", "1000"};
+   int   unit_test_argc    = ARRAY_SIZE(unit_test_argv0);
+
+   char **unit_test_argv = unit_test_argv0;
+   rc = parse_cmdline_args(data, unit_test_argc, unit_test_argv);
+   ASSERT_FALSE(SUCCESS(rc));
+
+   char *unit_test_argv1[] = {"--page-size", "4096", "--fanout", "100"};
+   unit_test_argc          = ARRAY_SIZE(unit_test_argv1);
+
+   unit_test_argv = unit_test_argv1;
+   rc             = parse_cmdline_args(data, unit_test_argc, unit_test_argv);
+   ASSERT_FALSE(SUCCESS(rc));
+
+   char *unit_test_argv2[] = {"--max-branches-per-node", "200"};
+   unit_test_argc          = ARRAY_SIZE(unit_test_argv2);
+
+   unit_test_argv = unit_test_argv2;
+   rc             = parse_cmdline_args(data, unit_test_argc, unit_test_argv);
+   ASSERT_FALSE(SUCCESS(rc));
+
+   // Release resources acquired in this test case.
+   if (data->cache_cfg) {
+      platform_free(data->hid, data->cache_cfg);
+   }
+
+   if (data->splinter_cfg) {
+      platform_free(data->hid, data->splinter_cfg);
+   }
+}
+
 CTEST2(limitations, test_zero_cache_size)
 {
    splinterdb       *kvsb;
@@ -442,4 +494,37 @@ create_default_cfg(splinterdb_config *out_cfg, data_config *default_data_cfg)
                           .page_size   = TEST_CONFIG_DEFAULT_PAGE_SIZE,
                           .extent_size = TEST_CONFIG_DEFAULT_EXTENT_SIZE,
                           .data_cfg    = default_data_cfg};
+}
+
+/*
+ * Helper function to parse command-line arguments to setup the configuration
+ * for SplinterDB.
+ */
+static platform_status
+parse_cmdline_args(void *datap, int unit_test_argc, char **unit_test_argv)
+{
+   // Cast void * datap to ptr-to-CTEST_DATA() struct in use.
+   struct CTEST_IMPL_DATA_SNAME(limitations) *data =
+      (struct CTEST_IMPL_DATA_SNAME(limitations) *)datap;
+
+   ZERO_STRUCT(data->test_exec_cfg);
+
+   uint64 num_memtable_bg_threads_unused = 0;
+   uint64 num_normal_bg_threads_unused   = 0;
+   uint64 seed                           = 0;
+
+   platform_status rc = test_parse_args(data->splinter_cfg,
+                                        &data->data_cfg,
+                                        &data->io_cfg,
+                                        &data->al_cfg,
+                                        data->cache_cfg,
+                                        &data->log_cfg,
+                                        &data->task_cfg,
+                                        &seed,
+                                        &data->gen,
+                                        &num_memtable_bg_threads_unused,
+                                        &num_normal_bg_threads_unused,
+                                        unit_test_argc,
+                                        unit_test_argv);
+   return rc;
 }


### PR DESCRIPTION
This commit does a minor cleanup in `trunk_config_init()` to correctly report the value for 'Maximum key size' reported when the checks fail for an invalid configuration. We were overflowing the value for an uint64 variable, leading to bogus values reported in the error. Changed this function and other helper functions in test-code that parse command-line arguments to return platform_status. Adjust the handling of this failed return-value in diff test code. Add new unit-test to verify that invalid config params correctly fail to init the trunk-config.

--- NOTE: While at it, I changed the code in `trunk_config_init()` from a `platform_assert()` to a clean error message. 
This should improve the usability of the library when, say, invoking `driver_test` with bogus configs that fail to init the trunk-configuration.