### PR TITLE
(#554) Fixes to get couple of tests running cleanly in ASAN-builds

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -59,6 +59,13 @@ function usage() {
    echo "To run CI-regression tests       : INCLUDE_SLOW_TESTS=true ./${Me}"
    echo "To run nightly regression tests  : RUN_NIGHTLY_TESTS=true ./${Me}"
    echo "To run make build-and-test tests : RUN_MAKE_TESTS=true ./${Me}"
+   echo
+   echo "To run a smaller collection of slow running tests,
+name the function that drives the test execution.
+Examples:"
+   echo "  INCLUDE_SLOW_TESTS=true ./test.sh run_btree_tests"
+   echo "  INCLUDE_SLOW_TESTS=true ./test.sh run_splinter_functionality_tests"
+   echo "  INCLUDE_SLOW_TESTS=true ./test.sh nightly_cache_perf_tests"
 }
 
 # ##################################################################
@@ -742,6 +749,24 @@ if [ "$INCLUDE_SLOW_TESTS" != "true" ]; then
 fi
 
 # ---- Rest of the coverage runs included in CI test runs ----
+
+# ------------------------------------------------------------------------
+# Fast-path execution support. You can invoke this script specifying the
+# name of one of the functions to execute a specific set of tests. If the
+# function takes arguments, pass them on the command-line. This way, one
+# can debug script changes to ensure that test-execution still works.
+#
+# Examples:
+#      INCLUDE_SLOW_TESTS=true ./test.sh run_btree_tests
+# ------------------------------------------------------------------------
+if [ $# -ge 1 ]; then
+
+   # shellcheck disable=SC2048
+   $*
+   record_elapsed_time ${testRunStartSeconds} "All Tests"
+   cat_exec_log_file
+   exit 0
+fi
 
 # Run all the unit-tests first, to get basic coverage
 run_with_timing "Fast unit tests" "$BINDIR"/unit_test

--- a/tests/functional/filter_test.c
+++ b/tests/functional/filter_test.c
@@ -411,6 +411,7 @@ filter_test(int argc, char *argv[])
    clockcache_deinit(cc);
    platform_free(hid, cc);
    rc_allocator_deinit(&al);
+   task_system_destroy(hid, &ts);
    io_handle_deinit(io);
 free_iohandle:
    platform_free(hid, io);

--- a/tests/functional/io_apis_test.c
+++ b/tests/functional/io_apis_test.c
@@ -277,7 +277,9 @@ splinter_io_apis_test(int argc, char *argv[])
 
    test_async_reads_by_threads(&io_test_fn_arg, NUM_THREADS);
 
+   task_system_destroy(hid, &tasks);
 io_free:
+   io_handle_deinit(io_hdl);
    platform_free(hid, io_hdl);
 heap_destroy:
    platform_heap_destroy(&hh);


### PR DESCRIPTION
This commit fixes minor errors in 2 tests (io_apis_test, filter_test) to get them running cleanly in ASAN-builds.