### PR TITLE
CI: Bump timeout from 2h to 3h. shmem-tests cause debug test runs to take longer.

### DIFF
--- a/ci/steps.lib.yml
+++ b/ci/steps.lib.yml
@@ -11,7 +11,7 @@
 #@   elif test_nightly:
 #@     return "6h"
 #@   else:
-#@     return "2h"
+#@     return "3h"
 #@   end
 #@ end
 


### PR DESCRIPTION

In-flight stabilization of shared memory support in Splinter is bringin along with tons more additional tests. We are effetively running most of the existing twice; once w/o and once w/ shared memory configured. Debug-build test runs are timing out at 2 hours. Bump timeout to 3hs, and once stabilized, we can look into dropping this to 2h.