### PR TITLE
CI can cover multiple trunk branches

### DIFF
--- a/ci/jobs.lib.yml
+++ b/ci/jobs.lib.yml
@@ -13,14 +13,6 @@
 #@         "get_task_timeout",
 #@ )
 
-
-#@ load("sequences.lib.yml",
-#@         "sequence_pr_debug_build_test",
-#@         "sequence_pr_clang_format",
-#@         "sequence_pr_shell_scripts",
-#@ )
-
-
 ---
 
 #! Build and push a container image
@@ -66,15 +58,16 @@ plan:
 
 
 #! Build, test and publish container images
-#@ def job_main_push(compiler, also_latest=False):
-name: #@ "main-push-" + compiler
+#@ def job_publish_container(compiler, branch, also_latest=False):
+name: #@ branch + "-push-" + compiler
 public: true
 on_success: #@ step_set_commit_status("success", compiler)
 on_failure: #@ step_set_commit_status("failure", compiler)
 on_error: #@ step_set_commit_status("error", compiler)
 plan:
 - in_parallel:
-  - get: branch-main
+  - get: source
+    resource: #@ "branch-" + branch
     trigger: true
   - get: run-env-image-latest
     passed: [ recreate-run-env ]
@@ -85,12 +78,12 @@ plan:
     params: { format: oci }
     trigger: true
 - load_var: git-commit-sha
-  file: branch-main/.git/ref
+  file: source/.git/ref
   reveal: true
 - #@ step_set_commit_status("pending", compiler)
-- #@ step_build_splinterdb_image("branch-main", compiler, git_sha=True)
+- #@ step_build_splinterdb_image("source", compiler)
 - #@ step_test_with_image()
-- #@ step_collect_tags(compiler)
+- #@ step_collect_tags("source", compiler)
 - put: #@ "splinterdb-image-" + compiler
   attempts: 2  #! allow 1 retry, since Distribution Harbor can be flaky
   params:
@@ -101,7 +94,7 @@ plan:
   attempts: 2  #! allow 1 retry, since Distribution Harbor can be flaky
   params:
     image: image/image.tar
-    additional_tags: branch-main/.git/ref
+    additional_tags: source/.git/ref
 #@ end
 
 #@ end
@@ -124,17 +117,18 @@ plan:
 
 
 #! Debug build and test
-#@ def job_main(compiler, sanitize="", trigger="main", is_debug=False, test_nightly=False):
+#@ def job_test(compiler, branch, sanitize="", trigger="commit", is_debug=False, test_nightly=False):
 #@   name = friendly_name(compiler, is_debug, sanitize, test_nightly)
-name: #@ "main-" + name
+name: #@ branch + "-" + name
 public: true
 on_success: #@ step_set_commit_status("success", name)
 on_failure: #@ step_set_commit_status("failure", name)
 on_error: #@ step_set_commit_status("error", name)
 plan:
 - in_parallel:
-  - get: branch-main
-    trigger: #@ (trigger == "main")
+  - get: source
+    resource: #@ "branch-" + branch
+    trigger: #@ (trigger == "commit")
   - get: build-env-image-latest
     passed: [ recreate-build-env ]
     trigger: true
@@ -143,20 +137,21 @@ plan:
     trigger: true
 #@ end
 - #@ step_set_commit_status("pending", name)
-- #@ step_build_test(compiler, "branch-main", is_debug=is_debug, sanitize=sanitize, test_nightly=test_nightly)
+- #@ step_build_test(compiler, "source", is_debug=is_debug, sanitize=sanitize, test_nightly=test_nightly)
 #@ end
 
 ---
 
 #! Job to run against every PR
-#@ def job_pr_check(job_name, sequence, depends_on=[], description=""):
-name: #@ "pr-" + job_name
+#@ def job_pr_check(job_name, branch, sequence, depends_on=[], description=""):
+name: #@ branch + "-pr-" + job_name
 public: true
-on_success: #@ step_set_pr_status(job_name, "success", description)
-on_failure: #@ step_set_pr_status(job_name, "failure", description)
-on_error: #@ step_set_pr_status(job_name, "error", description)
+on_success: #@ step_set_pr_status(job_name, branch, "success", description)
+on_failure: #@ step_set_pr_status(job_name, branch, "failure", description)
+on_error: #@ step_set_pr_status(job_name, branch, "error", description)
 plan:
 - get: github-pull-request
+  resource: #@ "github-prs-" + branch
   trigger: true
   #@ if depends_on:
   passed: #@ depends_on
@@ -165,6 +160,6 @@ plan:
   #@ end
   params:
     list_changed_files: true
-- #@ step_set_pr_status(job_name, "pending", description)
+- #@ step_set_pr_status(job_name, branch, "pending", description)
 - #@ template.replace(sequence)
 #@ end

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -21,10 +21,14 @@
 
 #@ load("jobs.lib.yml",
 #@         "job_recreate_image",
-#@         "job_main_push",
-#@         "job_main",
+#@         "job_publish_container",
+#@         "job_test",
 #@         "job_pr_check",
 #@ )
+
+#! List of branches to cover with tests
+#! The first one is special, it is used for publishing container images to the public Docker registry
+#@ branches = ["main"]
 ---
 
 resource_types:
@@ -56,13 +60,14 @@ resources:
 - #@ resource_container_image("splinterdb", "latest")
 
 #! Source code for the container image holding the build environment
-- #@ resource_splinterdb_git_repo("build-env-source", "main", { "paths": [ "Dockerfile.build-env" ] })
+- #@ resource_splinterdb_git_repo("build-env-source", branches[0], { "paths": [ "Dockerfile.build-env" ] })
 
 #! Source code for the container image holding the run environment
-- #@ resource_splinterdb_git_repo("run-env-source", "main", { "paths": [ "Dockerfile.run-env" ] })
+- #@ resource_splinterdb_git_repo("run-env-source", branches[0], { "paths": [ "Dockerfile.run-env" ] })
 
-#! Source code repo, main branch
-- #@ resource_splinterdb_git_repo("branch-main", "main", { "ignore_paths": [ "ci" ] })
+#@ for b in branches:
+- #@ resource_splinterdb_git_repo("branch-" + b, b, { "ignore_paths": [ "ci" ] })
+#@ end
 
 #! Set status on individual commits in the github repo
 - name: github-commit-status
@@ -73,14 +78,16 @@ resources:
     repo: splinterdb
     access_token: ((github-bot-access-token))
 
+#@ for b in branches:
 #! Discover pull requests and set status on them
-- name: github-pull-request
+- name: #@ "github-prs-" + b
   type: pull-request
   check_every: 2m
   source:
     repository: vmware/splinterdb
     access_token: ((github-bot-access-token))
-    base_branch: main
+    base_branch: #@ b
+#@ end
 
 #! Define nightly timer resource
 #! Ref: https://concourse-ci.org/time-trigger-example.html
@@ -95,58 +102,69 @@ resources:
 #! List of jobs
 jobs:
 
-#! Create the container image that holds the build environment
+#! Create the container images that hold the build-time and run-time environments
 - #@ job_recreate_image("build-env")
 - #@ job_recreate_image("run-env")
 
-#! Commits to main will build, test and publish container images
-- #@ job_main_push("clang")
-- #@ job_main_push("gcc", also_latest=True)
-- #@ job_main("clang", is_debug=True)
-- #@ job_main("gcc", is_debug=True)
+#! branches[0] is used for publishing container images
+- #@ job_publish_container("clang", branches[0])
+- #@ job_publish_container("gcc", branches[0], also_latest=True)
+
+#@ for b in branches:
+
+#! Commits to covered branches will build and test
+- #@ job_test("clang", b, is_debug=True)
+- #@ job_test("gcc", b, is_debug=True)
 
 #! Nightly jobs which take too long to run per-PR
-- #@ job_main("gcc", trigger="nightly", test_nightly=True)
-- #@ job_main("clang", trigger="nightly", sanitize="asan")
-- #@ job_main("clang", trigger="nightly", sanitize="msan")
+- #@ job_test("gcc", b, trigger="nightly", test_nightly=True)
+- #@ job_test("clang", b, trigger="nightly", sanitize="asan")
+- #@ job_test("clang", b, trigger="nightly", sanitize="msan")
 
-#! Pull requests go through a fast stage and fan out to a slow stage
-#@ stage_one = ["pr-quick-check", "pr-clang-format", "pr-shell-scripts"]
-- #@ job_pr_check("clang-format", sequence_pr_clang_format(), description="check C source formatting")
-- #@ job_pr_check("shell-scripts", sequence_pr_shell_scripts(), description="lint and format any shell scripts")
-- #@ job_pr_check("quick-check", sequence_pr_debug_build_test("clang", quick=True), description="build and run fast unit tests")
+
+#! Pull requests to a covered branch
+#! must first pass a fast stage and then fan out to a slow stage
+#@ stage_one = [b + "-pr-quick-check", b + "-pr-clang-format", b + "-pr-shell-scripts"]
+- #@ job_pr_check("clang-format", b, sequence_pr_clang_format(), description="check C source formatting")
+- #@ job_pr_check("shell-scripts", b, sequence_pr_shell_scripts(), description="lint and format any shell scripts")
+- #@ job_pr_check("quick-check", b, sequence_pr_debug_build_test("clang", quick=True), description="build and run fast unit tests")
 
 #! second stage of pipeline, only triggers if all of the first-stage passes
-- #@ job_pr_check("clang", sequence_pr_build_test("clang"), depends_on=stage_one, description="build and test")
-- #@ job_pr_check("gcc", sequence_pr_build_test("gcc"), depends_on=stage_one, description="build and test")
-- #@ job_pr_check("debug-clang", sequence_pr_debug_build_test("clang"), depends_on=stage_one, description="debug build and test")
-- #@ job_pr_check("debug-gcc", sequence_pr_debug_build_test("gcc"), depends_on=stage_one, description="debug build and test")
+- #@ job_pr_check("clang", b, sequence_pr_build_test("clang"), depends_on=stage_one, description="build and test")
+- #@ job_pr_check("gcc", b, sequence_pr_build_test("gcc"), depends_on=stage_one, description="build and test")
+- #@ job_pr_check("debug-clang", b, sequence_pr_debug_build_test("clang"), depends_on=stage_one, description="debug build and test")
+- #@ job_pr_check("debug-gcc", b, sequence_pr_debug_build_test("gcc"), depends_on=stage_one, description="debug build and test")
+
+#@ end  #! for loop over branches
 
 
 #! List of CI-groups of jobs
 groups:
-- name: main_branch
-  jobs:
-  - main-push-clang
-  - main-push-gcc
-  - main-debug-clang
-  - main-debug-gcc
 
-- name: pull_requests
+#@ for b in branches:
+- name: #@ b + "_commits"
   jobs:
-  - pr-quick-check
-  - pr-clang
-  - pr-debug-clang
-  - pr-gcc
-  - pr-debug-gcc
-  - pr-clang-format
-  - pr-shell-scripts
+  - #@ b + "-push-clang"
+  - #@ b + "-push-gcc"
+  - #@ b + "-debug-clang"
+  - #@ b + "-debug-gcc"
 
-- name: nightly
+- name: #@ b + "_pull_requests"
   jobs:
-  - main-nightly-test-gcc
-  - main-asan-clang
-  - main-msan-clang
+  - #@ b + "-pr-quick-check"
+  - #@ b + "-pr-clang"
+  - #@ b + "-pr-debug-clang"
+  - #@ b + "-pr-gcc"
+  - #@ b + "-pr-debug-gcc"
+  - #@ b + "-pr-clang-format"
+  - #@ b + "-pr-shell-scripts"
+
+- name: #@ b + "_nightly"
+  jobs:
+  - #@ b + "-nightly-test-gcc"
+  - #@ b + "-asan-clang"
+  - #@ b + "-msan-clang"
+#@ end
 
 - name: env_images
   jobs:

--- a/ci/resources.lib.yml
+++ b/ci/resources.lib.yml
@@ -3,6 +3,8 @@
 
 #@ load("@ytt:template", "template")
 
+---
+
 #@ def resource_container_image(name, tag):
 name: #@ name + "-image-" + tag
 type: registry-image

--- a/ci/sequences.lib.yml
+++ b/ci/sequences.lib.yml
@@ -8,6 +8,8 @@
 #@         "get_task_timeout",
 #@ )
 
+---
+
 #! Build plan sequences for various PR checks
 
 #@ def sequence_pr_build_test(compiler):
@@ -20,6 +22,9 @@
     - get: build-env-image-latest
       passed: [ recreate-build-env ]
       params: { format: oci }
+- load_var: git-commit-sha
+  file: "github-pull-request/.git/resource/head_sha"
+  reveal: true
 - #@ step_build_splinterdb_image("github-pull-request", compiler)
 - #@ step_test_with_image()
 #@ end

--- a/ci/steps.lib.yml
+++ b/ci/steps.lib.yml
@@ -1,6 +1,7 @@
 #! Copyright 2018-2021 VMware, Inc.
 #! SPDX-License-Identifier: Apache-2.0
 
+---
 
 #@ def get_task_timeout(quick=False, sanitize="", test_nightly=False):
 #@   if sanitize:
@@ -14,14 +15,12 @@
 #@   end
 #@ end
 
-#@ def step_build_splinterdb_image(source, compiler, git_sha=False):
+#@ def step_build_splinterdb_image(source, compiler):
 task: build
 timeout: #@ get_task_timeout()
 privileged: true
-#@ if git_sha:
 params:
   LABEL_git_sha: ((.:git-commit-sha))
-#@ end
 config:
   platform: linux
   image_resource:
@@ -40,7 +39,6 @@ config:
     IMAGE_ARG_run_env_image: run-env-image-latest/image.tar
     BUILD_ARG_compiler: #@ compiler
     LABEL_compiler: #@ compiler
-    LABEL_source: #@ source
     LABEL_created_by: "SplinterDB Concourse CI"
     CONTEXT: splinterdb-src
     UNPACK_ROOTFS: true
@@ -64,7 +62,7 @@ config:
 #@ end
 
 ---
-#@ def step_collect_tags(compiler):
+#@ def step_collect_tags(source, compiler):
 task: collect-tags
 timeout: #@ get_task_timeout()
 config:
@@ -74,7 +72,7 @@ config:
     source:
       repository: harbor-repo.vmware.com/dockerhub-proxy-cache/library/busybox
   inputs:
-  - name: branch-main
+  - name: #@ source
     path: repo
   outputs:
   - name: tags
@@ -88,11 +86,7 @@ config:
 ---
 
 #@ def step_build_test(compiler, input_name, is_debug=True, quick=False, sanitize="", test_nightly=False):
-#@ if is_debug:
-task: debug-build-test
-#@ else:
-task: release-build-test
-#@ end
+task: #@ "debug-build-test" if is_debug else "release-build-test"
 timeout: #@ get_task_timeout(quick=quick, sanitize=sanitize, test_nightly=test_nightly)
 image: build-env-image-latest
 config:
@@ -108,11 +102,7 @@ config:
     VERBOSE: "3"
 
     #! Exercise 'make help' in quick tests mode, to ensure 'help' still works.
-    #@ if quick:
-    MAKE_HELP: help
-    #@ else:
-    MAKE_HELP: ""
-    #@ end
+    MAKE_HELP: #@ "help" if quick else ""
 
     #@ if is_debug:
     BUILD_MODE: "debug"
@@ -136,9 +126,9 @@ config:
 
 ---
 
-#@ def step_set_pr_status(context, status, description=""):
+#@ def step_set_pr_status(context, branch, status, description=""):
 put: update-status
-resource: github-pull-request
+resource: #@ "github-prs-" + branch
 params:
   path: github-pull-request
   status: #@ status
@@ -154,7 +144,7 @@ get_params: {skip_download: true}
 
 #@ def step_set_commit_status(status, context=""):
 put: github-commit-status
-inputs: [branch-main]
+inputs: [ "source" ]
 params:
   state: #@ status
   #@ if context:

--- a/ci/tasks/pr-check-shell-scripts.sh
+++ b/ci/tasks/pr-check-shell-scripts.sh
@@ -48,8 +48,7 @@ fi
 cd github-pull-request
 
 if ! [ -s ".editorconfig" ]; then
-   echo Expecting to find .editorconfig file in source repo root
-   echo Please check that your code is rebased on a recent commit of branch main
+   echo Missing expected .editorconfig file in source repo root
    exit 1
 fi
 


### PR DESCRIPTION
CI currently tests
- every commit to `main`
- every pull-request that targets `main`
- every night it runs some slower tests against the latest commit on `main`

But we may want to have more than 1 long-lived branch that receives this kind of test coverage.

This PR refactors the configuration for CI to us to enable that.