### PR TITLE
Add COMMIT support; add splinterdb_commit(). --commit-every test option. Update unit tests.

### DIFF
--- a/include/splinterdb/splinterdb.h
+++ b/include/splinterdb/splinterdb.h
@@ -165,6 +165,10 @@ splinterdb_delete(const splinterdb *kvsb, slice key);
 int
 splinterdb_update(const splinterdb *kvsb, slice key, slice delta);
 
+// Commit the set of changes done to Splinter since the last COMMIT
+int
+splinterdb_commit(const splinterdb *kvsb);
+
 // Lookups
 
 // Size of opaque data required to hold a lookup result

--- a/src/cache.h
+++ b/src/cache.h
@@ -165,7 +165,7 @@ typedef cache_async_result (*page_get_async_fn)(cache            *cc,
 typedef void (*page_async_done_fn)(cache            *cc,
                                    page_type         type,
                                    cache_async_ctxt *ctxt);
-typedef bool (*page_try_claim_fn)(cache *cc, page_handle *page);
+typedef bool (*page_claim_fn)(cache *cc, page_handle *page);
 typedef void (*page_write_fn)(cache *cc, page_handle *page, page_type type);
 typedef void (*extent_sync_fn)(cache  *cc,
                                uint64  addr,

--- a/src/cache.h
+++ b/src/cache.h
@@ -165,11 +165,8 @@ typedef cache_async_result (*page_get_async_fn)(cache            *cc,
 typedef void (*page_async_done_fn)(cache            *cc,
                                    page_type         type,
                                    cache_async_ctxt *ctxt);
-typedef bool (*page_claim_fn)(cache *cc, page_handle *page);
-typedef void (*page_sync_fn)(cache       *cc,
-                             page_handle *page,
-                             bool         is_blocking,
-                             page_type    type);
+typedef bool (*page_try_claim_fn)(cache *cc, page_handle *page);
+typedef void (*page_write_fn)(cache *cc, page_handle *page, page_type type);
 typedef void (*extent_sync_fn)(cache  *cc,
                                uint64  addr,
                                uint64 *pages_outstanding);
@@ -208,7 +205,8 @@ typedef struct cache_ops {
    page_generic_fn      page_mark_dirty;
    page_generic_fn      page_pin;
    page_generic_fn      page_unpin;
-   page_sync_fn         page_sync;
+   page_write_fn        page_async_write;
+   page_write_fn        page_sync_write;
    extent_sync_fn       extent_sync;
    cache_generic_fn     flush;
    evict_fn             evict;
@@ -336,10 +334,37 @@ cache_unpin(cache *cc, page_handle *page)
    return cc->ops->page_unpin(cc, page);
 }
 
+/*
+ *-----------------------------------------------------------------------------
+ * cache_page_async_write
+ *
+ * Asynchronously writes the page back to disk.
+ *
+ * This is used to write log pages opportunistically. The current API doesn't
+ * inform the user when this happens. "It's not the ideal API." -- @aconway
+ *-----------------------------------------------------------------------------
+ */
 static inline void
-cache_page_sync(cache *cc, page_handle *page, bool is_blocking, page_type type)
+cache_page_async_write(cache *cc, page_handle *page, page_type type)
 {
-   return cc->ops->page_sync(cc, page, is_blocking, type);
+   return cc->ops->page_async_write(cc, page, type);
+}
+
+/*
+ *-----------------------------------------------------------------------------
+ * cache_page_sync_write
+ *
+ * Synchronously writes the page back to disk.
+ *
+ * This is used to write pages that need to be made durable before returning
+ * control to the caller. Some examples: Writing out the superblock after
+ * updating some key fields. Log pages are written synchronously on commit.
+ *-----------------------------------------------------------------------------
+ */
+static inline void
+cache_page_sync_write(cache *cc, page_handle *page, page_type type)
+{
+   return cc->ops->page_sync_write(cc, page, type);
 }
 
 static inline void

--- a/src/clockcache.c
+++ b/src/clockcache.c
@@ -1408,7 +1408,7 @@ clockcache_batch_start_writeback(clockcache *cc, uint64 batch, bool is_urgent)
          // walk backwards through extent to find first cleanable entry
          do {
             first_addr -= clockcache_page_size(cc);
-            if (clockcache_pages_share_extent(cc, first_addr, addr))
+            if (clockcache_pages_share_extent(cc, first_addr, addr)) {
                next_entry_no = clockcache_lookup(cc, first_addr);
             } else {
                next_entry_no = CC_UNMAPPED_ENTRY;
@@ -1422,7 +1422,7 @@ clockcache_batch_start_writeback(clockcache *cc, uint64 batch, bool is_urgent)
          // walk forwards through extent to find last cleanable entry
          do {
             end_addr += clockcache_page_size(cc);
-            if (clockcache_pages_share_extent(cc, end_addr, addr))
+            if (clockcache_pages_share_extent(cc, end_addr, addr)) {
                next_entry_no = clockcache_lookup(cc, end_addr);
             } else {
                next_entry_no = CC_UNMAPPED_ENTRY;

--- a/src/log.h
+++ b/src/log.h
@@ -20,7 +20,7 @@ typedef struct log_iterator log_iterator;
 typedef struct log_config   log_config;
 
 typedef platform_status (*log_write_fn)(log_handle *log,
-                                        key         tuple_key,
+                                        slice       key,
                                         message     data,
                                         uint64      generation);
 typedef void (*log_release_fn)(log_handle *log);
@@ -45,7 +45,7 @@ struct log_handle {
 };
 
 static inline platform_status
-log_write(log_handle *log, key tuple_key, message data, uint64 generation)
+log_write(log_handle *log, slice key, message data, uint64 generation)
 {
    return log->ops->write(log, key, data, generation);
 }

--- a/src/log.h
+++ b/src/log.h
@@ -19,20 +19,24 @@ typedef struct log_handle   log_handle;
 typedef struct log_iterator log_iterator;
 typedef struct log_config   log_config;
 
-typedef int (*log_write_fn)(log_handle *log,
-                            slice       key,
-                            message     data,
-                            uint64      generation);
+typedef platform_status (*log_write_fn)(log_handle *log,
+                                        key         tuple_key,
+                                        message     data,
+                                        uint64      generation);
 typedef void (*log_release_fn)(log_handle *log);
 typedef uint64 (*log_addr_fn)(log_handle *log);
 typedef uint64 (*log_magic_fn)(log_handle *log);
+typedef uint64 (*log_page_size_fn)(log_handle *log);
+typedef platform_status (*log_commit_fn)(log_handle *log);
 
 typedef struct log_ops {
-   log_write_fn   write;
-   log_release_fn release;
-   log_addr_fn    addr;
-   log_addr_fn    meta_addr;
-   log_magic_fn   magic;
+   log_write_fn     write;
+   log_release_fn   release;
+   log_addr_fn      addr;
+   log_addr_fn      meta_addr;
+   log_magic_fn     magic;
+   log_commit_fn    commit;
+   log_page_size_fn page_size;
 } log_ops;
 
 // to sub-class log, make a log_handle your first field
@@ -40,10 +44,16 @@ struct log_handle {
    const log_ops *ops;
 };
 
-static inline int
-log_write(log_handle *log, slice key, message data, uint64 generation)
+static inline platform_status
+log_write(log_handle *log, key tuple_key, message data, uint64 generation)
 {
    return log->ops->write(log, key, data, generation);
+}
+
+static inline platform_status
+log_commit(log_handle *log)
+{
+   return log->ops->commit(log);
 }
 
 static inline void
@@ -70,6 +80,11 @@ log_magic(log_handle *log)
    return log->ops->magic(log);
 }
 
+static inline uint64
+log_page_size(log_handle *log)
+{
+   return log->ops->page_size(log);
+}
 log_handle *
 log_create(cache *cc, log_config *cfg, platform_heap_id hid);
 

--- a/src/platform_linux/laio.c
+++ b/src/platform_linux/laio.c
@@ -247,7 +247,7 @@ io_handle_init(laio_handle         *io,
 
    bool is_create = ((cfg->flags & O_CREAT) != 0);
    if (is_create) {
-      io->fd = open(cfg->filename, cfg->flags, cfg->perms);
+      io->fd = open(cfg->filename, (cfg->flags | O_TRUNC), cfg->perms);
    } else {
       io->fd = open(cfg->filename, cfg->flags);
    }

--- a/src/platform_linux/platform.h
+++ b/src/platform_linux/platform.h
@@ -111,16 +111,27 @@
 // Return, as int, the fractional portion modulo a GiB for given x bytes.
 #define B_TO_GiB_FRACT(x) (int)((((x)-B_TO_GiB(x) * GiB) / (GiB * 1.0)) * 100)
 
-// Time unit constants
+// Number / Time unit constants
 #define THOUSAND (1000UL)
 #define MILLION  (THOUSAND * THOUSAND)
 #define BILLION  (THOUSAND * MILLION)
 
-#define USEC_TO_SEC(x)  ((x) / MILLION)
+// Convert number N to unit-specifier, in terms of thousands, million, billion
+#define N_TO_THOUSAND(x) ((x) / THOUSAND)
+#define N_TO_MILLION(x)  ((x) / MILLION)
+#define N_TO_BILLION(x)  ((x) / BILLION)
+
+// For number N, returns as int the fractional portion modulo a unit-specifier
+#define N_TO_T_FRACT(x) ((100 * ((x) % THOUSAND)) / THOUSAND)
+#define N_TO_M_FRACT(x) ((100 * ((x) % MILLION)) / MILLION)
+#define N_TO_B_FRACT(x) ((100 * ((x) % BILLION)) / BILLION)
+
+// Convert time-value across different units of time measurement
+#define USEC_TO_SEC(x)  N_TO_MILLION((x) / MILLION)
 #define USEC_TO_NSEC(x) ((x)*THOUSAND)
-#define NSEC_TO_SEC(x)  ((x) / BILLION)
-#define NSEC_TO_MSEC(x) ((x) / MILLION)
-#define NSEC_TO_USEC(x) ((x) / THOUSAND)
+#define NSEC_TO_SEC(x)  N_TO_BILLION(x)
+#define NSEC_TO_MSEC(x) N_TO_MILLION(x)
+#define NSEC_TO_USEC(x) N_TO_THOUSAND(x)
 #define SEC_TO_MSEC(x)  ((x)*THOUSAND)
 #define SEC_TO_USEC(x)  ((x)*MILLION)
 #define SEC_TO_NSEC(x)  ((x)*BILLION)

--- a/src/platform_linux/shmem.c
+++ b/src/platform_linux/shmem.c
@@ -220,10 +220,9 @@ platform_heap_id_to_shmaddr(platform_heap_id hid)
 }
 
 _Pragma("GCC diagnostic push")
-_Pragma("GCC diagnostic ignored \"-Wunused-function\"")
-/* Evaluates to valid 'low' address within shared segment. */
-static inline void *
-platform_shm_lop(platform_heap_id hid)
+   _Pragma("GCC diagnostic ignored \"-Wunused-function\"")
+   /* Evaluates to valid 'low' address within shared segment. */
+   static inline void *platform_shm_lop(platform_heap_id hid)
 {
    return (void *)platform_heap_id_to_handle(hid);
 }

--- a/src/shard_log.c
+++ b/src/shard_log.c
@@ -22,7 +22,7 @@
 static uint64 shard_log_magic_idx = 0;
 
 platform_status
-shard_log_write(log_handle *log, key tuple_key, message msg, uint64 generation);
+shard_log_write(log_handle *log, slice key, message msg, uint64 generation);
 
 uint64
 shard_log_addr(log_handle *log);
@@ -216,7 +216,7 @@ first_log_entry(char *page)
 static bool
 terminal_log_entry(shard_log_config *cfg, char *page, log_entry *le)
 {
-   return page + shard_log_page_size(cfg) - (char *)le < sizeof(log_entry)
+   return page + shard_log_cfg_page_size(cfg) - (char *)le < sizeof(log_entry)
           || (le->keylen == 0 && le->messagelen == 0);
 }
 

--- a/src/shard_log.h
+++ b/src/shard_log.h
@@ -41,8 +41,8 @@ typedef struct shard_log {
    shard_log_config     *cfg;
    shard_log_thread_data thread_data[MAX_THREADS];
    mini_allocator        mini;
-   uint64                addr;
-   uint64                meta_head;
+   uint64                addr;      // Addr of root page of log
+   uint64                meta_head; // Addr of metadata page of mini-allocator
    uint64                magic;
 } shard_log;
 

--- a/src/splinterdb.c
+++ b/src/splinterdb.c
@@ -833,6 +833,13 @@ splinterdb_update(const splinterdb *kvsb, slice key, slice update)
    return splinterdb_insert_message(kvsb, key, msg);
 }
 
+int
+splinterdb_commit(const splinterdb *kvsb)
+{
+   platform_status status = log_commit(kvsb->spl->log);
+   return platform_status_to_int(status);
+}
+
 /*
  *-----------------------------------------------------------------------------
  * _splinterdb_lookup_result structure --

--- a/src/trunk.c
+++ b/src/trunk.c
@@ -822,7 +822,7 @@ trunk_set_super_block(trunk_handle *spl,
    cache_unlock(spl->cc, super_page);
    cache_unclaim(spl->cc, super_page);
    cache_unget(spl->cc, super_page);
-   cache_page_sync(spl->cc, super_page, TRUE, PAGE_TYPE_SUPERBLOCK);
+   cache_page_sync_write(spl->cc, super_page, PAGE_TYPE_SUPERBLOCK);
 }
 
 trunk_super_block *
@@ -3144,9 +3144,8 @@ trunk_memtable_insert(trunk_handle *spl, char *key, message msg)
    }
 
    if (spl->cfg.use_log) {
-      slice key_slice = slice_create(trunk_key_size(spl), key);
-      int   crappy_rc = log_write(spl->log, key_slice, msg, leaf_generation);
-      if (crappy_rc != 0) {
+      platform_status rc = log_write(spl->log, tuple_key, msg, leaf_generation);
+      if (!SUCCESS(rc)) {
          goto unlock_insert_lock;
       }
    }

--- a/src/trunk.c
+++ b/src/trunk.c
@@ -3144,7 +3144,8 @@ trunk_memtable_insert(trunk_handle *spl, char *key, message msg)
    }
 
    if (spl->cfg.use_log) {
-      platform_status rc = log_write(spl->log, tuple_key, msg, leaf_generation);
+      slice           key_slice = slice_create(trunk_key_size(spl), key);
+      platform_status rc = log_write(spl->log, key_slice, msg, leaf_generation);
       if (!SUCCESS(rc)) {
          goto unlock_insert_lock;
       }

--- a/tests/config.c
+++ b/tests/config.c
@@ -38,6 +38,9 @@
 #define TEST_CONFIG_DEFAULT_NUM_INSERTS 0
 #define TEST_CONFIG_DEFAULT_NUM_THREADS 8
 
+// Never issue sync-write on log buffer at run-time
+#define TEST_CONFIG_DEFAULT_COMMIT_FREQ 0
+
 // By default, background threads are disabled in Splinter task system.
 // Most threads run w/o background threads. Very small # of tests exercise
 // background threads through --num-bg-threads and --num-memtable-bg-threads
@@ -93,6 +96,8 @@ config_set_defaults(master_config *cfg)
       .message_size             = TEST_CONFIG_DEFAULT_MESSAGE_SIZE,
       .num_inserts              = TEST_CONFIG_DEFAULT_NUM_INSERTS,
       .num_threads              = TEST_CONFIG_DEFAULT_NUM_THREADS,
+
+      .commit_every_n           = TEST_CONFIG_DEFAULT_COMMIT_FREQ,
       .seed                     = TEST_CONFIG_DEFAULT_SEED,
    };
 }
@@ -156,6 +161,8 @@ config_usage()
    platform_error_log("\t--data-size (%d)\n", TEST_CONFIG_DEFAULT_MESSAGE_SIZE);
    platform_error_log("\t--num-inserts (%d)\n",
                       TEST_CONFIG_DEFAULT_NUM_INSERTS);
+   platform_error_log("\t--commit-every (%d)\n",
+                      TEST_CONFIG_DEFAULT_COMMIT_FREQ);
    platform_error_log("\t--seed (%d)\n", TEST_CONFIG_DEFAULT_SEED);
 }
 
@@ -370,6 +377,7 @@ config_parse(master_config *cfg, const uint8 num_config, int argc, char *argv[])
          config_set_uint64("seed", cfg, seed) {}
          config_set_uint64("num-inserts", cfg, num_inserts) {}
          config_set_uint64("num-threads", cfg, num_threads) {}
+         config_set_uint64("commit-every", cfg, commit_every_n) {}
 
          config_set_else
          {

--- a/tests/config.h
+++ b/tests/config.h
@@ -105,6 +105,8 @@ typedef struct master_config {
    uint64 num_inserts;
    uint64 num_threads;
    bool   wait_for_gdb; // To debug child processes.
+
+   uint64 commit_every_n; // sync-write log buffer every n-entries.
 } master_config;
 
 

--- a/tests/functional/test.h
+++ b/tests/functional/test.h
@@ -268,6 +268,7 @@ test_config_init(trunk_config           *splinter_cfg,  // OUT
 typedef struct test_exec_config {
    uint64 seed;
    uint64 num_inserts;
+   uint64 commit_every_n;   // sync-write log buffer every n-entries.
    bool   verbose_progress; // --verbose-progress: During test execution
 } test_exec_config;
 
@@ -335,6 +336,7 @@ test_parse_args_n(trunk_config           *splinter_cfg,  // OUT
    if (test_exec_cfg) {
       test_exec_cfg->seed             = master_cfg[0].seed;
       test_exec_cfg->num_inserts      = master_cfg[0].num_inserts;
+      test_exec_cfg->commit_every_n   = master_cfg[0].commit_every_n;
       test_exec_cfg->verbose_progress = master_cfg[0].verbose_progress;
    }
 

--- a/tests/unit/large_inserts_bugs_stress_test.c
+++ b/tests/unit/large_inserts_bugs_stress_test.c
@@ -125,9 +125,11 @@ CTEST_SETUP(large_inserts_bugs_stress)
       argv++;
    }
 
+   // On AWS, noted that db-size at end of some test cases is ~40 GiB.
+   // So, create a max-size slightly bigger than that.
    data->cfg = (splinterdb_config){.filename   = TEST_DB_NAME,
                                    .cache_size = 512 * Mega,
-                                   .disk_size  = 40 * Giga,
+                                   .disk_size  = 42 * Giga,
                                    .use_shmem  = use_shmem,
                                    .shmem_size = (4 * GiB),
                                    .data_cfg   = &data->default_data_config};
@@ -139,9 +141,11 @@ CTEST_SETUP(large_inserts_bugs_stress)
    rc = config_parse(&data->master_cfg, 1, argc, (char **)argv);
    ASSERT_TRUE(SUCCESS(rc));
 
+   // With default # of configured threads for this test, 8, with each
+   // thread inserting 10M rows we fill-up almost 40GiB of device size.
    data->num_inserts =
       (data->master_cfg.num_inserts ? data->master_cfg.num_inserts
-                                    : (20 * MILLION));
+                                    : (10 * MILLION));
 
    // If num_threads is unspecified, use default for this test.
    if (!data->master_cfg.num_threads) {

--- a/tests/unit/large_inserts_bugs_stress_test.c
+++ b/tests/unit/large_inserts_bugs_stress_test.c
@@ -284,7 +284,8 @@ CTEST2(large_inserts_bugs_stress, test_random_key_random_values_inserts)
    close(wcfg.random_val_fd);
 }
 
-static void safe_wait()
+static void
+safe_wait()
 {
    int wstatus;
    int wr = wait(&wstatus);

--- a/tests/unit/main.c
+++ b/tests/unit/main.c
@@ -190,7 +190,7 @@ ctest_main(int argc, const char *argv[])
       argc, argv, program_is_unit_test, &suite_name, &testcase_name);
 
    if (num_filter_args < 0) {
-      fprintf(stderr, "Incorrect usage. ");
+      fprintf(stderr, "%s(): Incorrect usage. ", __func__);
       ctest_usage(argv[0], program_is_unit_test);
       return num_fail;
    }
@@ -422,6 +422,7 @@ ctest_process_args(const int    argc,
                    const char **suite_name,    // OUT
                    const char **testcase_name) // OUT
 {
+   // No command-line arguments were provided
    if (argc <= 1) {
       return 0;
    }
@@ -441,9 +442,9 @@ ctest_process_args(const int    argc,
 
    /*
     * Here, argc >= 2; i.e. we are dealing with either one of these cases:
-    *   - bin/unit_test <suite-name>
-    *   - bin/unit_test <suite-name> <test-case-name>
-    *   - bin/unit/standalone <test-case-name>
+    *   - bin/unit_test <suite-name_test>
+    *   - bin/unit_test <suite-name> <test_case-name>
+    *   - bin/unit/standalone_test <test_case-name>
     * We expect up to 2 trailing "name"-args to be provided.
     */
    if (program_is_unit_test) {


### PR DESCRIPTION
This is a collection of multiple commits that bring-in support for `COMMIT` capability in the SplinterDB library.
This is stitched through in `large_inserts_bugs_stress_test.c`, with new `--commit-every` option. Test is enhanced to now run with `--log` option, which will turn logging ON.