### PR TITLE
(#156) Extend trunk_node_print_branches() to print size w/units

### DIFF
--- a/src/btree.c
+++ b/src/btree.c
@@ -3097,13 +3097,20 @@ btree_print_btree_pivot_stats(platform_log_handle *log_handle,
    }
 
    // Indentation is dictated by outer caller
+   size_t nkbytes = pivot_stats->key_bytes;
+   char   nkbytes_str[SIZE_TO_STR_LEN];
+
+   size_t nmbytes = pivot_stats->message_bytes;
+   char   nmbytes_str[SIZE_TO_STR_LEN];
    platform_log(log_handle,
                 "   (num_kvs=%u\n"
-                "    key_bytes=%u\n"
-                "    message_bytes=%u)\n",
+                "    key_bytes=%lu (%s)\n"
+                "    message_bytes=%lu (%s))\n",
                 pivot_stats->num_kvs,
-                pivot_stats->key_bytes,
-                pivot_stats->message_bytes);
+                nkbytes,
+                size_to_str(nkbytes_str, sizeof(nkbytes_str), nkbytes),
+                nmbytes,
+                size_to_str(nmbytes_str, sizeof(nmbytes_str), nmbytes));
 }
 
 static void
@@ -3255,6 +3262,7 @@ btree_print_subtree(platform_log_handle *log_handle,
    node.addr = addr;
    btree_print_node(log_handle, cc, cfg, &node);
    if (!allocator_page_valid(cache_get_allocator(cc), node.addr)) {
+      platform_log(log_handle, "Invalid BTree node addr=%lu\n", addr);
       return;
    }
    btree_node_get(cc, cfg, &node, PAGE_TYPE_BRANCH);

--- a/src/btree.c
+++ b/src/btree.c
@@ -1116,15 +1116,6 @@ btree_addrs_share_extent(cache *cc, uint64 left_addr, uint64 right_addr)
       allocator_get_config(al), right_addr, left_addr);
 }
 
-static inline uint64
-btree_root_to_meta_addr(const btree_config *cfg,
-                        uint64              root_addr,
-                        uint64              meta_page_no)
-{
-   return root_addr + (meta_page_no + 1) * btree_page_size(cfg);
-}
-
-
 /*----------------------------------------------------------
  * Creating and destroying B-trees.
  *----------------------------------------------------------

--- a/src/btree_private.h
+++ b/src/btree_private.h
@@ -305,3 +305,11 @@ btree_get_child_addr(const btree_config *cfg,
 {
    return index_entry_child_addr(btree_get_index_entry(cfg, hdr, k));
 }
+
+static inline uint64
+btree_root_to_meta_addr(const btree_config *cfg,
+                        uint64              root_addr,
+                        uint64              meta_page_no)
+{
+   return root_addr + (meta_page_no + 1) * btree_page_size(cfg);
+}

--- a/src/data_internal.h
+++ b/src/data_internal.h
@@ -604,7 +604,7 @@ static inline void
 data_key_to_string(const data_config *cfg, key k, char *str, size_t size)
 {
    if (key_is_negative_infinity(k)) {
-      snprintf(str, size, "(negaitive_infinity)");
+      snprintf(str, size, "(negative_infinity)");
    } else if (key_is_negative_infinity(k)) {
       snprintf(str, size, "(positive_infinity)");
    } else {

--- a/src/mini_allocator.c
+++ b/src/mini_allocator.c
@@ -1314,20 +1314,14 @@ mini_keyed_print(cache       *cc,
    allocator *al             = cache_get_allocator(cc);
    uint64     next_meta_addr = meta_head;
 
-   platform_default_log("------------------------------------------------------"
-                        "---------------\n");
+   // clang-format off
+   const char *dashes = "---------------------------------------------------------------------";
+   // clang-format on
+   platform_default_log("%s\n", dashes);
    platform_default_log(
       "| Mini Keyed Allocator -- meta_head: %12lu                   |\n",
       meta_head);
-   platform_default_log("|-----------------------------------------------------"
-                        "--------------|\n");
-   platform_default_log("| idx | %5s | %14s | %18s | %3s |\n",
-                        "batch",
-                        "extent_addr",
-                        "start_key",
-                        "rc");
-   platform_default_log("|-----------------------------------------------------"
-                        "--------------|\n");
+   platform_default_log("%s\n", dashes);
 
    do {
       page_handle *meta_page = cache_get(cc, next_meta_addr, TRUE, type);
@@ -1336,8 +1330,14 @@ mini_keyed_print(cache       *cc,
          "| meta addr: %12lu (%u)                                       |\n",
          next_meta_addr,
          allocator_get_refcount(al, base_addr(cc, next_meta_addr)));
-      platform_default_log("|--------------------------------------------------"
-                           "-----------------|\n");
+      platform_default_log("%s\n", dashes);
+      platform_default_log("| idx | %5s | %14s | %18s | %3s |\n",
+                           "batch",
+                           "extent_addr",
+                           "start_key",
+                           "rc");
+      platform_default_log("%s\n", dashes);
+
 
       uint64            num_entries = mini_num_entries(meta_page);
       keyed_meta_entry *entry       = keyed_first_entry(meta_page);
@@ -1365,8 +1365,7 @@ mini_keyed_print(cache       *cc,
                               ref_str);
          entry = keyed_next_entry(entry);
       }
-      platform_default_log("|--------------------------------------------------"
-                           "-----------------|\n");
+      platform_default_log("%s\n", dashes);
 
       next_meta_addr = mini_get_next_meta_addr(meta_page);
       cache_unget(cc, meta_page);

--- a/src/platform_linux/platform.h
+++ b/src/platform_linux/platform.h
@@ -88,14 +88,37 @@
 
 // Data unit constants
 #define KiB (1024UL)
-#define MiB (KiB * KiB)
-#define GiB (MiB * KiB)
+#define MiB (KiB * 1024)
+#define GiB (MiB * 1024)
+#define TiB (GiB * 1024)
 
+// Convert 'x' in unit-specifiers to bytes
 #define KiB_TO_B(x) ((x)*KiB)
 #define MiB_TO_B(x) ((x)*MiB)
 #define GiB_TO_B(x) ((x)*GiB)
+#define TiB_TO_B(x) ((x)*TiB)
+
+// Convert 'x' in bytes to 'int'-value with unit-specifiers
+#define B_TO_KiB(x) ((x) / KiB)
 #define B_TO_MiB(x) ((x) / MiB)
 #define B_TO_GiB(x) ((x) / GiB)
+#define B_TO_TiB(x) ((x) / TiB)
+
+// Return, as int, the fractional portion modulo a KiB for given x bytes.
+#define B_TO_KiB_FRACT(x)                                                      \
+   (int)((((x) - (B_TO_KiB(x) * KiB)) / (KiB * 1.0)) * 100)
+
+// Return, as int, the fractional portion modulo a MiB for given x bytes.
+#define B_TO_MiB_FRACT(x)                                                      \
+   (int)((((x) - (B_TO_MiB(x) * MiB)) / (MiB * 1.0)) * 100)
+
+// Return, as int, the fractional portion modulo a GiB for given x bytes.
+#define B_TO_GiB_FRACT(x)                                                      \
+   (int)((((x) - (B_TO_GiB(x) * GiB)) / (GiB * 1.0)) * 100)
+
+// Return, as int, the fractional portion modulo a TiB for given x bytes.
+#define B_TO_TiB_FRACT(x)                                                      \
+   (int)((((x) - (B_TO_TiB(x) * TiB)) / (TiB * 1.0)) * 100)
 
 // Time unit constants
 #define THOUSAND (1000UL)

--- a/src/rc_allocator.h
+++ b/src/rc_allocator.h
@@ -44,8 +44,8 @@ _Static_assert(offsetof(rc_allocator_meta_page, splinters) == 0,
  *----------------------------------------------------------------------
  */
 typedef struct rc_allocator_stats {
-   int64 curr_allocated;
-   int64 max_allocated;
+   int64 curr_allocated; // # of extents allocated
+   int64 max_allocated;  // # of extents allocated hwm
    int64 extent_allocs[NUM_PAGE_TYPES];
    int64 extent_deallocs[NUM_PAGE_TYPES];
 } rc_allocator_stats;

--- a/src/trunk.c
+++ b/src/trunk.c
@@ -1719,6 +1719,10 @@ trunk_pivot_branch_count(trunk_handle     *spl,
       spl, node->hdr->end_branch, pdata->start_branch);
 }
 
+/*
+ * Returns the # tuples (num_tuples) and # KV-bytes (num_kv_bytes) used for
+ * a single BTree rooted at 'root_addr'.
+ */
 static inline void
 trunk_pivot_btree_tuple_counts(trunk_handle *spl,
                                trunk_node   *node,
@@ -1730,12 +1734,17 @@ trunk_pivot_btree_tuple_counts(trunk_handle *spl,
    key               min_key = trunk_get_pivot(spl, node, pivot_no);
    key               max_key = trunk_get_pivot(spl, node, pivot_no + 1);
    btree_pivot_stats stats;
+   ZERO_STRUCT(stats);
    btree_count_in_range(
       spl->cc, trunk_btree_config(spl), root_addr, min_key, max_key, &stats);
    *num_tuples   = stats.num_kvs;
    *num_kv_bytes = stats.key_bytes + stats.message_bytes;
 }
 
+/*
+ * Returns the # tuples and # KV-bytes tracked by a single branch, with branch #
+ * branch_no, for a given pivot number.
+ */
 static inline void
 trunk_pivot_branch_tuple_counts(trunk_handle *spl,
                                 trunk_node   *node,
@@ -8791,6 +8800,10 @@ trunk_reset_stats(trunk_handle *spl)
    }
 }
 
+/*
+ * Returns the # tuples (num_tuples) and # KV-bytes (num_kv_bytes) used by all
+ * branches that are live for each pivot under trunk node 'node'.
+ */
 void
 trunk_branch_count_num_tuples(trunk_handle *spl,
                               trunk_node   *node,
@@ -8820,68 +8833,101 @@ trunk_node_print_branches(trunk_handle *spl, uint64 addr, void *arg)
    trunk_node           node;
    trunk_node_get(spl->cc, addr, &node);
 
-   platform_log(
-      log_handle,
-      "------------------------------------------------------------------\n");
+   // clang-format off
+   const char *dashes = "------------------------------------------------------------------";
+   const char *dashes_long = "-------------------------------------------------------------------------------------------------";
+   // clang-format on
+
+   platform_log(log_handle, "%s\n", dashes);
    platform_log(
       log_handle, "| node %12lu height %u\n", addr, trunk_height(&node));
-   platform_log(
-      log_handle,
-      "------------------------------------------------------------------\n");
+   platform_log(log_handle, "%s\n", dashes);
+
    uint16 num_pivot_keys = trunk_num_pivot_keys(spl, &node);
-   platform_log(log_handle, "| pivots:\n");
+   platform_log(log_handle, "| pivots: %u\n", num_pivot_keys);
    for (uint16 pivot_no = 0; pivot_no < num_pivot_keys; pivot_no++) {
       char key_str[128];
       trunk_key_to_string(spl, trunk_get_pivot(spl, &node, pivot_no), key_str);
       platform_log(log_handle, "| %u: %s\n", pivot_no, key_str);
    }
 
+   platform_log(log_handle, "%s\n", dashes_long);
+
    // clang-format off
    platform_log(log_handle,
-         "-----------------------------------------------------------------------------------\n");
-   platform_log(log_handle,
-         "| branch |     addr     |  num tuples  | num kv bytes |    space    |  space amp  |\n");
-   platform_log(log_handle,
-         "-----------------------------------------------------------------------------------\n");
+         "    | branch |     addr     |  num tuples  |       num kv bytes        |    space    |space amp |\n");
    // clang-format on
+
+   platform_log(log_handle, "%s\n", dashes_long);
+
    uint16 start_branch = trunk_start_branch(spl, &node);
    uint16 end_branch   = trunk_end_branch(spl, &node);
+   uint16 num_branches = 0;
+   uint64 sum_ntuples  = 0;
+   uint64 sum_nkvbytes = 0;
+
+   size_t nkvbytes = 0;
+   char   nkvbytes_str[SIZE_TO_STR_LEN];
+
    for (uint16 branch_no = start_branch; branch_no != end_branch;
         branch_no        = trunk_add_branch_number(spl, branch_no, 1))
    {
       uint64 addr = trunk_get_branch(spl, &node, branch_no)->root_addr;
       uint64 num_tuples_in_branch;
-      uint64 kv_bytes_in_branch;
+      uint64 kv_bytes_in_branch = 0;
+      num_branches++;
+
       trunk_branch_count_num_tuples(
          spl, &node, branch_no, &num_tuples_in_branch, &kv_bytes_in_branch);
-      uint64 kib_in_branch = 0;
+
+      nkvbytes = kv_bytes_in_branch;
+
+      sum_ntuples += num_tuples_in_branch;
+      sum_nkvbytes += kv_bytes_in_branch;
+
+      uint64 kib_in_branch = 1;
       // trunk_branch_extent_count(spl, &node, branch_no);
       kib_in_branch *= B_TO_KiB(trunk_extent_size(&spl->cfg));
       fraction space_amp =
-         init_fraction(kib_in_branch * 1024, kv_bytes_in_branch);
+         init_fraction(KiB_TO_B(kib_in_branch), kv_bytes_in_branch);
+
       platform_log(
          log_handle,
-         "| %6u | %12lu | %12lu | %9luKiB | %8luKiB |   " FRACTION_FMT(
+         "    | %6u | %12lu | %12lu |%12lu %14s| %8lu KiB|   " FRACTION_FMT(
             2, 2) "   |\n",
          branch_no,
          addr,
          num_tuples_in_branch,
-         B_TO_KiB(kv_bytes_in_branch),
+         nkvbytes,
+         size_to_fmtstr(nkvbytes_str, sizeof(nkvbytes_str), "(%s)", nkvbytes),
          kib_in_branch,
          FRACTION_ARGS(space_amp));
    }
-   platform_log(
-      log_handle,
-      "------------------------------------------------------------------\n");
-   platform_log(log_handle, "\n");
    trunk_node_unget(spl->cc, &node);
+
+   platform_log(log_handle, "%s\n", dashes_long);
+   // clang-format off
+   platform_log(log_handle,
+                "Sum | %6u | %12s | %12lu |%12lu %14s| %8s    |   \n",
+                num_branches,
+                "",
+                sum_ntuples,
+                sum_nkvbytes,
+                size_to_fmtstr(nkvbytes_str, sizeof(nkvbytes_str), "(%s)", sum_nkvbytes),
+                "");
+   // clang-format on
+
+   platform_log(log_handle, "%s\n", dashes_long);
+   platform_log(log_handle, "\n");
    return TRUE;
 }
 
 void
 trunk_print_branches(platform_log_handle *log_handle, trunk_handle *spl)
 {
+   platform_log(log_handle, "{\n");
    trunk_for_each_node(spl, trunk_node_print_branches, log_handle);
+   platform_log(log_handle, "}\n");
 }
 
 // bool

--- a/src/trunk.c
+++ b/src/trunk.c
@@ -7905,8 +7905,13 @@ trunk_print_space_use(platform_log_handle *log_handle, trunk_handle *spl)
                 "Space used by level: trunk_tree_height=%d\n",
                 trunk_tree_height(spl));
    for (uint16 i = 0; i <= trunk_tree_height(spl); i++) {
-      platform_log(
-         log_handle, "%u: %8lu MiB\n", i, B_TO_MiB(bytes_used_by_level[i]));
+      char size_str[SIZE_TO_STR_LEN];
+      size_to_str(size_str, sizeof(size_str), bytes_used_by_level[i]);
+      platform_log(log_handle,
+                   "%u: %lu bytes (%s)\n",
+                   i,
+                   bytes_used_by_level[i],
+                   size_str);
    }
    platform_log(log_handle, "\n");
 }
@@ -8851,7 +8856,7 @@ trunk_node_print_branches(trunk_handle *spl, uint64 addr, void *arg)
          spl, &node, branch_no, &num_tuples_in_branch, &kv_bytes_in_branch);
       uint64 kib_in_branch = 0;
       // trunk_branch_extent_count(spl, &node, branch_no);
-      kib_in_branch *= trunk_extent_size(&spl->cfg) / 1024;
+      kib_in_branch *= B_TO_KiB(trunk_extent_size(&spl->cfg));
       fraction space_amp =
          init_fraction(kib_in_branch * 1024, kv_bytes_in_branch);
       platform_log(
@@ -8861,7 +8866,7 @@ trunk_node_print_branches(trunk_handle *spl, uint64 addr, void *arg)
          branch_no,
          addr,
          num_tuples_in_branch,
-         kv_bytes_in_branch / 1024,
+         B_TO_KiB(kv_bytes_in_branch),
          kib_in_branch,
          FRACTION_ARGS(space_amp));
    }

--- a/src/util.c
+++ b/src/util.c
@@ -364,3 +364,67 @@ debug_hex_dump_slice(platform_log_handle *plh, uint64 grouping, slice data)
 {
    debug_hex_dump(plh, grouping, slice_length(data), slice_data(data));
 }
+
+/*
+ * Format a size value with unit-specifiers, in an output buffer.
+ * Returns 'outbuf', as ptr to size-value snprintf()'ed as a string.
+ */
+char *
+size_to_str(char *outbuf, size_t outbuflen, size_t size)
+{
+   debug_assert(outbuflen >= SIZE_TO_STR_MINLEN, "outbuflen=%lu\n", outbuflen);
+   size_t unit_val  = 0;
+   size_t frac_val  = 0;
+   bool   is_approx = FALSE;
+
+   char  fmtstr[SIZE_TO_STR_LEN];
+   char *units = NULL;
+   if (size >= TiB) {
+      unit_val  = B_TO_TiB(size);
+      frac_val  = B_TO_TiB_FRACT(size);
+      is_approx = (size > TiB_TO_B(unit_val));
+      units     = "TiB";
+
+   } else if (size >= GiB) {
+      unit_val  = B_TO_GiB(size);
+      frac_val  = B_TO_GiB_FRACT(size);
+      is_approx = (size > GiB_TO_B(unit_val));
+      units     = "GiB";
+
+   } else if (size >= MiB) {
+      unit_val  = B_TO_MiB(size);
+      frac_val  = B_TO_MiB_FRACT(size);
+      is_approx = (size > MiB_TO_B(unit_val));
+      units     = "MiB";
+
+   } else if (size >= KiB) {
+      unit_val  = B_TO_KiB(size);
+      frac_val  = B_TO_KiB_FRACT(size);
+      is_approx = (size > KiB_TO_B(unit_val));
+      units     = "KiB";
+   } else {
+      unit_val = size;
+      units    = "bytes";
+   }
+   if (frac_val || is_approx) {
+      snprintf(fmtstr, sizeof(fmtstr), "~%%ld.%%d %s", units);
+   } else {
+      snprintf(fmtstr, sizeof(fmtstr), "%%ld %s", units);
+   }
+   snprintf(outbuf, outbuflen, fmtstr, unit_val, frac_val);
+   return outbuf;
+}
+
+/*
+ * Sibling of size_to_str(), but uses user-provided print format specifier.
+ * 'fmtstr' is expected to have just one '%s', and whatever other text user
+ * wishes to print with the output string.
+ */
+char *
+size_to_fmtstr(char *outbuf, size_t outbuflen, const char *fmtstr, size_t size)
+{
+   char *size_str = (outbuf + 1);
+   char *outstr   = size_to_str(size_str, (outbuflen - 2), size);
+   snprintf(outbuf, outbuflen, fmtstr, outstr);
+   return outbuf;
+}

--- a/src/util.h
+++ b/src/util.h
@@ -382,4 +382,20 @@ debug_hex_dump_slice(platform_log_handle *, uint64 grouping, slice data);
     : ((intval) < 1000) ? "3d"                                                 \
                         : "4d")
 
+// Size of on-stack char message buffer (mostly used in diagnostics)
+#define DIAG_MSGBUF_SIZE 80
+
+// Convenience specifier for output buffer to convert size with unit specifier
+#define SIZE_TO_STR_LEN 20
+
+// Min size of buffer needed if size is enclosed in (), as : '(~3.50 GiB)'
+#define SIZE_TO_STR_MINLEN (SIZE_TO_STR_LEN - 2)
+
+// Format a size value with unit-specifiers, in an output buffer.
+char *
+size_to_str(char *outbuf, size_t outbuflen, size_t size);
+
+char *
+size_to_fmtstr(char *outbuf, size_t outbuflen, const char *fmtstr, size_t size);
+
 #endif // _SPLINTER_UTIL_H_

--- a/tests/unit/btree_stress_test.c
+++ b/tests/unit/btree_stress_test.c
@@ -332,11 +332,22 @@ CTEST2(btree_stress, test_btree_print_diags)
    }
 
    // Exercise print method to verify that it basically continues to work.
-   CTEST_LOG_INFO("\n**** btree_print_tree() ****\n");
+   CTEST_LOG_INFO("\n**** btree_print_tree() on BTree root=%lu****\n",
+                  packed_root_addr);
    btree_print_tree(Platform_default_log_handle,
                     (cache *)&data->cc,
                     &data->dbtree_cfg,
                     packed_root_addr);
+
+   uint64 meta_page_addr =
+      btree_root_to_meta_addr(&data->dbtree_cfg, packed_root_addr, 0);
+   CTEST_LOG_INFO("\n**** mini_keyed_print() BTree root=%lu"
+                  ", meta page addr=%lu****\n",
+                  packed_root_addr,
+                  meta_page_addr);
+
+   mini_keyed_print(
+      (cache *)&data->cc, data->data_cfg, meta_page_addr, PAGE_TYPE_BRANCH);
 
    // Release memory allocated in this test case
    for (uint64 i = 0; i < nthreads; i++) {

--- a/tests/unit/btree_stress_test.c
+++ b/tests/unit/btree_stress_test.c
@@ -113,6 +113,16 @@ CTEST_DATA(btree_stress)
 // Setup function for suite, called before every test in suite
 CTEST_SETUP(btree_stress)
 {
+   if (Ctest_verbose) {
+      platform_set_log_streams(stdout, stderr);
+      CTEST_LOG_INFO("\nVerbose mode on.  This test exercises an error case, "
+                     "so on sucess it "
+                     "will print a message that appears to be an error.\n");
+   } else {
+      FILE *dev_null = fopen("/dev/null", "w");
+      ASSERT_NOT_NULL(dev_null);
+      platform_set_log_streams(dev_null, dev_null);
+   }
    config_set_defaults(&data->master_cfg);
    data->master_cfg.cache_capacity = GiB_TO_B(5);
    data->data_cfg                  = test_data_config;
@@ -256,6 +266,12 @@ CTEST2(btree_stress, test_random_inserts_concurrent)
    rc = iterator_tests(
       (cache *)&data->cc, &data->dbtree_cfg, packed_root_addr, nkvs, data->hid);
    ASSERT_NOT_EQUAL(0, rc, "Invalid ranges in packed tree\n");
+
+   // Exercise print method to verify that it basically continues to work.
+   btree_print_tree(Platform_default_log_handle,
+                    (cache *)&data->cc,
+                    &data->dbtree_cfg,
+                    packed_root_addr);
 
    // Release memory allocated in this test case
    for (uint64 i = 0; i < nthreads; i++) {

--- a/tests/unit/misc_test.c
+++ b/tests/unit/misc_test.c
@@ -12,6 +12,8 @@
 #include "platform.h"
 #include "unit_tests.h"
 #include "ctest.h" // This is required for all test-case files.
+#include "util.h"
+#include "platform.h"
 
 #define ASSERT_OUTBUF_LEN 200
 
@@ -21,7 +23,7 @@
    "Test assertion msg with arguments id = %d, name = '%s'."
 
 /* Function prototypes and caller-macros to invoke testing interfaces */
-void
+static void
 test_platform_assert_msg(platform_log_handle *log_handle,
                          const char          *filename,
                          int                  linenumber,
@@ -39,7 +41,7 @@ test_platform_assert_msg(platform_log_handle *log_handle,
    test_platform_assert_msg(                                                   \
       log_handle, __FILE__, __LINE__, __FUNCTION__, #expr, "" __VA_ARGS__)
 
-void
+static void
 test_vfprintf_usermsg(platform_log_handle *log_handle,
                       const char          *message,
                       ...);
@@ -52,6 +54,9 @@ test_vfprintf_usermsg(platform_log_handle *log_handle,
  */
 #define test_assert_usermsg(log_handle, ...)                                   \
    test_vfprintf_usermsg(log_handle, "" __VA_ARGS__)
+
+static void
+test_streqn(char *expstr, char *actstr, int caseno);
 
 /*
  * Global data declaration macro:
@@ -67,12 +72,14 @@ CTEST_SETUP(misc)
    // So lets send those messages to /dev/null unless VERBOSE=1.
    if (Ctest_verbose) {
       data->log_output = stdout;
+      platform_set_log_streams(stdout, stderr);
       CTEST_LOG_INFO("\nVerbose mode on.  This test exercises error-reporting "
                      "logic, so on success it will print a message "
                      "that appears to be an error.\n");
    } else {
-      data->log_output = fopen("/dev/null", "w");
+      FILE *dev_null = data->log_output = fopen("/dev/null", "w");
       ASSERT_NOT_NULL(data->log_output);
+      platform_set_log_streams(dev_null, dev_null);
    }
 }
 
@@ -183,13 +190,102 @@ CTEST2(misc, test_ctest_assert_prints_user_msg_with_params)
    platform_close_log_stream(&stream, data->log_output);
 }
 
+/*
+ * Simple test to verify lower-level conversion macros used by size_to_str()
+ */
+CTEST2(misc, test_bytes_to_fractional_value_macros)
+{
+   // Run through a few typical cases to check lower-level macros
+   size_t size = 1.25 * KiB;
+   ASSERT_EQUAL(25, B_TO_KiB_FRACT(size));
+
+   size = 1.5 * MiB;
+   ASSERT_EQUAL(50, B_TO_MiB_FRACT(size));
+
+   size = 1.75 * GiB;
+   ASSERT_EQUAL(75, B_TO_GiB_FRACT(size));
+
+   size = 1.50 * TiB;
+   ASSERT_EQUAL(50, B_TO_TiB_FRACT(size));
+}
+
+/*
+ * Test case to verify conversion of size value to a string with
+ * unit-specifiers. Do quick cross-check of the lower-level conversion macros
+ * involved.
+ */
+CTEST2(misc, test_size_to_str)
+{
+   char size_str[SIZE_TO_STR_LEN];
+   char size_str2[SIZE_TO_STR_LEN + 2]; // size-as-string enclosed in ()
+   typedef struct size_to_expstr {
+      size_t size;
+      char  *expstr;
+   } size_to_expstr;
+
+   // Verify base-case, and validate ptr returned to output string buffer.
+   size_t size   = 0;
+   char  *expstr = "0 bytes";
+   char  *outstr = size_to_str(size_str, sizeof(size_str), size);
+   // Conversion fn should return input-str's start addr as outstr.
+   ASSERT_TRUE(outstr == size_str);
+   test_streqn(expstr, outstr, 0);
+
+   // Built expected string enclosed in ()
+   snprintf(size_str2, sizeof(size_str2), "(%s)", size_str);
+
+   // Size as string enclosed in () will be generated in this buffer
+   char *expstr2 = size_str2;
+   outstr        = size_to_fmtstr(size_str2, sizeof(size_str2), "(%s)", size);
+
+   // Conversion fn should return input-str's start addr as outstr.
+   ASSERT_TRUE(outstr == size_str2);
+   test_streqn(expstr2, size_str2, 0);
+
+   // Exercise the string formatter with typical data values.
+   // clang-format off
+   size_to_expstr size_to_str_cases[] =
+   {
+          { 129                        , "129 bytes"  }
+
+        , { KiB                        , "1 KiB"      }
+        , { MiB                        , "1 MiB"      }
+        , { GiB                        , "1 GiB"      }
+        , { TiB                        , "1 TiB"      }
+
+        , { KiB + 128                  , "~1.12 KiB"  }
+        , { KiB + (0.25 * KiB)         , "~1.25 KiB"  }
+        , { MiB + 128                  , "~1.0 MiB"   }
+        , { MiB + (0.5 * MiB)          , "~1.50 MiB"  }
+        , { GiB + 128                  , "~1.0 GiB"   }
+        , { GiB + (0.75 * GiB)         , "~1.75 GiB"  }
+        , { (3 * GiB) + (0.50 * GiB)   , "~3.50 GiB"  }
+
+        , { TiB + 128                  , "~1.0 TiB"   }
+        , { (2 * TiB) + (0.25 * TiB)   , "~2.25 TiB"  }
+   };
+   // clang-format on
+
+   for (int cctr = 0; cctr < ARRAY_SIZE(size_to_str_cases); cctr++) {
+      size         = size_to_str_cases[cctr].size;
+      expstr       = size_to_str_cases[cctr].expstr;
+      char *outstr = size_to_str(size_str, sizeof(size_str), size);
+      test_streqn(expstr, outstr, cctr);
+
+      // Built expected string enclosed in ()
+      snprintf(size_str2, sizeof(size_str2), "(%s)", size_str);
+      size_to_fmtstr(size_str, sizeof(size_str), "(%s)", size);
+      test_streqn(expstr2, size_str, cctr);
+   }
+}
+
 /* Helper functions follow all test case methods */
 
 /*
  * Wrapper function to exercise platform_assert_msg() into an output
  * buffer. Used to test that the message is generated as expected.
  */
-void
+static void
 test_platform_assert_msg(platform_log_handle *log_handle,
                          const char          *filename,
                          int                  linenumber,
@@ -210,8 +306,24 @@ test_platform_assert_msg(platform_log_handle *log_handle,
  * into an output buffer. Used to test that the message is generated as
  * expected.
  */
-void
+static void
 test_vfprintf_usermsg(platform_log_handle *log_handle, const char *message, ...)
 {
    VFPRINTF_USERMSG(log_handle, message);
+}
+
+/* Helper fn to check that expected / actual null-terminated strings match */
+static void
+test_streqn(char *expstr, char *actstr, int caseno)
+{
+   ASSERT_STREQN(expstr,
+                 actstr,
+                 strlen(expstr),
+                 "Test case=%d failed, Expected: '%.*s', "
+                 "Received: '%.*s'\n",
+                 caseno,
+                 strlen(expstr),
+                 expstr,
+                 strlen(expstr),
+                 actstr);
 }

--- a/tests/unit/splinter_test.c
+++ b/tests/unit/splinter_test.c
@@ -662,6 +662,9 @@ CTEST2(splinter, test_splinter_print_diags)
 
    trunk_print_space_use(Platform_default_log_handle, spl);
 
+   CTEST_LOG_INFO("\n** trunk_print_branches() **\n");
+   trunk_print_branches(Platform_default_log_handle, spl);
+
    CTEST_LOG_INFO("\n** trunk_print() **\n");
    trunk_print(Platform_default_log_handle, spl);
 


### PR DESCRIPTION
Preliminary changes; Actual fix requested by issue #156, yet, to be fleshed out.
This commit adds minor improvements to trunk_node_print_branches() to:

    - Print # of kv-bytes in unit-specifiers, also
    - Print sum of # of branches, num tuples & num of kv-bytes for
      each trunk node.

    - Extend unit-test test_splinter_print_diags() to now also call
      trunk_print_branches() so we have a basic exercise of these
      print methods.

---
NOTE: These changes are built on top of in-flight PRs for issue #520 and issue #511. Those changes bring in the ability to print size values in `bytes` as a string with unit-specifiers. The actual changes related to this PR are in `trunk.c`. In the diffs, kindly ignore other changes from `btree.c` and other files which are from the above two in-flight PRs / issues.