### PR TITLE
(#561) Fix routing_filter_prefetch() to account for page-size while computing next page-address.

### DIFF
--- a/src/btree.c
+++ b/src/btree.c
@@ -2986,7 +2986,11 @@ btree_pack(btree_pack_req *req)
    while (SUCCESS(iterator_at_end(req->itor, &at_end)) && !at_end) {
       iterator_get_curr(req->itor, &tuple_key, &data);
       if (!btree_pack_can_fit_tuple(req, tuple_key, data)) {
-         platform_error_log("btree_pack exceeded output size limit\n");
+         platform_error_log("%s(): req->num_tuples=%lu exceeded output size "
+                            "limit, req->max_tuples=%lu\n",
+                            __func__,
+                            req->num_tuples,
+                            req->max_tuples);
          btree_pack_abort(req);
          return STATUS_LIMIT_EXCEEDED;
       }

--- a/src/clockcache.c
+++ b/src/clockcache.c
@@ -2088,7 +2088,9 @@ clockcache_get_internal(clockcache   *cc,       // IN
                         page_type     type,     // IN
                         page_handle **page)     // OUT
 {
-   debug_assert(addr % clockcache_page_size(cc) == 0);
+   debug_only uint64 page_size = clockcache_page_size(cc);
+   debug_assert(
+      ((addr % page_size) == 0), "addr=%lu, page_size=%lu\n", addr, page_size);
    uint32            entry_number = CC_UNMAPPED_ENTRY;
    uint64            lookup_no    = clockcache_divide_by_page_size(cc, addr);
    debug_only uint64 base_addr =

--- a/src/routing_filter.c
+++ b/src/routing_filter.c
@@ -634,14 +634,14 @@ routing_filter_prefetch(cache          *cc,
                         uint64          num_indices)
 {
    uint64 last_extent_addr = 0;
-   uint64 addrs_per_page =
-      cache_config_page_size(cfg->cache_cfg) / sizeof(uint64);
-   uint64 num_index_pages = (num_indices - 1) / addrs_per_page + 1;
-   uint64 index_no        = 0;
+   uint64 page_size        = cache_config_page_size(cfg->cache_cfg);
+   uint64 addrs_per_page   = page_size / sizeof(uint64);
+   uint64 num_index_pages  = (num_indices - 1) / addrs_per_page + 1;
+   uint64 index_no         = 0;
 
    for (uint64 index_page_no = 0; index_page_no < num_index_pages;
         index_page_no++) {
-      uint64       index_addr = filter->addr + index_page_no;
+      uint64       index_addr = filter->addr + (page_size * index_page_no);
       page_handle *index_page =
          cache_get(cc, index_addr, TRUE, PAGE_TYPE_FILTER);
       platform_assert(index_no < num_indices);

--- a/tests/unit/splinterdb_stress_test.c
+++ b/tests/unit/splinterdb_stress_test.c
@@ -52,7 +52,8 @@ CTEST_SETUP(splinterdb_stress)
                                              .cache_size = 1000 * Mega,
                                              .disk_size  = 9000 * Mega,
                                              .data_cfg   = &data->default_data_config,
-                                             .queue_scale_percent = 100};
+                                             .num_memtable_bg_threads = 2,
+                                             .num_normal_bg_threads   = 2};
    size_t max_key_size = TEST_KEY_SIZE;
    default_data_config_init(max_key_size, data->cfg.data_cfg);
 
@@ -138,6 +139,59 @@ CTEST2(splinterdb_stress, test_naive_range_delete)
    }
 }
 
+/*
+ * Test case that inserts large # of KV-pairs, and goes into a code path
+ * reported by issue# 458, tripping a debug assert. This test case also
+ * triggered the failure(s) reported by issue # 545.
+ * FIXME: This test still runs into an assertion "filter->addr != 0"
+ * from trunk_inc_filter(), which is being triaged separately.
+ */
+CTEST2_SKIP(splinterdb_stress, test_issue_458_mini_destroy_unused_debug_assert)
+{
+   char key_data[TEST_KEY_SIZE];
+   char val_data[TEST_VALUE_SIZE];
+
+   uint64 test_start_time = platform_get_timestamp();
+
+   for (uint64 ictr = 0, jctr = 0; ictr < 100; ictr++) {
+
+      uint64 start_time = platform_get_timestamp();
+
+      for (jctr = 0; jctr < MILLION; jctr++) {
+
+         uint64 id = (ictr * MILLION) + jctr;
+         snprintf(key_data, sizeof(key_data), "%lu", id);
+         snprintf(val_data, sizeof(val_data), "Row-%lu", id);
+
+         slice key = slice_create(strlen(key_data), key_data);
+         slice val = slice_create(strlen(val_data), val_data);
+
+         int rc = splinterdb_insert(data->kvsb, key, val);
+         ASSERT_EQUAL(0, rc);
+      }
+      uint64 elapsed_ns      = platform_timestamp_elapsed(start_time);
+      uint64 test_elapsed_ns = platform_timestamp_elapsed(test_start_time);
+
+      uint64 elapsed_s = NSEC_TO_SEC(elapsed_ns);
+      if (elapsed_s == 0) {
+         elapsed_s = 1;
+      }
+      uint64 test_elapsed_s = NSEC_TO_SEC(test_elapsed_ns);
+      if (test_elapsed_s == 0) {
+         test_elapsed_s = 1;
+      }
+
+      CTEST_LOG_INFO(
+         "\n" // PLATFORM_CR
+         "Inserted %lu million KV-pairs"
+         ", this batch: %lu s, %lu rows/s, cumulative: %lu s, %lu rows/s ...",
+         (ictr + 1),
+         elapsed_s,
+         (jctr / elapsed_s),
+         test_elapsed_s,
+         (((ictr + 1) * jctr) / test_elapsed_s));
+   }
+}
 
 // Per-thread workload
 static void *


### PR DESCRIPTION
This commit fixes a simple arithmetic error in `routing_filter_prefetch()` while computing next page's address. A new test case `test_issue_458_mini_destroy_unused_debug_assert` has been added to existing `unit/splinterdb_stress_test`, which reproduces the problem.

NOTE: Even with this fix, this simple test case does not succeed in debug builds. We are failing with a new assertion:

```
(gdb) c
Continuing.
btree_pack(): req->num_tuples=6291456 exceeded output size limit, req->max_tuples=6291456
btree_pack(): req->num_tuples=6291456 exceeded output size limit, req->max_tuples=6291456
[Switching to Thread 0x7ffff6894640 (LWP 484069)]

Thread 4 "splinterdb_stre" hit Breakpoint 1, trunk_flush_into_bundle (spl=0x7fffb5f8c040, parent=0x7ffff68917c0, child=0x7ffff6891620, pdata=0x7fffd355458c, req=0x7fffac388640) at src/trunk.c:4102
4102	            trunk_inc_filter(spl, child_filter);
(gdb) p parent_filter->addr
$6 = 0
(gdb) p *parent_filter
$7 = {addr = 0, meta_head = 0, num_fingerprints = 0, num_unique = 0, value_size = 0}
(gdb) bt
#0  trunk_flush_into_bundle (spl=0x7fffb5f8c040, parent=0x7ffff68917c0,
    child=0x7ffff6891620, pdata=0x7fffd355458c, req=0x7fffac388640) at src/trunk.c:4102
#1  0x00007ffff7f828b1 in trunk_flush (spl=0x7fffb5f8c040, parent=0x7ffff68917c0,
    pdata=0x7fffd355458c, is_space_rec=0) at src/trunk.c:4214
#2  0x00007ffff7f82e58 in trunk_flush_fullest (spl=0x7fffb5f8c040, node=0x7ffff68917c0)
    at src/trunk.c:4295
#3  0x00007ffff7f83e23 in trunk_compact_bundle (arg=0x55555747bfc0,
    scratch_buf=0x7ffff6895040) at src/trunk.c:4642
#4  0x00007ffff7f7291b in task_group_run_task (group=0x555555575b80,
    assigned_task=0x555557479c40) at src/task.c:475
#5  0x00007ffff7f72a94 in task_worker_thread (arg=0x555555575b80) at src/task.c:514
#6  0x00007ffff7f72068 in task_invoke_with_hooks (func_and_args=0x5555555782c0)
    at src/task.c:221
#7  0x00007ffff7d4db43 in start_thread (arg=<optimized out>)

(gdb) n
OS-pid=484066, OS-tid=484069, Thread-ID=3, Assertion failed at src/trunk.c:3543:trunk_inc_filter(): "filter->addr != 0".
```