### PR TITLE
(#548) Change typedef of bool from int32 to 1-byte 'unsigned char'.

### DIFF
--- a/include/splinterdb/data.h
+++ b/include/splinterdb/data.h
@@ -90,10 +90,10 @@ merge_accumulator_length(const merge_accumulator *ma);
 slice
 merge_accumulator_to_slice(const merge_accumulator *ma);
 
-bool
+_Bool
 merge_accumulator_copy_message(merge_accumulator *ma, message msg);
 
-bool
+_Bool
 merge_accumulator_resize(merge_accumulator *ma, uint64 newsize);
 
 void

--- a/include/splinterdb/platform_linux/public_platform.h
+++ b/include/splinterdb/platform_linux/public_platform.h
@@ -61,9 +61,6 @@ static_assert(sizeof(uint64) == 8, "incorrect type");
 #   define FALSE (0)
 #endif
 
-#if !defined(__cplusplus)
-typedef int32 bool;
-#endif
 typedef uint8 bool8;
 
 typedef FILE platform_log_handle;

--- a/include/splinterdb/public_util.h
+++ b/include/splinterdb/public_util.h
@@ -27,7 +27,7 @@ typedef struct slice {
 #define NULL_SLICE    ((slice){.length = 0, .data = NULL})
 #define INVALID_SLICE ((slice){.length = (uint64)-1, .data = NULL})
 
-static inline bool
+static inline _Bool
 slice_is_null(const slice b)
 {
    return b.length == 0 && b.data == NULL;

--- a/include/splinterdb/splinterdb.h
+++ b/include/splinterdb/splinterdb.h
@@ -47,7 +47,7 @@ typedef struct {
    uint64 io_async_queue_depth;
 
    // cache
-   bool        cache_use_stats;
+   _Bool       cache_use_stats;
    const char *cache_logfile;
 
    // task system
@@ -73,7 +73,7 @@ typedef struct {
    uint64 filter_index_size;
 
    // log
-   bool use_log;
+   _Bool use_log;
 
    // splinter
    uint64 memtable_capacity;
@@ -237,7 +237,7 @@ void
 splinterdb_lookup_result_deinit(splinterdb_lookup_result *result); // IN
 
 // Returns true if the result was found
-bool
+_Bool
 splinterdb_lookup_found(const splinterdb_lookup_result *result); // IN
 
 // Decode the value from a found result
@@ -332,7 +332,7 @@ splinterdb_iterator_deinit(splinterdb_iterator *iter);
 // will succeed. If false, there are two possibilities:
 // 1. Iterator has passed the final item.  In this case, status() == 0
 // 2. Iterator has encountered an error.  In this case, status() != 0
-bool
+_Bool
 splinterdb_iterator_valid(splinterdb_iterator *iter);
 
 // Attempts to advance the iterator to the next item.

--- a/src/btree.c
+++ b/src/btree.c
@@ -434,13 +434,13 @@ btree_find_pivot(const btree_config *cfg,
 
    debug_assert(!key_is_null(target));
 
-   *found = 0;
+   *found = FALSE;
 
    while (lo < hi) {
       int64 mid = (lo + hi) / 2;
       int cmp = btree_key_compare(cfg, btree_get_pivot(cfg, hdr, mid), target);
       if (cmp == 0) {
-         *found = 1;
+         *found = TRUE;
          return mid;
       } else if (cmp < 0) {
          lo = mid + 1;
@@ -476,14 +476,14 @@ btree_find_tuple(const btree_config *cfg,
 {
    int64 lo = 0, hi = btree_num_entries(hdr);
 
-   *found = 0;
+   *found = FALSE;
 
    while (lo < hi) {
       int64 mid = (lo + hi) / 2;
       int   cmp =
          btree_key_compare(cfg, btree_get_tuple_key(cfg, hdr, mid), target);
       if (cmp == 0) {
-         *found = 1;
+         *found = TRUE;
          return mid;
       } else if (cmp < 0) {
          lo = mid + 1;

--- a/src/data_internal.c
+++ b/src/data_internal.c
@@ -26,7 +26,7 @@ merge_accumulator_to_slice(const merge_accumulator *ma)
 }
 
 /* Copy a message into an already-initialized merge_accumulator. */
-bool
+_Bool
 merge_accumulator_copy_message(merge_accumulator *ma, message msg)
 {
    platform_status rc =
@@ -38,7 +38,7 @@ merge_accumulator_copy_message(merge_accumulator *ma, message msg)
    return TRUE;
 }
 
-bool
+_Bool
 merge_accumulator_resize(merge_accumulator *ma, uint64 newsize)
 {
    platform_status rc = writable_buffer_resize(&ma->data, newsize);

--- a/src/platform_linux/platform.h
+++ b/src/platform_linux/platform.h
@@ -33,6 +33,10 @@
  * Section 1:
  * Shared types/typedefs that don't rely on anything platform-specific
  */
+#if !defined(__cplusplus)
+typedef int32 bool;
+#endif
+
 #if !defined(SPLINTER_DEBUG)
 #   define SPLINTER_DEBUG 0
 #else

--- a/src/routing_filter.c
+++ b/src/routing_filter.c
@@ -532,10 +532,10 @@ routing_filter_add(cache           *cc,
          while (new_fps_added < new_index_count
                 || old_fps_added < old_index_count) {
             uint32 fp;
-            bool   is_old =
-               (0 || new_fps_added == new_index_count
-                || (1 && old_fps_added != old_index_count
-                    && old_src_fp[old_fps_added] <= new_src_fp[new_fps_added]));
+            bool   is_old = ((new_fps_added == new_index_count)
+                           || ((old_fps_added != old_index_count)
+                               && (old_src_fp[old_fps_added]
+                                   <= new_src_fp[new_fps_added])));
             if (is_old) {
                fp = old_src_fp[old_fps_added++];
             } else {

--- a/src/routing_filter.h
+++ b/src/routing_filter.h
@@ -122,7 +122,7 @@ routing_filter_get_next_value(uint64 found_values, uint16 last_value)
 static inline bool
 routing_filter_is_value_found(uint64 found_values, uint16 value)
 {
-   return found_values & (1 << value);
+   return ((found_values & (1 << value)) != 0);
 }
 
 

--- a/src/splinterdb.c
+++ b/src/splinterdb.c
@@ -531,7 +531,7 @@ splinterdb_lookup_result_deinit(splinterdb_lookup_result *result) // IN
    merge_accumulator_deinit(&_result->value);
 }
 
-bool
+_Bool
 splinterdb_lookup_found(const splinterdb_lookup_result *result) // IN
 {
    _splinterdb_lookup_result *_result = (_splinterdb_lookup_result *)result;
@@ -637,7 +637,7 @@ splinterdb_iterator_deinit(splinterdb_iterator *iter)
    platform_free(spl->heap_id, range_itor);
 }
 
-bool
+_Bool
 splinterdb_iterator_valid(splinterdb_iterator *kvi)
 {
    if (!SUCCESS(kvi->last_rc)) {

--- a/tests/functional/splinter_test.c
+++ b/tests/functional/splinter_test.c
@@ -95,7 +95,7 @@ typedef void (*test_trunk_thread_hdlr)(void *arg);
 static inline bool
 test_is_done(const uint8 done, const uint8 n)
 {
-   return ((done >> n) & 1);
+   return (((done >> n) & 1) != 0);
 }
 
 static inline void
@@ -610,7 +610,6 @@ do_operation(test_splinter_thread_params *params,
 
             if (async_lookup->max_async_inflight == 0) {
                platform_status rc;
-               bool            found;
 
                test_key(&keybuf,
                         test_cfg[spl_idx].key_type,
@@ -626,7 +625,7 @@ do_operation(test_splinter_thread_params *params,
                if (ts > params->lookup_stats[SYNC_LU].latency_max) {
                   params->lookup_stats[SYNC_LU].latency_max = ts;
                }
-               found = trunk_lookup_found(&msg);
+               bool found = trunk_lookup_found(&msg);
                if (found) {
                   params->lookup_stats[SYNC_LU].num_found++;
                } else {

--- a/tests/functional/ycsb_test.c
+++ b/tests/functional/ycsb_test.c
@@ -181,7 +181,7 @@ print_latency_table(latency_table table, platform_log_handle *log_handle)
 {
    uint64_t exponent;
    uint64_t mantissa;
-   bool     started = 0;
+   bool     started = FALSE;
    uint64_t max     = max_latency(table);
 
    platform_log(log_handle, "latency count\n");
@@ -192,7 +192,7 @@ print_latency_table(latency_table table, platform_log_handle *log_handle)
                          "%20lu %20lu\n",
                          compute_latency(exponent, mantissa),
                          table[exponent][mantissa]);
-            started = 1;
+            started = TRUE;
             if (max == compute_latency(exponent, mantissa))
                return;
          }


### PR DESCRIPTION
In SplinterDB's public splinterdb_config{} config, we have few fields defined as 'bool' which is typedef'ed to int32 on our side. This creates compatibility problems when linking this library with other s/w which may have defined 'bool' as 1-byte field. (Offsets of fields in the splinterdb_config{} struct following 1st field defined as 'bool' changes across objects. This commit addresses this issue by defining boolean fields in public struct to be of type `_Bool`. This should, hopefully,reduce the risk of such incompatibilities. 

(Splinter's internal definition of `bool` remains as `int32`, to avoid any other product change / compatibility issues.)

Found only one instance where 'bool' return value from routing_filter_is_value_found() had to be adjusted to fit 1-byte return value.