### PR TITLE
(#537) Add unit-tests to exercise rc/allocator.c; Other minor cleanup.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -392,12 +392,14 @@ PLATFORM_IO_SYS = $(OBJDIR)/$(SRCDIR)/$(PLATFORM_DIR)/laio.o
 
 UTIL_SYS = $(OBJDIR)/$(SRCDIR)/util.o $(PLATFORM_SYS)
 
-CLOCKCACHE_SYS = $(OBJDIR)/$(SRCDIR)/clockcache.o	  \
-                 $(OBJDIR)/$(SRCDIR)/allocator.o    \
-                 $(OBJDIR)/$(SRCDIR)/rc_allocator.o \
+ALLOCATOR_SYS = $(OBJDIR)/$(SRCDIR)/allocator.o    \
+                $(OBJDIR)/$(SRCDIR)/rc_allocator.o \
+                $(PLATFORM_IO_SYS)
+
+CLOCKCACHE_SYS = $(OBJDIR)/$(SRCDIR)/clockcache.o	 \
                  $(OBJDIR)/$(SRCDIR)/task.o         \
+                 $(ALLOCATOR_SYS)                   \
                  $(UTIL_SYS)                        \
-                 $(PLATFORM_IO_SYS)
 
 BTREE_SYS = $(OBJDIR)/$(SRCDIR)/btree.o           \
             $(OBJDIR)/$(SRCDIR)/data_internal.o   \
@@ -465,6 +467,11 @@ $(BINDIR)/$(UNITDIR)/task_system_test: $(UTIL_SYS)                              
 $(BINDIR)/$(UNITDIR)/platform_apis_test: $(UTIL_SYS)               \
                                          $(COMMON_UNIT_TESTOBJ)    \
                                          $(PLATFORM_SYS)
+
+$(BINDIR)/$(UNITDIR)/allocator_test: $(ALLOCATOR_SYS)                 \
+                                     $(COMMON_UNIT_TESTOBJ)           \
+                                     $(OBJDIR)/$(TESTS_DIR)/config.o  \
+                                     $(UTIL_SYS)
 
 ########################################
 # Convenience mini unit-test targets

--- a/src/allocator.c
+++ b/src/allocator.c
@@ -25,3 +25,32 @@ allocator_config_init(allocator_config *allocator_cfg,
    uint64 log_extent_size         = 63 - __builtin_clzll(io_cfg->extent_size);
    allocator_cfg->extent_mask     = ~((1ULL << log_extent_size) - 1);
 }
+
+/*
+ * Return page number for the page at 'addr', in terms of page-size.
+ * This routine assume that input 'addr' is a valid page address.
+ */
+uint64
+allocator_page_number(allocator *al, uint64 page_addr)
+{
+   allocator_config *allocator_cfg = allocator_get_config(al);
+   debug_assert(allocator_valid_page_addr(al, page_addr));
+   return ((page_addr / allocator_cfg->io_cfg->page_size));
+}
+
+/*
+ * Return page offset for the page at 'addr', in terms of page-size,
+ * as an index into the extent holding the page.
+ * This routine assume that input 'addr' is a valid page address.
+ *
+ * Returns index from [0 .. ( <#-of-pages-in-an-extent> - 1) ]
+ */
+uint64
+allocator_page_offset(allocator *al, uint64 page_addr)
+{
+   allocator_config *allocator_cfg = allocator_get_config(al);
+   debug_assert(allocator_valid_page_addr(al, page_addr));
+   uint64 npages_in_extent =
+      (allocator_cfg->io_cfg->extent_size / allocator_cfg->io_cfg->page_size);
+   return (allocator_page_number(al, page_addr) % npages_in_extent);
+}

--- a/src/allocator.h
+++ b/src/allocator.h
@@ -98,6 +98,7 @@ allocator_config_init(allocator_config *allocator_cfg,
                       io_config        *io_cfg,
                       uint64            capacity);
 
+// Return the address of the extent holding page at address 'addr'
 static inline uint64
 allocator_config_extent_base_addr(allocator_config *allocator_cfg, uint64 addr)
 {
@@ -253,12 +254,42 @@ allocator_print_allocated(allocator *al)
    return al->ops->print_allocated(al);
 }
 
+// Return the address of the extent holding page at address 'addr'
+static inline uint64
+allocator_extent_base_addr(allocator *al, uint64 addr)
+{
+   allocator_config *allocator_cfg = allocator_get_config(al);
+   return allocator_config_extent_base_addr(allocator_cfg, addr);
+}
+
+// Is the 'addr' a valid page address?
+static inline bool
+allocator_valid_page_addr(allocator *al, uint64 addr)
+{
+   allocator_config *allocator_cfg = allocator_get_config(al);
+   return ((addr % allocator_cfg->io_cfg->page_size) == 0);
+}
+
+/*
+ * Is the 'addr' a valid address of the start of an extent;
+ * i.e. an extent address?
+ */
+static inline bool
+allocator_valid_extent_addr(allocator *al, uint64 addr)
+{
+   return (allocator_extent_base_addr(al, addr) == addr);
+}
+
+/*
+ * Check if the page given by address 'addr' is a valid page-address within the
+ * database capacity and that the holding extent is also allocated (i.e., has a
+ * non-zero ref-count).
+ */
 static inline bool
 allocator_page_valid(allocator *al, uint64 addr)
 {
    allocator_config *allocator_cfg = allocator_get_config(al);
-
-   if ((addr % allocator_cfg->io_cfg->page_size) != 0) {
+   if (!allocator_valid_page_addr(al, addr)) {
       platform_error_log("%s():%d: Specified addr=%lu is not divisible by"
                          " configured page size=%lu\n",
                          __FUNCTION__,
@@ -268,8 +299,8 @@ allocator_page_valid(allocator *al, uint64 addr)
       return FALSE;
    }
 
-   uint64 base_addr = allocator_config_extent_base_addr(allocator_cfg, addr);
-   if ((base_addr != 0) && (addr < allocator_cfg->capacity)) {
+   uint64 base_addr = allocator_extent_base_addr(al, addr);
+   if ((base_addr != 0) && (addr < allocator_get_capacity(al))) {
       uint8 refcount = allocator_get_refcount(al, base_addr);
       if (refcount == 0) {
          platform_error_log(
@@ -285,7 +316,7 @@ allocator_page_valid(allocator *al, uint64 addr)
    } else {
       platform_error_log("%s():%d: Extent out of allocator capacity range."
                          " base_addr=%lu, addr=%lu"
-                         ", allocator_get_capacity()=%lu\n",
+                         ", allocator_get_capacity()=%lu pages.\n",
                          __FUNCTION__,
                          __LINE__,
                          base_addr,
@@ -294,3 +325,21 @@ allocator_page_valid(allocator *al, uint64 addr)
       return FALSE;
    }
 }
+
+/*
+ * Return extent number of the extent holding the page at 'addr'.
+ * This routine assume that input 'addr' is a valid page address.
+ */
+static inline uint64
+allocator_extent_number(allocator *al, uint64 page_addr)
+{
+   allocator_config *allocator_cfg = allocator_get_config(al);
+   debug_assert(allocator_valid_page_addr(al, page_addr));
+   return ((allocator_extent_base_addr(al, page_addr)
+            / allocator_cfg->io_cfg->extent_size));
+}
+uint64
+allocator_page_number(allocator *al, uint64 addr);
+
+uint64
+allocator_page_offset(allocator *al, uint64 page_addr);

--- a/src/mini_allocator.h
+++ b/src/mini_allocator.h
@@ -73,9 +73,9 @@ mini_alloc(mini_allocator *mini,
            key             alloc_key,
            uint64         *next_extent);
 
-
 uint8
 mini_unkeyed_inc_ref(cache *cc, uint64 meta_head);
+
 uint8
 mini_unkeyed_dec_ref(cache *cc, uint64 meta_head, page_type type, bool pinned);
 
@@ -112,6 +112,7 @@ mini_unkeyed_prefetch(cache *cc, page_type type, uint64 meta_head);
 
 void
 mini_unkeyed_print(cache *cc, uint64 meta_head, page_type type);
+
 void
 mini_keyed_print(cache       *cc,
                  data_config *data_cfg,

--- a/src/rc_allocator.c
+++ b/src/rc_allocator.c
@@ -206,7 +206,7 @@ const static allocator_ops rc_allocator_ops = {
 debug_only static inline bool
 rc_allocator_valid_extent_addr(rc_allocator *al, uint64 base_addr)
 {
-   return ((base_addr % al->cfg->io_cfg->extent_size) == 0);
+   return (allocator_valid_extent_addr((allocator *)al, base_addr));
 }
 
 /*
@@ -219,7 +219,7 @@ rc_allocator_valid_extent_addr(rc_allocator *al, uint64 base_addr)
 static inline uint64
 rc_allocator_extent_number(rc_allocator *al, uint64 addr)
 {
-   return (addr / al->cfg->io_cfg->extent_size);
+   return (allocator_extent_number((allocator *)al, addr));
 }
 
 static platform_status
@@ -472,7 +472,6 @@ rc_allocator_mount(rc_allocator      *al,
    return STATUS_OK;
 }
 
-
 void
 rc_allocator_unmount(rc_allocator *al)
 {
@@ -487,42 +486,49 @@ rc_allocator_unmount(rc_allocator *al)
    rc_allocator_deinit(al);
 }
 
-
 /*
  *----------------------------------------------------------------------
  * rc_allocator_[inc,dec,get]_ref --
  *
- *      Increments/decrements/fetches the ref count of the given address and
- *      returns the new one. If the ref_count goes to 0, then the extent is
- *      freed.
+ *      Increments/decrements/fetches the ref count of the extent given
+ *      by its address, extent_addr, and returns the new one.
  *----------------------------------------------------------------------
  */
 uint8
-rc_allocator_inc_ref(rc_allocator *al, uint64 addr)
+rc_allocator_inc_ref(rc_allocator *al, uint64 extent_addr)
 {
-   debug_assert(rc_allocator_valid_extent_addr(al, addr));
+   debug_assert(rc_allocator_valid_extent_addr(al, extent_addr));
 
-   uint64 extent_no = addr / al->cfg->io_cfg->extent_size;
-   debug_assert(extent_no < al->cfg->extent_capacity);
+   uint64 extent_no = allocator_extent_number((allocator *)al, extent_addr);
+   debug_assert((extent_no < al->cfg->extent_capacity),
+                "extent_no=%lu should be < extent_capacity=%lu\n",
+                extent_no,
+                al->cfg->extent_capacity);
 
    uint8 ref_count = __sync_add_and_fetch(&al->ref_count[extent_no], 1);
    platform_assert(ref_count != 1 && ref_count != 0);
-   if (SHOULD_TRACE(addr)) {
+   if (SHOULD_TRACE(extent_addr)) {
       platform_default_log("rc_allocator_inc_ref(%lu): %d -> %d\n",
-                           addr,
+                           extent_addr,
                            ref_count,
                            ref_count + 1);
    }
    return ref_count;
 }
 
+/*
+ * Upon decrement, if the ref_count goes to 0, then the extent is freed.
+ */
 uint8
-rc_allocator_dec_ref(rc_allocator *al, uint64 addr, page_type type)
+rc_allocator_dec_ref(rc_allocator *al, uint64 extent_addr, page_type type)
 {
-   debug_assert(rc_allocator_valid_extent_addr(al, addr));
+   debug_assert(rc_allocator_valid_extent_addr(al, extent_addr));
 
-   uint64 extent_no = addr / al->cfg->io_cfg->extent_size;
-   debug_assert(extent_no < al->cfg->extent_capacity);
+   uint64 extent_no = allocator_extent_number((allocator *)al, extent_addr);
+   debug_assert((extent_no < al->cfg->extent_capacity),
+                "extent_no=%lu should be < extent_capacity=%lu\n",
+                extent_no,
+                al->cfg->extent_capacity);
 
    uint8 ref_count = __sync_sub_and_fetch(&al->ref_count[extent_no], 1);
    platform_assert(ref_count != UINT8_MAX);
@@ -531,23 +537,29 @@ rc_allocator_dec_ref(rc_allocator *al, uint64 addr, page_type type)
       __sync_sub_and_fetch(&al->stats.curr_allocated, 1);
       __sync_add_and_fetch(&al->stats.extent_deallocs[type], 1);
    }
-   if (SHOULD_TRACE(addr)) {
+   if (SHOULD_TRACE(extent_addr)) {
       platform_default_log("rc_allocator_dec_ref(%lu): %d -> %d\n",
-                           addr,
+                           extent_addr,
                            ref_count,
                            ref_count - 1);
    }
    return ref_count;
 }
 
+/*
+ * Return the refcount for the extent given by its extent_addr address.
+ */
 uint8
-rc_allocator_get_ref(rc_allocator *al, uint64 addr)
+rc_allocator_get_ref(rc_allocator *al, uint64 extent_addr)
 {
    uint64 extent_no;
 
-   debug_assert(rc_allocator_valid_extent_addr(al, addr));
-   extent_no = rc_allocator_extent_number(al, addr);
-   debug_assert(extent_no < al->cfg->extent_capacity);
+   debug_assert(rc_allocator_valid_extent_addr(al, extent_addr));
+   extent_no = rc_allocator_extent_number(al, extent_addr);
+   debug_assert((extent_no < al->cfg->extent_capacity),
+                "extent_no=%lu should be < extent_capacity=%lu\n",
+                extent_no,
+                al->cfg->extent_capacity);
    return al->ref_count[extent_no];
 }
 
@@ -679,12 +691,13 @@ rc_allocator_get_config(rc_allocator *al)
  * rc_allocator_alloc--
  *
  *      Allocate an extent
+ *      Return the start of allocated extent via 'extent_addr'.
  *----------------------------------------------------------------------
  */
 platform_status
-rc_allocator_alloc(rc_allocator *al,   // IN
-                   uint64       *addr, // OUT
-                   page_type     type)     // IN
+rc_allocator_alloc(rc_allocator *al,          // IN
+                   uint64       *extent_addr, // OUT
+                   page_type     type)            // IN
 {
    uint64 first_hand = al->hand % al->cfg->extent_capacity;
    uint64 hand;
@@ -715,10 +728,12 @@ rc_allocator_alloc(rc_allocator *al,   // IN
       max_allocated = al->stats.max_allocated;
    }
    __sync_add_and_fetch(&al->stats.extent_allocs[type], 1);
-   *addr = hand * al->cfg->io_cfg->extent_size;
-   if (SHOULD_TRACE(*addr)) {
-      platform_default_log(
-         "rc_allocator_alloc_extent %12lu (%s)\n", *addr, page_type_str[type]);
+   *extent_addr = hand * al->cfg->io_cfg->extent_size;
+   if (SHOULD_TRACE(*extent_addr)) {
+      platform_default_log("%s(): extent=%12lu (for %s page)\n",
+                           __func__,
+                           *extent_addr,
+                           page_type_str[type]);
    }
 
    return STATUS_OK;

--- a/src/rc_allocator.h
+++ b/src/rc_allocator.h
@@ -94,3 +94,9 @@ rc_allocator_mount(rc_allocator      *al,
 
 void
 rc_allocator_unmount(rc_allocator *al);
+
+uint64
+rc_allocator_extent_size(rc_allocator *al);
+
+uint64
+rc_allocator_page_size(rc_allocator *al);

--- a/src/trunk.c
+++ b/src/trunk.c
@@ -315,8 +315,8 @@ trunk_log_node_if_enabled(platform_stream_handle *stream,
  *
  *  o Flushes and internal/leaf splits:
  *
- *          Flushes and internal/leaf splits are synchronous and do not
- *          interact.
+ *          Flushes and splits of trunk internal nodes / trunk leaf nodes are
+ *          synchronous and do not interact.
  *
  *  o Internal splits and compaction:
  *
@@ -2844,8 +2844,8 @@ trunk_zap_branch_range(trunk_handle *spl,
 }
 
 /*
- * Decrement the ref count for branch and destroy it and its filter if it
- * reaches 0.
+ * Decrement the ref count for a branch. Destroy the branch and its filter if
+ * the ref count reaches 0.
  */
 static inline void
 trunk_dec_ref(trunk_handle *spl, trunk_branch *branch, bool is_memtable)

--- a/tests/unit/allocator_test.c
+++ b/tests/unit/allocator_test.c
@@ -1,0 +1,362 @@
+// Copyright 2023 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+ * -----------------------------------------------------------------------------
+ * allocator_test.c --
+ *
+ * Exercises some of the interfaces in allocator.c . Also exercises some
+ * extern interfaces from rc_allocator.c, which is based on allocator.c
+ * -----------------------------------------------------------------------------
+ */
+#include "splinterdb/public_platform.h"
+#include "unit_tests.h"
+#include "ctest.h" // This is required for all test-case files.
+#include "rc_allocator.h"
+#include "config.h"
+
+/*
+ * Global data declaration macro:
+ */
+CTEST_DATA(allocator)
+{
+   // Declare head handles for io, allocator, cache and splinter allocation.
+   platform_heap_handle hh;
+   platform_heap_id     hid;
+   platform_module_id   mid;
+
+   // Config structs for sub-systems that clockcache depends on
+   io_config        io_cfg;
+   allocator_config al_cfg;
+
+   platform_io_handle *io;
+   allocator          *al;
+   rc_allocator       *rc_al;
+};
+
+// Setup function for suite, called before every test in suite
+CTEST_SETUP(allocator)
+{
+   uint64 heap_capacity = 1024 * MiB;
+
+   // Create a heap for io and allocator sub-systems
+   platform_status rc = platform_heap_create(
+      platform_get_module_id(), heap_capacity, &data->hh, &data->hid);
+   ASSERT_TRUE(SUCCESS(rc));
+
+   // Allocate memory for and set defaults for a master config struct
+   master_config *master_cfg = TYPED_ZALLOC(data->hid, master_cfg);
+   config_set_defaults(master_cfg);
+
+   io_config_init(&data->io_cfg,
+                  master_cfg->page_size,
+                  master_cfg->extent_size,
+                  master_cfg->io_flags,
+                  master_cfg->io_perms,
+                  master_cfg->io_async_queue_depth,
+                  master_cfg->io_filename);
+
+   allocator_config_init(
+      &data->al_cfg, &data->io_cfg, master_cfg->allocator_capacity);
+
+   // Allocate and initialize the IO, rc-allocator sub-systems.
+   data->io = TYPED_ZALLOC(data->hid, data->io);
+   ASSERT_TRUE((data->io != NULL));
+   rc = io_handle_init(data->io, &data->io_cfg, data->hh, data->hid);
+
+   data->rc_al = TYPED_ZALLOC(data->hid, data->rc_al);
+   ASSERT_TRUE((data->rc_al != NULL));
+   rc_allocator_init(data->rc_al,
+                     &data->al_cfg,
+                     (io_handle *)data->io,
+                     data->hid,
+                     platform_get_module_id());
+   data->al = (allocator *)data->rc_al;
+
+   platform_free(data->hid, master_cfg);
+}
+
+// Teardown function for suite, called after every test in suite
+CTEST_TEARDOWN(allocator)
+{
+   rc_allocator_deinit(data->rc_al);
+   platform_free(data->hid, data->rc_al);
+   data->al = NULL;
+
+   io_handle_deinit(data->io);
+   platform_free(data->hid, data->io);
+
+   platform_heap_destroy(&data->hh);
+}
+
+/*
+ * Validate that page-/extent-address methods work correctly on some
+ * fabricated page and extent addresses.
+ */
+CTEST2(allocator, test_allocator_valid_page_addr)
+{
+   ASSERT_TRUE(allocator_valid_page_addr(data->al, 0));
+
+   // Directly access innards of allocator to get page/extent sizes.
+   allocator_config *allocator_cfg = allocator_get_config(data->al);
+
+   uint64 page_size   = allocator_cfg->io_cfg->page_size;
+   uint64 extent_size = allocator_cfg->io_cfg->extent_size;
+
+   ASSERT_TRUE(allocator_valid_page_addr(data->al, page_size));
+   ASSERT_TRUE(allocator_valid_page_addr(data->al, (2 * page_size)));
+   ASSERT_TRUE(allocator_valid_page_addr(data->al, (3 * page_size)));
+
+   ASSERT_TRUE(allocator_valid_page_addr(data->al, extent_size));
+   ASSERT_TRUE(allocator_valid_page_addr(data->al, (2 * extent_size)));
+   ASSERT_TRUE(allocator_valid_page_addr(data->al, (extent_size + page_size)));
+
+   /* Following are invalid page-addresses; so the check should fail */
+   ASSERT_FALSE(allocator_valid_page_addr(data->al, (page_size - 1)));
+   ASSERT_FALSE(allocator_valid_page_addr(data->al, (page_size + 1)));
+   ASSERT_FALSE(allocator_valid_page_addr(data->al, (extent_size - 1)));
+   ASSERT_FALSE(allocator_valid_page_addr(data->al, (extent_size + 1)));
+   ASSERT_FALSE(allocator_valid_page_addr(
+      data->al, ((2 * extent_size) + (page_size / 2))));
+}
+
+/* Validate correctness of allocator_valid_extent_addr() boolean */
+CTEST2(allocator, test_allocator_valid_extent_addr)
+{
+   // Use accessor method from rc_allocator to get page/extent size
+   uint64 page_size   = rc_allocator_page_size(data->rc_al);
+   uint64 extent_size = rc_allocator_extent_size(data->rc_al);
+   ASSERT_TRUE(allocator_valid_extent_addr(data->al, extent_size));
+
+   ASSERT_FALSE(allocator_valid_extent_addr(data->al, (extent_size - 1)));
+   ASSERT_FALSE(allocator_valid_extent_addr(data->al, (extent_size + 1)));
+
+   ASSERT_FALSE(
+      allocator_valid_extent_addr(data->al, (extent_size + page_size)));
+
+   // Run through all page-addresses in an extent to verify boolean macro
+   uint64 npages_in_extent = (extent_size / page_size);
+   uint64 extent_addr      = (42 * extent_size);
+
+   uint64 page_addr = extent_addr;
+   ASSERT_TRUE(allocator_valid_extent_addr(data->al, page_addr));
+
+   // Position to 2nd page in the extent.
+   page_addr += page_size;
+   for (uint64 pgctr = 1; pgctr < npages_in_extent;
+        pgctr++, page_addr += page_size)
+   {
+      ASSERT_FALSE(allocator_valid_extent_addr(data->al, page_addr),
+                   "pgctr=%lu, page_addr=%lu\n",
+                   pgctr,
+                   page_addr);
+   }
+
+   // Now we should be positioned at the start of next extent.
+   ASSERT_TRUE(allocator_valid_extent_addr(data->al, page_addr));
+}
+
+/* Validate correctness of allocator_extent_base_addr() conversion function */
+CTEST2(allocator, test_allocator_extent_base_addr)
+{
+   uint64 extent_size = rc_allocator_extent_size(data->rc_al);
+   uint64 page_size   = rc_allocator_page_size(data->rc_al);
+
+   uint64 extent_num  = 4321;
+   uint64 extent_addr = (extent_num * extent_size);
+
+   // Run through all page-addresses in an extent to verify conversion macro
+   uint64 npages_in_extent = (extent_size / page_size);
+   uint64 page_addr        = extent_addr;
+   ASSERT_EQUAL(extent_addr, allocator_extent_base_addr(data->al, page_addr));
+
+   // Position to 2nd page in the extent.
+   page_addr += page_size;
+   for (uint64 pgctr = 1; pgctr < npages_in_extent;
+        pgctr++, page_addr += page_size)
+   {
+      ASSERT_EQUAL(extent_addr,
+                   allocator_extent_base_addr(data->al, page_addr));
+   }
+
+   // Now page_addr should be positioned on the next extent.
+   ASSERT_EQUAL((extent_addr + extent_size),
+                allocator_extent_base_addr(data->al, page_addr));
+}
+
+/* Validate correctness of allocator_extent_number() conversion function */
+CTEST2(allocator, test_allocator_extent_number)
+{
+   uint64 page_size   = rc_allocator_page_size(data->rc_al);
+   uint64 extent_size = rc_allocator_extent_size(data->rc_al);
+
+   uint64 extent_num  = 42;
+   uint64 extent_addr = (extent_num * extent_size);
+
+   // Run through all page-addresses in an extent to verify conversion macro
+   uint64 npages_in_extent = (extent_size / page_size);
+   uint64 page_addr        = extent_addr;
+   ASSERT_EQUAL(extent_num, allocator_extent_number(data->al, page_addr));
+
+   // Position to 2nd page in the extent.
+   page_addr += page_size;
+   for (uint64 pgctr = 1; pgctr < npages_in_extent;
+        pgctr++, page_addr += page_size)
+   {
+      ASSERT_EQUAL(extent_num, allocator_extent_number(data->al, page_addr));
+   }
+   // Now page_addr should be positioned on the next extent.
+   ASSERT_TRUE(allocator_valid_extent_addr(data->al, page_addr));
+   ASSERT_EQUAL((extent_num + 1), allocator_extent_number(data->al, page_addr));
+}
+
+/* Validate correctness of allocator_page_number() conversion function */
+CTEST2(allocator, test_allocator_page_number)
+{
+   uint64 page_size   = rc_allocator_page_size(data->rc_al);
+   uint64 extent_size = rc_allocator_extent_size(data->rc_al);
+
+   uint64 extent_num  = 4200;
+   uint64 extent_addr = (extent_num * extent_size);
+
+   // Run through all page-addresses in an extent to verify conversion macro
+   uint64 npages_in_extent = (extent_size / page_size);
+   uint64 start_pageno     = (extent_num * npages_in_extent);
+
+   uint64 page_addr = extent_addr;
+   for (uint64 pgctr = 0; pgctr < npages_in_extent;
+        pgctr++, page_addr += page_size)
+   {
+      uint64 exp_pageno = (start_pageno + pgctr);
+      ASSERT_EQUAL(exp_pageno, allocator_page_number(data->al, page_addr));
+   }
+}
+
+/* Validate correctness of allocator_page_offset() conversion function */
+CTEST2(allocator, test_allocator_page_offset)
+{
+   uint64 page_size   = rc_allocator_page_size(data->rc_al);
+   uint64 extent_size = rc_allocator_extent_size(data->rc_al);
+
+   uint64 extent_num  = 4200;
+   uint64 extent_addr = (extent_num * extent_size);
+
+   // Run through all page-addresses in an extent to verify conversion macro
+   uint64 npages_in_extent = (extent_size / page_size);
+
+   uint64 page_addr = extent_addr;
+   for (uint64 pgctr = 0; pgctr < npages_in_extent;
+        pgctr++, page_addr += page_size)
+   {
+      ASSERT_EQUAL(pgctr, allocator_page_offset(data->al, page_addr));
+   }
+   // Now page_addr should be positioned at the start of the next extent.
+   ASSERT_EQUAL(0, allocator_page_offset(data->al, page_addr));
+}
+
+/*
+ * Validate correctness of allocator_page_valid() boolean checker function.
+ * In this test case, we have not done any actual allocations, yet. So use
+ * use page-addresses to verify different checks done in the boolean
+ * checker-function, some of which may raise error messages. (We don't quite
+ * check the actual error, just that all code paths are exercised.)
+ */
+CTEST2(allocator, test_error_checks_in_allocator_page_valid)
+{
+   uint64 extent_size = rc_allocator_extent_size(data->rc_al);
+   uint64 page_size   = rc_allocator_page_size(data->rc_al);
+
+   uint64 extent_num  = 4200;
+   uint64 extent_addr = (extent_num * extent_size);
+
+   uint64 page_addr = extent_addr;
+
+   // Invalid page-address should trip an error message.
+   ASSERT_FALSE(allocator_page_valid(data->al, (page_addr + 1)));
+
+   // Should raise an error that extent is unreferenced.
+   ASSERT_FALSE(allocator_page_valid(data->al, page_addr));
+
+   // Check pages outside capacity of configured db
+   page_addr = allocator_get_capacity(data->al) + page_size;
+   ASSERT_FALSE(allocator_page_valid(data->al, page_addr));
+}
+
+/*
+ * Validate correctness of allocator_alloc() function. Successive calls
+ * to this function should 'allocate' different extents.
+ */
+CTEST2(allocator, test_allocator_alloc)
+{
+   uint64          extent_addr1 = 0;
+   platform_status rc           = STATUS_TEST_FAILED;
+
+   rc = allocator_alloc(data->al, &extent_addr1, PAGE_TYPE_BRANCH);
+   ASSERT_TRUE(SUCCESS(rc));
+   ASSERT_TRUE(extent_addr1 != 0);
+
+   uint64 extent_addr2 = 0;
+   rc = allocator_alloc(data->al, &extent_addr2, PAGE_TYPE_BRANCH);
+   ASSERT_TRUE(SUCCESS(rc));
+   ASSERT_TRUE(extent_addr2 != 0);
+
+   ASSERT_TRUE(extent_addr1 != extent_addr2);
+}
+
+/*
+ * Validate correctness of allocator_alloc() and subsequent refcount handling.
+ */
+CTEST2(allocator, test_allocator_refcounts)
+{
+   page_type       ptype       = PAGE_TYPE_BRANCH;
+   uint64          extent_addr = 0;
+   platform_status rc          = STATUS_TEST_FAILED;
+
+   rc = allocator_alloc(data->al, &extent_addr, ptype);
+   ASSERT_TRUE(SUCCESS(rc));
+
+   uint8 refcount = allocator_get_refcount(data->al, extent_addr);
+   ASSERT_EQUAL(2, refcount);
+
+   refcount = allocator_inc_ref(data->al, extent_addr);
+   ASSERT_EQUAL(3, refcount);
+
+   refcount = allocator_dec_ref(data->al, extent_addr, ptype);
+   ASSERT_EQUAL(2, refcount);
+
+   refcount = allocator_dec_ref(data->al, extent_addr, ptype);
+   ASSERT_EQUAL(1, refcount);
+
+   refcount = allocator_dec_ref(data->al, extent_addr, ptype);
+   ASSERT_EQUAL(0, refcount);
+
+   refcount = allocator_get_refcount(data->al, extent_addr);
+   ASSERT_EQUAL(0, refcount);
+}
+
+/*
+ * Validate correctness of allocator_page_valid() boolean checker function
+ * after having allocated an extent. As long as it's a valid page address
+ * and the holding extent has a non-zero reference count, the boolean function
+ * will return TRUE.
+ */
+CTEST2(allocator, test_allocator_page_valid)
+{
+   uint64 extent_size = rc_allocator_extent_size(data->rc_al);
+   uint64 page_size   = rc_allocator_page_size(data->rc_al);
+
+   uint64          extent_addr = 0;
+   platform_status rc =
+      allocator_alloc(data->al, &extent_addr, PAGE_TYPE_BRANCH);
+   ASSERT_TRUE(SUCCESS(rc));
+
+   // All pages in extent should appear as validly 'allocated'
+   uint64 page_addr        = extent_addr;
+   uint64 npages_in_extent = (extent_size / page_size);
+
+   for (uint64 pgctr = 0; pgctr < npages_in_extent;
+        pgctr++, page_addr += page_size)
+   {
+      ASSERT_TRUE(allocator_page_valid(data->al, page_addr));
+   }
+}


### PR DESCRIPTION
This commit refactors and does some minor cleanup of code in `allocator.{h,c}` and couple of related files. Some page / extent number / offset boolean and conversion macros are added, along with unit-tests. No significant change in code-logic is being introduced with this fix.


---- 
No major code / logic changes. Introduced a new unit-test to exercise interfaces in `allocator.c` and `rc_allocator.c` (indirectly), along with additions of minor interfaces to manipulate page / extent addresses / validity etc.