### PR TITLE
(#546) Fix the segmentation fault after splinterdb_stats_reset()

### DIFF
--- a/src/trunk.c
+++ b/src/trunk.c
@@ -8785,7 +8785,33 @@ void
 trunk_reset_stats(trunk_handle *spl)
 {
    if (spl->cfg.use_stats) {
-      memset(spl->stats, 0, MAX_THREADS * sizeof(trunk_stats));
+      for (threadid thr_i = 0; thr_i < MAX_THREADS; thr_i++) {
+         platform_histo_destroy(spl->heap_id,
+                                spl->stats[thr_i].insert_latency_histo);
+         platform_histo_destroy(spl->heap_id,
+                                spl->stats[thr_i].update_latency_histo);
+         platform_histo_destroy(spl->heap_id,
+                                spl->stats[thr_i].delete_latency_histo);
+
+         memset(&spl->stats[thr_i], 0, sizeof(spl->stats[thr_i]));
+
+         platform_status rc;
+         rc = platform_histo_create(spl->heap_id,
+                                    LATENCYHISTO_SIZE + 1,
+                                    latency_histo_buckets,
+                                    &spl->stats[thr_i].insert_latency_histo);
+         platform_assert_status_ok(rc);
+         rc = platform_histo_create(spl->heap_id,
+                                    LATENCYHISTO_SIZE + 1,
+                                    latency_histo_buckets,
+                                    &spl->stats[thr_i].update_latency_histo);
+         platform_assert_status_ok(rc);
+         rc = platform_histo_create(spl->heap_id,
+                                    LATENCYHISTO_SIZE + 1,
+                                    latency_histo_buckets,
+                                    &spl->stats[thr_i].delete_latency_histo);
+         platform_assert_status_ok(rc);
+      }
    }
 }
 


### PR DESCRIPTION
Previously, when `trunk_stats_reset()` was called by splinterdb_stats_reset(), the entire statistics of a trunk, including the histogram handles, were reset to zero.