### PR TITLE
(#538) Unit-test to exercise mini_allocator. Minor cleanup of module.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -468,6 +468,7 @@ $(BINDIR)/$(UNITDIR)/platform_apis_test: $(UTIL_SYS)               \
 
 $(BINDIR)/$(UNITDIR)/mini_allocator_test: $(COMMON_TESTOBJ)                             \
                                           $(OBJDIR)/$(FUNCTIONAL_TESTSDIR)/test_async.o \
+                                          $(COMMON_UNIT_TESTOBJ)                        \
                                           $(LIBDIR)/libsplinterdb.so
 
 ########################################

--- a/Makefile
+++ b/Makefile
@@ -466,6 +466,10 @@ $(BINDIR)/$(UNITDIR)/platform_apis_test: $(UTIL_SYS)               \
                                          $(COMMON_UNIT_TESTOBJ)    \
                                          $(PLATFORM_SYS)
 
+$(BINDIR)/$(UNITDIR)/mini_allocator_test: $(COMMON_TESTOBJ)                             \
+                                          $(OBJDIR)/$(FUNCTIONAL_TESTSDIR)/test_async.o \
+                                          $(LIBDIR)/libsplinterdb.so
+
 ########################################
 # Convenience mini unit-test targets
 unit/util_test:                    $(BINDIR)/$(UNITDIR)/util_test

--- a/src/allocator.h
+++ b/src/allocator.h
@@ -253,6 +253,23 @@ allocator_print_allocated(allocator *al)
    return al->ops->print_allocated(al);
 }
 
+// Return the address of the extent holding page at address 'addr'
+static inline uint64
+allocator_extent_base_addr(allocator *al, uint64 addr)
+{
+   allocator_config *allocator_cfg = allocator_get_config(al);
+   return allocator_config_extent_base_addr(allocator_cfg, addr);
+}
+
+// Returns the address of the page next to input 'page_addr'
+static inline uint64
+allocator_next_page_addr(allocator *al, uint64 page_addr)
+{
+   allocator_config *allocator_cfg = allocator_get_config(al);
+   return (page_addr + allocator_cfg->io_cfg->page_size);
+}
+
+
 static inline bool
 allocator_page_valid(allocator *al, uint64 addr)
 {

--- a/src/btree.c
+++ b/src/btree.c
@@ -1016,8 +1016,11 @@ btree_truncate_index(const btree_config *cfg, // IN
  *-----------------------------------------------------------------------------
  * btree_alloc --
  *
- *      Allocates a node from the preallocator. Will refill it if there are no
- *      more nodes available for the given height.
+ *      Allocates a new page from the mini-allocator for a new BTree node.
+ *      from the (previously setup) mini-allocator. Will refill the mini-
+ *      allocator's cache of pre-allocated extents if there are no more nodes
+ *      (pages) available from the already-allocated extent for the given
+ *      height.
  *-----------------------------------------------------------------------------
  */
 bool

--- a/src/mini_allocator.c
+++ b/src/mini_allocator.c
@@ -255,7 +255,7 @@ static uint64
 allocator_page_number(allocator *al, uint64 page_addr)
 {
    allocator_config *allocator_cfg = allocator_get_config(al);
-   debug_assert(allocator_valid_page_addr(al, page_addr));
+   // debug_assert(allocator_valid_page_addr(al, page_addr));
    return ((page_addr / allocator_cfg->io_cfg->page_size));
 }
 
@@ -275,7 +275,7 @@ static uint64
 allocator_extent_number(allocator *al, uint64 page_addr)
 {
    allocator_config *allocator_cfg = allocator_get_config(al);
-   debug_assert(allocator_valid_page_addr(al, page_addr));
+   // debug_assert(allocator_valid_page_addr(al, page_addr));
    return ((allocator_extent_base_addr(al, page_addr)
             / allocator_cfg->io_cfg->extent_size));
 }

--- a/src/mini_allocator.h
+++ b/src/mini_allocator.h
@@ -49,6 +49,10 @@ typedef struct mini_allocator {
    uint64          next_extent[MINI_MAX_BATCHES];
 } mini_allocator;
 
+/*
+ * Initialize a new mini allocator.
+ * Returns the next address to be allocated from the 0th batch.
+ */
 uint64
 mini_init(mini_allocator *mini,
           cache          *cc,
@@ -58,15 +62,30 @@ mini_init(mini_allocator *mini,
           uint64          num_batches,
           page_type       type,
           bool            keyed);
+
+void
+mini_deinit(mini_allocator *mini, key start_key, key end_key);
+
+/*
+ * Called to finalize the mini_allocator. After calling, no more
+ * allocations can be made, but the mini_allocator's linked list containing
+ * the extents allocated and their metadata can be accessed by functions
+ * using its meta_head.
+ */
 void
 mini_release(mini_allocator *mini, key end_key);
 
 /*
- * NOTE: Can only be called on a mini_allocator which has made no allocations.
+ * Called to destroy a mini_allocator that was created but never used to
+ * allocate an extent. Can only be called on a keyed mini allocator.
  */
 void
 mini_destroy_unused(mini_allocator *mini);
 
+/*
+ * Allocate a next disk address from the mini_allocator.
+ * Returns a newly allocated disk address.
+ */
 uint64
 mini_alloc(mini_allocator *mini,
            uint64          batch,

--- a/src/trunk.c
+++ b/src/trunk.c
@@ -7289,9 +7289,6 @@ trunk_prepare_for_shutdown(trunk_handle *spl)
       platform_free(spl->heap_id, spl->log);
    }
 
-   // release the trunk mini allocator
-   mini_release(&spl->mini, NULL_KEY);
-
    // flush all dirty pages in the cache
    cache_flush(spl->cc);
 }
@@ -7346,7 +7343,8 @@ trunk_destroy(trunk_handle *spl)
 
    trunk_for_each_node(spl, trunk_node_destroy, NULL);
 
-   mini_unkeyed_dec_ref(spl->cc, spl->mini.meta_head, PAGE_TYPE_TRUNK, FALSE);
+   // Deinit the trunk's unkeyed mini allocator; release all its resources
+   mini_deinit(&spl->mini, NULL_KEY, NULL_KEY);
 
    // clear out this splinter table from the meta page.
    allocator_remove_super_addr(spl->al, spl->id);

--- a/tests/unit/mini_allocator_test.c
+++ b/tests/unit/mini_allocator_test.c
@@ -48,9 +48,6 @@ CTEST_DATA(mini_allocator)
 // Setup function for suite, called before every test in suite
 CTEST_SETUP(mini_allocator)
 {
-   if (Ctest_verbose) {
-      platform_set_log_streams(stdout, stderr);
-   }
    uint64 heap_capacity = 1024 * MiB;
 
    default_data_config_init(TEST_MAX_KEY_SIZE, &data->default_data_cfg);

--- a/tests/unit/mini_allocator_test.c
+++ b/tests/unit/mini_allocator_test.c
@@ -1,0 +1,430 @@
+// Copyright 2023 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+ * -----------------------------------------------------------------------------
+ * mini_allocator_test.c --
+ *
+ * Exercises some of the interfaces in mini_allocator.c to exercise this
+ * sub-system for both keyed and unkeyed page allocations.
+ * -----------------------------------------------------------------------------
+ */
+#include "splinterdb/public_platform.h"
+#include "unit_tests.h"
+#include "ctest.h" // This is required for all test-case files.
+#include "rc_allocator.h"
+#include "config.h"
+#include "splinterdb/default_data_config.h"
+#include "btree.h"
+#include "functional/random.h"
+
+#define TEST_MAX_KEY_SIZE 44
+
+/*
+ * Global data declaration macro:
+ */
+CTEST_DATA(mini_allocator)
+{
+   // Declare head handles for io, allocator, cache memory allocation.
+   platform_heap_handle hh;
+   platform_heap_id     hid;
+   platform_module_id   mid;
+
+   // Config structs for sub-systems that clockcache depends on
+   io_config          io_cfg;
+   task_system_config task_cfg;
+   allocator_config   al_cfg;
+   clockcache_config  cache_cfg;
+   data_config        default_data_cfg;
+
+   // Handles to various sub-systems for which memory will be allocated
+   platform_io_handle *io;
+   task_system        *tasks;
+   allocator          *al;
+   rc_allocator       *rc_al;
+   clockcache         *clock_cache;
+};
+
+// Setup function for suite, called before every test in suite
+CTEST_SETUP(mini_allocator)
+{
+   if (Ctest_verbose) {
+      platform_set_log_streams(stdout, stderr);
+   }
+   uint64 heap_capacity = 1024 * MiB;
+
+   default_data_config_init(TEST_MAX_KEY_SIZE, &data->default_data_cfg);
+
+   // Create a heap for io, allocator, cache and splinter
+   platform_status rc = platform_heap_create(
+      platform_get_module_id(), heap_capacity, &data->hh, &data->hid);
+   ASSERT_TRUE(SUCCESS(rc));
+
+   // Allocate memory for and set default for a master config struct
+   master_config *master_cfg = TYPED_ZALLOC(data->hid, master_cfg);
+   config_set_defaults(master_cfg);
+
+   io_config_init(&data->io_cfg,
+                  master_cfg->page_size,
+                  master_cfg->extent_size,
+                  master_cfg->io_flags,
+                  master_cfg->io_perms,
+                  master_cfg->io_async_queue_depth,
+                  master_cfg->io_filename);
+
+   // no background threads by default.
+   uint64 num_bg_threads[NUM_TASK_TYPES] = {0};
+   rc = task_system_config_init(&data->task_cfg,
+                                TRUE, // use stats
+                                num_bg_threads,
+                                trunk_get_scratch_size());
+
+   ASSERT_TRUE(SUCCESS(rc));
+   allocator_config_init(
+      &data->al_cfg, &data->io_cfg, master_cfg->allocator_capacity);
+
+   clockcache_config_init(&data->cache_cfg,
+                          &data->io_cfg,
+                          master_cfg->cache_capacity,
+                          master_cfg->cache_logfile,
+                          master_cfg->use_stats);
+
+   // Allocate and initialize the task, IO, rc-allocator sub-systems.
+   data->io = TYPED_ZALLOC(data->hid, data->io);
+   ASSERT_TRUE((data->io != NULL));
+   rc = io_handle_init(data->io, &data->io_cfg, data->hh, data->hid);
+
+   rc = task_system_create(data->hid, data->io, &data->tasks, &data->task_cfg);
+   ASSERT_TRUE(SUCCESS(rc));
+
+   data->rc_al = TYPED_ZALLOC(data->hid, data->rc_al);
+   ASSERT_TRUE((data->rc_al != NULL));
+   rc_allocator_init(data->rc_al,
+                     &data->al_cfg,
+                     (io_handle *)data->io,
+                     data->hid,
+                     platform_get_module_id());
+   data->al = (allocator *)data->rc_al;
+
+   data->clock_cache = TYPED_ZALLOC(data->hid, data->clock_cache);
+   ASSERT_TRUE((data->clock_cache != NULL));
+
+   rc = clockcache_init(data->clock_cache,
+                        &data->cache_cfg,
+                        (io_handle *)data->io,
+                        data->al,
+                        "test_mini_allocator",
+                        data->hid,
+                        data->mid);
+   ASSERT_TRUE(SUCCESS(rc));
+
+   platform_free(data->hid, master_cfg);
+}
+
+// Teardown function for suite, called after every test in suite
+CTEST_TEARDOWN(mini_allocator)
+{
+   clockcache_deinit(data->clock_cache);
+   platform_free(data->hid, data->clock_cache);
+
+   rc_allocator_deinit(data->rc_al);
+   platform_free(data->hid, data->rc_al);
+   data->al = NULL;
+
+   task_system_destroy(data->hid, &data->tasks);
+
+   io_handle_deinit(data->io);
+   platform_free(data->hid, data->io);
+
+   platform_heap_destroy(&data->hh);
+}
+
+/*
+ * ----------------------------------------------------------------------------
+ * Exercise the core APIs of the mini-allocator for allocating keyed pages.
+ * This will be typically used to allocated BTree pages, which have keys.
+ * Before we can do page-allocation, need to allocate a new extent, which will
+ * be used by the mini-allocator.
+ * ----------------------------------------------------------------------------
+ */
+CTEST2(mini_allocator, test_mini_keyed_allocator_basic)
+{
+   platform_status rc          = STATUS_TEST_FAILED;
+   uint64          extent_addr = 0;
+
+   rc = allocator_alloc(data->al, &extent_addr, PAGE_TYPE_BRANCH);
+   ASSERT_TRUE(SUCCESS(rc));
+
+   mini_allocator  mini_alloc_ctxt;
+   mini_allocator *mini = &mini_alloc_ctxt;
+   ZERO_CONTENTS(mini);
+
+   page_type type             = PAGE_TYPE_BRANCH;
+   uint64    first_ext_addr   = extent_addr;
+   bool      keyed_mini_alloc = TRUE;
+
+   uint64 meta_head_addr = allocator_next_page_addr(data->al, first_ext_addr);
+
+   first_ext_addr = mini_init(mini,
+                              (cache *)data->clock_cache,
+                              &data->default_data_cfg,
+                              meta_head_addr,
+                              0,
+                              MINI_MAX_BATCHES,
+                              type,
+                              keyed_mini_alloc);
+   ASSERT_TRUE(first_ext_addr != extent_addr);
+
+   mini_destroy_unused(mini);
+}
+
+/*
+ * Exercise the mini-allocator's interfaces for unkeyed page allocations.
+ */
+CTEST2(mini_allocator, test_mini_unkeyed_many_allocs_one_batch)
+{
+   platform_status rc          = STATUS_TEST_FAILED;
+   uint64          extent_addr = 0;
+   page_type       pgtype      = PAGE_TYPE_BRANCH;
+
+   uint64 extents_in_use_prev = allocator_in_use(data->al);
+   ASSERT_TRUE(extents_in_use_prev != 0);
+
+   rc = allocator_alloc(data->al, &extent_addr, pgtype);
+   ASSERT_TRUE(SUCCESS(rc));
+
+   mini_allocator  mini_alloc_ctxt;
+   mini_allocator *mini = &mini_alloc_ctxt;
+   ZERO_CONTENTS(mini);
+
+   uint64 first_ext_addr     = extent_addr;
+   uint64 num_batches        = 1;
+   bool   unkeyed_mini_alloc = FALSE;
+
+   uint64 meta_head_addr = allocator_next_page_addr(data->al, first_ext_addr);
+
+   first_ext_addr = mini_init(mini,
+                              (cache *)data->clock_cache,
+                              &data->default_data_cfg,
+                              meta_head_addr,
+                              0,
+                              num_batches,
+                              pgtype,
+                              unkeyed_mini_alloc);
+   ASSERT_TRUE(first_ext_addr != extent_addr);
+
+   // 1 for the extent holding the metadata page and 1 for the newly allocated
+   // extent.
+   uint64 exp_num_extents = 2;
+   ASSERT_EQUAL(exp_num_extents, mini_num_extents(mini));
+
+   allocator_config *allocator_cfg = allocator_get_config(data->al);
+
+   uint64 extent_size = allocator_cfg->io_cfg->extent_size;
+   uint64 page_size   = allocator_cfg->io_cfg->page_size;
+
+   // Test that mini-allocator's state of extent-to-use changes when all pages
+   // in currently pre-allocated extent are allocated.
+   uint64 next_ext_addr    = 0;
+   uint64 exp_next_page    = first_ext_addr;
+   uint64 next_page_addr   = 0;
+   uint64 npages_in_extent = (extent_size / page_size);
+   uint64 batch_num        = 0;
+   uint64 pgctr;
+
+   for (pgctr = 0; pgctr < npages_in_extent; pgctr++) {
+      next_page_addr = mini_alloc(mini, batch_num, NULL_KEY, &next_ext_addr);
+
+      // All pages allocated should be from previously allocated extent
+      ASSERT_EQUAL(first_ext_addr,
+                   allocator_extent_base_addr(data->al, next_page_addr));
+
+      // And we should get a diff page for each allocation request
+      ASSERT_EQUAL(exp_next_page,
+                   next_page_addr,
+                   "pgctr=%lu, exp_next_page=%lu, next_page_addr=%lu\n",
+                   pgctr,
+                   exp_next_page,
+                   next_page_addr);
+
+      // We should have pre-allocated a new extent when we just started to
+      // allocate pages from currently allocated extent.
+      if (pgctr == 0) {
+         exp_num_extents++;
+      }
+      ASSERT_EQUAL(exp_num_extents, mini_num_extents(mini));
+
+      exp_next_page = allocator_next_page_addr(data->al, next_page_addr);
+   }
+
+   uint64 new_next_ext_addr;
+
+   // Allocating the next page in a new extent pre-allocates a new extent.
+   next_page_addr = mini_alloc(mini, batch_num, NULL_KEY, &new_next_ext_addr);
+
+   ASSERT_NOT_EQUAL(first_ext_addr, next_ext_addr);
+
+   // This most-recently allocated page should be from the recently
+   // pre-allocated extent, tracked by next_ext_addr. In fact it should be
+   // exactly that 1st page on that pre-allocated extent.
+   ASSERT_EQUAL(next_ext_addr,
+                next_page_addr,
+                "pgctr=%lu, next_ext_addr=%lu, next_page_addr=%lu\n",
+                pgctr,
+                next_ext_addr,
+                next_page_addr);
+
+   // The alloc of this 1st page should have pre-allocated a new extent.
+   exp_num_extents++;
+   ASSERT_EQUAL(exp_num_extents, mini_num_extents(mini));
+
+   // Release extents reserved by mini-allocator, to verify extents in-use.
+   mini_deinit(mini, NULL_KEY, NULL_KEY);
+
+   exp_num_extents = 0;
+   ASSERT_EQUAL(exp_num_extents, mini_num_extents(mini));
+
+   uint64 extents_in_use_now = allocator_in_use(data->al);
+   ASSERT_EQUAL(extents_in_use_prev, extents_in_use_now);
+}
+
+/*
+ * ----------------------------------------------------------------------------
+ * Exercise the mini-allocator's interfaces for unkeyed page allocations,
+ * pretending that we are allocating pages for all levels of the trunk's nodes.
+ * Then, exercise the method to print contents of chain of unkeyed allocator's
+ * meta-data pages to ensure that the print function works reasonably.
+ * ----------------------------------------------------------------------------
+ */
+CTEST2(mini_allocator, test_trunk_mini_unkeyed_allocs_print_diags)
+{
+   platform_status rc          = STATUS_TEST_FAILED;
+   uint64          extent_addr = 0;
+   page_type       pgtype      = PAGE_TYPE_TRUNK;
+
+   rc = allocator_alloc(data->al, &extent_addr, pgtype);
+   ASSERT_TRUE(SUCCESS(rc));
+
+   mini_allocator  mini_alloc_ctxt;
+   mini_allocator *mini = &mini_alloc_ctxt;
+   ZERO_CONTENTS(mini);
+
+   uint64 first_ext_addr     = extent_addr;
+   uint64 num_batches        = TRUNK_MAX_HEIGHT;
+   bool   unkeyed_mini_alloc = FALSE;
+
+   uint64 meta_head_addr = allocator_next_page_addr(data->al, first_ext_addr);
+
+   first_ext_addr = mini_init(mini,
+                              (cache *)data->clock_cache,
+                              &data->default_data_cfg,
+                              meta_head_addr,
+                              0,
+                              num_batches,
+                              pgtype,
+                              unkeyed_mini_alloc);
+   ASSERT_TRUE(first_ext_addr != extent_addr);
+
+   uint64 npages_in_extent = data->clock_cache->cfg->pages_per_extent;
+   uint64 npages_allocated = 0;
+
+   uint64 exp_num_extents = mini_num_extents(mini);
+
+   // Allocate n-pages for each level (bctr) of the trunk tree. Pick some
+   // large'ish # of pages to allocate so we fill-up multiple metadata pages
+   // worth of unkeyed_meta_entry{} entries.
+   for (uint64 bctr = 0; bctr < num_batches; bctr++) {
+      uint64 num_extents_per_level = (64 * bctr);
+      for (uint64 pgctr = 0; pgctr < (num_extents_per_level * npages_in_extent);
+           pgctr++)
+      {
+         uint64 next_page_addr = mini_alloc(mini, bctr, NULL_KEY, NULL);
+         ASSERT_FALSE(next_page_addr == 0);
+
+         npages_allocated++;
+      }
+      exp_num_extents += num_extents_per_level;
+   }
+   // Validate book-keeping of # of extents allocated by mini-allocator
+   ASSERT_EQUAL(exp_num_extents, mini_num_extents(mini));
+
+   // Exercise print method of mini-allocator's keyed meta-page
+   CTEST_LOG_INFO("\n** Unkeyed Mini-Allocator dump **\n");
+   mini_unkeyed_print((cache *)data->clock_cache, meta_head_addr, pgtype);
+
+   mini_deinit(mini, NULL_KEY, NULL_KEY);
+}
+
+/*
+ * ----------------------------------------------------------------------------
+ * Exercise the mini-allocator's interfaces for keyed page allocations,
+ * pretending that we are allocating pages for all levels of a BTree.
+ * Then, exercise the method to print contents of chain of keyed allocator's
+ * meta-data pages to ensure that the print function works reasonably.
+ * ----------------------------------------------------------------------------
+ */
+CTEST2(mini_allocator, test_trunk_mini_keyed_allocs_print_diags)
+{
+   platform_status rc          = STATUS_TEST_FAILED;
+   uint64          extent_addr = 0;
+   page_type       pgtype      = PAGE_TYPE_BRANCH;
+
+   rc = allocator_alloc(data->al, &extent_addr, pgtype);
+   ASSERT_TRUE(SUCCESS(rc));
+
+   mini_allocator  mini_alloc_ctxt;
+   mini_allocator *mini = &mini_alloc_ctxt;
+   ZERO_CONTENTS(mini);
+
+   uint64 first_ext_addr   = extent_addr;
+   uint64 num_batches      = BTREE_MAX_HEIGHT;
+   bool   keyed_mini_alloc = TRUE;
+
+   uint64 meta_head_addr = allocator_next_page_addr(data->al, first_ext_addr);
+
+   first_ext_addr = mini_init(mini,
+                              (cache *)data->clock_cache,
+                              &data->default_data_cfg,
+                              meta_head_addr,
+                              0,
+                              num_batches,
+                              pgtype,
+                              keyed_mini_alloc);
+   ASSERT_TRUE(first_ext_addr != extent_addr);
+
+   uint64 npages_in_extent = data->clock_cache->cfg->pages_per_extent;
+   uint64 npages_allocated = 0;
+
+   uint64 exp_num_extents = mini_num_extents(mini);
+
+   // Allocate n-pages for each level (bctr) of the Btree. Pick some
+   // large'ish # of pages to allocate so we fill-up multiple metadata pages
+   // worth of unkeyed_meta_entry{} entries.
+   for (uint64 bctr = 0; bctr < num_batches; bctr++) {
+      uint64 num_extents_per_level = (64 * bctr);
+      for (uint64 pgctr = 0; pgctr < (num_extents_per_level * npages_in_extent);
+           pgctr++)
+      {
+         random_state rand_state;
+         random_init(&rand_state, pgctr + 42, 0);
+         char key_buffer[TEST_MAX_KEY_SIZE] = {0};
+         random_bytes(&rand_state, key_buffer, TEST_MAX_KEY_SIZE);
+
+         uint64 next_page_addr = mini_alloc(
+            mini, bctr, key_create(sizeof(key_buffer), key_buffer), NULL);
+         ASSERT_FALSE(next_page_addr == 0);
+
+         npages_allocated++;
+      }
+      exp_num_extents += num_extents_per_level;
+   }
+   // Validate book-keeping of # of extents allocated by mini-allocator
+   ASSERT_EQUAL(exp_num_extents, mini_num_extents(mini));
+
+   // Exercise print method of mini-allocator's keyed meta-page
+   CTEST_LOG_INFO("\n** Keyed Mini-Allocator dump **\n");
+   mini_keyed_print(
+      (cache *)data->clock_cache, mini->data_cfg, meta_head_addr, pgtype);
+
+   mini_deinit(mini, NEGATIVE_INFINITY_KEY, POSITIVE_INFINITY_KEY);
+}


### PR DESCRIPTION
This commit does some minor cleanup of the mini-allocator module. Some interfaces are slightly changed to streamline init / deinit interfaces. A new unit-test is added to exercise core interfaces of this page allocation system, and to test the print methods for keyed and unkeyed page allocation schemes.

-----
No major code / logic changes. Introduced a new unit-test to exercise interfaces in `mini_allocator.c` along with additions of minor interfaces to manipulate page / extent addresses / validity etc. Some of the changes to streamline `init`, `deinit` calls will need some discussion during review. I've done my best effort, but think there is still room for improvement in this rework.