### PR TITLE
Replace all instances of platform_default_log() with CTEST_LOG_INFO()

### DIFF
--- a/tests/unit/large_inserts_bugs_stress_test.c
+++ b/tests/unit/large_inserts_bugs_stress_test.c
@@ -198,7 +198,7 @@ CTEST2_SKIP(large_inserts_bugs_stress,
       uint64 elapsed_ns      = platform_timestamp_elapsed(start_time);
       uint64 test_elapsed_ns = platform_timestamp_elapsed(test_start_time);
 
-      platform_default_log(
+      CTEST_LOG_INFO(
          PLATFORM_CR
          "Inserted %lu million KV-pairs"
          ", this batch: %lu s, %lu rows/s, cumulative: %lu s, %lu rows/s ...",
@@ -314,19 +314,19 @@ CTEST2(large_inserts_bugs_stress, test_seq_key_seq_values_inserts_forked)
          platform_error_log("fork() of child process failed: pid=%d\n", pid);
          return;
       } else if (pid) {
-         platform_default_log("Thread-ID=%lu, OS-pid=%d: "
-                              "Waiting for child pid=%d to complete ...\n",
-                              platform_get_tid(),
-                              getpid(),
-                              pid);
+         CTEST_LOG_INFO("Thread-ID=%lu, OS-pid=%d: "
+                        "Waiting for child pid=%d to complete ...\n",
+                        platform_get_tid(),
+                        getpid(),
+                        pid);
 
          wait(NULL);
 
-         platform_default_log("Thread-ID=%lu, OS-pid=%d: "
-                              "Child execution wait() completed."
-                              " Resuming parent ...\n",
-                              platform_get_tid(),
-                              getpid());
+         CTEST_LOG_INFO("Thread-ID=%lu, OS-pid=%d: "
+                        "Child execution wait() completed."
+                        " Resuming parent ...\n",
+                        platform_get_tid(),
+                        getpid());
       }
    }
    if (pid == 0) {
@@ -334,19 +334,18 @@ CTEST2(large_inserts_bugs_stress, test_seq_key_seq_values_inserts_forked)
       data->am_parent = FALSE;
       data->this_pid  = getpid();
 
-      platform_default_log(
-         "Running as %s process OS-pid=%d ...\n",
-         (wcfg.master_cfg->fork_child ? "forked child" : "parent"),
-         data->this_pid);
+      CTEST_LOG_INFO("Running as %s process OS-pid=%d ...\n",
+                     (wcfg.master_cfg->fork_child ? "forked child" : "parent"),
+                     data->this_pid);
 
       splinterdb_register_thread(wcfg.kvsb);
 
       exec_worker_thread(&wcfg);
 
-      platform_default_log("Child process Thread-ID=%lu"
-                           ", OS-pid=%d completed inserts.\n",
-                           platform_get_tid(),
-                           data->this_pid);
+      CTEST_LOG_INFO("Child process Thread-ID=%lu"
+                     ", OS-pid=%d completed inserts.\n",
+                     platform_get_tid(),
+                     data->this_pid);
       splinterdb_deregister_thread(wcfg.kvsb);
       return;
    }
@@ -607,19 +606,19 @@ exec_worker_thread(void *w)
                                    : (random_val_fd == 0) ? "sequential"
                                                           : "fully-packed constant");
 
-   platform_default_log("%s()::%d:Thread %-2lu inserts %lu (%lu million)"
-                        ", %s key, %s value, "
-                        "KV-pairs starting from %lu (%lu%s) ...\n",
-                        __FUNCTION__,
-                        __LINE__,
-                        thread_idx,
-                        num_inserts,
-                        (num_inserts / MILLION),
-                        ((random_key_fd > 0) ? "random" : "sequential"),
-                        random_val_descr,
-                        start_key,
-                        (start_key / MILLION),
-                        (start_key ? " million" : ""));
+   CTEST_LOG_INFO("%s()::%d:Thread %-2lu inserts %lu (%lu million)"
+                  ", %s key, %s value, "
+                  "KV-pairs starting from %lu (%lu%s) ...\n",
+                  __FUNCTION__,
+                  __LINE__,
+                  thread_idx,
+                  num_inserts,
+                  (num_inserts / MILLION),
+                  ((random_key_fd > 0) ? "random" : "sequential"),
+                  random_val_descr,
+                  start_key,
+                  (start_key / MILLION),
+                  (start_key ? " million" : ""));
 
    uint64 ictr = 0;
    uint64 jctr = 0;
@@ -662,12 +661,12 @@ exec_worker_thread(void *w)
 
             val_len = result;
             if (!val_length_msg_printed) {
-               platform_default_log("OS-pid=%d, Thread-ID=%lu"
-                                    ", Insert random value of "
-                                    "fixed-length=%lu bytes.\n",
-                                    getpid(),
-                                    thread_idx,
-                                    val_len);
+               CTEST_LOG_INFO("OS-pid=%d, Thread-ID=%lu"
+                              ", Insert random value of "
+                              "fixed-length=%lu bytes.\n",
+                              getpid(),
+                              thread_idx,
+                              val_len);
                val_length_msg_printed = TRUE;
             }
          } else if (random_val_fd == 0) {
@@ -676,21 +675,21 @@ exec_worker_thread(void *w)
             val_len = strlen(val_data);
 
             if (!val_length_msg_printed) {
-               platform_default_log("OS-pid=%d, Thread-ID=%lu"
-                                    ", Insert small-width sequential values of "
-                                    "different lengths.\n",
-                                    getpid(),
-                                    thread_idx);
+               CTEST_LOG_INFO("OS-pid=%d, Thread-ID=%lu"
+                              ", Insert small-width sequential values of "
+                              "different lengths.\n",
+                              getpid(),
+                              thread_idx);
                val_length_msg_printed = TRUE;
             }
          } else if (random_val_fd < 0) {
             if (!val_length_msg_printed) {
-               platform_default_log("OS-pid=%d, Thread-ID=%lu"
-                                    ", Insert fully-packed fixed value of "
-                                    "length=%lu bytes.\n",
-                                    getpid(),
-                                    thread_idx,
-                                    val_len);
+               CTEST_LOG_INFO("OS-pid=%d, Thread-ID=%lu"
+                              ", Insert fully-packed fixed value of "
+                              "length=%lu bytes.\n",
+                              getpid(),
+                              thread_idx,
+                              val_len);
                val_length_msg_printed = TRUE;
             }
          }
@@ -702,7 +701,7 @@ exec_worker_thread(void *w)
          ASSERT_EQUAL(0, rc);
       }
       if (verbose_progress) {
-         platform_default_log(
+         CTEST_LOG_INFO(
             "%s()::%d:Thread-%lu Inserted %lu million KV-pairs ...\n",
             __FUNCTION__,
             __LINE__,
@@ -711,15 +710,19 @@ exec_worker_thread(void *w)
       }
    }
    uint64 elapsed_ns = platform_timestamp_elapsed(start_time);
+   uint64 elapsed_s  = NSEC_TO_SEC(elapsed_ns);
+   if (elapsed_ns == 0) {
+      elapsed_s = 1;
+   }
 
-   platform_default_log("%s()::%d:Thread-%lu Inserted %lu million KV-pairs in "
-                        "%lu s, %lu rows/s\n",
-                        __FUNCTION__,
-                        __LINE__,
-                        thread_idx,
-                        ictr, // outer-loop ends at #-of-Millions inserted
-                        NSEC_TO_SEC(elapsed_ns),
-                        (num_inserts / NSEC_TO_SEC(elapsed_ns)));
+   CTEST_LOG_INFO("%s()::%d:Thread-%lu Inserted %lu million KV-pairs in "
+                  "%lu ns, %lu rows/s\n",
+                  __FUNCTION__,
+                  __LINE__,
+                  thread_idx,
+                  ictr, // outer-loop ends at #-of-Millions inserted
+                  elapsed_ns,
+                  (num_inserts / elapsed_s));
 
    if (wcfg->is_thread) {
       splinterdb_deregister_thread(kvsb);

--- a/tests/unit/splinter_shmem_test.c
+++ b/tests/unit/splinter_shmem_test.c
@@ -349,11 +349,11 @@ CTEST2(splinter_shmem, test_concurrent_allocs_by_n_threads)
 
    ZERO_ARRAY(thread_cfg);
 
-   platform_default_log("\nExecute %d concurrent threads peforming memory "
-                        "allocation till we run out of memory in the shared "
-                        "segment.\n"
-                        "('Insufficient memory' errors are expected below.)\n",
-                        TEST_MAX_THREADS);
+   CTEST_LOG_INFO("\nExecute %d concurrent threads peforming memory "
+                  "allocation till we run out of memory in the shared "
+                  "segment.\n"
+                  "('Insufficient memory' errors are expected below.)\n",
+                  TEST_MAX_THREADS);
 
    // Start-up n-threads, record their expected thread-IDs, which will be
    // validated by the thread's execution function below.
@@ -648,7 +648,7 @@ exec_thread_memalloc(void *arg)
    }
    splinterdb_deregister_thread(kvs);
 
-   platform_default_log(
+   CTEST_LOG_INFO(
       "Thread-ID=%lu allocated %lu memory fragments of %lu bytes each.\n",
       this_thread_idx,
       nallocs,

--- a/tests/unit/splinter_test.c
+++ b/tests/unit/splinter_test.c
@@ -67,7 +67,7 @@ test_lookup_by_range(void         *datap,
 #define SHOW_PCT_PROGRESS(op_num, num_ops, msg)                                \
    do {                                                                        \
       if (((op_num) % ((num_ops) / 100)) == 0) {                               \
-         platform_default_log(PLATFORM_CR msg, (op_num) / ((num_ops) / 100));  \
+         CTEST_LOG_INFO(PLATFORM_CR msg, (op_num) / ((num_ops) / 100));        \
       }                                                                        \
    } while (0)
 
@@ -129,9 +129,6 @@ CTEST_SETUP(splinter)
    heap_capacity        = MAX(heap_capacity, 2 * GiB);
 
    bool use_shmem = test_using_shmem(Ctest_argc, (char **)Ctest_argv);
-   if (use_shmem) {
-      platform_default_log("Run test using shared memory segment.\n");
-   }
 
    // Create a heap for io, allocator, cache and splinter
    platform_status rc = platform_heap_create(platform_get_module_id(),

--- a/tests/unit/splinterdb_forked_child_test.c
+++ b/tests/unit/splinterdb_forked_child_test.c
@@ -131,8 +131,7 @@ CTEST2(splinterdb_forked_child, test_data_structures_handles)
    // Parent / main() process is always at tid==0.
    ASSERT_EQUAL(0, platform_get_tid());
 
-   platform_default_log(
-      "Thread-ID=%lu, Parent OS-pid=%d\n", platform_get_tid(), pid);
+   CTEST_LOG_INFO("Thread-ID=%lu, Parent OS-pid=%d\n", platform_get_tid(), pid);
    pid = fork();
 
    if (pid < 0) {
@@ -243,8 +242,7 @@ CTEST2(splinterdb_forked_child, test_one_insert_then_close_bug)
 
    int pid = getpid();
 
-   platform_default_log(
-      "Thread-ID=%lu, Parent OS-pid=%d\n", platform_get_tid(), pid);
+   CTEST_LOG_INFO("Thread-ID=%lu, Parent OS-pid=%d\n", platform_get_tid(), pid);
    pid = fork();
 
    if (pid < 0) {
@@ -254,10 +252,10 @@ CTEST2(splinterdb_forked_child, test_one_insert_then_close_bug)
       // Perform some inserts through child process
       splinterdb_register_thread(spl_handle);
 
-      platform_default_log("Thread-ID=%lu, OS-pid=%d: "
-                           "Child execution started ...\n",
-                           platform_get_tid(),
-                           getpid());
+      CTEST_LOG_INFO("Thread-ID=%lu, OS-pid=%d: "
+                     "Child execution started ...\n",
+                     platform_get_tid(),
+                     getpid());
 
       char   key_data[30];
       size_t key_len;
@@ -283,19 +281,19 @@ CTEST2(splinterdb_forked_child, test_one_insert_then_close_bug)
 
    // Only parent can close Splinter
    if (pid) {
-      platform_default_log("Thread-ID=%lu, OS-pid=%d: "
-                           "Waiting for child pid=%d to complete ...\n",
-                           platform_get_tid(),
-                           getpid(),
-                           pid);
+      CTEST_LOG_INFO("Thread-ID=%lu, OS-pid=%d: "
+                     "Waiting for child pid=%d to complete ...\n",
+                     platform_get_tid(),
+                     getpid(),
+                     pid);
 
       safe_wait();
 
-      platform_default_log("Thread-ID=%lu, OS-pid=%d: "
-                           "Child execution wait() completed."
-                           " Resuming parent ...\n",
-                           platform_get_tid(),
-                           getpid());
+      CTEST_LOG_INFO("Thread-ID=%lu, OS-pid=%d: "
+                     "Child execution wait() completed."
+                     " Resuming parent ...\n",
+                     platform_get_tid(),
+                     getpid());
 
       // We would get assertions tripping from BTree iterator code here,
       // if the fix in platform_buffer_create_mmap() to use MAP_SHARED
@@ -361,8 +359,7 @@ CTEST2(splinterdb_forked_child,
 
    int pid = getpid();
 
-   platform_default_log(
-      "Thread-ID=%lu, Parent OS-pid=%d\n", platform_get_tid(), pid);
+   CTEST_LOG_INFO("Thread-ID=%lu, Parent OS-pid=%d\n", platform_get_tid(), pid);
    pid = fork();
 
    if (pid < 0) {
@@ -372,7 +369,7 @@ CTEST2(splinterdb_forked_child,
       // Perform some inserts through child process
       splinterdb_register_thread(spl_handle);
 
-      platform_default_log(
+      CTEST_LOG_INFO(
          "Thread-ID=%lu, OS-pid=%d: "
          "Child execution started: Test cache-flush before deregister ...\n",
          platform_get_tid(),
@@ -387,7 +384,7 @@ CTEST2(splinterdb_forked_child,
       // Repeat the insert exercise: Perform some inserts through child process
       splinterdb_register_thread(spl_handle);
 
-      platform_default_log(
+      CTEST_LOG_INFO(
          "Thread-ID=%lu, OS-pid=%d: Test cache-flush after deregister:\n",
          platform_get_tid(),
          getpid());
@@ -407,19 +404,19 @@ CTEST2(splinterdb_forked_child,
 
    // Only parent can close Splinter
    if (pid) {
-      platform_default_log("Thread-ID=%lu, OS-pid=%d: "
-                           "Waiting for child pid=%d to complete ...\n",
-                           platform_get_tid(),
-                           getpid(),
-                           pid);
+      CTEST_LOG_INFO("Thread-ID=%lu, OS-pid=%d: "
+                     "Waiting for child pid=%d to complete ...\n",
+                     platform_get_tid(),
+                     getpid(),
+                     pid);
 
       safe_wait();
 
-      platform_default_log("Thread-ID=%lu, OS-pid=%d: "
-                           "Child execution wait() completed."
-                           " Resuming parent ...\n",
-                           platform_get_tid(),
-                           getpid());
+      CTEST_LOG_INFO("Thread-ID=%lu, OS-pid=%d: "
+                     "Child execution wait() completed."
+                     " Resuming parent ...\n",
+                     platform_get_tid(),
+                     getpid());
       splinterdb_close(&spl_handle);
    } else {
       // child should not attempt to run the rest of the tests
@@ -464,7 +461,7 @@ CTEST2(splinterdb_forked_child, test_forked_processes_doing_IOs)
 
    int pid = getpid();
 
-   platform_default_log(
+   CTEST_LOG_INFO(
       "Thread-ID=%lu, Parent OS-pid=%d, fork %lu child processes.\n",
       platform_get_tid(),
       pid,
@@ -496,7 +493,7 @@ CTEST2(splinterdb_forked_child, test_forked_processes_doing_IOs)
          // Perform some inserts through child process
          splinterdb_register_thread(spl_handle);
 
-         platform_default_log(
+         CTEST_LOG_INFO(
             "\n**** Thread-ID=%lu, OS-pid=%d: "
             "Child execution started: Perform %lu (%d million) inserts ...\n",
             platform_get_tid(),
@@ -522,13 +519,13 @@ CTEST2(splinterdb_forked_child, test_forked_processes_doing_IOs)
 
    // Only parent can close Splinter
    if (data->am_parent && pid) {
-      platform_default_log("Thread-ID=%lu, OS-pid=%d: "
-                           "Waiting for child pids to complete: ",
-                           platform_get_tid(),
-                           getpid());
+      CTEST_LOG_INFO("Thread-ID=%lu, OS-pid=%d: "
+                     "Waiting for child pids to complete: ",
+                     platform_get_tid(),
+                     getpid());
 
       for (int fctr = 0; fctr < data->num_forked_procs; fctr++) {
-         platform_default_log("pid=%d ", forked_pids[fctr]);
+         CTEST_LOG_INFO("pid=%d ", forked_pids[fctr]);
       }
 
       // Wait-for -ALL- children to finish; duh!
@@ -542,11 +539,11 @@ CTEST2(splinterdb_forked_child, test_forked_processes_doing_IOs)
          platform_assert(WEXITSTATUS(wstatus) == 0);
       }
 
-      platform_default_log("\nThread-ID=%lu, OS-pid=%d: "
-                           "Child execution wait() completed."
-                           " Resuming parent ...\n",
-                           platform_get_tid(),
-                           getpid());
+      CTEST_LOG_INFO("\nThread-ID=%lu, OS-pid=%d: "
+                     "Child execution wait() completed."
+                     " Resuming parent ...\n",
+                     platform_get_tid(),
+                     getpid());
       splinterdb_close(&spl_handle);
    } else {
       // child should not attempt to run the rest of the tests
@@ -589,15 +586,15 @@ do_many_inserts(splinterdb *kvsb, uint64 num_inserts)
    // Test is written to insert multiples of millions per thread.
    ASSERT_EQUAL(0, (num_inserts % MILLION));
 
-   platform_default_log("%s()::%d:Thread-%-lu inserts %lu (%lu million)"
-                        ", sequential key, sequential value, "
-                        "KV-pairs starting from %lu ...\n",
-                        __FUNCTION__,
-                        __LINE__,
-                        thread_idx,
-                        num_inserts,
-                        (num_inserts / MILLION),
-                        start_key);
+   CTEST_LOG_INFO("%s()::%d:Thread-%-lu inserts %lu (%lu million)"
+                  ", sequential key, sequential value, "
+                  "KV-pairs starting from %lu ...\n",
+                  __FUNCTION__,
+                  __LINE__,
+                  thread_idx,
+                  num_inserts,
+                  (num_inserts / MILLION),
+                  start_key);
 
    uint64 ictr = 0;
    uint64 jctr = 0;
@@ -622,7 +619,7 @@ do_many_inserts(splinterdb *kvsb, uint64 num_inserts)
          ASSERT_EQUAL(0, rc);
       }
       if (verbose_progress) {
-         platform_default_log(
+         CTEST_LOG_INFO(
             "%s()::%d:Thread-%lu Inserted %lu million KV-pairs ...\n",
             __FUNCTION__,
             __LINE__,
@@ -632,12 +629,12 @@ do_many_inserts(splinterdb *kvsb, uint64 num_inserts)
    }
    uint64 elapsed_ns = platform_timestamp_elapsed(start_time);
 
-   platform_default_log("%s()::%d:Thread-%lu Inserted %lu million KV-pairs in "
-                        "%lu s, %lu rows/s\n",
-                        __FUNCTION__,
-                        __LINE__,
-                        thread_idx,
-                        ictr, // outer-loop ends at #-of-Millions inserted
-                        NSEC_TO_SEC(elapsed_ns),
-                        (num_inserts / NSEC_TO_SEC(elapsed_ns)));
+   CTEST_LOG_INFO("%s()::%d:Thread-%lu Inserted %lu million KV-pairs in "
+                  "%lu s, %lu rows/s\n",
+                  __FUNCTION__,
+                  __LINE__,
+                  thread_idx,
+                  ictr, // outer-loop ends at #-of-Millions inserted
+                  NSEC_TO_SEC(elapsed_ns),
+                  (num_inserts / NSEC_TO_SEC(elapsed_ns)));
 }


### PR DESCRIPTION
Also, minor fix in exec_worker_thread() in large_inserts_bugs_stress_test.c to avoid divide-by-0 error when elapsed_ns is too small.

-- Note to @rosenhouse : With this change, all unit-tests added newly by my shared-memory prototype work are changed to consistently use `CTEST_LOG_INFO()`. This brings them in-sync with recently added unit-test verbosity levels interfaces and behaviour.

Here is the confirmation:

```
agurajada/gabe/shmem-squash-logging-ovhds-poc

sdb-fdb-build:[16] $ grep -l -w platform_log *.c
sdb-fdb-build:[17] $ grep -l -w platform_default_log *.c
```