### PR TITLE
(#499) Minor cleanup of INVALID_TID, and MAX_THREADS in task-system

### DIFF
--- a/src/task.c
+++ b/src/task.c
@@ -255,7 +255,7 @@ task_create_thread_with_hooks(platform_thread       *thread,
       platform_error_log("Cannot create a new thread as the limit on"
                          " concurrent threads, %d, will be exceeded.\n",
                          MAX_THREADS);
-      return STATUS_LIMIT_EXCEEDED;
+      return STATUS_BUSY;
    }
 
    if (0 < scratch_size) {
@@ -359,8 +359,9 @@ task_register_thread(task_system *ts,
                    thread_tid);
 
    thread_tid = task_allocate_threadid(ts);
+   // Unavailable threads is a temporary state that could go away.
    if (thread_tid == INVALID_TID) {
-      return STATUS_NO_SPACE;
+      return STATUS_BUSY;
    }
 
    platform_assert(ts->thread_scratch[thread_tid] == NULL,


### PR DESCRIPTION
This commit applies some minor clean-up to task system as a follow-on to the larger rework done under PR #497. Consistently use STATUS_BUSY, as a way to report when all concurrent threads are in-use. This will result in a `Resource temporarily unavailable` message to the client. Minor changes to task system unit-test code & cleanup of comments.

--- NOTE to the reviewer:

Nothing is changing substantially; minor corrections to keep code & test code consistent.