### PR TITLE
Core changes to support running Splinter with allocated shared memory.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ TESTSRC := $(COMMON_TESTSRC) $(FUNCTIONAL_TESTSRC) $(UNIT_TESTSRC)
 # Construct a list of fast unit-tests that will be linked into unit_test binary,
 # eliminating a sequence of slow-running unit-test programs.
 ALL_UNIT_TESTSRC := $(call rwildcard, $(UNIT_TESTSDIR), *.c)
-SLOW_UNIT_TESTSRC = splinter_test.c config_parse_test.c
+SLOW_UNIT_TESTSRC = splinter_test.c config_parse_test.c large_inserts_bugs_stress_test.c
 SLOW_UNIT_TESTSRC_FILTER := $(foreach slowf,$(SLOW_UNIT_TESTSRC), $(UNIT_TESTSDIR)/$(slowf))
 FAST_UNIT_TESTSRC := $(sort $(filter-out $(SLOW_UNIT_TESTSRC_FILTER), $(ALL_UNIT_TESTSRC)))
 
@@ -386,7 +386,8 @@ $(foreach unit,$(UNIT_TESTBINS),$(eval $(call unit_test_self_dependency,$(unit))
 #
 # These will need to be fleshed out for filters, io subsystem, trunk,
 # etc. as we create mini unit test executables for those subsystems.
-PLATFORM_SYS = $(OBJDIR)/$(SRCDIR)/$(PLATFORM_DIR)/platform.o
+PLATFORM_SYS = $(OBJDIR)/$(SRCDIR)/$(PLATFORM_DIR)/platform.o \
+               $(OBJDIR)/$(SRCDIR)/$(PLATFORM_DIR)/shmem.o
 
 PLATFORM_IO_SYS = $(OBJDIR)/$(SRCDIR)/$(PLATFORM_DIR)/laio.o
 
@@ -443,7 +444,10 @@ $(BINDIR)/$(UNITDIR)/splinterdb_stress_test: $(COMMON_TESTOBJ)                  
                                              $(LIBDIR)/libsplinterdb.so
 
 $(BINDIR)/$(UNITDIR)/writable_buffer_test: $(UTIL_SYS)            \
-                                           $(COMMON_UNIT_TESTOBJ)
+                                           $(COMMON_TESTOBJ)      \
+                                           $(COMMON_UNIT_TESTOBJ) \
+                                           $(OBJDIR)/$(FUNCTIONAL_TESTSDIR)/test_async.o \
+                                           $(LIBDIR)/libsplinterdb.so
 
 $(BINDIR)/$(UNITDIR)/limitations_test: $(COMMON_TESTOBJ)                             \
                                        $(COMMON_UNIT_TESTOBJ)                        \
@@ -466,6 +470,25 @@ $(BINDIR)/$(UNITDIR)/platform_apis_test: $(UTIL_SYS)               \
                                          $(COMMON_UNIT_TESTOBJ)    \
                                          $(PLATFORM_SYS)
 
+$(BINDIR)/$(UNITDIR)/splinter_shmem_test: $(UTIL_SYS)            \
+                                          $(COMMON_UNIT_TESTOBJ) \
+                                          $(LIBDIR)/libsplinterdb.so
+
+$(BINDIR)/$(UNITDIR)/splinter_ipc_test: $(UTIL_SYS)            \
+                                        $(COMMON_UNIT_TESTOBJ)
+
+$(BINDIR)/$(UNITDIR)/large_inserts_bugs_stress_test: $(UTIL_SYS)                      \
+                                                     $(OBJDIR)/$(TESTS_DIR)/config.o  \
+                                                     $(COMMON_UNIT_TESTOBJ)           \
+                                                     $(LIBDIR)/libsplinterdb.so
+
+$(BINDIR)/$(UNITDIR)/splinterdb_heap_id_mgmt_test: $(COMMON_TESTOBJ)         \
+                                                   $(COMMON_UNIT_TESTOBJ)    \
+                                                   $(OBJDIR)/$(FUNCTIONAL_TESTSDIR)/test_async.o \
+                                                   $(LIBDIR)/libsplinterdb.so
+
+
+
 ########################################
 # Convenience mini unit-test targets
 unit/util_test:                    $(BINDIR)/$(UNITDIR)/util_test
@@ -476,6 +499,11 @@ unit/splinter_test:                $(BINDIR)/$(UNITDIR)/splinter_test
 unit/splinterdb_quick_test:        $(BINDIR)/$(UNITDIR)/splinterdb_quick_test
 unit/splinterdb_stress_test:       $(BINDIR)/$(UNITDIR)/splinterdb_stress_test
 unit/writable_buffer_test:         $(BINDIR)/$(UNITDIR)/writable_buffer_test
+unit/config_parse_test:            $(BINDIR)/$(UNITDIR)/config_parse_test
+unit/limitations_test:             $(BINDIR)/$(UNITDIR)/limitations_test
+unit/task_system_test:             $(BINDIR)/$(UNITDIR)/task_system_test
+unit/splinter_shmem_test:          $(BINDIR)/$(UNITDIR)/splinter_shmem_test
+unit/splinter_ipc_test:            $(BINDIR)/$(UNITDIR)/splinter_ipc_test
 unit_test:                         $(BINDIR)/unit_test
 
 # -----------------------------------------------------------------------------

--- a/include/splinterdb/splinterdb.h
+++ b/include/splinterdb/splinterdb.h
@@ -20,8 +20,29 @@
 const char *
 splinterdb_get_version();
 
-// Configuration options for SplinterDB
-typedef struct {
+/*
+ * ****************************************************************************
+ * Configuration options for SplinterDB:
+ *
+ * Physical configuration things such as file name, cache & disk-size,
+ * extent- and page-size are specified here. Application-specific data
+ * configuration is also provided through this struct. Additionally,
+ * user can select whether to use malloc()/free()-based memory allocation
+ * for all structures (default), or choose to setup a shared segment
+ * which will be used for shared structures.
+ *
+ * ******************* EXPERIMENTAL FEATURES ********************
+ *
+ * - use_shmem: Support for shared memory segments:
+ *   This flag will configure a shared memory segment. All (most) run-time
+ *   memory allocation will be done from this shared segment. Currently,
+ *   we do not support free(), so you will likely run out of shared memory
+ *   and run into shared-memory OOM errors. This functionality is
+ *   solely meant for internal development uses.
+ *
+ * ******************* EXPERIMENTAL FEATURES ********************
+ */
+typedef struct splinterdb_config {
    // required configuration
    const char *filename;
    uint64      cache_size;
@@ -32,11 +53,14 @@ typedef struct {
    // For a simple reference implementation, see default_data_config.h
    data_config *data_cfg;
 
-
    // optional advanced config below
    // if unset, defaults will be used
    void *heap_handle;
    void *heap_id;
+
+   // Shared memory support
+   uint64 shmem_size;
+   _Bool  use_shmem; // Default is FALSE.
 
    uint64 page_size;
    uint64 extent_size;
@@ -121,7 +145,6 @@ typedef struct {
    // work to be performed on foreground threads, increasing tail
    // latencies.
    uint64 queue_scale_percent;
-
 } splinterdb_config;
 
 // Opaque handle to an opened instance of SplinterDB

--- a/src/btree.h
+++ b/src/btree.h
@@ -325,7 +325,7 @@ btree_iterator_init(cache          *cc,
 void
 btree_iterator_deinit(btree_iterator *itor);
 
-static inline void
+static inline platform_status
 btree_pack_req_init(btree_pack_req  *req,
                     cache           *cc,
                     btree_config    *cfg,
@@ -344,8 +344,18 @@ btree_pack_req_init(btree_pack_req  *req,
    req->seed       = seed;
    if (hash != NULL && max_tuples > 0) {
       req->fingerprint_arr =
-         TYPED_ARRAY_MALLOC(hid, req->fingerprint_arr, max_tuples);
+         TYPED_ARRAY_ZALLOC(hid, req->fingerprint_arr, max_tuples);
+
+      // When we run with shared-memory configured, we expect that it is sized
+      // big-enough to not get OOMs from here. Hence, only a debug_assert().
+      debug_assert(req->fingerprint_arr,
+                   "Unable to allocate memory for %lu tuples",
+                   max_tuples);
+      if (!req->fingerprint_arr) {
+         return STATUS_NO_MEMORY;
+      }
    }
+   return STATUS_OK;
 }
 
 static inline void

--- a/src/data_internal.h
+++ b/src/data_internal.h
@@ -182,6 +182,12 @@ key_buffer_init_from_key(key_buffer *kb, platform_heap_id hid, key src)
    return key_buffer_copy_key(kb, src);
 }
 
+static inline uint64
+key_buffer_length(key_buffer *kb)
+{
+   return writable_buffer_length(&kb->wb);
+}
+
 /* Converts kb to a user key if it isn't already. */
 static inline platform_status
 key_buffer_resize(key_buffer *kb, uint64 length)

--- a/src/default_data_config.c
+++ b/src/default_data_config.c
@@ -46,6 +46,10 @@ message_to_string(const data_config *cfg,
 }
 
 
+/*
+ * Function to initialize application-specific data_config{} struct
+ * with default values.
+ */
 void
 default_data_config_init(const size_t max_key_size, // IN
                          data_config *out_cfg       // OUT

--- a/src/io.h
+++ b/src/io.h
@@ -89,10 +89,7 @@ struct io_handle {
 };
 
 platform_status
-io_handle_init(platform_io_handle  *ioh,
-               io_config           *cfg,
-               platform_heap_handle hh,
-               platform_heap_id     hid);
+io_handle_init(platform_io_handle *ioh, io_config *cfg, platform_heap_id hid);
 
 void
 io_handle_deinit(platform_io_handle *ioh);

--- a/src/merge.c
+++ b/src/merge.c
@@ -545,7 +545,7 @@ merge_iterator_create(platform_heap_id hid,
                      == ARRAY_SIZE(merge_itor->ordered_iterators),
                   "size mismatch");
 
-   merge_itor = TYPED_ZALLOC(hid, merge_itor);
+   merge_itor = TYPED_ZALLOC(PROCESS_PRIVATE_HEAP_ID, merge_itor);
    if (merge_itor == NULL) {
       return STATUS_NO_MEMORY;
    }
@@ -598,7 +598,7 @@ platform_status
 merge_iterator_destroy(platform_heap_id hid, merge_iterator **merge_itor)
 {
    merge_accumulator_deinit(&(*merge_itor)->merge_buffer);
-   platform_free(hid, *merge_itor);
+   platform_free(PROCESS_PRIVATE_HEAP_ID, *merge_itor);
    *merge_itor = NULL;
 
    return STATUS_OK;

--- a/src/platform_linux/laio.c
+++ b/src/platform_linux/laio.c
@@ -91,10 +91,7 @@ static io_ops laio_ops = {
  * structures and initialize the IO sub-system.
  */
 platform_status
-io_handle_init(laio_handle         *io,
-               io_config           *cfg,
-               platform_heap_handle hh,
-               platform_heap_id     hid)
+io_handle_init(laio_handle *io, io_config *cfg, platform_heap_id hid)
 {
    int           status;
    uint64        req_size;

--- a/src/platform_linux/platform.c
+++ b/src/platform_linux/platform.c
@@ -3,9 +3,9 @@
 
 #include <stdarg.h>
 #include <unistd.h>
-#include "platform.h"
-
 #include <sys/mman.h>
+#include "platform.h"
+#include "shmem.h"
 
 __thread threadid xxxtid = INVALID_TID;
 
@@ -18,6 +18,14 @@ bool32 platform_use_mlock   = FALSE;
 // Use platform_set_log_streams() to send the log messages elsewhere.
 platform_log_handle *Platform_default_log_handle = NULL;
 platform_log_handle *Platform_error_log_handle   = NULL;
+
+/*
+ * Declare globals to track heap handle/ID that may have been created when
+ * using shared memory. We stash away these handles so that we can return the
+ * right handle via platform_get_heap_id() interface, in case shared segments
+ * are in use.
+ */
+platform_heap_id Heap_id = NULL;
 
 // This function is run automatically at library-load time
 void __attribute__((constructor)) platform_init_log_file_handles(void)
@@ -47,21 +55,39 @@ platform_get_stdout_stream(void)
    return Platform_default_log_handle;
 }
 
+/*
+ * platform_heap_create() - Create a heap for memory allocation.
+ *
+ * By default, we just revert to process' heap-memory and use malloc() / free()
+ * for memory management. If Splinter is run with shared-memory configuration,
+ * create a shared-segment which acts as the 'heap' for memory allocation.
+ */
 platform_status
-platform_heap_create(platform_module_id    UNUSED_PARAM(module_id),
-                     uint32                max,
-                     platform_heap_handle *heap_handle,
-                     platform_heap_id     *heap_id)
+platform_heap_create(platform_module_id UNUSED_PARAM(module_id),
+                     size_t             max,
+                     bool               use_shmem,
+                     platform_heap_id  *heap_id)
 {
-   *heap_handle = NULL;
-   *heap_id     = NULL;
+   if (use_shmem) {
+      platform_status rc = platform_shmcreate(max, heap_id);
+      if (SUCCESS(rc)) {
+         Heap_id = *heap_id;
+      }
+      return rc;
+   }
+   *heap_id = NULL;
 
    return STATUS_OK;
 }
 
 void
-platform_heap_destroy(platform_heap_handle UNUSED_PARAM(*heap_handle))
-{}
+platform_heap_destroy(platform_heap_id *heap_id)
+{
+   // If shared segment was allocated, it's being tracked thru heap ID.
+   if (*heap_id) {
+      return platform_shmdestroy(heap_id);
+   }
+}
 
 /*
  * platform_buffer_init() - Initialize an input buffer_handle, bh.

--- a/src/platform_linux/platform.h
+++ b/src/platform_linux/platform.h
@@ -219,6 +219,17 @@ extern platform_log_handle *Platform_error_log_handle;
 // hash functions
 typedef uint32 (*hash_fn)(const void *input, size_t length, unsigned int seed);
 
+extern platform_heap_id Heap_id;
+
+/*
+ * Provide a tag for callers that do not want to use shared-memory allocation,
+ * when configured but want to fallback to default scheme of allocating
+ * process-private memory. Typically, this would default to malloc()/free().
+ * (Clients that repeatedly allocate and free a large chunk of memory in some
+ *  code path would want to use this tag.)
+ */
+#define PROCESS_PRIVATE_HEAP_ID (platform_heap_id) NULL
+
 /*
  * -----------------------------------------------------------------------------
  * TYPED_MANUAL_MALLOC(), TYPED_MANUAL_ZALLOC() -
@@ -317,12 +328,24 @@ typedef uint32 (*hash_fn)(const void *input, size_t length, unsigned int seed);
 #define TYPED_MANUAL_MALLOC(hid, v, n)                                         \
    ({                                                                          \
       debug_assert((n) >= sizeof(*(v)));                                       \
-      (typeof(v))platform_aligned_malloc(hid, PLATFORM_CACHELINE_SIZE, (n));   \
+      (typeof(v))platform_aligned_malloc(hid,                                  \
+                                         PLATFORM_CACHELINE_SIZE,              \
+                                         (n),                                  \
+                                         STRINGIFY(v),                         \
+                                         __FUNCTION__,                         \
+                                         __FILE__,                             \
+                                         __LINE__);                            \
    })
 #define TYPED_MANUAL_ZALLOC(hid, v, n)                                         \
    ({                                                                          \
       debug_assert((n) >= sizeof(*(v)));                                       \
-      (typeof(v))platform_aligned_zalloc(hid, PLATFORM_CACHELINE_SIZE, (n));   \
+      (typeof(v))platform_aligned_zalloc(hid,                                  \
+                                         PLATFORM_CACHELINE_SIZE,              \
+                                         (n),                                  \
+                                         STRINGIFY(v),                         \
+                                         __FUNCTION__,                         \
+                                         __FILE__,                             \
+                                         __LINE__);                            \
    })
 
 /*
@@ -341,12 +364,14 @@ typedef uint32 (*hash_fn)(const void *input, size_t length, unsigned int seed);
 #define TYPED_ALIGNED_MALLOC(hid, a, v, n)                                     \
    ({                                                                          \
       debug_assert((n) >= sizeof(*(v)));                                       \
-      (typeof(v))platform_aligned_malloc(hid, (a), (n));                       \
+      (typeof(v))platform_aligned_malloc(                                      \
+         hid, (a), (n), STRINGIFY(v), __FUNCTION__, __FILE__, __LINE__);       \
    })
 #define TYPED_ALIGNED_ZALLOC(hid, a, v, n)                                     \
    ({                                                                          \
       debug_assert((n) >= sizeof(*(v)));                                       \
-      (typeof(v))platform_aligned_zalloc(hid, (a), (n));                       \
+      (typeof(v))platform_aligned_zalloc(                                      \
+         hid, (a), (n), STRINGIFY(v), __FUNCTION__, __FILE__, __LINE__);       \
    })
 
 /*
@@ -420,8 +445,8 @@ typedef uint32 (*hash_fn)(const void *input, size_t length, unsigned int seed);
  *  hid - Platform heap-ID to allocate memory from.
  *  v   - Structure to allocate memory for.
  */
-#define TYPED_MALLOC(hid, v) TYPED_ARRAY_MALLOC(hid, (v), 1)
-#define TYPED_ZALLOC(hid, v) TYPED_ARRAY_ZALLOC(hid, (v), 1)
+#define TYPED_MALLOC(hid, v) TYPED_ARRAY_MALLOC(hid, v, 1)
+#define TYPED_ZALLOC(hid, v) TYPED_ARRAY_ZALLOC(hid, v, 1)
 
 /*
  * -----------------------------------------------------------------------------
@@ -444,7 +469,7 @@ typedef uint32 (*hash_fn)(const void *input, size_t length, unsigned int seed);
  */
 #define ZERO_ARRAY(v)                                                          \
    do {                                                                        \
-      _Static_assert(IS_ARRAY(v), "ZERO_ARRAY on non-array");                  \
+      _Static_assert(IS_ARRAY(v), "Use of ZERO_ARRAY on non-array object");    \
       memset((v), 0, sizeof(v));                                               \
    } while (0)
 
@@ -454,7 +479,7 @@ typedef uint32 (*hash_fn)(const void *input, size_t length, unsigned int seed);
  */
 #define ZERO_CONTENTS_N(v, n)                                                  \
    do {                                                                        \
-      _Static_assert(!IS_ARRAY(v), "ZERO_CONTENTS on array");                  \
+      _Static_assert(!IS_ARRAY(v), "Use of ZERO_CONTENTS on array");           \
       debug_assert((v) != NULL);                                               \
       memset((v), 0, (n) * sizeof(*(v)));                                      \
    } while (0)
@@ -636,13 +661,13 @@ platform_log_handle *
 platform_get_stdout_stream(void);
 
 platform_status
-platform_heap_create(platform_module_id    module_id,
-                     uint32                max,
-                     platform_heap_handle *heap_handle,
-                     platform_heap_id     *heap_id);
+platform_heap_create(platform_module_id module_id,
+                     size_t             max,
+                     bool               use_shmem,
+                     platform_heap_id  *heap_id);
 
 void
-platform_heap_destroy(platform_heap_handle *heap_handle);
+platform_heap_destroy(platform_heap_id *heap_id);
 
 platform_status
 platform_buffer_init(buffer_handle *bh, size_t length);
@@ -686,6 +711,15 @@ platform_thread_id_self();
 char *
 platform_strtok_r(char *str, const char *delim, platform_strtok_ctx *ctx);
 
+void
+platform_enable_tracing_shm_ops();
+
+void
+platform_enable_tracing_shm_allocs();
+
+void
+platform_enable_tracing_shm_frees();
+
 
 /*
  * Section 5:
@@ -711,28 +745,42 @@ platform_strtok_r(char *str, const char *delim, platform_strtok_ctx *ctx);
  */
 #define platform_free(id, p)                                                   \
    do {                                                                        \
-      platform_free_from_heap(id, (p));                                        \
+      platform_free_from_heap(                                                 \
+         id, (p), STRINGIFY(p), __FUNCTION__, __FILE__, __LINE__);             \
       (p) = NULL;                                                              \
    } while (0)
 
 #define platform_free_volatile(id, p)                                          \
    do {                                                                        \
-      platform_free_volatile_from_heap(id, (p));                               \
+      platform_free_volatile_from_heap(                                        \
+         id, (p), STRINGIFY(p), __FUNCTION__, __FILE__, __LINE__);             \
       (p) = NULL;                                                              \
    } while (0)
 
 // Convenience function to free something volatile
 static inline void
-platform_free_volatile_from_heap(platform_heap_id heap_id, volatile void *ptr)
+platform_free_volatile_from_heap(platform_heap_id heap_id,
+                                 volatile void   *ptr,
+                                 const char      *objname,
+                                 const char      *func,
+                                 const char      *file,
+                                 int              lineno)
 {
    // Ok to discard volatile qualifier for free
-   platform_free_from_heap(heap_id, (void *)ptr);
+   platform_free_from_heap(heap_id, (void *)ptr, objname, func, file, lineno);
 }
 
 static inline void *
-platform_aligned_zalloc(platform_heap_id heap_id, size_t alignment, size_t size)
+platform_aligned_zalloc(platform_heap_id heap_id,
+                        size_t           alignment,
+                        size_t           size,
+                        const char      *objname,
+                        const char      *func,
+                        const char      *file,
+                        int              lineno)
 {
-   void *x = platform_aligned_malloc(heap_id, alignment, size);
+   void *x = platform_aligned_malloc(
+      heap_id, alignment, size, objname, func, file, lineno);
    if (LIKELY(x)) {
       memset(x, 0, size);
    }
@@ -779,4 +827,4 @@ platform_backtrace(void **buffer, int size)
    return backtrace(buffer, size);
 }
 
-#endif
+#endif // PLATFORM_H

--- a/src/platform_linux/platform_inline.h
+++ b/src/platform_linux/platform_inline.h
@@ -8,6 +8,8 @@
 #include <string.h> // for memcpy, strerror
 #include <time.h>   // for nanosecond sleep api.
 
+#include "shmem.h"
+
 static inline size_t
 platform_strnlen(const char *s, size_t maxlen)
 {
@@ -34,11 +36,13 @@ platform_checksum_is_equal(checksum128 left, checksum128 right)
    return XXH128_isEqual(left, right);
 }
 
-static inline void
-platform_free_from_heap(platform_heap_id UNUSED_PARAM(heap_id), void *ptr)
-{
-   free(ptr);
-}
+static void
+platform_free_from_heap(platform_heap_id UNUSED_PARAM(heap_id),
+                        void            *ptr,
+                        const char      *objname,
+                        const char      *func,
+                        const char      *file,
+                        int              lineno);
 
 static inline timestamp
 platform_get_timestamp(void)
@@ -261,7 +265,8 @@ platform_close_log_stream(platform_stream_handle *stream,
    fclose(stream->stream);
    fputs(stream->str, log_handle);
    fflush(log_handle);
-   platform_free_from_heap(NULL, stream->str);
+   platform_free_from_heap(
+      NULL, stream->str, "stream", __FUNCTION__, __FILE__, __LINE__);
 }
 
 static inline platform_log_handle *
@@ -390,7 +395,7 @@ static inline platform_heap_id
 platform_get_heap_id(void)
 {
    // void* NULL since we don't actually need a heap id
-   return NULL;
+   return Heap_id;
 }
 
 static inline platform_module_id
@@ -400,10 +405,32 @@ platform_get_module_id()
    return NULL;
 }
 
+/*
+ * Return # of bytes needed to align requested 'size' bytes at 'alignment'
+ * boundary.
+ */
+static inline size_t
+platform_align_bytes_reqd(const size_t alignment, const size_t size)
+{
+   return ((alignment - (size % alignment)) % alignment);
+}
+
+/*
+ * platform_aligned_malloc() -- Allocate n-bytes accounting for alignment.
+ *
+ * This interface will, by default, allocate using aligned_alloc(). Currently
+ * this supports alignments up to a cache-line.
+ * If Splinter is configured to run with shared memory, we will invoke the
+ * shmem-allocation function, working off of the (non-NULL) platform_heap_id.
+ */
 static inline void *
-platform_aligned_malloc(const platform_heap_id UNUSED_PARAM(heap_id),
+platform_aligned_malloc(const platform_heap_id heap_id,
                         const size_t           alignment, // IN
-                        const size_t           size)                // IN
+                        const size_t           size,      // IN
+                        const char            *objname,
+                        const char            *func,
+                        const char            *file,
+                        const int              lineno)
 {
    // Requirement for aligned_alloc
    platform_assert(IS_POWER_OF_2(alignment));
@@ -415,19 +442,68 @@ platform_aligned_malloc(const platform_heap_id UNUSED_PARAM(heap_id),
     * Note that since this is inlined, the compiler will turn the constant
     * (power of 2) alignment mod operations into bitwise &
     */
-   const size_t padding = (alignment - (size % alignment)) % alignment;
-   return aligned_alloc(alignment, size + padding);
+   // RESOLVE: Delete this padding from caller. Push this down to
+   // platform_shm_alloc().
+   const size_t padding  = platform_align_bytes_reqd(alignment, size);
+   const size_t required = (size + padding);
+
+   void *retptr =
+      (heap_id
+          ? platform_shm_alloc(heap_id, required, objname, func, file, lineno)
+          : aligned_alloc(alignment, required));
+   return retptr;
 }
 
-/* Reallocing to size 0 must be equivalent to freeing.
-   Reallocing from NULL must be equivalent to allocing. */
+/*
+ * platform_realloc() - Reallocate 'newsize' bytes and copy over old contents.
+ *
+ * This is a wrapper around C-realloc() but farms over to shared-memory
+ * based realloc, when needed.
+ *
+ * The interface is intentional to avoid inadvertently swapping 'oldsize' and
+ * 'newsize' in the call, if they were to appear next to each other.
+ *
+ * Reallocing to size 0 must be equivalent to freeing.
+ * Reallocing from NULL must be equivalent to allocing.
+ */
 static inline void *
-platform_realloc(const platform_heap_id UNUSED_PARAM(heap_id),
+platform_realloc(const platform_heap_id heap_id,
+                 const size_t           oldsize,
                  void                  *ptr, // IN
-                 const size_t           size)          // IN
+                 const size_t           newsize)       // IN
 {
    /* FIXME: alignment? */
-   return realloc(ptr, size);
+
+   // Farm control off to shared-memory based realloc, if it's configured
+   if (heap_id) {
+      // The shmem-based allocator is expecting all memory requests to be of
+      // aligned sizes, as that's what platform_aligned_malloc() does. So, to
+      // keep that allocator happy, align this memory request if needed.
+      // As this is the case of realloc, we assume that it would suffice to
+      // align at platform's natural cacheline boundary.
+      const size_t padding =
+         platform_align_bytes_reqd(PLATFORM_CACHELINE_SIZE, newsize);
+      const size_t required = (newsize + padding);
+      return platform_shm_realloc(
+         heap_id, ptr, oldsize, required, __func__, __FILE__, __LINE__);
+   } else {
+      return realloc(ptr, newsize);
+   }
+}
+
+static inline void
+platform_free_from_heap(platform_heap_id heap_id,
+                        void            *ptr,
+                        const char      *objname,
+                        const char      *func,
+                        const char      *file,
+                        int              lineno)
+{
+   if (heap_id) {
+      platform_shm_free(heap_id, ptr, objname, func, file, lineno);
+   } else {
+      free(ptr);
+   }
 }
 
 static inline platform_status
@@ -455,4 +531,4 @@ platform_condvar_destroy(platform_condvar *cv)
    pthread_cond_destroy(&cv->cond);
 }
 
-#endif
+#endif // PLATFORM_LINUX_INLINE_H

--- a/src/platform_linux/platform_types.h
+++ b/src/platform_linux/platform_types.h
@@ -161,7 +161,6 @@ typedef struct {
 typedef struct laio_handle platform_io_handle;
 
 typedef void *platform_module_id;
-typedef void *platform_heap_handle;
 typedef void *platform_heap_id;
 
 typedef struct {

--- a/src/platform_linux/shmem.c
+++ b/src/platform_linux/shmem.c
@@ -1,0 +1,1221 @@
+// Copyright 2018-2023 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+ * shmem.c --
+ *
+ * This file contains the implementation for managing shared memory created
+ * for use by SplinterDB and all its innards.
+ */
+#include <unistd.h>
+
+#include "platform.h"
+#include "shmem.h"
+#include "util.h"
+
+// SplinterDB's shared segment magic identifier. Mainly needed for diagnostics.
+#define SPLINTERDB_SHMEM_MAGIC (uint64)0x543e4a6d
+
+// Boolean globals controlling tracing of shared memory allocs / frees
+static bool Trace_shmem_allocs = FALSE;
+static bool Trace_shmem_frees  = FALSE;
+static bool Trace_shmem        = FALSE;
+static bool Trace_large_frags  = FALSE;
+
+/*
+ * ---------------------------------------------------------------------------
+ * shm_frag_info{} - Struct describing a large memory fragment allocation.
+ *
+ * This is a specialized memory-fragment tracker solely constructed to satisfy
+ * large memory requests. In Splinter large memory requests, i.e. something over
+ * 1 M bytes, occur rarely, mainly when we do stuff like compact or pack.
+ * And these operations are generally short-lived but could occur very
+ * frequently in heavy insert workloads. This mechanism is a way to track a
+ * free-list of such memory fragments that were allocated previously and are now
+ * 'freed'. They will be re-allocated to the next requestor, thereby, keeping
+ * the overall space required in shared memory to be somewhat optimal.
+ *
+ * NOTE: {to_pid, to_tid} and {by_pid, by_tid} fields go hand-in-hand.
+ *       We track both for improved debugging.
+ *
+ * Lifecyle:
+ *  - When a large fragment is initially allocated, frag_addr / frag_size will
+ *    be set.
+ *  - (allocated_to_pid != 0) && (freed_by_pid == 0) - Fragment is in use.
+ *  - (allocated_to_pid != 0) && (freed_by_pid != 0) - Fragment is free.
+ * ---------------------------------------------------------------------------
+ */
+typedef struct shm_frag_info {
+   void *shm_frag_addr;  // Start address of this memory fragment
+                         // NULL => tracking fragment is empty
+   size_t shm_frag_size; // bytes (Used in re-allocation logic.)
+
+   // Following fields are used mainly for assertions and diagnostics.
+   int      shm_frag_allocated_to_pid; // Allocated to this OS-pid
+   threadid shm_frag_allocated_to_tid; // Allocated to this Splinter thread-ID
+   int      shm_frag_freed_by_pid;     // OS-pid that freed this
+   threadid shm_frag_freed_by_tid;     // Splinter thread-ID that freed this
+} shm_frag_info;
+
+/*
+ * All memory allocations of this size or larger will be tracked in the
+ * above fragment tracker array. For large inserts workload, we allocate large
+ * memory chunks for fingerprint array, which is more than a MiB. For scans,
+ * splinterdb_iterator_init() allocates memory for an iterator which is ~92+KiB.
+ * Set this to a lower value so we can re-cycle free fragments for iterators
+ * also.
+ */
+#if SPLINTER_DEBUG
+#   define SHM_LARGE_FRAG_SIZE (90 * KiB)
+#else
+#   define SHM_LARGE_FRAG_SIZE (38 * KiB)
+#endif // SPLINTER_DEBUG
+
+/*
+ * In the worst case we may have all threads performing activities that need
+ * such large memory fragments. We track up to twice the # of configured
+ * threads, which is still a small array to search.
+ */
+#define SHM_NUM_LARGE_FRAGS (MAX_THREADS * 2)
+
+/*
+ * -----------------------------------------------------------------------------
+ * shmem_heap{}: Shared memory Control Block: Used as a heap for memory allocs
+ *
+ * Core structure describing shared memory segment created. This lives right
+ * at the start of the allocated shared segment.
+ *
+ * NOTE(s):
+ *  - shm_large_frag_hip tracks the highest-address of all the large fragments
+ *    that are tracked. This is an optimization to short-circuit the search
+ *    done when freeing any fragment, to see if it's a large-fragment.
+ * -----------------------------------------------------------------------------
+ */
+typedef struct shmem_heap {
+   void *shm_start;      // Points to start address of shared segment.
+   void *shm_end;        // Points to end address; one past end of sh segment
+   void *shm_next;       // Points to next 'free' address to allocate from.
+   void *shm_last_alloc; // Points to address most-recently allocated
+   void *shm_splinterdb_handle;
+   void *shm_large_frag_hip; // Highest addr of large-fragments tracked
+
+   platform_spinlock shm_mem_lock; // To sync alloc / free
+
+   platform_spinlock shm_mem_frags_lock;
+   // Protected by shm_mem_frags_lock. Must hold to read or modify.
+   shm_frag_info shm_mem_frags[SHM_NUM_LARGE_FRAGS];
+   uint32        shm_num_frags_tracked;
+   uint32        shm_num_frags_inuse;
+   uint32        shm_num_frags_inuse_HWM;
+   size_t        shm_used_by_large_frags; // Actually reserved
+   size_t        shm_nfrees;              // # of calls to free memory
+   size_t        shm_nfrees_last_frag;    // Freed last small-fragment
+
+   size_t shm_total_bytes; // Total size of shared segment allocated initially.
+   size_t shm_free_bytes;  // Free bytes of memory left (that can be allocated)
+   size_t shm_used_bytes;  // Used bytes of memory left (that were allocated)
+   size_t shm_used_bytes_HWM; // High-water mark of memory used bytes
+   uint64 shm_magic;          // Magic identifier for shared memory segment
+   int    shm_id;             // Shared memory ID returned by shmget()
+
+} PLATFORM_CACHELINE_ALIGNED shmem_heap;
+
+/* Permissions for accessing shared memory and IPC objects */
+#define PLATFORM_IPC_OBJS_PERMS (S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP)
+
+// Function prototypes
+
+static void
+platform_shm_track_alloc(shmem_heap *shm, void *addr, size_t size);
+
+static void
+platform_shm_track_free(shmem_heap *shm,
+                        void       *addr,
+                        const char *objname,
+                        const char *func,
+                        const char *file,
+                        const int   lineno);
+
+static void *
+platform_shm_find_free(shmem_heap *shm,
+                       size_t      size,
+                       const char *objname,
+                       const char *func,
+                       const char *file,
+                       const int   lineno);
+
+static void
+platform_shm_trace_allocs(shmem_heap  *shm,
+                          const size_t size,
+                          const char  *verb,
+                          const void  *retptr,
+                          const char  *objname,
+                          const char  *func,
+                          const char  *file,
+                          const int    lineno);
+
+static int
+platform_trace_large_frags(shmem_heap *shm);
+
+bool
+platform_shm_heap_valid(shmem_heap *shmheap);
+
+/*
+ * PLATFORM_HEAP_ID_TO_SHMADDR() --
+ *
+ * The shared memory create function returns the address of shmem_heap->shm_id
+ * as the platform_heap_id heap-ID to the caller. Rest of Splinter will use this
+ * heap-ID as a 'handle' to manage / allocate shared memory. This macro converts
+ * the heap-ID handle to the shared memory's start address, from which the
+ * location of the next-free-byte can be tracked.
+ */
+static inline shmem_heap *
+platform_heap_id_to_shmaddr(platform_heap_id hid)
+{
+   debug_assert(hid != NULL);
+   void *shmaddr = ((void *)hid - offsetof(shmem_heap, shm_id));
+   return (shmem_heap *)shmaddr;
+}
+
+/* Evaluates to valid 'low' address within shared segment. */
+static inline void *
+platform_shm_lop(platform_heap_id hid)
+{
+   return (void *)platform_heap_id_to_shmaddr(hid);
+}
+
+/*
+ * Evaluates to valid 'high' address within shared segment.
+ * shm_end points to one-byte-just-past-end of shared segment.
+ * Valid 'high' byte is last byte just before shm_end inside segment.
+ */
+static inline void *
+platform_shm_hip(platform_heap_id hid)
+{
+   return (void *)(platform_heap_id_to_shmaddr(hid)->shm_end - 1);
+}
+
+static inline void
+shm_lock_mem(shmem_heap *shm)
+{
+   platform_spin_lock(&shm->shm_mem_lock);
+}
+
+static inline void
+shm_unlock_mem(shmem_heap *shm)
+{
+   platform_spin_unlock(&shm->shm_mem_lock);
+}
+
+static inline void
+shm_lock_mem_frags(shmem_heap *shm)
+{
+   platform_spin_lock(&shm->shm_mem_frags_lock);
+}
+
+static inline void
+shm_unlock_mem_frags(shmem_heap *shm)
+{
+   platform_spin_unlock(&shm->shm_mem_frags_lock);
+}
+
+/*
+ * Address 'addr' is valid if it's just past end of control block and within
+ * shared segment.
+ */
+static inline bool
+platform_valid_addr_in_shm(shmem_heap *shmaddr, void *addr)
+{
+   return ((addr >= ((void *)shmaddr + platform_shm_ctrlblock_size()))
+           && (addr < shmaddr->shm_end));
+}
+
+/*
+ * platform_valid_addr_in_heap(), platform_valid_addr_in_shm()
+ *
+ * Validate that input address 'addr' is a valid address within shared segment
+ * region.
+ */
+static inline bool
+platform_valid_addr_in_heap(platform_heap_id heap_id, void *addr)
+{
+   return platform_valid_addr_in_shm(platform_heap_id_to_shmaddr(heap_id),
+                                     addr);
+}
+
+/*
+ * -----------------------------------------------------------------------------
+ * platform_shmcreate() -- Create a new shared memory segment.
+ *
+ * For a given heap ID, we expect that this create method will only be called
+ * once. [ Otherwise, it means some code is erroneously creating
+ * the shared segment twice, clobbering previously established handles. ]
+ * -----------------------------------------------------------------------------
+ */
+platform_status
+platform_shmcreate(size_t            size,
+                   platform_heap_id *heap_id) // Out
+{
+   platform_assert((*heap_id == NULL),
+                   "Heap handle is expected to be NULL while creating a new "
+                   "shared segment.\n");
+
+   int shmid = shmget(0, size, (IPC_CREAT | PLATFORM_IPC_OBJS_PERMS));
+   if (shmid == -1) {
+      platform_error_log(
+         "Failed to created shared segment of size %lu bytes (%s).\n",
+         size,
+         size_str(size));
+      return STATUS_NO_MEMORY;
+   }
+   platform_default_log(
+      "Created shared memory of size %lu bytes (%s), shmid=%d.\n",
+      size,
+      size_str(size),
+      shmid);
+
+   // Get start of allocated shared segment
+   void *shmaddr = shmat(shmid, NULL, 0);
+
+   if (shmaddr == (void *)-1) {
+      platform_error_log("Failed to attach to shared segment, shmid=%d.\n",
+                         shmid);
+      return STATUS_NO_MEMORY;
+   }
+
+   // Setup shared segment's control block at head of shared segment.
+   size_t      free_bytes;
+   shmem_heap *shm = (shmem_heap *)shmaddr;
+
+   shm->shm_start          = shmaddr;
+   shm->shm_end            = (shmaddr + size);
+   shm->shm_next           = (shmaddr + sizeof(shmem_heap));
+   shm->shm_total_bytes    = size;
+   free_bytes              = (size - sizeof(shmem_heap));
+   shm->shm_free_bytes     = free_bytes;
+   shm->shm_used_bytes     = 0;
+   shm->shm_used_bytes_HWM = 0;
+   shm->shm_id             = shmid;
+   shm->shm_magic          = SPLINTERDB_SHMEM_MAGIC;
+
+   // Return 'heap-ID' handle, if requested, pointing to shared segment handle.
+   if (heap_id) {
+      *heap_id = (platform_heap_id *)&shm->shm_id;
+   }
+
+   platform_spinlock_init(
+      &shm->shm_mem_lock, platform_get_module_id(), *heap_id);
+
+   // Initialize spinlock needed to access memory fragments tracker
+   platform_spinlock_init(
+      &shm->shm_mem_frags_lock, platform_get_module_id(), *heap_id);
+
+   // Always trace creation of shared memory segment.
+   platform_default_log("Completed setup of shared memory of size "
+                        "%lu bytes (%s), shmaddr=%p, shmid=%d,"
+                        " available memory = %lu bytes (%s).\n",
+                        size,
+                        size_str(size),
+                        shmaddr,
+                        shmid,
+                        free_bytes,
+                        size_str(free_bytes));
+   return STATUS_OK;
+}
+
+/*
+ * -----------------------------------------------------------------------------
+ * platform_shmdestroy() -- Destroy a shared memory created for SplinterDB.
+ * -----------------------------------------------------------------------------
+ */
+void
+platform_shmdestroy(platform_heap_id *hid_out)
+{
+   if (!hid_out) {
+      platform_error_log(
+         "Error! Attempt to destroy shared memory with NULL heap ID!");
+      return;
+   }
+
+   const void *shmaddr = (const void *)platform_heap_id_to_shmaddr(*hid_out);
+
+   // Heap ID may be coming from the shared segment, itself, that we will
+   // be detaching from now and freeing, below. So, an attempt to NULL out
+   // this handle after memory is freed will run into an exception. Clear
+   // out this handle prior to all this circus.
+   *hid_out = NULL;
+
+   // Use a cached copy in case we are dealing with bogus input shmem address.
+   shmem_heap shmem_heap_struct;
+   memmove(&shmem_heap_struct, shmaddr, sizeof(shmem_heap_struct));
+
+   shmem_heap *shm = &shmem_heap_struct;
+
+   if (shm->shm_magic != SPLINTERDB_SHMEM_MAGIC) {
+      platform_error_log("%s(): Input heap ID, %p, does not seem to be a "
+                         "valid SplinterDB shared segment's start address."
+                         " Found magic 0x%lX does not match expected"
+                         " magic 0x%lX.\n",
+                         __func__,
+                         hid_out,
+                         shm->shm_magic,
+                         SPLINTERDB_SHMEM_MAGIC);
+      return;
+   }
+
+   int shmid = shm->shm_id;
+   int rv    = shmdt(shmaddr);
+   if (rv != 0) {
+      platform_error_log("Failed to detach from shared segment at address "
+                         "%p, shmid=%d.\n",
+                         shmaddr,
+                         shmid);
+      return;
+   }
+
+   // Externally, heap_id is pointing to this field. In anticipation that the
+   // removal of shared segment will succeed, below, clear this out. This way,
+   // any future accesses to this shared segment by its heap-ID will run into
+   // assertions.
+   shm->shm_id = 0;
+
+   // Retain some memory usage stats before releasing shmem
+   size_t shm_total_bytes           = shm->shm_total_bytes;
+   size_t shm_used_bytes            = shm->shm_used_bytes;
+   size_t shm_used_bytes_HWM        = shm->shm_used_bytes_HWM;
+   size_t shm_free_bytes            = shm->shm_free_bytes;
+   uint32 frags_inuse_HWM           = shm->shm_num_frags_inuse_HWM;
+   size_t used_by_large_frags_bytes = shm->shm_used_by_large_frags;
+   size_t shm_nfrees                = shm->shm_nfrees;
+   size_t shm_nfrees_last_frag      = shm->shm_nfrees_last_frag;
+
+   // Print large-fragment tracking metrics (for deep debugging)
+   int found_in_use = platform_trace_large_frags(shm);
+
+   rv = shmctl(shmid, IPC_RMID, NULL);
+   if (rv != 0) {
+      platform_error_log(
+         "shmctl failed to remove shared segment at address %p, shmid=%d.\n",
+         shmaddr,
+         shmid);
+
+      // restore state
+      shm->shm_id = shmid;
+      return;
+   }
+
+   // Reset globals to NULL; to avoid accessing stale handles.
+   Heap_id = NULL;
+
+   fraction used_bytes_pct;
+   fraction used_bytes_hwm_pct;
+   fraction free_bytes_pct;
+   used_bytes_pct     = init_fraction(shm_used_bytes, shm_total_bytes);
+   used_bytes_hwm_pct = init_fraction(shm_used_bytes_HWM, shm_total_bytes);
+   free_bytes_pct     = init_fraction(shm_free_bytes, shm_total_bytes);
+
+   // clang-format off
+   // Always trace destroy of shared memory segment.
+   platform_default_log("Deallocated SplinterDB shared memory "
+                        "segment at %p, shmid=%d."
+                        " Used=%lu bytes (%s, " FRACTION_FMT(4, 2) " %%)"
+                        " Used HWM=%lu bytes (%s, " FRACTION_FMT(4, 2) " %%)"
+                        ", Free=%lu bytes (%s, " FRACTION_FMT( 4, 2) " %%)"
+                        ".\n",
+                        shmaddr,
+                        shmid,
+                        shm_used_bytes,
+                        size_str(shm_used_bytes),
+                        (FRACTION_ARGS(used_bytes_pct) * 100),
+                        shm_used_bytes_HWM,
+                        size_str(shm_used_bytes_HWM),
+                        (FRACTION_ARGS(used_bytes_hwm_pct) * 100),
+                        shm_free_bytes,
+                        size_str(shm_free_bytes),
+                        (FRACTION_ARGS(free_bytes_pct) * 100));
+   // clang-format on
+
+   fraction freed_last_frag_pct;
+   freed_last_frag_pct = init_fraction(shm_nfrees_last_frag, shm_nfrees);
+
+   // clang-format off
+   platform_default_log("SplinterDB shared memory stats:"
+                        " nfrees=%lu"
+                        ", nfrees-last-small-frag=%lu ("
+                        FRACTION_FMT(4, 2) " %%)"
+                        ", Large fragments in-use HWM=%u (found in-use=%d)"
+                        ", consumed=%lu bytes (%s)"
+                        ".\n",
+                        shm_nfrees,
+                        shm_nfrees_last_frag,
+                        (FRACTION_ARGS(freed_last_frag_pct) * 100),
+                        frags_inuse_HWM,
+                        found_in_use,
+                        used_by_large_frags_bytes,
+                        size_str(used_by_large_frags_bytes));
+   // clang-format on
+}
+
+/*
+ * -----------------------------------------------------------------------------
+ * platform_shm_alloc() -- Allocate n-bytes from shared memory segment.
+ *
+ * Allocation request is expected to have added-in pad-bytes required for
+ * alignment to some power-of-2 # of bytes. As a result, we can assert that
+ * the addr-of-next-free-byte is always aligned to PLATFORM_CACHELINE_SIZE.
+ * -----------------------------------------------------------------------------
+ */
+// RESOLVE: Pass down user requested alignment and handle it here.
+void *
+platform_shm_alloc(platform_heap_id hid,
+                   const size_t     size,
+                   const char      *objname,
+                   const char      *func,
+                   const char      *file,
+                   const int        lineno)
+{
+   shmem_heap *shm = platform_heap_id_to_shmaddr(hid);
+
+   debug_assert((platform_shm_heap_valid(shm) == TRUE),
+                "Shared memory heap ID at %p is not a valid shared memory ptr.",
+                hid);
+
+   debug_assert(((size % PLATFORM_CACHELINE_SIZE) == 0),
+                "size=%lu is not aligned to PLATFORM_CACHELINE_SIZE",
+                size);
+   platform_assert(((((uint64)shm->shm_next) % PLATFORM_CACHELINE_SIZE) == 0),
+                   "[%s:%d] Next free-addr is not aligned: "
+                   "shm_next=%p, shm_total_bytes=%lu, shm_used_bytes=%lu"
+                   ", shm_free_bytes=%lu",
+                   file,
+                   lineno,
+                   shm->shm_next,
+                   shm->shm_total_bytes,
+                   shm->shm_used_bytes,
+                   shm->shm_free_bytes);
+
+   void *retptr = NULL;
+
+   // See if we can satisfy requests for large memory fragments from a cached
+   // list of used/free fragments that are tracked separately.
+   if ((size >= SHM_LARGE_FRAG_SIZE)
+       && ((retptr =
+               platform_shm_find_free(shm, size, objname, func, file, lineno))
+           != NULL))
+   {
+      return retptr;
+   }
+
+   _Static_assert(sizeof(void *) == sizeof(size_t),
+                  "check our casts are valid");
+
+   shm_lock_mem(shm);
+
+   // Optimistically, allocate the requested 'size' bytes of memory.
+   retptr = __sync_fetch_and_add(&shm->shm_next, (void *)size);
+
+   if ((retptr + size) > shm->shm_end) {
+      // This memory request cannot fit in available space. Reset.
+      __sync_fetch_and_sub(&shm->shm_next, (void *)size);
+      shm_unlock_mem(shm);
+
+      platform_error_log(
+         "[%s:%d::%s()]: Insufficient memory in shared segment"
+         " to allocate %lu bytes for '%s'. Approx free space=%lu bytes."
+         " shm_num_frags_tracked=%u, shm_num_frags_inuse=%u (HWM=%u).\n",
+         file,
+         lineno,
+         func,
+         size,
+         objname,
+         shm->shm_free_bytes,
+         shm->shm_num_frags_tracked,
+         shm->shm_num_frags_inuse,
+         shm->shm_num_frags_inuse_HWM);
+      platform_trace_large_frags(shm);
+      return NULL;
+   }
+
+   shm->shm_last_alloc = retptr;
+   // Track approx memory usage metrics; mainly for troubleshooting
+   __sync_fetch_and_add(&shm->shm_used_bytes, size);
+   __sync_fetch_and_sub(&shm->shm_free_bytes, size);
+   if (shm->shm_used_bytes > shm->shm_used_bytes_HWM) {
+      shm->shm_used_bytes_HWM = shm->shm_used_bytes;
+   }
+   shm_unlock_mem(shm);
+
+   if (size >= SHM_LARGE_FRAG_SIZE) {
+      platform_shm_track_alloc(shm, retptr, size);
+   }
+
+   // Trace shared memory allocation; then return memory ptr.
+   if (Trace_shmem || Trace_shmem_allocs
+       || (Trace_large_frags && (size >= SHM_LARGE_FRAG_SIZE)))
+   {
+      platform_shm_trace_allocs(shm,
+                                size,
+                                "Allocated new fragment",
+                                retptr,
+                                objname,
+                                func,
+                                file,
+                                lineno);
+   }
+   return retptr;
+}
+
+/*
+ * -----------------------------------------------------------------------------
+ * platform_shm_realloc() -- Re-allocate n-bytes from shared segment.
+ *
+ * Functionally is similar to 'realloc' system call. We allocate required # of
+ * bytes, copy over the old contents (if any), and do a fake free of the oldptr.
+ * -----------------------------------------------------------------------------
+ */
+void *
+platform_shm_realloc(platform_heap_id hid,
+                     void            *oldptr,
+                     const size_t     oldsize,
+                     const size_t     newsize,
+                     const char      *func,
+                     const char      *file,
+                     const int        lineno)
+{
+   debug_assert(((oldptr == NULL) && (oldsize == 0)) || (oldptr && oldsize),
+                "oldptr=%p, oldsize=%lu",
+                oldptr,
+                oldsize);
+
+   // We can only realloc from an oldptr that's allocated from shmem
+   debug_assert(!oldptr || platform_valid_addr_in_heap(hid, oldptr),
+                "oldptr=%p is not allocated from shared memory",
+                oldptr);
+
+   void *retptr =
+      platform_shm_alloc(hid, newsize, "Unknown", func, file, lineno);
+   if (retptr) {
+
+      // Copy over old contents, if any, and free that memory piece
+      if (oldptr) {
+         memcpy(retptr, oldptr, oldsize);
+         platform_shm_free(hid, oldptr, "Unknown", func, file, lineno);
+      }
+   } else {
+      // Report approx memory usage metrics w/o spinlock (diagnostics)
+      shmem_heap *shm             = platform_heap_id_to_shmaddr(hid);
+      size_t      shm_total_bytes = shm->shm_total_bytes;
+      size_t      shm_used_bytes  = shm->shm_used_bytes;
+      size_t      shm_free_bytes  = shm->shm_free_bytes;
+      size_t      shm_num_frees   = shm->shm_nfrees;
+      fraction    used_bytes_pct;
+      fraction    free_bytes_pct;
+      used_bytes_pct = init_fraction(shm_used_bytes, shm_total_bytes);
+      free_bytes_pct = init_fraction(shm_free_bytes, shm_total_bytes);
+
+      // clang-format off
+      platform_error_log("%s() failed to reallocate newsize=%lu bytes (%s)"
+                         ", oldsize=%lu bytes (%s)"
+                         ", Used=%lu bytes (%s, " FRACTION_FMT(4, 2)
+                         " %%), Free=%lu bytes (%s, " FRACTION_FMT(4, 2)
+                         " %%)"
+                         ", num-free-calls=%lu\n",
+                        __func__,
+                        newsize,
+                        size_str(newsize),
+                        oldsize,
+                        size_str(oldsize),
+                        shm_used_bytes,
+                        size_str(shm_used_bytes),
+                        (FRACTION_ARGS(used_bytes_pct) * 100),
+                        shm_free_bytes,
+                        size_str(shm_free_bytes),
+                        (FRACTION_ARGS(free_bytes_pct) * 100),
+                        shm_num_frees);
+      // clang-format off
+   }
+   return retptr;
+}
+
+/*
+ * -----------------------------------------------------------------------------
+ * platform_shm_free() -- 'Free' the memory fragment at given address in shmem.
+ *
+ * We expect that the 'ptr' is a valid address within the shared segment.
+ * Otherwise, it means that Splinter was configured to run with shared memory,
+ * -and- in some code path we allocated w/o using shared memory
+ * (i.e. PROCESS_PRIVATE_HEAP_ID interface), but ended up calling shmem-free
+ * interface. That would be a code error which results in a memory leak.
+ * -----------------------------------------------------------------------------
+ */
+void
+platform_shm_free(platform_heap_id hid,
+                  void            *ptr,
+                  const char      *objname,
+                  const char      *func,
+                  const char      *file,
+                  const int        lineno)
+{
+   shmem_heap *shm = platform_heap_id_to_shmaddr(hid);
+
+   debug_assert(
+      (platform_shm_heap_valid(shm) == TRUE),
+      "Shared memory heap ID at %p is not a valid shared memory handle.",
+      hid);
+
+   if (!platform_valid_addr_in_heap(hid, ptr)) {
+      platform_error_log("[%s:%d::%s()] -> %s: Requesting to free memory"
+                         " at %p, for object '%s' which is a memory chunk not"
+                         " allocated from shared memory {start=%p, end=%p}.\n",
+                         file,
+                         lineno,
+                         func,
+                         __func__,
+                         ptr,
+                         objname,
+                         platform_shm_lop(hid),
+                         platform_shm_hip(hid));
+      return;
+   }
+
+   // Micro-optimization for very-last-fragment-allocated being freed
+   bool   maybe_large_frag = TRUE;
+   size_t frag_size        = 0;
+
+   shm_lock_mem(shm);
+   shm->shm_nfrees++;
+   if (shm->shm_last_alloc == ptr) {
+      debug_assert(
+         shm->shm_next > ptr, "shm_next=%p, free-ptr=%p", shm->shm_next, ptr);
+      frag_size = (shm->shm_next - ptr);
+      if (frag_size < SHM_LARGE_FRAG_SIZE) {
+         // Recycle the most-recently-allocated-small-fragment, now being freed.
+         shm->shm_next       = ptr;
+         shm->shm_last_alloc = NULL;
+         shm->shm_free_bytes += frag_size;
+         shm->shm_used_bytes -= frag_size;
+         shm->shm_nfrees_last_frag += 1;
+
+         // We know fragment being freed is not a large fragment
+         maybe_large_frag = FALSE;
+      }
+   }
+   shm_unlock_mem(shm);
+
+   if (maybe_large_frag) {
+      platform_shm_track_free(shm, ptr, objname, func, file, lineno);
+   }
+
+   if (Trace_shmem || Trace_shmem_frees) {
+      platform_default_log("  [%s:%d::%s()] -> %s: Request to free memory at "
+                           "%p for object '%s'.\n",
+                           file,
+                           lineno,
+                           func,
+                           __func__,
+                           ptr,
+                           objname);
+   }
+   return;
+}
+
+/*
+ * -----------------------------------------------------------------------------
+ * platform_shm_track_alloc() - Track the allocation of this large fragment.
+ * 'Tracking' here means we record this large-fragment in an array tracking
+ * large-memory fragments allocated.
+ * -----------------------------------------------------------------------------
+ */
+static void
+platform_shm_track_alloc(shmem_heap *shm, void *addr, size_t size)
+{
+   debug_assert(
+      (size >= SHM_LARGE_FRAG_SIZE),
+      "Incorrect usage of this interface for requested size=%lu bytes."
+      " Size should be >= %lu bytes.\n",
+      size,
+      SHM_LARGE_FRAG_SIZE);
+
+
+   // Iterate through the list of memory fragments being tracked.
+   int            fctr = 0;
+   shm_frag_info *frag = shm->shm_mem_frags;
+   shm_lock_mem_frags(shm);
+   while ((fctr < ARRAY_SIZE(shm->shm_mem_frags)) && frag->shm_frag_addr) {
+      // As this is a newly allocated fragment being tracked, it should
+      // not be found elsewhere in the tracker array.
+      platform_assert((frag->shm_frag_addr != addr),
+                      "Error! Newly allocated large memory fragment at %p"
+                      " is already tracked at slot %d."
+                      " Fragment is allocated to PID=%d, to tid=%lu,"
+                      " and is %s (freed by PID=%d, by tid=%lu)\n.",
+                      addr,
+                      fctr,
+                      frag->shm_frag_allocated_to_pid,
+                      frag->shm_frag_allocated_to_tid,
+                      (frag->shm_frag_freed_by_pid ? "free" : "in use"),
+                      frag->shm_frag_freed_by_pid,
+                      frag->shm_frag_freed_by_tid);
+      fctr++;
+      frag++;
+   }
+   // If we found a free slot, track our memory fragment at fctr'th slot.
+   if (fctr < ARRAY_SIZE(shm->shm_mem_frags)) {
+      shm->shm_num_frags_tracked++;
+      shm->shm_num_frags_inuse++;
+      shm->shm_used_by_large_frags += size;
+      if (shm->shm_num_frags_inuse > shm->shm_num_frags_inuse_HWM) {
+         shm->shm_num_frags_inuse_HWM = shm->shm_num_frags_inuse;
+      }
+
+      // We should really assert that the other fields are zero, but for now
+      // re-init this fragment tracker.
+      memset(frag, 0, sizeof(*frag));
+      frag->shm_frag_addr = addr;
+      frag->shm_frag_size = size;
+
+      frag->shm_frag_allocated_to_pid = getpid();
+      frag->shm_frag_allocated_to_tid = platform_get_tid();
+
+      // The freed_by_pid/freed_by_tid == 0 means fragment is still allocated.
+
+      // Track highest address of large-fragment that is being tracked.
+      if (shm->shm_large_frag_hip < addr) {
+         shm->shm_large_frag_hip = addr;
+      }
+   }
+
+   shm_unlock_mem_frags(shm);
+}
+
+/*
+ * -----------------------------------------------------------------------------
+ * platform_shm_track_free() - See if this memory fragment being freed is
+ * already being tracked. If so, it's a large fragment allocation, which can be
+ * re-cycled after this free. Do the book-keeping accordingly to record that
+ * this large-fragment is no longer in-use and can be recycled.
+ * -----------------------------------------------------------------------------
+ */
+static void
+platform_shm_track_free(shmem_heap *shm,
+                        void       *addr,
+                        const char *objname,
+                        const char *func,
+                        const char *file,
+                        const int   lineno)
+{
+   shm_lock_mem_frags(shm);
+
+   // If we are freeing a fragment beyond the high-address of all
+   // large fragments tracked, then this is certainly not a large
+   // fragment. So, no further need to see if it's a tracked fragment.
+   if (addr > shm->shm_large_frag_hip) {
+      shm_unlock_mem_frags(shm);
+      return;
+   }
+   bool found_tracked_frag = FALSE;
+   bool trace_shmem        = (Trace_shmem || Trace_shmem_frees);
+
+   shm_frag_info *frag = shm->shm_mem_frags;
+   int            fctr = 0;
+   while ((fctr < ARRAY_SIZE(shm->shm_mem_frags))
+          && (!frag->shm_frag_addr || (frag->shm_frag_addr != addr)))
+   {
+      fctr++;
+      frag++;
+   }
+   if (fctr < ARRAY_SIZE(shm->shm_mem_frags)) {
+      debug_assert(frag->shm_frag_addr == addr);
+      found_tracked_frag = TRUE;
+
+      // Cross-check the recording we did when fragment was allocated
+      // We cannot check the tid as the parent process' tid may be 0.
+      // We could have come across a free fragment that was previously
+      // used by the parent process.
+      // debug_assert(frag->shm_frag_allocated_to_tid != 0);
+      debug_assert(frag->shm_frag_allocated_to_pid != 0);
+      debug_assert(frag->shm_frag_size != 0);
+
+      shm->shm_num_frags_inuse--;
+
+      // Mark the fragment as in-use by recording the process/thread that's
+      // doing the free.
+      frag->shm_frag_freed_by_pid = getpid();
+      frag->shm_frag_freed_by_tid = platform_get_tid();
+
+      if (trace_shmem) {
+         platform_default_log("OS-pid=%d, ThreadID=%lu"
+                              ", Track freed fragment of size=%lu bytes"
+                              ", at slot=%d, addr=%p"
+                              ", allocated_to_pid=%d, allocated_to_tid=%lu"
+                              ", shm_large_frag_hip=%p\n",
+                              frag->shm_frag_freed_by_pid,
+                              frag->shm_frag_freed_by_tid,
+                              frag->shm_frag_size,
+                              fctr,
+                              addr,
+                              frag->shm_frag_allocated_to_pid,
+                              frag->shm_frag_allocated_to_tid,
+                              shm->shm_large_frag_hip);
+      }
+   }
+   shm_unlock_mem_frags(shm);
+
+   if (!found_tracked_frag && trace_shmem) {
+      platform_default_log("[OS-pid=%d, ThreadID=%lu, %s:%d::%s()] "
+                           ", Fragment %p for object '%s' is not tracked\n",
+                           getpid(),
+                           platform_get_tid(),
+                           file,
+                           lineno,
+                           func,
+                           addr,
+                           objname);
+   }
+}
+
+/*
+ * -----------------------------------------------------------------------------
+ * platform_shm_find_free() - Search the array of large-fragments being tracked
+ * to see if there is an already allocated and now-free large memory fragment.
+ * If so, allocate that fragment to this requester. Do the book-keeping
+ * accordingly.
+ * -----------------------------------------------------------------------------
+ */
+static void *
+platform_shm_find_free(shmem_heap *shm,
+                       size_t      size,
+                       const char *objname,
+                       const char *func,
+                       const char *file,
+                       const int   lineno)
+{
+   debug_assert((size >= SHM_LARGE_FRAG_SIZE),
+                "Incorrect usage of this interface for requested"
+                " size=%lu bytes. Size should be >= %lu bytes.\n",
+                size,
+                SHM_LARGE_FRAG_SIZE);
+
+   void          *retptr = NULL;
+   shm_frag_info *frag   = shm->shm_mem_frags;
+   int local_in_use      = 0; // Tracked while iterating in this fn, locally
+
+   int  found_at_fctr      = -1;
+   bool found_tracked_frag = FALSE;
+
+   shm_lock_mem_frags(shm);
+
+   uint32 shm_num_frags_tracked = shm->shm_num_frags_tracked;
+   uint32 shm_num_frags_inuse   = shm->shm_num_frags_inuse;
+
+   for (int fctr = 0; fctr < ARRAY_SIZE(shm->shm_mem_frags); fctr++, frag++) {
+      if (!frag->shm_frag_addr || (frag->shm_frag_size < size)) {
+         continue;
+      }
+
+      // Skip fragment if it's still in-use
+      if (frag->shm_frag_freed_by_pid == 0) {
+         platform_assert((frag->shm_frag_freed_by_tid == 0),
+                         "Invalid state found for fragment at index %d,"
+                         "freed_by_pid=%d but freed_by_tid=%lu "
+                         "(which should also be 0)\n",
+                         fctr,
+                         frag->shm_frag_freed_by_pid,
+                         frag->shm_frag_freed_by_tid);
+
+         local_in_use++;
+         continue;
+      }
+      found_tracked_frag = TRUE;
+      found_at_fctr      = fctr;
+
+      // Record the process/thread to which free fragment is being allocated
+      frag->shm_frag_allocated_to_pid = getpid();
+      frag->shm_frag_allocated_to_tid = platform_get_tid();
+
+      shm->shm_num_frags_inuse++;
+      if (shm->shm_num_frags_inuse > shm->shm_num_frags_inuse_HWM) {
+         shm->shm_num_frags_inuse_HWM = shm->shm_num_frags_inuse;
+      }
+      shm_num_frags_inuse = shm->shm_num_frags_inuse;
+
+      // Now, mark that this fragment is in-use
+      frag->shm_frag_freed_by_pid = 0;
+      frag->shm_frag_freed_by_tid = 0;
+
+      retptr = frag->shm_frag_addr;
+
+      // Zero out the recycled large-memory fragment, just to be sure ...
+      memset(retptr, 0, frag->shm_frag_size);
+      break;
+   }
+   shm_unlock_mem_frags(shm);
+
+   // Trace whether we found tracked fragment or not.
+   if (Trace_shmem || Trace_shmem_allocs) {
+      char msg[200];
+      if (found_tracked_frag) {
+         /*
+          * In this trace message, don't be confused if you see a wide gap
+          * between local_in_use and shm_num_frags_inuse. The latter is a global
+          * counter while the former is a local counter. We may have found a
+          * free fragment to reallocate early in the array w/o processing the
+          * full array. Hence, these two values are likely to diff (by a big
+          * margin, even).
+          */
+         snprintf(msg,
+                  sizeof(msg),
+                  "Reallocated free fragment at slot=%d, addr=%p, "
+                  "shm_num_frags_tracked=%u, shm_num_frags_inuse=%u"
+                  " (local_in_use=%d)",
+                  found_at_fctr,
+                  retptr,
+                  shm_num_frags_tracked,
+                  shm_num_frags_inuse,
+                  local_in_use);
+      } else {
+         snprintf(msg,
+                  sizeof(msg),
+                  "Did not find free fragment of size=%lu bytes to reallocate."
+                  " shm_num_frags_tracked=%u, shm_num_frags_inuse=%u"
+                  " (local_in_use=%d)",
+                  size,
+                  shm_num_frags_tracked,
+                  shm_num_frags_inuse,
+                  local_in_use);
+      }
+      platform_shm_trace_allocs(
+         shm, size, msg, retptr, objname, func, file, lineno);
+   }
+   return retptr;
+}
+
+/*
+ * -----------------------------------------------------------------------------
+ * platform_trace_large_frags() - Walk through large-fragments tracking array
+ * and dump info about fragments that still appear "in-use".
+ * This diagnostic routine will -always- be called when shared segment is
+ * being destroyed. If any "in-use" large-fragments are found, a message will
+ * be generated.
+ * -----------------------------------------------------------------------------
+ */
+static int
+platform_trace_large_frags(shmem_heap *shm)
+{
+   int local_in_use    = 0; // Tracked while iterating in this fn, locally
+   shm_frag_info *frag = shm->shm_mem_frags;
+
+   threadid thread_tid     = platform_get_tid();
+   bool     print_new_line = false;
+   // Walk the tracked-fragments array looking for an in-use fragment
+   for (int fctr = 0; fctr < ARRAY_SIZE(shm->shm_mem_frags); fctr++, frag++) {
+      if (!frag->shm_frag_addr) {
+         continue;
+      }
+
+      // Skip freed fragments.
+      if (frag->shm_frag_freed_by_pid != 0) {
+         continue;
+      }
+      // Found a large fragment that is still "in-use"
+      local_in_use++;
+
+      // Do -NOT- assert here. As this is a diagnostic routine, report
+      // the inconsistency, and continue to find more stray large fragments.
+      if (frag->shm_frag_freed_by_tid != 0) {
+         platform_error_log("Invalid state found for fragment at index %d,"
+                            "freed_by_pid=%d but freed_by_tid=%lu "
+                            "(which should also be 0)\n",
+                            fctr,
+                            frag->shm_frag_freed_by_pid,
+                            frag->shm_frag_freed_by_tid);
+      }
+
+      if (!print_new_line) {
+         platform_error_log("\n**** [TID=%lu] Large fragment usage "
+                            "diagnostics:\n",
+                            thread_tid);
+         print_new_line = true;
+      }
+
+      platform_error_log("  **** [TID=%lu] Fragment at slot=%d, addr=%p"
+                         ", size=%lu (%s) is in-use, allocated_to_pid=%d"
+                         ", allocated_to_tid=%lu\n",
+                         thread_tid,
+                         fctr,
+                         frag->shm_frag_addr,
+                         frag->shm_frag_size,
+                         size_str(frag->shm_frag_size),
+                         frag->shm_frag_allocated_to_pid,
+                         frag->shm_frag_allocated_to_tid);
+   }
+   return local_in_use;
+}
+
+/*
+ * -----------------------------------------------------------------------------
+ * Accessor interfaces - mainly intended as assert / testing / debugging
+ * hooks.
+ * -----------------------------------------------------------------------------
+ */
+bool
+platform_shm_heap_valid(shmem_heap *shmheap)
+{
+   // Use a cached copy in case we are dealing with a bogus input shmem
+   // address.
+   shmem_heap shmem_heap_struct;
+   memmove(&shmem_heap_struct, (void *)shmheap, sizeof(shmem_heap_struct));
+
+   shmem_heap *shm = &shmem_heap_struct;
+
+   if (shm->shm_magic != SPLINTERDB_SHMEM_MAGIC) {
+      platform_error_log(
+         "%s(): Input shared memory heap, %p, does not seem to be a valid "
+         "SplinterDB shared segment's start address."
+         " Found magic 0x%lX does not match expected magic 0x%lX.\n",
+         __func__,
+         shmheap,
+         shm->shm_magic,
+         SPLINTERDB_SHMEM_MAGIC);
+      return FALSE;
+   }
+
+   return TRUE;
+}
+
+/*
+ * Initialize tracing of shared memory allocs / frees. This is invoked as a
+ * result of parsing command-line args:
+ */
+void
+platform_shm_tracing_init(const bool trace_shmem,
+                          const bool trace_shmem_allocs,
+                          const bool trace_shmem_frees)
+{
+   if (trace_shmem) {
+      Trace_shmem = TRUE;
+   }
+   if (trace_shmem_allocs) {
+      Trace_shmem_allocs = TRUE;
+   }
+   if (trace_shmem_frees) {
+      Trace_shmem_frees = TRUE;
+   }
+}
+
+/*
+ * Action-methods to enable / disable tracing of shared memory operations:
+ *  ops == allocs & frees.
+ */
+void
+platform_enable_tracing_shm_ops()
+{
+   Trace_shmem = TRUE;
+}
+
+void
+platform_enable_tracing_shm_allocs()
+{
+   Trace_shmem_allocs = TRUE;
+}
+
+void
+platform_enable_tracing_shm_frees()
+{
+   Trace_shmem_frees = TRUE;
+}
+
+void
+platform_disable_tracing_shm_ops()
+{
+   Trace_shmem        = FALSE;
+   Trace_shmem_allocs = FALSE;
+   Trace_shmem_frees  = FALSE;
+}
+
+void
+platform_disable_tracing_shm_allocs()
+{
+   Trace_shmem_allocs = FALSE;
+}
+
+void
+platform_disable_tracing_shm_frees()
+{
+   Trace_shmem_frees = FALSE;
+}
+
+void
+platform_enable_tracing_large_frags()
+{
+   Trace_large_frags = TRUE;
+}
+
+void
+platform_disable_tracing_large_frags()
+{
+   Trace_large_frags = FALSE;
+}
+
+/* Size of control block at start of shared memory describing shared segment
+ */
+size_t
+platform_shm_ctrlblock_size()
+{
+   return sizeof(shmem_heap);
+}
+
+/*
+ * Shmem-accessor interfaces by heap_id.
+ */
+size_t
+platform_shmsize(platform_heap_id heap_id)
+{
+   return (platform_heap_id_to_shmaddr(heap_id)->shm_total_bytes);
+}
+
+size_t
+platform_shmbytes_used(platform_heap_id heap_id)
+{
+   return (platform_heap_id_to_shmaddr(heap_id)->shm_used_bytes);
+}
+size_t
+platform_shmbytes_free(platform_heap_id heap_id)
+{
+   return (platform_heap_id_to_shmaddr(heap_id)->shm_free_bytes);
+}
+
+void *
+platform_shm_next_free_addr(platform_heap_id heap_id)
+{
+   return (platform_heap_id_to_shmaddr(heap_id)->shm_next);
+}
+
+static void
+platform_shm_trace_allocs(shmem_heap  *shm,
+                          const size_t size,
+                          const char  *verb,
+                          const void  *retptr,
+                          const char  *objname,
+                          const char  *func,
+                          const char  *file,
+                          const int    lineno)
+{
+   platform_default_log("  [OS-pid=%d,ThreadID=%lu, %s:%d::%s()] "
+                        "-> %s: %s size=%lu bytes (%s)"
+                        " for object '%s', at %p, "
+                        "free bytes=%lu (%s).\n",
+                        getpid(),
+                        platform_get_tid(),
+                        file,
+                        lineno,
+                        func,
+                        __func__,
+                        verb,
+                        size,
+                        size_str(size),
+                        objname,
+                        retptr,
+                        shm->shm_free_bytes,
+                        size_str(shm->shm_free_bytes));
+}

--- a/src/platform_linux/shmem.h
+++ b/src/platform_linux/shmem.h
@@ -1,0 +1,101 @@
+// Copyright 2018-2023 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <sys/types.h>
+#include <sys/shm.h>
+
+platform_status
+platform_shmcreate(size_t size, platform_heap_id *heap_id);
+
+void
+platform_shmdestroy(platform_heap_id *heap_id);
+
+/*
+ * Allocate memory fragment from the shared memory of requested 'size'.
+ */
+void *
+platform_shm_alloc(platform_heap_id hid,
+                   const size_t     size,
+                   const char      *objname,
+                   const char      *func,
+                   const char      *file,
+                   const int        lineno);
+
+/*
+ * Free the memory fragment at 'ptr' address.
+ */
+void
+platform_shm_free(platform_heap_id hid,
+                  void            *ptr,
+                  const char      *objname,
+                  const char      *func,
+                  const char      *file,
+                  const int        lineno);
+
+/*
+ * Reallocate the memory (fragment) at 'oldptr' of size 'oldsize' bytes.
+ * Any contents at 'oldptr' are copied to 'newptr' for 'oldsize' bytes.
+ *
+ * NOTE: This interface does -not- do any cache-line alignment for 'newsize'
+ * request. Caller is expected to do so. platform_realloc() takes care of it.
+ *
+ * Returns ptr to re-allocated memory of 'newsize' bytes.
+ */
+void *
+platform_shm_realloc(platform_heap_id hid,
+                     void            *oldptr,
+                     const size_t     oldsize,
+                     const size_t     newsize,
+                     const char      *func,
+                     const char      *file,
+                     const int        lineno);
+
+void
+platform_shm_tracing_init(const bool trace_shmem,
+                          const bool trace_shmem_allocs,
+                          const bool trace_shmem_frees);
+
+void
+platform_enable_tracing_shm_ops();
+
+void
+platform_enable_tracing_shm_allocs();
+
+void
+platform_enable_tracing_shm_frees();
+
+void
+platform_disable_tracing_shm_ops();
+
+void
+platform_disable_tracing_shm_allocs();
+
+void
+platform_disable_tracing_shm_frees();
+
+size_t
+platform_shm_ctrlblock_size();
+
+/*
+ * Interfaces to retrieve size(s) using heap_id, which is what's
+ * known externally to memory allocation interfaces.
+ */
+size_t
+platform_shmsize(platform_heap_id heap_id);
+
+size_t
+platform_shmbytes_free(platform_heap_id heap_id);
+
+size_t
+platform_shmbytes_used(platform_heap_id heap_id);
+
+void *
+platform_shm_next_free_addr(platform_heap_id heap_id);
+
+void
+platform_enable_tracing_large_frags();
+
+void
+platform_disable_tracing_large_frags();

--- a/src/routing_filter.c
+++ b/src/routing_filter.c
@@ -318,14 +318,13 @@ routing_get_bucket_counts(routing_config *cfg, routing_hdr *hdr, uint32 *count)
  *----------------------------------------------------------------------
  */
 platform_status
-routing_filter_add(cache           *cc,
-                   routing_config  *cfg,
-                   platform_heap_id hid,
-                   routing_filter  *old_filter,
-                   routing_filter  *filter,
-                   uint32          *new_fp_arr,
-                   uint64           num_new_fp,
-                   uint16           value)
+routing_filter_add(cache          *cc,
+                   routing_config *cfg,
+                   routing_filter *old_filter,
+                   routing_filter *filter,
+                   uint32         *new_fp_arr,
+                   uint64          num_new_fp,
+                   uint16          value)
 {
    ZERO_CONTENTS(filter);
 
@@ -396,7 +395,8 @@ routing_filter_add(cache           *cc,
                               ROUTING_FPS_PER_PAGE +      // old_fp_buffer
                               ROUTING_FPS_PER_PAGE / 32;  // encoding_buffer
    debug_assert(temp_buffer_count < 100000000);
-   uint32 *temp = TYPED_ARRAY_ZALLOC(hid, temp, temp_buffer_count);
+   uint32 *temp =
+      TYPED_ARRAY_ZALLOC(PROCESS_PRIVATE_HEAP_ID, temp, temp_buffer_count);
 
    if (temp == NULL) {
       return STATUS_NO_MEMORY;
@@ -505,7 +505,10 @@ routing_filter_add(cache           *cc,
                                           << old_remainder_and_value_size;
             }
          }
-         debug_assert(old_fp_no == old_index_count);
+         debug_assert((old_fp_no == old_index_count),
+                      "old_fp_no=%u, old_index_count=%u\n",
+                      old_fp_no,
+                      old_index_count);
 
          if (old_value_size != value_size) {
             for (old_fp_no = 0; old_fp_no < old_index_count; old_fp_no++) {
@@ -622,7 +625,7 @@ routing_filter_add(cache           *cc,
 
    mini_release(&mini, NULL_KEY);
 
-   platform_free(hid, temp);
+   platform_free(PROCESS_PRIVATE_HEAP_ID, temp);
 
    return STATUS_OK;
 }
@@ -729,7 +732,11 @@ routing_filter_estimate_unique_fp(cache           *cc,
 
             uint32  index_bucket_start = index_no * index_size;
             uint32 *src_fp             = &fp_arr[src_fp_no];
-            platform_assert(src_fp_no + index_count <= buffer_size);
+            platform_assert((src_fp_no + index_count <= buffer_size),
+                            "src_fp_no=%u, index_count=%u, buffer_size=%u\n",
+                            src_fp_no,
+                            index_count,
+                            buffer_size);
             if (index_count != 0) {
                debug_only uint32 index_start = src_fp_no;
                PackedArray_unpack((uint32 *)block_start,

--- a/src/routing_filter.h
+++ b/src/routing_filter.h
@@ -90,14 +90,13 @@ typedef struct routing_async_ctxt {
 } routing_async_ctxt;
 
 platform_status
-routing_filter_add(cache           *cc,
-                   routing_config  *cfg,
-                   platform_heap_id hid,
-                   routing_filter  *old_filter,
-                   routing_filter  *filter,
-                   uint32          *new_fp_arr,
-                   uint64           num_new_fingerprints,
-                   uint16           value);
+routing_filter_add(cache          *cc,
+                   routing_config *cfg,
+                   routing_filter *old_filter,
+                   routing_filter *filter,
+                   uint32         *new_fp_arr,
+                   uint64          num_new_fingerprints,
+                   uint16          value);
 
 platform_status
 routing_filter_lookup(cache          *cc,

--- a/src/splinterdb.c
+++ b/src/splinterdb.c
@@ -23,6 +23,12 @@
 #include "poison.h"
 
 const char *BUILD_VERSION = "splinterdb_build_version " GIT_VERSION;
+
+// Function prototypes
+
+static void
+splinterdb_close_print_stats(splinterdb *kvs);
+
 const char *
 splinterdb_get_version()
 {
@@ -30,21 +36,21 @@ splinterdb_get_version()
 }
 
 typedef struct splinterdb {
-   task_system         *task_sys;
-   io_config            io_cfg;
-   platform_io_handle   io_handle;
-   allocator_config     allocator_cfg;
-   rc_allocator         allocator_handle;
-   clockcache_config    cache_cfg;
-   clockcache           cache_handle;
-   shard_log_config     log_cfg;
-   task_system_config   task_cfg;
-   allocator_root_id    trunk_id;
-   trunk_config         trunk_cfg;
-   trunk_handle        *spl;
-   platform_heap_handle heap_handle; // for platform_buffer_create
-   platform_heap_id     heap_id;
-   data_config         *data_cfg;
+   task_system       *task_sys;
+   io_config          io_cfg;
+   platform_io_handle io_handle;
+   allocator_config   allocator_cfg;
+   rc_allocator       allocator_handle;
+   clockcache_config  cache_cfg;
+   clockcache         cache_handle;
+   shard_log_config   log_cfg;
+   task_system_config task_cfg;
+   allocator_root_id  trunk_id;
+   trunk_config       trunk_cfg;
+   trunk_handle      *spl;
+   platform_heap_id   heap_id;
+   data_config       *data_cfg;
+   bool               we_created_heap;
 } splinterdb;
 
 
@@ -59,7 +65,6 @@ platform_status_to_int(const platform_status status) // IN
 {
    return status.r;
 }
-
 
 static void
 splinterdb_config_set_defaults(splinterdb_config *cfg)
@@ -160,9 +165,6 @@ splinterdb_init_config(const splinterdb_config *kvs_cfg, // IN
    memcpy(&cfg, kvs_cfg, sizeof(cfg));
    splinterdb_config_set_defaults(&cfg);
 
-   kvs->heap_handle = cfg.heap_handle;
-   kvs->heap_id     = cfg.heap_id;
-
    io_config_init(&kvs->io_cfg,
                   cfg.page_size,
                   cfg.extent_size,
@@ -227,20 +229,49 @@ splinterdb_init_config(const splinterdb_config *kvs_cfg, // IN
 int
 splinterdb_create_or_open(const splinterdb_config *kvs_cfg,      // IN
                           splinterdb             **kvs_out,      // OUT
-                          bool32                   open_existing // IN
+                          bool                     open_existing // IN
 )
 {
-   splinterdb     *kvs;
+   splinterdb     *kvs = NULL;
    platform_status status;
+
+   bool             we_created_heap  = FALSE;
+   platform_heap_id use_this_heap_id = kvs_cfg->heap_id;
+
+   // Allocate a shared segment if so requested. For now, we hard-code
+   // the required size big enough to run most tests. Eventually this
+   // has to be calculated here based on other run-time params.
+   // (Some tests externally create the platform_heap, so we should
+   // only create one if it does not already exist.)
+   if (kvs_cfg->use_shmem && (use_this_heap_id == NULL)) {
+      size_t shmem_size = (kvs_cfg->shmem_size ? kvs_cfg->shmem_size : 2 * GiB);
+      status            = platform_heap_create(
+         platform_get_module_id(), shmem_size, TRUE, &use_this_heap_id);
+      if (!SUCCESS(status)) {
+         platform_error_log(
+            "Shared memory creation failed. "
+            "Failed to %s SplinterDB device '%s' with specified "
+            "configuration: %s\n",
+            (open_existing ? "open existing" : "initialize"),
+            kvs_cfg->filename,
+            platform_status_to_string(status));
+         goto deinit_kvhandle;
+      }
+      we_created_heap = TRUE;
+   }
 
    platform_assert(kvs_out != NULL);
 
-   kvs = TYPED_ZALLOC(kvs_cfg->heap_id, kvs);
+   kvs = TYPED_ZALLOC(use_this_heap_id, kvs);
    if (kvs == NULL) {
       status = STATUS_NO_MEMORY;
-      return platform_status_to_int(status);
+      goto deinit_kvhandle;
    }
+   // Remember, so at close() we only destroy heap if we created it here.
+   kvs->we_created_heap = we_created_heap;
 
+   // All memory allocation after this call should -ONLY- use heap handles
+   // from the handle to the running Splinter instance; i.e. 'kvs'.
    status = splinterdb_init_config(kvs_cfg, kvs);
    if (!SUCCESS(status)) {
       platform_error_log("Failed to %s SplinterDB device '%s' with specified "
@@ -251,12 +282,15 @@ splinterdb_create_or_open(const splinterdb_config *kvs_cfg,      // IN
       goto deinit_kvhandle;
    }
 
-   status = io_handle_init(
-      &kvs->io_handle, &kvs->io_cfg, kvs->heap_handle, kvs->heap_id);
+   // All future memory allocation should come from shared memory, if so
+   // configured.
+   kvs->heap_id = use_this_heap_id;
+
+   status = io_handle_init(&kvs->io_handle, &kvs->io_cfg, kvs->heap_id);
    if (!SUCCESS(status)) {
       platform_error_log("Failed to initialize IO handle: %s\n",
                          platform_status_to_string(status));
-      goto deinit_kvhandle;
+      goto io_handle_init_failed;
    }
 
    status = task_system_create(
@@ -336,8 +370,18 @@ deinit_system:
    task_system_destroy(kvs->heap_id, &kvs->task_sys);
 deinit_iohandle:
    io_handle_deinit(&kvs->io_handle);
+io_handle_init_failed:
 deinit_kvhandle:
-   platform_free(kvs_cfg->heap_id, kvs);
+   // Depending on the place where a configuration / setup error lead
+   // us to here via a 'goto', heap_id handle, if in use, may be in a
+   // different place. Use one carefully, to avoid ASAN-errors.
+   if (we_created_heap) {
+      // => Caller did not setup a platform-heap on entry.
+      debug_assert(kvs_cfg->heap_id == NULL);
+
+      platform_free(use_this_heap_id, kvs);
+      platform_heap_destroy(&use_this_heap_id);
+   }
 
    return platform_status_to_int(status);
 }
@@ -362,7 +406,8 @@ splinterdb_open(const splinterdb_config *cfg, // IN
  *-----------------------------------------------------------------------------
  * splinterdb_close --
  *
- *      Close a splinterdb, flushing to disk and releasing resources
+ *      Close a splinterdb, flushing to disk and releasing resources.
+ *      Platform heap memory is also destroyed when closing SplinterDB.
  *
  * Results:
  *      None.
@@ -377,6 +422,10 @@ splinterdb_close(splinterdb **kvs_in) // IN
    splinterdb *kvs = *kvs_in;
    platform_assert(kvs != NULL);
 
+   // Print stats if shared memory is enabled.
+   if (kvs->heap_id) {
+      splinterdb_close_print_stats(kvs);
+   }
    /*
     * NOTE: These dismantling routines must appear in exactly the reverse
     * order when these sub-systems were init'ed when a Splinter device was
@@ -388,7 +437,13 @@ splinterdb_close(splinterdb **kvs_in) // IN
    task_system_destroy(kvs->heap_id, &kvs->task_sys);
    io_handle_deinit(&kvs->io_handle);
 
+   // Free resources carefully to avoid ASAN-test failures
+   platform_heap_id heap_id         = kvs->heap_id;
+   bool             we_created_heap = kvs->we_created_heap;
    platform_free(kvs->heap_id, kvs);
+   if (we_created_heap) {
+      platform_heap_destroy(&heap_id);
+   }
    *kvs_in = (splinterdb *)NULL;
 }
 
@@ -722,4 +777,11 @@ void
 splinterdb_stats_reset(splinterdb *kvs)
 {
    trunk_reset_stats(kvs->spl);
+}
+
+static void
+splinterdb_close_print_stats(splinterdb *kvs)
+{
+   task_print_stats(kvs->task_sys);
+   splinterdb_stats_print_insertion(kvs);
 }

--- a/src/task.c
+++ b/src/task.c
@@ -3,6 +3,7 @@
 
 #include "platform.h"
 #include "task.h"
+#include "util.h"
 
 #include "poison.h"
 
@@ -220,8 +221,12 @@ task_invoke_with_hooks(void *func_and_args)
    // the actual Splinter work will be done.
    func(arg);
 
-   platform_free(thread_started->ts->heap_id,
-                 thread_started->ts->thread_scratch[thread_started->tid]);
+   // Some [test] callers may have created a task w/o requesting for any
+   // scratch space. So, check before trying to free memory.
+   void *scratchptr = thread_started->ts->thread_scratch[thread_started->tid];
+   if (scratchptr) {
+      platform_free(thread_started->ts->heap_id, scratchptr);
+   }
 
    platform_set_tid(INVALID_TID);
    task_deallocate_threadid(thread_started->ts, thread_started->tid);
@@ -447,7 +452,10 @@ task_group_get_next_task(task_group *group)
    if (tq->head == NULL) {
       platform_assert(tq->tail == assigned_task);
       tq->tail = NULL;
-      platform_assert(outstanding_tasks == 1);
+      platform_assert((outstanding_tasks == 1),
+                      "outstanding_tasks=%lu\n",
+                      outstanding_tasks);
+      ;
    }
 
    return assigned_task;
@@ -647,13 +655,12 @@ task_enqueue(task_system *ts,
 
    if (group->use_stats) {
       new_task->enqueue_time = platform_get_timestamp();
-   }
-   if (group->use_stats) {
-      const threadid tid = platform_get_tid();
+      const threadid tid     = platform_get_tid();
       if (group->current_waiting_tasks
           > group->stats[tid].max_outstanding_tasks) {
          group->stats[tid].max_outstanding_tasks = group->current_waiting_tasks;
       }
+      group->stats[tid].total_tasks_enqueued += 1;
    }
    platform_condvar_signal(&group->cv);
    return task_group_unlock(group);
@@ -978,6 +985,7 @@ task_group_print_stats(task_group *group, task_type type)
       }
       global.max_outstanding_tasks = MAX(global.max_outstanding_tasks,
                                          group->stats[i].max_outstanding_tasks);
+      global.total_tasks_enqueued += group->stats[i].total_tasks_enqueued;
    }
 
    switch (type) {
@@ -1000,6 +1008,14 @@ task_group_print_stats(task_group *group, task_type type)
                         global.total_queue_wait_time_ns);
    platform_default_log("| max queue_wait_time (ns)     : %10lu\n",
                         global.max_queue_wait_time_ns);
+
+   uint64 nbytes = (global.total_tasks_enqueued * sizeof(task));
+   platform_default_log("| total tasks enqueued : %lu consumed=%lu bytes (%s) "
+                        "of memory\n",
+                        global.total_tasks_enqueued,
+                        nbytes,
+                        size_str(nbytes));
+
    platform_default_log("| total bg tasks run      : %10lu\n",
                         global.total_bg_task_executions);
    platform_default_log("| total fg tasks run      : %10lu\n",

--- a/src/task.h
+++ b/src/task.h
@@ -30,6 +30,7 @@ typedef struct {
    uint64    total_queue_wait_time_ns;
    uint64    total_bg_task_executions;
    uint64    total_fg_task_executions;
+   uint64    total_tasks_enqueued;
 } PLATFORM_CACHELINE_ALIGNED task_stats;
 
 typedef struct task_queue {

--- a/src/trunk.c
+++ b/src/trunk.c
@@ -823,7 +823,12 @@ static inline void                 trunk_inc_intersection          (trunk_handle
 void                               trunk_memtable_flush_virtual    (void *arg, uint64 generation);
 platform_status                    trunk_memtable_insert           (trunk_handle *spl, key tuple_key, message data);
 void                               trunk_bundle_build_filters      (void *arg, void *scratch);
-static inline void                 trunk_inc_filter                (trunk_handle *spl, routing_filter *filter);
+
+#define trunk_inc_filter(spl, filter)                     \
+        trunk_inc_filter_ref((spl), (filter), __LINE__)
+
+static inline void                 trunk_inc_filter_ref            (trunk_handle *spl, routing_filter *filter, uint32 lineno);
+
 static inline void                 trunk_dec_filter                (trunk_handle *spl, routing_filter *filter);
 void                               trunk_compact_bundle            (void *arg, void *scratch);
 platform_status                    trunk_flush                     (trunk_handle *spl, trunk_node *parent, trunk_pivot_data *pdata, bool32 is_space_rec);
@@ -3494,7 +3499,6 @@ trunk_memtable_compact_and_build_filter(trunk_handle  *spl,
 
    platform_status rc = routing_filter_add(spl->cc,
                                            &spl->cfg.filter_cfg,
-                                           spl->heap_id,
                                            &empty_filter,
                                            &cmt->filter,
                                            cmt->req->fp_arr,
@@ -3887,9 +3891,15 @@ trunk_routing_cfg(trunk_handle *spl)
 }
 
 static inline void
-trunk_inc_filter(trunk_handle *spl, routing_filter *filter)
+trunk_inc_filter_ref(trunk_handle *spl, routing_filter *filter, uint32 lineno)
 {
-   debug_assert(filter->addr != 0);
+   debug_assert((filter->addr != 0),
+                "From line=%d: addr=%lu, meta_head=%lu"
+                ", num_fingerprints=%u\n",
+                lineno,
+                filter->addr,
+                filter->meta_head,
+                filter->num_fingerprints);
    mini_unkeyed_inc_ref(spl->cc, filter->meta_head);
 }
 
@@ -4040,6 +4050,7 @@ trunk_prepare_build_filter(trunk_handle             *spl,
    uint16 num_children = trunk_num_children(spl, node);
    for (uint16 pivot_no = 0; pivot_no < num_children; pivot_no++) {
       trunk_pivot_data *pdata = trunk_get_pivot_data(spl, node, pivot_no);
+
       if (trunk_bundle_live_for_pivot(
              spl, node, compact_req->bundle_no, pivot_no)) {
          uint64 pos = trunk_process_generation_to_pos(
@@ -4117,7 +4128,6 @@ trunk_build_filters(trunk_handle             *spl,
       uint16          value      = filter_scratch->value[pos];
       platform_status rc         = routing_filter_add(spl->cc,
                                               filter_cfg,
-                                              spl->heap_id,
                                               &old_filter,
                                               &new_filter,
                                               fp_arr,
@@ -4495,6 +4505,7 @@ trunk_flush_into_bundle(trunk_handle             *spl,    // IN
    if (trunk_pivot_bundle_count(spl, parent, pdata) != 0) {
       uint16 pivot_start_sb_no =
          trunk_pivot_start_subbundle(spl, parent, pdata);
+
       for (uint16 parent_sb_no = pivot_start_sb_no;
            parent_sb_no != trunk_end_subbundle(spl, parent);
            parent_sb_no = trunk_add_subbundle_number(spl, parent_sb_no, 1))
@@ -4512,6 +4523,7 @@ trunk_flush_into_bundle(trunk_handle             *spl,    // IN
                                      "subbundle %hu from subbundle %hu\n",
                                      trunk_subbundle_no(spl, child, child_sb),
                                      parent_sb_no);
+
          for (uint16 branch_no = parent_sb->start_branch;
               branch_no != parent_sb->end_branch;
               branch_no = trunk_add_branch_number(spl, branch_no, 1))
@@ -4523,7 +4535,9 @@ trunk_flush_into_bundle(trunk_handle             *spl,    // IN
             trunk_branch *new_branch = trunk_get_new_branch(spl, child);
             *new_branch              = *parent_branch;
          }
+
          child_sb->end_branch = trunk_end_branch(spl, child);
+
          for (uint16 i = 0; i < filter_count; i++) {
             routing_filter *child_filter =
                trunk_subbundle_filter(spl, child, child_sb, i);
@@ -5009,19 +5023,23 @@ trunk_btree_skiperator_deinit(trunk_handle           *spl,
  *-----------------------------------------------------------------------------
  */
 
-static inline void
+/*
+ * btree_pack_req_init() may fail due to insufficient memory in the shared
+ * segment. Inform the caller, so a graceful exit could be attempted.
+ */
+static inline platform_status
 trunk_btree_pack_req_init(trunk_handle   *spl,
                           iterator       *itor,
                           btree_pack_req *req)
 {
-   btree_pack_req_init(req,
-                       spl->cc,
-                       &spl->cfg.btree_cfg,
-                       itor,
-                       spl->cfg.max_tuples_per_node,
-                       spl->cfg.filter_cfg.hash,
-                       spl->cfg.filter_cfg.seed,
-                       spl->heap_id);
+   return btree_pack_req_init(req,
+                              spl->cc,
+                              &spl->cfg.btree_cfg,
+                              itor,
+                              spl->cfg.max_tuples_per_node,
+                              spl->cfg.filter_cfg.hash,
+                              spl->cfg.filter_cfg.seed,
+                              spl->heap_id);
 }
 
 static void
@@ -5216,7 +5234,16 @@ trunk_compact_bundle(void *arg, void *scratch_buf)
                               &merge_itor);
    platform_assert_status_ok(rc);
    btree_pack_req pack_req;
-   trunk_btree_pack_req_init(spl, &merge_itor->super, &pack_req);
+   rc = trunk_btree_pack_req_init(spl, &merge_itor->super, &pack_req);
+   if (!SUCCESS(rc)) {
+      platform_error_log("trunk_btree_pack_req_init failed: %s\n",
+                         platform_status_to_string(rc));
+
+      trunk_compact_bundle_cleanup_iterators(
+         spl, &merge_itor, num_branches, skip_itor_arr);
+      platform_free(spl->heap_id, req);
+      goto out;
+   }
    req->fp_arr = pack_req.fingerprint_arr;
    if (spl->cfg.use_stats) {
       pack_start = platform_get_timestamp();
@@ -5816,8 +5843,13 @@ trunk_split_leaf(trunk_handle *spl,
    key_buffer_init_from_key(
       &scratch->pivot[num_leaves], spl->heap_id, trunk_max_key(spl, leaf));
 
-   platform_assert(num_leaves + trunk_num_pivot_keys(spl, parent)
-                   <= spl->cfg.max_pivot_keys);
+   platform_assert((num_leaves + trunk_num_pivot_keys(spl, parent)
+                    <= spl->cfg.max_pivot_keys),
+                   "num_leaves=%u, trunk_num_pivot_keys()=%u"
+                   ", cfg.max_pivot_keys=%lu\n",
+                   num_leaves,
+                   trunk_num_pivot_keys(spl, parent),
+                   spl->cfg.max_pivot_keys);
 
    /*
     * 3. Clear old bundles from leaf and put all branches in a new bundle
@@ -7511,8 +7543,9 @@ trunk_range(trunk_handle  *spl,
             tuple_function func,
             void          *arg)
 {
-   trunk_range_iterator *range_itor = TYPED_MALLOC(spl->heap_id, range_itor);
-   platform_status       rc         = trunk_range_iterator_init(spl,
+   trunk_range_iterator *range_itor =
+      TYPED_MALLOC(PROCESS_PRIVATE_HEAP_ID, range_itor);
+   platform_status rc = trunk_range_iterator_init(spl,
                                                   range_itor,
                                                   start_key,
                                                   POSITIVE_INFINITY_KEY,
@@ -7537,7 +7570,7 @@ trunk_range(trunk_handle  *spl,
 
 destroy_range_itor:
    trunk_range_iterator_deinit(range_itor);
-   platform_free(spl->heap_id, range_itor);
+   platform_free(PROCESS_PRIVATE_HEAP_ID, range_itor);
    return rc;
 }
 
@@ -7699,6 +7732,14 @@ trunk_mount(trunk_config     *cfg,
       trunk_release_super_block(spl, super_page);
    }
    if (spl->root_addr == 0) {
+      platform_error_log(
+         "SplinterDB device's root_addr=%lu, trunk super_block=%p."
+         " meta_tail=%lu, latest_timestamp=%lu."
+         " Cannot mount device.\n",
+         spl->root_addr,
+         super,
+         meta_tail,
+         latest_timestamp);
       platform_free(hid, spl);
       return (trunk_handle *)NULL;
    }

--- a/src/util.c
+++ b/src/util.c
@@ -18,14 +18,19 @@ writable_buffer_ensure_space(writable_buffer *wb, uint64 minspace)
       minspace = 2 * wb->buffer_capacity;
    }
 
-   void *oldptr  = wb->can_free ? wb->buffer : NULL;
-   void *newdata = platform_realloc(wb->heap_id, oldptr, minspace);
+   void *newdata = NULL;
+   if (wb->can_free) {
+      newdata = platform_realloc(
+         wb->heap_id, wb->buffer_capacity, wb->buffer, minspace);
+   } else {
+      char *newbuf = TYPED_MANUAL_MALLOC(wb->heap_id, newbuf, minspace);
+      if (newbuf && writable_buffer_data(wb)) {
+         memcpy(newbuf, wb->buffer, wb->length);
+      }
+      newdata = (void *)newbuf;
+   }
    if (newdata == NULL) {
       return STATUS_NO_MEMORY;
-   }
-
-   if (oldptr == NULL && wb->length != WRITABLE_BUFFER_NULL_LENGTH) {
-      memcpy(newdata, wb->buffer, wb->length);
    }
 
    wb->buffer_capacity = minspace;

--- a/src/util.h
+++ b/src/util.h
@@ -119,6 +119,7 @@ slice_lex_cmp(const slice a, const slice b)
  * When initializing a writable_buffer, you can provide an initial
  * buffer for it to use.  The writable_buffer will _never_ free the
  * buffer you give it during initialization.
+ * ----------------------------------------------------------------------
  */
 typedef struct writable_buffer {
    platform_heap_id heap_id;
@@ -260,8 +261,9 @@ writable_buffer_to_slice(const writable_buffer *wb)
 static inline uint64
 writable_buffer_append(writable_buffer *wb, uint64 length, const void *newdata)
 {
-   uint64 oldsize = writable_buffer_length(wb);
-   platform_assert(SUCCESS(writable_buffer_resize(wb, oldsize + length)));
+   uint64          oldsize = writable_buffer_length(wb);
+   platform_status rc      = writable_buffer_resize(wb, oldsize + length);
+   platform_assert(SUCCESS(rc));
    char *data = writable_buffer_data(wb);
    memcpy(data + oldsize, newdata, length);
    return oldsize;
@@ -370,7 +372,6 @@ debug_hex_dump(platform_log_handle *,
 
 void
 debug_hex_dump_slice(platform_log_handle *, uint64 grouping, slice data);
-
 
 /*
  * Evaluates to a print format specifier based on the value being printed.

--- a/tests/config.c
+++ b/tests/config.c
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "config.h"
+#include "util.h"
 
 /*
  * --------------------------------------------------------------------------
@@ -19,6 +20,7 @@
 #define TEST_CONFIG_DEFAULT_DISK_SIZE_GB         30
 #define TEST_CONFIG_DEFAULT_CACHE_SIZE_GB        1
 #define TEST_CONFIG_DEFAULT_MEMTABLE_CAPACITY_MB 24
+#define TEST_CONFIG_DEFAULT_SHMEM_SIZE_GB        2
 
 // Setup reasonable BTree and branch tree configurations
 #define TEST_CONFIG_DEFAULT_FILTER_INDEX_SIZE     256
@@ -52,6 +54,13 @@
  * useful default values. The expectation is that the input 'cfg' is zero'ed
  * out before calling this initializer, so that all other fields will have
  * some reasonable 0-defaults.
+ *
+ * ******************* EXPERIMENTAL FEATURES ********************
+ *  - use_shmem: Support for shared memory segments.
+ *    This functionality is solely meant for internal development uses.
+ *    We don't support free(), so your test / usage will likely run into
+ *    shared-memory OOMs errors.
+ *
  * ---------------------------------------------------------------------------
  */
 void
@@ -81,6 +90,11 @@ config_set_defaults(master_config *cfg)
       .queue_scale_percent      = TEST_CONFIG_DEFAULT_QUEUE_SCALE_PERCENT,
       .verbose_logging_enabled  = FALSE,
       .verbose_progress         = FALSE,
+
+      .use_shmem                = FALSE,
+      // Default shared-memory sze if it is configured
+      .shmem_size               = GiB_TO_B(TEST_CONFIG_DEFAULT_SHMEM_SIZE_GB),
+
       .log_handle               = NULL,
       .max_key_size             = TEST_CONFIG_DEFAULT_KEY_SIZE,
       .message_size             = TEST_CONFIG_DEFAULT_MESSAGE_SIZE,
@@ -93,7 +107,7 @@ config_set_defaults(master_config *cfg)
 void
 config_usage()
 {
-   platform_error_log("Configuration: (default)\n");
+   platform_error_log("\nConfiguration: (default)\n");
    platform_error_log("\t--page-size (%d)\n", TEST_CONFIG_DEFAULT_PAGE_SIZE);
    platform_error_log("\t--extent-size (%d)\n",
                       TEST_CONFIG_DEFAULT_EXTENT_SIZE);
@@ -130,7 +144,6 @@ config_usage()
 
    platform_error_log("\t--num-normal-bg-threads (%d)\n",
                       TEST_CONFIG_DEFAULT_NUM_NORMAL_BG_THREADS);
-
    platform_error_log("\t--num-memtable-bg-threads (%d)\n",
                       TEST_CONFIG_DEFAULT_NUM_MEMTABLE_BG_THREADS);
 
@@ -141,11 +154,36 @@ config_usage()
    platform_error_log("\t--verbose-logging\n");
    platform_error_log("\t--no-verbose-logging\n");
    platform_error_log("\t--verbose-progress\n");
+
+   platform_error_log(
+      "\t--use-shmem           **** Experimental feature ****\n");
+   // clang-format off
+   platform_error_log("\t       [ --trace-shmem | --trace-shmem-allocs | --trace-shmem-frees ]\n");
+   platform_error_log("\t       [ --shmem-capacity-mib <mb> (%lu) | --shmem-capacity-gib <gb> (%d) ]\n",
+                      (TEST_CONFIG_DEFAULT_SHMEM_SIZE_GB * KiB),
+                      TEST_CONFIG_DEFAULT_SHMEM_SIZE_GB);
+   // clang-format on
+
    platform_error_log("\t--key-size (%d)\n", TEST_CONFIG_DEFAULT_KEY_SIZE);
    platform_error_log("\t--data-size (%d)\n", TEST_CONFIG_DEFAULT_MESSAGE_SIZE);
    platform_error_log("\t--num-inserts (%d)\n",
                       TEST_CONFIG_DEFAULT_NUM_INSERTS);
    platform_error_log("\t--seed (%d)\n", TEST_CONFIG_DEFAULT_SEED);
+}
+
+/*
+ * config_parse_use_shmem() - Check if --use-shmem argument was supplied on
+ * the cmdline. Some tests need to know this to setup the shared memory heap
+ * before other test configuration is done.
+ */
+bool
+config_parse_use_shmem(int argc, char *argv[])
+{
+   master_config master_cfg;
+   config_set_defaults(&master_cfg);
+   platform_status rc = config_parse(&master_cfg, 1, argc, argv);
+   platform_assert(SUCCESS(rc), "Failed to parse config arguments.");
+   return master_cfg.use_shmem;
 }
 
 /*
@@ -307,6 +345,30 @@ config_parse(master_config *cfg, const uint8 num_config, int argc, char *argv[])
             for (uint8 cfg_idx = 0; cfg_idx < num_config; cfg_idx++) {
                cfg[cfg_idx].verbose_progress = TRUE;
             }
+         }
+         /*
+          * Arguments to run Splinter configured with shared memory.
+          */
+         config_has_option("use-shmem")
+         {
+            for (uint8 cfg_idx = 0; cfg_idx < num_config; cfg_idx++) {
+               cfg[cfg_idx].use_shmem = TRUE;
+            }
+         }
+         config_set_mib("shmem-capacity", cfg, shmem_size) {}
+         config_set_gib("shmem-capacity", cfg, shmem_size) {}
+         config_has_option("trace-shmem-allocs")
+         {
+            platform_enable_tracing_shm_allocs();
+         }
+         config_has_option("trace-shmem-frees")
+         {
+            platform_enable_tracing_shm_frees();
+         }
+         config_has_option("trace-shmem")
+         {
+            // Trace both allocations & frees from shared memory segment.
+            platform_enable_tracing_shm_ops();
          }
 
          config_set_uint64("key-size", cfg, max_key_size) {}

--- a/tests/config.h
+++ b/tests/config.h
@@ -9,13 +9,7 @@
 
 #pragma once
 
-#include "clockcache.h"
-#include "splinterdb/data.h"
-#include "io.h"
-#include "rc_allocator.h"
-#include "shard_log.h"
-#include "trunk.h"
-#include "util.h"
+#include "cache.h"
 
 extern const char *BUILD_VERSION;
 
@@ -40,6 +34,16 @@ _Static_assert(TEST_CONFIG_DEFAULT_PAGES_PER_EXTENT <= MAX_PAGES_PER_EXTENT,
  * Convenience structure to hold configuration options for all sub-systems.
  * Command-line parsing routines parse config params into these structs.
  * Mostly needed for testing interfaces.
+ *
+ * ******************* EXPERIMENTAL FEATURES ********************
+ *
+ * - use_shmem: Support for shared memory segments:
+ *
+ *   This flag will configure a shared memory segment. All (most) run-time
+ *   memory allocation will be done from this shared segment. Currently,
+ *   we do not support free(), so you will likely run out of shared memory
+ *   and run into shared-memory OOM errors. This functionality is
+ *   solely meant for internal development uses.
  * --------------------------------------------------------------------------
  */
 typedef struct master_config {
@@ -75,14 +79,19 @@ typedef struct master_config {
    uint64 num_memtable_bg_threads; // for background threads to be enabled
 
    // splinter
-   uint64               memtable_capacity;
-   uint64               fanout;
-   uint64               max_branches_per_node;
-   uint64               use_stats;
-   uint64               reclaim_threshold;
-   uint64               queue_scale_percent;
-   bool32               verbose_logging_enabled;
-   bool32               verbose_progress;
+   uint64 memtable_capacity;
+   uint64 fanout;
+   uint64 max_branches_per_node;
+   uint64 use_stats;
+   uint64 reclaim_threshold;
+   uint64 queue_scale_percent;
+   bool   verbose_logging_enabled;
+   bool   verbose_progress;
+
+   // Shared memory support      **** Experimental feature ****
+   uint64 shmem_size;
+   bool   use_shmem; // Memory allocation done from shared segment
+
    platform_log_handle *log_handle;
 
    // data
@@ -107,6 +116,8 @@ config_parse(master_config *cfg,
              int            argc,
              char          *argv[]);
 
+bool
+config_parse_use_shmem(int argc, char *argv[]);
 
 /*
  * Config option parsing macros

--- a/tests/functional/filter_test.c
+++ b/tests/functional/filter_test.c
@@ -69,14 +69,8 @@ test_filter_basic(cache           *cc,
 
    routing_filter filter[MAX_FILTERS] = {{0}};
    for (uint64 i = 0; i < num_values; i++) {
-      rc = routing_filter_add(cc,
-                              cfg,
-                              hid,
-                              &filter[i],
-                              &filter[i + 1],
-                              fp_arr[i],
-                              num_fingerprints,
-                              i);
+      rc = routing_filter_add(
+         cc, cfg, &filter[i], &filter[i + 1], fp_arr[i], num_fingerprints, i);
       // platform_default_log("FILTER %lu\n", i);
       // routing_filter_print(cc, cfg, &filter);
       uint32 estimated_input_keys =
@@ -191,7 +185,6 @@ test_filter_perf(cache           *cc,
             k * num_fingerprints * num_values + i * num_fingerprints;
          platform_status rc = routing_filter_add(cc,
                                                  cfg,
-                                                 hid,
                                                  &filter[k],
                                                  &new_filter,
                                                  &fp_arr[fp_start],
@@ -313,10 +306,12 @@ filter_test(int argc, char *argv[])
       config_argv   = argv + 1;
    }
 
+   bool use_shmem = config_parse_use_shmem(config_argc, config_argv);
+
    // Create a heap for io, allocator, cache and splinter
-   platform_heap_handle hh;
-   platform_heap_id     hid;
-   rc = platform_heap_create(platform_get_module_id(), 1 * GiB, &hh, &hid);
+   platform_heap_id hid = NULL;
+   rc =
+      platform_heap_create(platform_get_module_id(), 1 * GiB, use_shmem, &hid);
    platform_assert_status_ok(rc);
 
    uint64 num_memtable_bg_threads_unused = 0;
@@ -350,7 +345,7 @@ filter_test(int argc, char *argv[])
 
    platform_io_handle *io = TYPED_MALLOC(hid, io);
    platform_assert(io != NULL);
-   rc = io_handle_init(io, &io_cfg, hh, hid);
+   rc = io_handle_init(io, &io_cfg, hid);
    if (!SUCCESS(rc)) {
       goto free_iohandle;
    }
@@ -418,7 +413,7 @@ free_iohandle:
    r = 0;
 cleanup:
    platform_free(hid, cfg);
-   platform_heap_destroy(&hh);
+   platform_heap_destroy(&hid);
 
    return r;
 }

--- a/tests/functional/splinter_test.c
+++ b/tests/functional/splinter_test.c
@@ -2372,14 +2372,12 @@ usage(const char *argv0)
       "\t%s --semiseq-perf --max-async-inflight [num] --num-insert-threads "
       "[num]\n"
       "\t   --num-lookup-threads [num] --num-range-lookup-threads [num]\n"
-      "\t%s --functionality NUM_INSERTS CORRECTNESS_CHECK_FREQUENCY\n"
-      "\t   --max-async-inflight [num]\n"
-      "\t%s --num-tables (number of tables to use for test)\n"
-      "\t%s --cache-per-table\n"
       "\t%s --parallel-perf --max-async-inflight [num] --num-pthreads [num] "
       "--lookup-positive-percent [num] --seed [num]\n"
+      "\t%s --functionality NUM_INSERTS CORRECTNESS_CHECK_FREQUENCY\n"
+      "\t   --max-async-inflight [num]\n"
+      "\t%s --num-tables <num> [ --cache-per-table ] [ --use-shmem ]\n"
       "\t%s --insert-rate (inserts_done_by_all_threads in a second)\n",
-      argv0,
       argv0,
       argv0,
       argv0,
@@ -2390,6 +2388,9 @@ usage(const char *argv0)
       argv0);
    platform_error_log("\nNOTE: splinter_basic basic has been refactored"
                       " to run as a stand-alone unit-test.\n");
+   platform_error_log("     --use-shmem is an experimental feature."
+                      " Use with care.\n");
+   platform_error_log("\n");
    test_config_usage();
    config_usage();
 }
@@ -2499,6 +2500,7 @@ splinter_test(int argc, char *argv[])
    bool32                 cache_per_table = FALSE;
    uint64                 insert_rate     = 0; // no rate throttling by default.
    task_system           *ts              = NULL;
+   bool                   use_shmem       = FALSE;
    uint8                  lookup_positive_pct = 0;
    test_message_generator gen;
    test_exec_config       test_exec_cfg;
@@ -2507,8 +2509,13 @@ splinter_test(int argc, char *argv[])
    // Defaults
    num_insert_threads = num_lookup_threads = num_range_lookup_threads = 1;
    max_async_inflight                                                 = 64;
+
    /*
-    * 1. Parse splinter_test options, see usage()
+    * 1. Parse splinter_test options to determine which type of test
+    *    is to be run. Code below will setup some defaults for parameters
+    *    that are applicable for a test type. These params can be further
+    *    over-ridden by extra args which will be parsed in the next block
+    *    below. See usage() for more details.
     */
    if (argc > 1 && strncmp(argv[1], "--help", sizeof("--help")) == 0) {
       usage(argv[0]);
@@ -2580,6 +2587,11 @@ splinter_test(int argc, char *argv[])
       config_argc = argc - 1;
       config_argv = argv + 1;
    }
+
+   /*
+    * IF there are any more arguments remaining, parse them in sequence.
+    * This set of args are expected to come in exactly this order.
+    */
    if (config_argc > 0
        && strncmp(config_argv[0], "--num-tables", sizeof("--num-tables")) == 0)
    {
@@ -2601,6 +2613,13 @@ splinter_test(int argc, char *argv[])
              == 0)
    {
       cache_per_table = TRUE;
+      config_argc -= 1;
+      config_argv += 1;
+   }
+   if (config_argc > 0
+       && strncmp(config_argv[0], "--use-shmem", sizeof("--use-shmem")) == 0)
+   {
+      use_shmem = TRUE;
       config_argc -= 1;
       config_argv += 1;
    }
@@ -2645,13 +2664,17 @@ splinter_test(int argc, char *argv[])
    uint8  num_caches    = cache_per_table ? num_tables : 1;
    uint64 heap_capacity = MAX(1024 * MiB * num_caches, 512 * MiB * num_tables);
    heap_capacity        = MIN(heap_capacity, UINT32_MAX);
-   heap_capacity        = MAX(heap_capacity, 2 * GiB);
+   heap_capacity        = MAX(heap_capacity, 8 * GiB);
+   if (use_shmem) {
+      platform_default_log(
+         "Attempt to create shared segment of size %lu bytes.\n",
+         heap_capacity);
+   }
 
    // Create a heap for io, allocator, cache and splinter
-   platform_heap_handle hh;
-   platform_heap_id     hid;
-   rc =
-      platform_heap_create(platform_get_module_id(), heap_capacity, &hh, &hid);
+   platform_heap_id hid = NULL;
+   rc                   = platform_heap_create(
+      platform_get_module_id(), heap_capacity, use_shmem, &hid);
    platform_assert_status_ok(rc);
 
    /*
@@ -2743,7 +2766,7 @@ splinter_test(int argc, char *argv[])
 
    platform_io_handle *io = TYPED_MALLOC(hid, io);
    platform_assert(io != NULL);
-   rc = io_handle_init(io, &io_cfg, hh, hid);
+   rc = io_handle_init(io, &io_cfg, hid);
    if (!SUCCESS(rc)) {
       goto io_free;
    }
@@ -2931,7 +2954,7 @@ cfg_free:
    platform_free(hid, splinter_cfg);
    platform_free(hid, test_cfg);
 heap_destroy:
-   platform_heap_destroy(&hh);
+   platform_heap_destroy(&hid);
 
    return SUCCESS(rc) ? 0 : -1;
 }

--- a/tests/functional/splinter_test.h
+++ b/tests/functional/splinter_test.h
@@ -135,7 +135,7 @@ test_config_parse(test_config *cfg,
 
    static inline void test_config_usage(void)
    {
-      platform_error_log("Test Configuration:\n");
+      platform_error_log("\nTest Configuration:\n");
       platform_error_log("\t--tree-size-gib\n");
       platform_error_log("\t--tree-size-mib\n");
       platform_error_log("\t--key-type (rand, seq, semiseq)\n");

--- a/tests/functional/test.h
+++ b/tests/functional/test.h
@@ -174,7 +174,11 @@ generate_test_message(const test_message_generator *generator,
       + (idx % (generator->max_payload_size - generator->min_payload_size + 1));
    uint64 total_size = sizeof(data_handle) + payload_size;
    merge_accumulator_set_class(msg, generator->type);
-   merge_accumulator_resize(msg, total_size);
+   bool resize_rv = merge_accumulator_resize(msg, total_size);
+   platform_assert(resize_rv,
+                   "merge_accumulator_resize() for %lu bytes failed "
+                   "to allocate memory.",
+                   total_size);
    data_handle *raw_data = merge_accumulator_data(msg);
    memset(raw_data, idx, total_size);
    raw_data->ref_count = 1;
@@ -317,6 +321,7 @@ test_parse_args_n(trunk_config           *splinter_cfg,  // OUT
       config_set_defaults(&master_cfg[i]);
    }
 
+   // Parse config-related command-line arguments
    rc = config_parse(master_cfg, num_config, argc, argv);
    if (!SUCCESS(rc)) {
       goto out;

--- a/tests/functional/ycsb_test.c
+++ b/tests/functional/ycsb_test.c
@@ -1182,9 +1182,8 @@ ycsb_test(int argc, char *argv[])
    config_argv = argv + args_consumed;
 
    // Create a heap for io, allocator, cache and splinter
-   platform_heap_handle hh;
-   platform_heap_id     hid;
-   rc = platform_heap_create(platform_get_module_id(), 1 * GiB, &hh, &hid);
+   platform_heap_id hid;
+   rc = platform_heap_create(platform_get_module_id(), 1 * GiB, FALSE, &hid);
    platform_assert_status_ok(rc);
 
    data_config  *data_cfg;
@@ -1274,7 +1273,7 @@ ycsb_test(int argc, char *argv[])
    if (!SUCCESS(rc)) {
       goto free_iohandle;
    }
-   rc = io_handle_init(io, &io_cfg, hh, hid);
+   rc = io_handle_init(io, &io_cfg, hid);
    if (!SUCCESS(rc)) {
       goto free_iohandle;
    }
@@ -1361,7 +1360,7 @@ free_iohandle:
    platform_free(hid, io);
 cleanup:
    platform_free(hid, splinter_cfg);
-   platform_heap_destroy(&hh);
+   platform_heap_destroy(&hid);
 
    return SUCCESS(rc) ? 0 : -1;
 }

--- a/tests/test_data.c
+++ b/tests/test_data.c
@@ -88,7 +88,10 @@ test_data_merge_tuples_final(const data_config *cfg,
                              merge_accumulator *oldest_raw_data) // IN/OUT
 {
    platform_assert(merge_accumulator_message_class(oldest_raw_data)
-                   == MESSAGE_TYPE_UPDATE);
+                      == MESSAGE_TYPE_UPDATE,
+                   "message_class=%d",
+                   merge_accumulator_message_class(oldest_raw_data));
+
    assert(sizeof(data_handle) <= merge_accumulator_length(oldest_raw_data));
 
    data_handle *old_data = merge_accumulator_data(oldest_raw_data);

--- a/tests/unit/btree_test.c
+++ b/tests/unit/btree_test.c
@@ -76,13 +76,24 @@ CTEST_DATA(btree)
 CTEST_SETUP(btree)
 {
    config_set_defaults(&data->master_cfg);
-   data->data_cfg = test_data_config;
-   data->hid      = platform_get_heap_id();
+   uint64 heap_capacity = (1 * GiB);
 
    if (!SUCCESS(
-          config_parse(&data->master_cfg, 1, Ctest_argc, (char **)Ctest_argv))
-       || !init_data_config_from_master_config(data->data_cfg,
-                                               &data->master_cfg)
+          config_parse(&data->master_cfg, 1, Ctest_argc, (char **)Ctest_argv)))
+   {
+      ASSERT_TRUE(FALSE, "Failed to parse args\n");
+   }
+
+   // Create a heap for io, allocator, cache and splinter
+   platform_status rc = platform_heap_create(platform_get_module_id(),
+                                             heap_capacity,
+                                             data->master_cfg.use_shmem,
+                                             &data->hid);
+   platform_assert_status_ok(rc);
+
+   data->data_cfg = test_data_config;
+
+   if (!init_data_config_from_master_config(data->data_cfg, &data->master_cfg)
        || !init_io_config_from_master_config(&data->io_cfg, &data->master_cfg)
        || !init_rc_allocator_config_from_master_config(
           &data->allocator_cfg, &data->master_cfg, &data->io_cfg)
@@ -98,7 +109,10 @@ CTEST_SETUP(btree)
 }
 
 // Optional teardown function for suite, called after every test in suite
-CTEST_TEARDOWN(btree) {}
+CTEST_TEARDOWN(btree)
+{
+   platform_heap_destroy(&data->hid);
+}
 
 /*
  * Test leaf_hdr APIs.

--- a/tests/unit/btree_test_common.h
+++ b/tests/unit/btree_test_common.h
@@ -11,6 +11,8 @@
 #include "io.h"
 #include "rc_allocator.h"
 #include "clockcache.h"
+#include "task.h"
+#include "btree.h"
 
 // Function Prototypes
 int

--- a/tests/unit/config_parse_test.c
+++ b/tests/unit/config_parse_test.c
@@ -33,9 +33,8 @@
 CTEST_DATA(config_parse)
 {
    // Declare head handles for io, allocator, cache and splinter allocation.
-   platform_heap_handle hh;
-   platform_heap_id     hid;
-   test_exec_config     test_exec_cfg;
+   platform_heap_id hid;
+   test_exec_config test_exec_cfg;
 };
 
 // Optional setup function for suite, called before every test in suite
@@ -44,7 +43,7 @@ CTEST_SETUP(config_parse)
    uint64 heap_capacity = (1024 * MiB);
    // Create a heap for io, allocator, cache and splinter
    platform_status rc = platform_heap_create(
-      platform_get_module_id(), heap_capacity, &data->hh, &data->hid);
+      platform_get_module_id(), heap_capacity, FALSE, &data->hid);
    platform_assert_status_ok(rc);
 
    ZERO_STRUCT(data->test_exec_cfg);
@@ -53,7 +52,7 @@ CTEST_SETUP(config_parse)
 // Optional teardown function for suite, called after every test in suite
 CTEST_TEARDOWN(config_parse)
 {
-   platform_heap_destroy(&data->hh);
+   platform_heap_destroy(&data->hid);
 }
 
 /*

--- a/tests/unit/large_inserts_bugs_stress_test.c
+++ b/tests/unit/large_inserts_bugs_stress_test.c
@@ -1,0 +1,648 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+ * -----------------------------------------------------------------------------
+ * large_inserts_bugs_stress_test.c --
+ *
+ * This test exercises simple very large #s of inserts which have found to
+ * trigger some bugs in some code paths. This is just a miscellaneous collection
+ * of test cases for different issues reported.
+ * -----------------------------------------------------------------------------
+ */
+#include <fcntl.h>
+#include <unistd.h>
+#include <string.h>
+#include "platform.h"
+#include "splinterdb/public_platform.h"
+#include "splinterdb/default_data_config.h"
+#include "splinterdb/splinterdb.h"
+#include "config.h"
+#include "unit_tests.h"
+#include "ctest.h" // This is required for all test-case files.
+
+// Nothing particularly significant about these constants.
+#define TEST_KEY_SIZE   30
+#define TEST_VALUE_SIZE 256
+
+// Configuration for each worker thread
+typedef struct {
+   splinterdb    *kvsb;
+   master_config *master_cfg;
+   uint64         start_value;
+   uint64         num_inserts;
+   uint64         num_insert_threads;
+   int            random_key_fd; // Also used as a boolean
+   int            random_val_fd; // Also used as a boolean
+   bool           is_thread;     // Is main() or thread executing worker fn
+} worker_config;
+
+// Function Prototypes
+static void *
+exec_worker_thread(void *w);
+
+static void
+do_inserts_n_threads(splinterdb      *kvsb,
+                     master_config   *master_cfg,
+                     platform_heap_id hid,
+                     int              random_key_fd,
+                     int              random_val_fd,
+                     uint64           num_inserts,
+                     uint64           num_insert_threads);
+
+// Run n-threads concurrently inserting many KV-pairs
+#define NUM_THREADS 8
+
+/*
+ * Some test-cases can drive multiple threads to use either the same start
+ * value for all threads. Or, each thread will use its own start value so
+ * that all threads are inserting in non-intersecting bands of keys.
+ * These mnemonics control these behaviours.
+ */
+#define TEST_INSERTS_SEQ_KEY_DIFF_START_KEYID_FD ((int)0)
+#define TEST_INSERTS_SEQ_KEY_SAME_START_KEYID_FD ((int)-1)
+
+/* Drive inserts to generate sequential short-length values */
+#define TEST_INSERT_SEQ_VALUES_FD ((int)0)
+
+/*
+ * Some test-cases drive inserts to choose a fully-packed value of size
+ * TEST_VALUE_SIZE bytes. This variation has been seen to trigger some
+ * assertions.
+ */
+#define TEST_INSERT_FULLY_PACKED_CONSTANT_VALUE_FD (int)-1
+
+/*
+ * Global data declaration macro:
+ */
+CTEST_DATA(large_inserts_bugs_stress)
+{
+   // Declare heap handles for on-stack buffer allocations
+   platform_heap_id hid;
+
+   splinterdb       *kvsb;
+   splinterdb_config cfg;
+   data_config       default_data_config;
+   master_config     master_cfg;
+   uint64            num_inserts; // per main() process or per thread
+   uint64            num_insert_threads;
+};
+
+// Optional setup function for suite, called before every test in suite
+CTEST_SETUP(large_inserts_bugs_stress)
+{
+   platform_status rc;
+   uint64          heap_capacity = (64 * MiB); // small heap is sufficient.
+
+   config_set_defaults(&data->master_cfg);
+
+   // Expected args to parse --num-inserts, --use-shmem, --verbose-progress.
+   rc = config_parse(&data->master_cfg, 1, Ctest_argc, (char **)Ctest_argv);
+   ASSERT_TRUE(SUCCESS(rc));
+
+   // Create a heap for allocating on-stack buffers for various arrays.
+   rc = platform_heap_create(platform_get_module_id(),
+                             heap_capacity,
+                             data->master_cfg.use_shmem,
+                             &data->hid);
+   platform_assert_status_ok(rc);
+
+   data->cfg = (splinterdb_config){.filename   = TEST_DB_NAME,
+                                   .cache_size = 1 * Giga,
+                                   .disk_size  = 40 * Giga,
+                                   .use_shmem  = data->master_cfg.use_shmem,
+                                   .shmem_size = (4 * GiB),
+                                   .data_cfg   = &data->default_data_config};
+
+   data->num_inserts =
+      (data->master_cfg.num_inserts ? data->master_cfg.num_inserts
+                                    : (1 * MILLION));
+   data->num_insert_threads = NUM_THREADS;
+
+   if ((data->num_inserts % MILLION) != 0) {
+      platform_error_log("Test expects --num-inserts parameter to be an"
+                         " integral multiple of a million.\n");
+      ASSERT_EQUAL(0, (data->num_inserts % MILLION));
+      return;
+   }
+
+   // Run with higher configured shared memory, if specified
+   if (data->master_cfg.shmem_size > data->cfg.shmem_size) {
+      data->cfg.shmem_size = data->master_cfg.shmem_size;
+   }
+   // Setup Splinter's background thread config, if specified
+   data->cfg.num_memtable_bg_threads = data->master_cfg.num_memtable_bg_threads;
+   data->cfg.num_normal_bg_threads   = data->master_cfg.num_normal_bg_threads;
+
+
+   size_t max_key_size = TEST_KEY_SIZE;
+   default_data_config_init(max_key_size, data->cfg.data_cfg);
+
+   int rv = splinterdb_create(&data->cfg, &data->kvsb);
+   ASSERT_EQUAL(0, rv);
+}
+
+// Optional teardown function for suite, called after every test in suite
+CTEST_TEARDOWN(large_inserts_bugs_stress)
+{
+   splinterdb_close(&data->kvsb);
+   platform_heap_destroy(&data->hid);
+}
+
+/*
+ * Test case that inserts large # of KV-pairs, and goes into a code path
+ * reported by issue# 458, tripping a debug assert.
+ */
+CTEST2_SKIP(large_inserts_bugs_stress,
+            test_issue_458_mini_destroy_unused_debug_assert)
+{
+   char key_data[TEST_KEY_SIZE];
+   char val_data[TEST_VALUE_SIZE];
+
+   uint64 test_start_time = platform_get_timestamp();
+
+   for (uint64 ictr = 0, jctr = 0; ictr < 100; ictr++) {
+
+      uint64 start_time = platform_get_timestamp();
+
+      for (jctr = 0; jctr < MILLION; jctr++) {
+
+         uint64 id = (ictr * MILLION) + jctr;
+         snprintf(key_data, sizeof(key_data), "%lu", id);
+         snprintf(val_data, sizeof(val_data), "Row-%lu", id);
+
+         slice key = slice_create(strlen(key_data), key_data);
+         slice val = slice_create(strlen(val_data), val_data);
+
+         int rc = splinterdb_insert(data->kvsb, key, val);
+         ASSERT_EQUAL(0, rc);
+      }
+      uint64 elapsed_ns      = platform_timestamp_elapsed(start_time);
+      uint64 test_elapsed_ns = platform_timestamp_elapsed(test_start_time);
+
+      platform_default_log(
+         PLATFORM_CR
+         "Inserted %lu million KV-pairs"
+         ", this batch: %lu s, %lu rows/s, cumulative: %lu s, %lu rows/s ...",
+         (ictr + 1),
+         NSEC_TO_SEC(elapsed_ns),
+         (jctr / NSEC_TO_SEC(elapsed_ns)),
+         NSEC_TO_SEC(test_elapsed_ns),
+         (((ictr + 1) * jctr) / NSEC_TO_SEC(test_elapsed_ns)));
+   }
+}
+
+/*
+ * Test cases exercise the thread's worker-function, exec_worker_thread(),
+ * from the main connection to splinter, for specified number of inserts.
+ *
+ * We play with 4 combinations just to get some basic coverage:
+ *  - sequential keys and values
+ *  - random keys, sequential values
+ *  - sequential keys, random values
+ *  - random keys, random values
+ */
+CTEST2(large_inserts_bugs_stress, test_seq_key_seq_values_inserts)
+{
+   worker_config wcfg;
+   ZERO_STRUCT(wcfg);
+
+   // Load worker config params
+   wcfg.kvsb        = data->kvsb;
+   wcfg.master_cfg  = &data->master_cfg;
+   wcfg.num_inserts = data->num_inserts;
+
+   exec_worker_thread(&wcfg);
+}
+
+CTEST2(large_inserts_bugs_stress, test_random_key_seq_values_inserts)
+{
+   worker_config wcfg;
+   ZERO_STRUCT(wcfg);
+
+   // Load worker config params
+   wcfg.kvsb          = data->kvsb;
+   wcfg.master_cfg    = &data->master_cfg;
+   wcfg.num_inserts   = data->num_inserts;
+   wcfg.random_key_fd = open("/dev/urandom", O_RDONLY);
+
+   exec_worker_thread(&wcfg);
+
+   close(wcfg.random_key_fd);
+}
+
+CTEST2(large_inserts_bugs_stress, test_seq_key_random_values_inserts)
+{
+   worker_config wcfg;
+   ZERO_STRUCT(wcfg);
+
+   // Load worker config params
+   wcfg.kvsb          = data->kvsb;
+   wcfg.master_cfg    = &data->master_cfg;
+   wcfg.num_inserts   = data->num_inserts;
+   wcfg.random_val_fd = open("/dev/urandom", O_RDONLY);
+
+   exec_worker_thread(&wcfg);
+
+   close(wcfg.random_val_fd);
+}
+
+CTEST2(large_inserts_bugs_stress, test_random_key_random_values_inserts)
+{
+   worker_config wcfg;
+   ZERO_STRUCT(wcfg);
+
+   // Load worker config params
+   wcfg.kvsb          = data->kvsb;
+   wcfg.master_cfg    = &data->master_cfg;
+   wcfg.num_inserts   = data->num_inserts;
+   wcfg.random_key_fd = open("/dev/urandom", O_RDONLY);
+   wcfg.random_val_fd = open("/dev/urandom", O_RDONLY);
+
+   exec_worker_thread(&wcfg);
+
+   close(wcfg.random_key_fd);
+   close(wcfg.random_val_fd);
+}
+
+/*
+ * ----------------------------------------------------------------------------
+ * Collection of test cases that fire-up diff combinations of inserts
+ * (sequential, random keys & values) executed by n-threads.
+ * ----------------------------------------------------------------------------
+ */
+/*
+ * Test case that fires up many threads each concurrently inserting large # of
+ * KV-pairs, with discrete ranges of keys inserted by each thread.
+ * RESOLVE: This hangs in this flow; never completes ...
+ * clockcache_try_get_read() -> memtable_maybe_rotate_and_get_insert_lock()
+ * This problem will probably occur in /main as well.
+ */
+CTEST2_SKIP(large_inserts_bugs_stress, test_seq_key_seq_values_inserts_threaded)
+{
+   // Run n-threads with sequential key and sequential values inserted
+   do_inserts_n_threads(data->kvsb,
+                        &data->master_cfg,
+                        data->hid,
+                        TEST_INSERTS_SEQ_KEY_DIFF_START_KEYID_FD,
+                        TEST_INSERT_SEQ_VALUES_FD,
+                        data->num_inserts,
+                        data->num_insert_threads);
+}
+
+/*
+ * Test case that fires up many threads each concurrently inserting large # of
+ * KV-pairs, with all threads inserting from same start-value.
+ *
+ * With --num-threads 63, hangs in
+ *  clockcache_get_read() -> memtable_maybe_rotate_and_get_insert_lock()
+ */
+CTEST2(large_inserts_bugs_stress,
+       test_seq_key_seq_values_inserts_threaded_same_start_keyid)
+{
+   // Run n-threads with sequential key and sequential values inserted
+   do_inserts_n_threads(data->kvsb,
+                        &data->master_cfg,
+                        data->hid,
+                        TEST_INSERTS_SEQ_KEY_SAME_START_KEYID_FD,
+                        TEST_INSERT_SEQ_VALUES_FD,
+                        data->num_inserts,
+                        data->num_insert_threads);
+}
+
+/*
+ * Test case that fires up many threads each concurrently inserting large # of
+ * KV-pairs, with all threads inserting from same start-value, using a fixed
+ * fully-packed value.
+ */
+CTEST2(large_inserts_bugs_stress,
+       test_seq_key_fully_packed_value_inserts_threaded_same_start_keyid)
+{
+   // Run n-threads with sequential key and sequential values inserted
+   do_inserts_n_threads(data->kvsb,
+                        &data->master_cfg,
+                        data->hid,
+                        TEST_INSERTS_SEQ_KEY_SAME_START_KEYID_FD,
+                        TEST_INSERT_FULLY_PACKED_CONSTANT_VALUE_FD,
+                        data->num_inserts,
+                        data->num_insert_threads);
+}
+
+CTEST2(large_inserts_bugs_stress, test_random_keys_seq_values_threaded)
+{
+   int random_key_fd = open("/dev/urandom", O_RDONLY);
+   ASSERT_TRUE(random_key_fd > 0);
+
+   // Run n-threads with sequential key and sequential values inserted
+   do_inserts_n_threads(data->kvsb,
+                        &data->master_cfg,
+                        data->hid,
+                        random_key_fd,
+                        TEST_INSERT_SEQ_VALUES_FD,
+                        data->num_inserts,
+                        data->num_insert_threads);
+
+   close(random_key_fd);
+}
+
+CTEST2(large_inserts_bugs_stress, test_seq_keys_random_values_threaded)
+{
+   int random_val_fd = open("/dev/urandom", O_RDONLY);
+   ASSERT_TRUE(random_val_fd > 0);
+
+   // Run n-threads with sequential key and sequential values inserted
+   do_inserts_n_threads(data->kvsb,
+                        &data->master_cfg,
+                        data->hid,
+                        TEST_INSERTS_SEQ_KEY_DIFF_START_KEYID_FD,
+                        random_val_fd,
+                        data->num_inserts,
+                        data->num_insert_threads);
+
+   close(random_val_fd);
+}
+
+CTEST2(large_inserts_bugs_stress,
+       test_seq_keys_random_values_threaded_same_start_keyid)
+{
+   int random_val_fd = open("/dev/urandom", O_RDONLY);
+   ASSERT_TRUE(random_val_fd > 0);
+
+   // Run n-threads with sequential key and sequential values inserted
+   do_inserts_n_threads(data->kvsb,
+                        &data->master_cfg,
+                        data->hid,
+                        TEST_INSERTS_SEQ_KEY_SAME_START_KEYID_FD,
+                        random_val_fd,
+                        data->num_inserts,
+                        data->num_insert_threads);
+
+   close(random_val_fd);
+}
+
+CTEST2(large_inserts_bugs_stress, test_random_keys_random_values_threaded)
+{
+   int random_key_fd = open("/dev/urandom", O_RDONLY);
+   ASSERT_TRUE(random_key_fd > 0);
+
+   int random_val_fd = open("/dev/urandom", O_RDONLY);
+   ASSERT_TRUE(random_val_fd > 0);
+
+   // Run n-threads with sequential key and sequential values inserted
+   do_inserts_n_threads(data->kvsb,
+                        &data->master_cfg,
+                        data->hid,
+                        random_key_fd,
+                        random_val_fd,
+                        data->num_inserts,
+                        data->num_insert_threads);
+
+   close(random_key_fd);
+   close(random_val_fd);
+}
+
+/*
+ * ----------------------------------------------------------------------------
+ * do_inserts_n_threads() - Driver function that will fire-up n-threads to
+ * perform different forms of inserts run by all the threads. The things we
+ * control via parameters are:
+ *
+ * Parameters:
+ * - random_key_fd      - Sequential / random key
+ * - random_val_fd      - Sequential / random value / fully-packed value.
+ * - num_inserts        - # of inserts / thread
+ * - num_insert_threads - # of inserting threads to start-up
+ * - same_start_value   - Boolean to control inserted batch' start-value.
+ *
+ * NOTE: Semantics of random_key_fd:
+ *
+ *  fd == 0: => Each thread will insert into its own assigned space of
+ *              {start-value, num-inserts} range. The concurrent inserts are all
+ *              unique non-conflicting keys.
+ *
+ *  fd  > 0: => Each thread will insert num_inserts rows with randomly generated
+ *              keys, usually fully-packed to TEST_KEY_SIZE.
+ *
+ *  fd  < 0: => Each thread will insert num_inserts rows all starting at the
+ *              same start value; chosen as 0.
+ *              This is a lapsed case to exercise heavy inserts of duplicate
+ *              keys, creating diff BTree split dynamics.
+ *
+ * NOTE: Semantics of random_val_fd:
+ *
+ * You can use this to control the type of value that will be generated:
+ *  fd == 0: Use sequential small-length values.
+ *  fd == 1: Use randomly generated values, fully-packed to TEST_VALUE_SIZE.
+ * ----------------------------------------------------------------------------
+ */
+static void
+do_inserts_n_threads(splinterdb      *kvsb,
+                     master_config   *master_cfg,
+                     platform_heap_id hid,
+                     int              random_key_fd,
+                     int              random_val_fd,
+                     uint64           num_inserts,
+                     uint64           num_insert_threads)
+{
+   worker_config *wcfg = TYPED_ARRAY_ZALLOC(hid, wcfg, num_insert_threads);
+
+   // Setup thread-specific insert parameters
+   for (int ictr = 0; ictr < num_insert_threads; ictr++) {
+      wcfg[ictr].kvsb        = kvsb;
+      wcfg[ictr].master_cfg  = master_cfg;
+      wcfg[ictr].num_inserts = num_inserts;
+
+      // Choose the same or diff start key-ID for each thread.
+      wcfg[ictr].start_value =
+         ((random_key_fd < 0) ? 0 : (wcfg[ictr].num_inserts * ictr));
+      wcfg[ictr].random_key_fd = random_key_fd;
+      wcfg[ictr].random_val_fd = random_val_fd;
+      wcfg[ictr].is_thread     = TRUE;
+   }
+
+   platform_thread *thread_ids =
+      TYPED_ARRAY_ZALLOC(hid, thread_ids, num_insert_threads);
+
+   // Fire-off the threads to drive inserts ...
+   for (int tctr = 0; tctr < num_insert_threads; tctr++) {
+      int rc = pthread_create(
+         &thread_ids[tctr], NULL, &exec_worker_thread, &wcfg[tctr]);
+      ASSERT_EQUAL(0, rc);
+   }
+
+   // Wait for all threads to complete ...
+   for (int tctr = 0; tctr < num_insert_threads; tctr++) {
+      void *thread_rc;
+      int   rc = pthread_join(thread_ids[tctr], &thread_rc);
+      ASSERT_EQUAL(0, rc);
+      if (thread_rc != 0) {
+         fprintf(stderr,
+                 "Thread %d [ID=%lu] had error: %p\n",
+                 tctr,
+                 thread_ids[tctr],
+                 thread_rc);
+         ASSERT_TRUE(FALSE);
+      }
+   }
+   platform_free(hid, thread_ids);
+   platform_free(hid, wcfg);
+}
+
+/*
+ * ----------------------------------------------------------------------------
+ * exec_worker_thread() - Thread-specific insert work-horse function.
+ *
+ * Each thread inserts 'num_inserts' KV-pairs from a 'start_value' ID.
+ * All inserts are sequential.
+ * ----------------------------------------------------------------------------
+ */
+static void *
+exec_worker_thread(void *w)
+{
+   char key_data[TEST_KEY_SIZE];
+   char val_data[TEST_VALUE_SIZE];
+
+   worker_config *wcfg = (worker_config *)w;
+
+   splinterdb *kvsb          = wcfg->kvsb;
+   uint64      start_key     = wcfg->start_value;
+   uint64      num_inserts   = wcfg->num_inserts;
+   int         random_key_fd = wcfg->random_key_fd;
+   int         random_val_fd = wcfg->random_val_fd;
+
+   uint64 start_time = platform_get_timestamp();
+
+   if (wcfg->is_thread) {
+      splinterdb_register_thread(kvsb);
+   }
+
+   threadid thread_idx = platform_get_tid();
+
+   // Test is written to insert multiples of millions per thread.
+   ASSERT_EQUAL(0, (num_inserts % MILLION));
+
+   const char *random_val_descr = NULL;
+   random_val_descr             = ((random_val_fd > 0)    ? "random"
+                                   : (random_val_fd == 0) ? "sequential"
+                                                          : "fully-packed constant");
+
+   platform_default_log("%s()::%d:Thread %-2lu inserts %lu (%lu million)"
+                        ", %s key, %s value, "
+                        "KV-pairs starting from %lu (%lu%s) ...\n",
+                        __func__,
+                        __LINE__,
+                        thread_idx,
+                        num_inserts,
+                        (num_inserts / MILLION),
+                        ((random_key_fd > 0) ? "random" : "sequential"),
+                        random_val_descr,
+                        start_key,
+                        (start_key / MILLION),
+                        (start_key ? " million" : ""));
+
+   uint64 ictr = 0;
+   uint64 jctr = 0;
+
+   bool verbose_progress = wcfg->master_cfg->verbose_progress;
+
+   // Insert fully-packed wider-values so we fill pages faster.
+   // This value-data will be chosen when random_key_fd < 0.
+   memset(val_data, 'V', sizeof(val_data));
+   uint64 val_len = sizeof(val_data);
+
+   bool val_length_msg_printed = FALSE;
+
+   for (ictr = 0; ictr < (num_inserts / MILLION); ictr++) {
+      for (jctr = 0; jctr < MILLION; jctr++) {
+
+         uint64 id = (start_key + (ictr * MILLION) + jctr);
+         uint64 key_len;
+
+         // Generate random key / value if calling test-case requests it.
+         if (random_key_fd > 0) {
+
+            // Generate random key-data for full width of key.
+            size_t result = read(random_key_fd, key_data, sizeof(key_data));
+            ASSERT_TRUE(result >= 0);
+
+            key_len = result;
+         } else {
+            // Generate sequential key data
+            snprintf(key_data, sizeof(key_data), "%lu", id);
+            key_len = strlen(key_data);
+         }
+
+         // Manage how the value-data is generated based on random_val_fd
+         if (random_val_fd > 0) {
+
+            // Generate random value for full width of value.
+            size_t result = read(random_val_fd, val_data, sizeof(val_data));
+            ASSERT_TRUE(result >= 0);
+
+            val_len = result;
+            if (!val_length_msg_printed) {
+               platform_default_log("OS-pid=%d, Thread-ID=%lu"
+                                    ", Insert random value of "
+                                    "fixed-length=%lu bytes.\n",
+                                    getpid(),
+                                    thread_idx,
+                                    val_len);
+               val_length_msg_printed = TRUE;
+            }
+         } else if (random_val_fd == 0) {
+            // Generate small-length sequential value data
+            snprintf(val_data, sizeof(val_data), "Row-%lu", id);
+            val_len = strlen(val_data);
+
+            if (!val_length_msg_printed) {
+               platform_default_log("OS-pid=%d, Thread-ID=%lu"
+                                    ", Insert small-width sequential values of "
+                                    "different lengths.\n",
+                                    getpid(),
+                                    thread_idx);
+               val_length_msg_printed = TRUE;
+            }
+         } else if (random_val_fd < 0) {
+            if (!val_length_msg_printed) {
+               platform_default_log("OS-pid=%d, Thread-ID=%lu"
+                                    ", Insert fully-packed fixed value of "
+                                    "length=%lu bytes.\n",
+                                    getpid(),
+                                    thread_idx,
+                                    val_len);
+               val_length_msg_printed = TRUE;
+            }
+         }
+
+         slice key = slice_create(key_len, key_data);
+         slice val = slice_create(val_len, val_data);
+
+         int rc = splinterdb_insert(kvsb, key, val);
+         ASSERT_EQUAL(0, rc);
+      }
+      if (verbose_progress) {
+         platform_default_log("Thread-%lu Inserted %lu million KV-pairs ...\n",
+                              thread_idx,
+                              (ictr + 1));
+      }
+   }
+   // Deal with low ns-elapsed times when inserting small #s of rows
+   uint64 elapsed_ns = platform_timestamp_elapsed(start_time);
+   uint64 elapsed_s  = NSEC_TO_SEC(elapsed_ns);
+   if (elapsed_s == 0) {
+      elapsed_s = 1;
+   }
+
+   platform_default_log(
+      "Thread-%lu Inserted %lu million KV-pairs in %lu s, %lu rows/s\n",
+      thread_idx,
+      ictr, // outer-loop ends at #-of-Millions inserted
+      elapsed_s,
+      (num_inserts / elapsed_s));
+
+   if (wcfg->is_thread) {
+      splinterdb_deregister_thread(kvsb);
+   }
+
+   return 0;
+}

--- a/tests/unit/main.c
+++ b/tests/unit/main.c
@@ -283,8 +283,15 @@ ctest_main(int argc, const char *argv[])
    if (!suite_name && (num_suites == 1)) {
       suite_name = curr_suite_name;
    }
-   printf("Running %d CTests, suite name '%s', test case '%s'.\n",
+   // Test will be run with shared memory configured if --use-shmem arg is
+   // specified. As a convenience for test-execution, if this happens to be
+   // the very 1st arg, a helpful info message indicating that the test is
+   // being run 'using shared memory' will be emitted.
+   bool use_shmem =
+      ((argc > 1) && STRING_EQUALS_LITERAL(argv[1], "--use-shmem"));
+   printf("Running %d CTests%s, suite name '%s', test case '%s'.\n",
           num_suites,
+          (use_shmem ? " using shared memory" : ""),
           (suite_name ? suite_name : "all"),
           (testcase_name ? testcase_name : "all"));
 

--- a/tests/unit/platform_apis_test.c
+++ b/tests/unit/platform_apis_test.c
@@ -20,24 +20,24 @@
 CTEST_DATA(platform_api)
 {
    // Declare heap handles for platform heap memory.
-   platform_heap_handle hh;
-   platform_heap_id     hid;
-   platform_module_id   mid;
+   platform_heap_id   hid;
+   platform_module_id mid;
 };
 
 CTEST_SETUP(platform_api)
 {
-   platform_status rc = STATUS_OK;
+   platform_status rc        = STATUS_OK;
+   bool            use_shmem = FALSE;
 
    uint64 heap_capacity = (256 * MiB); // small heap is sufficient.
    data->mid            = platform_get_module_id();
-   rc = platform_heap_create(data->mid, heap_capacity, &data->hh, &data->hid);
+   rc = platform_heap_create(data->mid, heap_capacity, use_shmem, &data->hid);
    platform_assert_status_ok(rc);
 }
 
 CTEST_TEARDOWN(platform_api)
 {
-   platform_heap_destroy(&data->hh);
+   platform_heap_destroy(&data->hid);
 }
 
 /*

--- a/tests/unit/splinter_shmem_test.c
+++ b/tests/unit/splinter_shmem_test.c
@@ -1,0 +1,657 @@
+// Copyright 2021 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+ * -----------------------------------------------------------------------------
+ * splinter_shmem_test.c --
+ *
+ *  Exercises the interfaces in SplinterDB shared memory allocation module.
+ * -----------------------------------------------------------------------------
+ */
+#include "splinterdb/public_platform.h"
+#include "platform.h"
+#include "unit_tests.h"
+#include "ctest.h" // This is required for all test-case files.
+#include "shmem.h"
+#include "splinterdb/splinterdb.h"
+#include "splinterdb/default_data_config.h"
+
+#define TEST_MAX_KEY_SIZE 42 // Just something to get going ...
+
+// Test these many threads concurrently performing memory allocation.
+#define TEST_MAX_THREADS 8
+
+/*
+ * To test heavily concurrent memory allocation from the shared memory, each
+ * thread will allocate a small fragment described by this structure. We then
+ * validate that the fragments are not clobbered by concurrent allocations.
+ */
+typedef struct shm_memfrag {
+   threadid            owner;
+   struct shm_memfrag *next;
+} shm_memfrag;
+
+// Configuration for each worker thread
+typedef struct {
+   splinterdb     *splinter;
+   platform_thread this_thread_id; // OS-generated thread ID
+   threadid        exp_thread_idx; // Splinter-generated expected thread index
+   shm_memfrag    *start;          // Start of chain of allocated memfrags
+} thread_config;
+
+// Function prototypes
+static void
+setup_cfg_for_test(splinterdb_config *out_cfg, data_config *default_data_cfg);
+
+static void
+exec_thread_memalloc(void *arg);
+
+/*
+ * Global data declaration macro:
+ */
+CTEST_DATA(splinter_shmem)
+{
+   // Declare heap handles to shake out shared memory based allocation.
+   size_t           shmem_capacity; // In bytes
+   platform_heap_id hid;
+};
+
+// By default, all test cases will deal with small shared memory segment.
+CTEST_SETUP(splinter_shmem)
+{
+   data->shmem_capacity = (256 * MiB); // bytes
+   platform_status rc   = platform_heap_create(
+      platform_get_module_id(), data->shmem_capacity, TRUE, &data->hid);
+   ASSERT_TRUE(SUCCESS(rc));
+
+   // Enable tracing all allocs / frees from shmem for this test.
+   platform_enable_tracing_shm_ops();
+}
+
+// Tear down the test shared segment.
+CTEST_TEARDOWN(splinter_shmem)
+{
+   platform_heap_destroy(&data->hid);
+}
+
+/*
+ * Basic test case. This goes through the basic create / destroy
+ * interfaces to setup a shared memory segment. While at it, run through
+ * few lookup interfaces to validate sizes.
+ */
+CTEST2(splinter_shmem, test_create_destroy_shmem)
+{
+   platform_heap_id hid           = NULL;
+   size_t           requested     = (512 * MiB); // bytes
+   size_t           heap_capacity = requested;
+   platform_status  rc =
+      platform_heap_create(platform_get_module_id(), heap_capacity, TRUE, &hid);
+   ASSERT_TRUE(SUCCESS(rc));
+
+   // Total size of shared segment must be what requested for.
+   ASSERT_EQUAL(platform_shmsize(hid), requested);
+
+   // A small chunk at the head is used for shmem_info{} tracking struct
+   ASSERT_EQUAL(platform_shmbytes_free(hid),
+                (requested - platform_shm_ctrlblock_size()));
+
+   // Destroy shared memory and release memory.
+   platform_shmdestroy(&hid);
+   ASSERT_TRUE(hid == NULL);
+}
+
+/*
+ * ---------------------------------------------------------------------------
+ * Test that used space and pad-bytes tracking is happening correctly
+ * when all allocation requests are fully aligned. No pad bytes should
+ * have been generated for alignment.
+ * ---------------------------------------------------------------------------
+ */
+CTEST2(splinter_shmem, test_aligned_allocations)
+{
+   int keybuf_size = 64;
+   int msgbuf_size = (2 * keybuf_size);
+
+   // Self-documenting assertion ... to future-proof this area.
+   ASSERT_EQUAL(keybuf_size, PLATFORM_CACHELINE_SIZE);
+
+   void  *next_free = platform_shm_next_free_addr(data->hid);
+   uint8 *keybuf    = TYPED_MANUAL_MALLOC(data->hid, keybuf, keybuf_size);
+
+   // Validate returned memory-ptrs, knowing that no pad bytes were needed.
+   ASSERT_TRUE((void *)keybuf == next_free);
+
+   next_free     = platform_shm_next_free_addr(data->hid);
+   uint8 *msgbuf = TYPED_MANUAL_MALLOC(data->hid, msgbuf, msgbuf_size);
+   ASSERT_TRUE((void *)msgbuf == next_free);
+
+   // Sum of requested alloc-sizes == total # of used-bytes
+   ASSERT_EQUAL((keybuf_size + msgbuf_size), platform_shmbytes_used(data->hid));
+
+   // Free bytes left in shared segment == (sum of requested alloc sizes, less
+   // a small bit of the control block.)
+   ASSERT_EQUAL((data->shmem_capacity
+                 - (keybuf_size + msgbuf_size + platform_shm_ctrlblock_size())),
+                platform_shmbytes_free(data->hid));
+}
+
+/*
+ * ---------------------------------------------------------------------------
+ * Test that used space and pad-bytes tracking is happening correctly
+ * when some allocation requests are not-fully aligned. Test verifies the
+ * tracking and computation of pad-bytes, free/used space.
+ * ---------------------------------------------------------------------------
+ */
+CTEST2(splinter_shmem, test_unaligned_allocations)
+{
+   void  *next_free   = platform_shm_next_free_addr(data->hid);
+   int    keybuf_size = 42;
+   uint8 *keybuf      = TYPED_MANUAL_MALLOC(data->hid, keybuf, keybuf_size);
+
+   int keybuf_pad =
+      platform_align_bytes_reqd(PLATFORM_CACHELINE_SIZE, keybuf_size);
+
+   // Sum of requested allocation + pad-bytes == total # of used-bytes
+   ASSERT_EQUAL((keybuf_size + keybuf_pad), platform_shmbytes_used(data->hid));
+
+   // Should have allocated what was previously determined as next free byte.
+   ASSERT_TRUE((void *)keybuf == next_free);
+
+   // Validate returned memory-ptrs, knowing that pad bytes were needed.
+   next_free = platform_shm_next_free_addr(data->hid);
+   ASSERT_TRUE(next_free == (void *)keybuf + keybuf_size + keybuf_pad);
+
+   int msgbuf_size = 100;
+   int msgbuf_pad =
+      platform_align_bytes_reqd(PLATFORM_CACHELINE_SIZE, msgbuf_size);
+   uint8 *msgbuf = TYPED_MANUAL_MALLOC(data->hid, msgbuf, msgbuf_size);
+
+   // Next allocation will abut prev-allocation + pad-bytes
+   ASSERT_TRUE((void *)msgbuf == (void *)keybuf + keybuf_size + keybuf_pad);
+
+   // Sum of requested allocation + pad-bytes == total # of used-bytes
+   ASSERT_EQUAL((keybuf_size + keybuf_pad + msgbuf_size + msgbuf_pad),
+                platform_shmbytes_used(data->hid));
+
+   // After accounting for the control block, next-free-addr should be
+   // exactly past the 2 allocations + their pad-bytes.
+   next_free = platform_shm_next_free_addr(data->hid);
+   /* RESOLVE: Fix this.
+   ASSERT_TRUE(next_free
+               == ((void *)data->hh + platform_shm_ctrlblock_size()
+                   + keybuf_size + keybuf_pad + msgbuf_size + msgbuf_pad));
+    */
+}
+
+/*
+ * ---------------------------------------------------------------------------
+ * Test allocation requests that result in an OOM from shared segment.
+ * Verify limits of memory allocation and handling of free/used bytes.
+ * These stats are maintained w/o full spinlocks, so will be approximate
+ * in concurrent scenarios. But for single-threaded allocations, these stats
+ * should be accurate even when shmem-OOMs occur.
+ * ---------------------------------------------------------------------------
+ */
+CTEST2(splinter_shmem, test_allocations_causing_OOMs)
+{
+   int keybuf_size = 64;
+
+   // Self-documenting assertion ... to future-proof this area.
+   ASSERT_EQUAL(keybuf_size, PLATFORM_CACHELINE_SIZE);
+
+   void  *next_free = platform_shm_next_free_addr(data->hid);
+   uint8 *keybuf    = TYPED_MANUAL_MALLOC(data->hid, keybuf, keybuf_size);
+
+   // Validate returned memory-ptr, knowing that no pad bytes were needed.
+   ASSERT_TRUE((void *)keybuf == next_free);
+
+   next_free = platform_shm_next_free_addr(data->hid);
+
+   size_t space_left =
+      (data->shmem_capacity - (keybuf_size + platform_shm_ctrlblock_size()));
+
+   ASSERT_EQUAL(space_left, platform_shmbytes_free(data->hid));
+
+   platform_error_log("\nNOTE: Test case intentionally triggers out-of-space"
+                      " errors in shared segment. 'Insufficient memory'"
+                      " error messages below are to be expected.\n");
+
+   // Note that although we have asked for 1 more byte than free space available
+   // the allocation interfaces round-up the # bytes for alignment. So the
+   // requested # of bytes will be a bit larger than free space in the error
+   // message you will see below.
+   keybuf_size       = (space_left + 1);
+   uint8 *keybuf_oom = TYPED_MANUAL_MALLOC(data->hid, keybuf_oom, keybuf_size);
+   ASSERT_TRUE(keybuf_oom == NULL);
+
+   // Free space counter is not touched if allocation fails.
+   ASSERT_EQUAL(space_left, platform_shmbytes_free(data->hid));
+
+   // As every memory request is rounded-up for alignment, the space left
+   // counter should always be an integral multiple of this constant.
+   ASSERT_EQUAL(0, (space_left % PLATFORM_CACHELINE_SIZE));
+
+   // If we request exactly what's available, it should succeed.
+   keybuf_size = space_left;
+   uint8 *keybuf_no_oom =
+      TYPED_MANUAL_MALLOC(data->hid, keybuf_no_oom, keybuf_size);
+   ASSERT_TRUE(keybuf_no_oom != NULL);
+   CTEST_LOG_INFO("Successfully allocated all remaining %lu bytes "
+                  "from shared segment.\n",
+                  space_left);
+
+   // We should be out of space by now.
+   ASSERT_EQUAL(0, platform_shmbytes_free(data->hid));
+
+   // This should fail.
+   keybuf_size = 1;
+   keybuf_oom  = TYPED_MANUAL_MALLOC(data->hid, keybuf_oom, keybuf_size);
+   ASSERT_TRUE(keybuf_oom == NULL);
+
+   // Free allocated memory before exiting.
+   platform_free(data->hid, keybuf);
+   platform_free(data->hid, keybuf_no_oom);
+}
+
+/*
+ * ---------------------------------------------------------------------------
+ * Test allocation interface using platform_get_heap_id() accessor, which
+ * is supposed to return in-use heap-ID. But, by default, this is NULL. This
+ * test shows that using this API will [correctly] allocate from shared memory
+ * once we've created the shared segment, and, therefore, all call-sites in
+ * the running library to platform_get_heap_id() should return the right
+ * handle(s) to the shared segment.
+ * ---------------------------------------------------------------------------
+ */
+CTEST2(splinter_shmem, test_allocations_using_get_heap_id)
+{
+   int keybuf_size = 64;
+
+   void  *next_free = platform_shm_next_free_addr(data->hid);
+   uint8 *keybuf =
+      TYPED_MANUAL_MALLOC(platform_get_heap_id(), keybuf, keybuf_size);
+
+   // Validate returned memory-ptrs, knowing that no pad bytes were needed.
+   ASSERT_TRUE((void *)keybuf == next_free);
+}
+
+/*
+ * ---------------------------------------------------------------------------
+ * Currently 'free' is a no-op; no space is released. Do minimal testing of
+ * this feature, to ensure that at least the code flow is exectuing correctly.
+ * ---------------------------------------------------------------------------
+ */
+CTEST2(splinter_shmem, test_free)
+{
+   int    keybuf_size = 64;
+   uint8 *keybuf      = TYPED_MANUAL_MALLOC(data->hid, keybuf, keybuf_size);
+
+   int    msgbuf_size = (2 * keybuf_size);
+   uint8 *msgbuf      = TYPED_MANUAL_MALLOC(data->hid, msgbuf, msgbuf_size);
+
+   size_t mem_used = platform_shmbytes_used(data->hid);
+
+   void *next_free = platform_shm_next_free_addr(data->hid);
+
+   platform_free(data->hid, keybuf);
+
+   // Even though we freed some memory, the next addr-to-allocate is unchanged.
+   ASSERT_TRUE(next_free == platform_shm_next_free_addr(data->hid));
+
+   // Space used remains unchanged, as free didn't quite return any memory
+   ASSERT_EQUAL(mem_used, platform_shmbytes_used(data->hid));
+}
+
+/*
+ * ---------------------------------------------------------------------------
+ * test_concurrent_allocs_by_n_threads() - Verify concurrency control
+ * implemented during shared memory allocation.
+ *
+ * Exercise concurrent memory allocations from the shared memory of small
+ * memory fragments. Each thread will record its ownership on the fragment
+ * allocated. After all memory is exhausted, we cross-check the chain of
+ * fragments allocated by each thread to verify that fragment still shows up
+ * as owned by the allocating thread.
+ *
+ * In the rudimentary version of allocation from shared memory, we did not have
+ * any concurrency control for allocations. So, it's likely that we may have
+ * been clobbering allocated memory.
+ *
+ * This test case does a basic verification of the fixes implemented to avoid
+ * such races during concurrent memory allocation.
+ *
+ * NOTE: This test case will exit immediately upon finding the first fragment
+ * whose ownership is flawed. That may still leave many other fragments waiting
+ * to be discovered with flawed ownership.
+ * ---------------------------------------------------------------------------
+ */
+CTEST2(splinter_shmem, test_concurrent_allocs_by_n_threads)
+{
+   splinterdb       *kvsb;
+   splinterdb_config cfg;
+   data_config       default_data_cfg;
+
+   platform_disable_tracing_shm_ops();
+
+   ZERO_STRUCT(cfg);
+   ZERO_STRUCT(default_data_cfg);
+
+   default_data_config_init(TEST_MAX_KEY_SIZE, &default_data_cfg);
+   setup_cfg_for_test(&cfg, &default_data_cfg);
+
+   int rv = splinterdb_create(&cfg, &kvsb);
+   ASSERT_EQUAL(0, rv);
+
+   // Setup multiple threads for concurrent memory allocation.
+   platform_thread new_thread;
+   thread_config   thread_cfg[TEST_MAX_THREADS];
+   thread_config  *thread_cfgp = NULL;
+   int             tctr        = 0;
+   platform_status rc          = STATUS_OK;
+
+   ZERO_ARRAY(thread_cfg);
+
+   platform_error_log("\nExecute %d concurrent threads peforming memory"
+                      " allocation till we run out of memory in the shared"
+                      " segment.\n'Insufficient memory' error messages"
+                      " below are to be expected.\n",
+                      TEST_MAX_THREADS);
+
+   // Start-up n-threads, record their expected thread-IDs, which will be
+   // validated by the thread's execution function below.
+   for (tctr = 1, thread_cfgp = &thread_cfg[tctr];
+        tctr < ARRAY_SIZE(thread_cfg);
+        tctr++, thread_cfgp++)
+   {
+      // These are independent of the new thread's creation.
+      thread_cfgp->splinter       = kvsb;
+      thread_cfgp->exp_thread_idx = tctr;
+
+      rc = platform_thread_create(
+         &new_thread, FALSE, exec_thread_memalloc, thread_cfgp, NULL);
+      ASSERT_TRUE(SUCCESS(rc));
+
+      thread_cfgp->this_thread_id = new_thread;
+   }
+
+   // Complete execution of n-threads. Worker fn does the validation.
+   for (tctr = 1, thread_cfgp = &thread_cfg[tctr];
+        tctr < ARRAY_SIZE(thread_cfg);
+        tctr++, thread_cfgp++)
+   {
+      rc = platform_thread_join(thread_cfgp->this_thread_id);
+      ASSERT_TRUE(SUCCESS(rc));
+   }
+
+   // Now run thru memory fragments allocated by each thread and verify that
+   // the identity recorded is kosher. If the same memory fragment was allocated
+   // to multiple threads, we should catch that error here.
+   for (tctr = 1, thread_cfgp = &thread_cfg[tctr];
+        tctr < ARRAY_SIZE(thread_cfg);
+        tctr++, thread_cfgp++)
+   {
+      shm_memfrag *this_frag = thread_cfgp->start;
+      while (this_frag) {
+         ASSERT_EQUAL(tctr,
+                      this_frag->owner,
+                      "Owner=%lu of memory frag=%p is not expected owner=%lu\n",
+                      this_frag->owner,
+                      this_frag,
+                      tctr);
+         this_frag = this_frag->next;
+      }
+   }
+
+   splinterdb_close(&kvsb);
+
+   platform_enable_tracing_shm_ops();
+}
+
+/*
+ * ---------------------------------------------------------------------------
+ * Test allocation, free and re-allocation of a large fragment should find
+ * this large fragment in the local tracker. That previously allocated
+ * fragment should be re-allocated. "Next-free-ptr" should, therefore, remain
+ * unchanged.
+ * ---------------------------------------------------------------------------
+ */
+CTEST2(splinter_shmem, test_realloc_of_large_fragment)
+{
+   void *next_free = platform_shm_next_free_addr(data->hid);
+
+   // Large fragments are tracked if their size >= this size.
+   size_t size   = (1 * MiB);
+   uint8 *keybuf = TYPED_MANUAL_MALLOC(data->hid, keybuf, size);
+
+   // Validate that a new large fragment will create a new allocation.
+   ASSERT_TRUE((void *)keybuf == next_free);
+
+   // Re-establish next-free-ptr after this large allocation. We will use it
+   // below to assert that this location will not change when we re-use this
+   // large fragment for reallocation after it's been freed.
+   next_free = platform_shm_next_free_addr(data->hid);
+
+   // Save this off, as free below will NULL out handle.
+   uint8 *keybuf_old = keybuf;
+
+   // If you free this fragment and reallocate exactly the same size,
+   // it should recycle the freed fragment.
+   platform_free(data->hid, keybuf);
+
+   uint8 *keybuf_new = TYPED_MANUAL_MALLOC(data->hid, keybuf_new, size);
+   ASSERT_TRUE((keybuf_old == keybuf_new),
+               "keybuf_old=%p, keybuf_new=%p\n",
+               keybuf_old,
+               keybuf_new);
+
+   // We have re-used freed fragment, so the next-free-ptr should be unchanged.
+   ASSERT_TRUE(next_free == platform_shm_next_free_addr(data->hid));
+
+   platform_free(data->hid, keybuf_new);
+}
+
+/*
+ * ---------------------------------------------------------------------------
+ * Test that free followed by a request of the same size will reallocate the
+ * recently-freed fragment, avoiding any existing in-use fragments of the same
+ * size.
+ * ---------------------------------------------------------------------------
+ */
+CTEST2(splinter_shmem, test_free_realloc_around_inuse_fragments)
+{
+   void *next_free = platform_shm_next_free_addr(data->hid);
+
+   // Large fragments are tracked if their size >= this size.
+   size_t size         = (1 * MiB);
+   uint8 *keybuf1_1MiB = TYPED_MANUAL_MALLOC(data->hid, keybuf1_1MiB, size);
+   uint8 *keybuf2_1MiB = TYPED_MANUAL_MALLOC(data->hid, keybuf2_1MiB, size);
+   uint8 *keybuf3_1MiB = TYPED_MANUAL_MALLOC(data->hid, keybuf3_1MiB, size);
+
+   // Re-establish next-free-ptr after this large allocation. We will use it
+   // below to assert that this location will not change when we re-use a
+   // large fragment for reallocation after it's been freed.
+   next_free = platform_shm_next_free_addr(data->hid);
+
+   // Save off fragment handles as free will NULL out ptr.
+   uint8 *old_keybuf2_1MiB = keybuf2_1MiB;
+
+   // Free the middle fragment that should get reallocated, below.
+   platform_free(data->hid, keybuf2_1MiB);
+
+   // Re-request (new) fragments of the same size.
+   keybuf2_1MiB = TYPED_MANUAL_MALLOC(data->hid, keybuf2_1MiB, size);
+   ASSERT_TRUE((keybuf2_1MiB == old_keybuf2_1MiB),
+               "Expected to satisfy new 1MiB request at %p"
+               " with old 1MiB fragment ptr at %p\n",
+               keybuf2_1MiB,
+               old_keybuf2_1MiB);
+
+   ASSERT_TRUE(next_free == platform_shm_next_free_addr(data->hid));
+
+   // As large-fragments allocated / freed are tracked in an array, verify
+   // that we will find the 1st one upon a re-request after a free.
+   uint8 *old_keybuf1_1MiB = keybuf1_1MiB;
+   platform_free(data->hid, keybuf1_1MiB);
+   platform_free(data->hid, keybuf2_1MiB);
+
+   // This re-request should re-allocate the 1st free fragment found.
+   keybuf2_1MiB = TYPED_MANUAL_MALLOC(data->hid, keybuf2_1MiB, size);
+   ASSERT_TRUE((keybuf2_1MiB == old_keybuf1_1MiB),
+               "Expected to satisfy new 1MiB request at %p"
+               " with old 1MiB fragment ptr at %p\n",
+               keybuf2_1MiB,
+               old_keybuf1_1MiB);
+
+   // We've already freed keybuf1_1MiB; can't free a NULL ptr again.
+   // platform_free(data->hid, keybuf1_1MiB);
+
+   platform_free(data->hid, keybuf2_1MiB);
+   platform_free(data->hid, keybuf3_1MiB);
+}
+
+/*
+ * ---------------------------------------------------------------------------
+ * Finding a free-fragment that's tracked for re-allocation implements a
+ * very naive linear-search; first-fit algorigthm. This test case verifies
+ * that:
+ *
+ * - Allocate 3 fragments of 1MiB, 5MiB, 2MiB
+ * - Free them all.
+ * - Request for a 2MiB fragment. 2nd free fragment (5MiB) will be used.
+ * - Request for a 5MiB fragment. We will allocate a new fragment.
+ *
+ * An improved best-fit search algorithm would have allocated the free 2MiB
+ * and then satisfy the next request with the free 5 MiB fragment.
+ * ---------------------------------------------------------------------------
+ */
+CTEST2(splinter_shmem, test_realloc_of_free_fragments_uses_first_fit)
+{
+   void *next_free = platform_shm_next_free_addr(data->hid);
+
+   // Large fragments are tracked if their size >= this size.
+   size_t size        = (1 * MiB);
+   uint8 *keybuf_1MiB = TYPED_MANUAL_MALLOC(data->hid, keybuf_1MiB, size);
+
+   size               = (5 * MiB);
+   uint8 *keybuf_5MiB = TYPED_MANUAL_MALLOC(data->hid, keybuf_5MiB, size);
+
+   size               = (2 * MiB);
+   uint8 *keybuf_2MiB = TYPED_MANUAL_MALLOC(data->hid, keybuf_2MiB, size);
+
+   // Re-establish next-free-ptr after this large allocation. We will use it
+   // below to assert that this location will not change when we re-use a
+   // large fragment for reallocation after it's been freed.
+   next_free = platform_shm_next_free_addr(data->hid);
+
+   // Save off fragment handles as free will NULL out ptr.
+   uint8 *old_keybuf_1MiB = keybuf_1MiB;
+   uint8 *old_keybuf_5MiB = keybuf_5MiB;
+   uint8 *old_keybuf_2MiB = keybuf_2MiB;
+
+   // Order in which we free these fragments does not matter.
+   platform_free(data->hid, keybuf_1MiB);
+   platform_free(data->hid, keybuf_2MiB);
+   platform_free(data->hid, keybuf_5MiB);
+
+   // Re-request (new) fragments in diff size order.
+   size        = (2 * MiB);
+   keybuf_2MiB = TYPED_MANUAL_MALLOC(data->hid, keybuf_2MiB, size);
+   ASSERT_TRUE((keybuf_2MiB == old_keybuf_5MiB),
+               "Expected to satisfy new 2MiB request at %p"
+               " with old 5MiB fragment ptr at %p\n",
+               keybuf_2MiB,
+               old_keybuf_5MiB);
+   ;
+
+   // We have re-used freed 5MiB fragment; so next-free-ptr should be unchanged.
+   ASSERT_TRUE(next_free == platform_shm_next_free_addr(data->hid));
+
+   size        = (5 * MiB);
+   keybuf_5MiB = TYPED_MANUAL_MALLOC(data->hid, keybuf_5MiB, size);
+
+   // We allocated a new fragment at next-free-ptr
+   ASSERT_TRUE(keybuf_5MiB != old_keybuf_1MiB);
+   ASSERT_TRUE(keybuf_5MiB != old_keybuf_2MiB);
+   ASSERT_TRUE(keybuf_5MiB == next_free);
+
+   platform_free(data->hid, keybuf_2MiB);
+   platform_free(data->hid, keybuf_5MiB);
+}
+
+/*
+ * ---------------------------------------------------------------------------
+ * Test case to verify that configuration checks that shared segment size
+ * is "big enough" to allocate memory for RC-allocator cache's lookup
+ * array. For very large devices, with insufficiently sized shared memory
+ * config, we will not be able to boot-up.
+ * RESOLVE - This test case is still incomplete.
+ * ---------------------------------------------------------------------------
+ */
+CTEST2(splinter_shmem, test_large_dev_with_small_shmem_error_handling)
+{
+   splinterdb       *kvsb;
+   splinterdb_config cfg;
+   data_config       default_data_cfg;
+
+   platform_disable_tracing_shm_ops();
+
+   ZERO_STRUCT(cfg);
+   ZERO_STRUCT(default_data_cfg);
+
+   default_data_config_init(TEST_MAX_KEY_SIZE, &default_data_cfg);
+   setup_cfg_for_test(&cfg, &default_data_cfg);
+
+   int rc = splinterdb_create(&cfg, &kvsb);
+   ASSERT_EQUAL(0, rc);
+
+   splinterdb_close(&kvsb);
+
+   platform_enable_tracing_shm_ops();
+}
+
+static void
+setup_cfg_for_test(splinterdb_config *out_cfg, data_config *default_data_cfg)
+{
+   *out_cfg = (splinterdb_config){.filename   = TEST_DB_NAME,
+                                  .cache_size = 512 * Mega,
+                                  .disk_size  = 2 * Giga,
+                                  .use_shmem  = TRUE,
+                                  .data_cfg   = default_data_cfg};
+}
+
+/*
+ * exec_thread_memalloc() - Worker fn for each thread to do concurrent memory
+ * allocation from the shared segment.
+ */
+static void
+exec_thread_memalloc(void *arg)
+{
+   thread_config *thread_cfg = (thread_config *)arg;
+   splinterdb    *kvs        = thread_cfg->splinter;
+
+   splinterdb_register_thread(kvs);
+
+   // Allocate a new memory fragment and connect head to output variable for
+   // thread
+   shm_memfrag **fragpp   = &thread_cfg->start;
+   shm_memfrag  *new_frag = NULL;
+
+   uint64   nallocs         = 0;
+   threadid this_thread_idx = thread_cfg->exp_thread_idx;
+
+   // Keep allocating fragments till we run out of memory.
+   // Build a linked list of memory fragments for this thread.
+   while ((new_frag = TYPED_ZALLOC(platform_get_heap_id(), new_frag)) != NULL) {
+      *fragpp         = new_frag;
+      new_frag->owner = this_thread_idx;
+      fragpp          = &new_frag->next;
+      nallocs++;
+   }
+   splinterdb_deregister_thread(kvs);
+
+   platform_default_log(
+      "Thread-ID=%lu allocated %lu memory fragments of %lu bytes each.\n",
+      this_thread_idx,
+      nallocs,
+      sizeof(*new_frag));
+}

--- a/tests/unit/splinter_test.c
+++ b/tests/unit/splinter_test.c
@@ -29,6 +29,7 @@
 #include "functional/test.h"
 #include "functional/test_async.h"
 #include "test_common.h"
+#include "config.h"
 #include "unit_tests.h"
 #include "ctest.h" // This is required for all test-case files.
 
@@ -76,8 +77,7 @@ test_lookup_by_range(void         *datap,
 CTEST_DATA(splinter)
 {
    // Declare head handles for io, allocator, cache and splinter allocation.
-   platform_heap_handle hh;
-   platform_heap_id     hid;
+   platform_heap_id hid;
 
    // Thread-related config parameters. These don't change for unit tests
    uint32 num_insert_threads;
@@ -114,6 +114,8 @@ CTEST_DATA(splinter)
 // clang-format off
 CTEST_SETUP(splinter)
 {
+   bool use_shmem = config_parse_use_shmem(Ctest_argc, (char **)Ctest_argv);
+
    // Defaults: For basic unit-tests, use single threads
    data->num_insert_threads = 1;
    data->num_lookup_threads = 1;
@@ -130,7 +132,7 @@ CTEST_SETUP(splinter)
    // Create a heap for io, allocator, cache and splinter
    platform_status rc = platform_heap_create(platform_get_module_id(),
                                              heap_capacity,
-                                             &data->hh,
+                                             use_shmem,
                                              &data->hid);
    platform_assert_status_ok(rc);
 
@@ -178,7 +180,7 @@ CTEST_SETUP(splinter)
    // Allocate and initialize the IO sub-system.
    data->io = TYPED_MALLOC(data->hid, data->io);
    ASSERT_TRUE((data->io != NULL));
-   rc = io_handle_init(data->io, &data->io_cfg, data->hh, data->hid);
+   rc = io_handle_init(data->io, &data->io_cfg, data->hid);
 
    data->tasks = NULL;
    rc = test_init_task_system(data->hid, data->io, &data->tasks, &data->task_cfg);
@@ -232,7 +234,7 @@ CTEST_TEARDOWN(splinter)
       platform_free(data->hid, data->splinter_cfg);
    }
 
-   platform_heap_destroy(&data->hh);
+   platform_heap_destroy(&data->hid);
 }
 
 /*
@@ -817,7 +819,7 @@ shadow_check_tuple_func(key returned_key, message value, void *varg)
       trunk_message_to_string(arg->spl, shadow_value, expected_value);
       trunk_message_to_string(arg->spl, value, actual_value);
 
-      CTEST_LOG_INFO("expected: '%s' | '%s'\n", expected_key, expected_value);
+      CTEST_LOG_INFO("\nexpected: '%s' | '%s'\n", expected_key, expected_value);
       CTEST_LOG_INFO("actual  : '%s' | '%s'\n", actual_key, actual_value);
       arg->errors++;
    }

--- a/tests/unit/splinterdb_heap_id_mgmt_test.c
+++ b/tests/unit/splinterdb_heap_id_mgmt_test.c
@@ -1,0 +1,160 @@
+// Copyright 2023 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+ * -----------------------------------------------------------------------------
+ * splinterdb_heap_id_mgmt_test.c
+ *
+ * This is a very specific white-box test to exercise splinterdb_create() and
+ * splinterdb_close() interfaces, to exercise the handling of platform heap
+ * in the presence of error paths. Usually, the platform_heap is created when
+ * splinterdb_create() is done, and the heap is destroyed upon close. There is
+ * another way for the calling code to create the platform-heap externally.
+ * The cases in this test verify that we can create(), close() and reopen
+ * SplinterDB even while managing the externally created platform heap.
+ *
+ * Tests for the other code-path, where splinterdb_create() itself creates
+ * the platform heap, and verifying that the heap is correctly managed in the
+ * face of errors exist in other unit-tests, e.g, splinterdb_quick_test.c,
+ * task_system_test.c etc.
+ * -----------------------------------------------------------------------------
+ */
+#include "splinterdb/splinterdb.h"
+#include "splinterdb/default_data_config.h"
+#include "config.h"
+#include "unit_tests.h"
+
+#define TEST_MAX_KEY_SIZE 20
+
+static void
+create_default_cfg(splinterdb_config *out_kvs_cfg,
+                   data_config       *default_data_cfg,
+                   bool               use_shmem);
+
+/*
+ * Global data declaration macro:
+ */
+CTEST_DATA(splinterdb_heap_id_mgmt)
+{
+   data_config       default_data_cfg;
+   platform_heap_id  hid;
+   splinterdb_config kvs_cfg;
+   splinterdb       *kvs;
+   size_t            shmem_size; // for assert validation
+};
+
+CTEST_SETUP(splinterdb_heap_id_mgmt)
+{
+   platform_status rc = STATUS_OK;
+
+   bool use_shmem = config_parse_use_shmem(Ctest_argc, (char **)Ctest_argv);
+
+   uint64 heap_capacity = (256 * MiB); // small heap is sufficient.
+   default_data_config_init(TEST_MAX_KEY_SIZE, &data->default_data_cfg);
+
+   memset(&data->kvs_cfg, 0, sizeof(data->kvs_cfg));
+   create_default_cfg(&data->kvs_cfg, &data->default_data_cfg, use_shmem);
+
+   platform_module_id mid = platform_get_module_id();
+
+   rc = platform_heap_create(
+      mid, heap_capacity, use_shmem, &data->kvs_cfg.heap_id);
+   platform_assert_status_ok(rc);
+
+   // Remember the heap-ID created here; used to cross-check in assertions
+   data->hid = data->kvs_cfg.heap_id;
+   if (data->kvs_cfg.use_shmem) {
+      data->shmem_size = platform_shmsize(data->hid);
+   }
+}
+
+CTEST_TEARDOWN(splinterdb_heap_id_mgmt)
+{
+   platform_heap_destroy(&data->kvs_cfg.heap_id);
+}
+
+/*
+ * Test create and close interfaces.
+ */
+CTEST2(splinterdb_heap_id_mgmt, test_create_close)
+{
+   int rc = splinterdb_create(&data->kvs_cfg, &data->kvs);
+   ASSERT_EQUAL(0, rc);
+
+   ASSERT_EQUAL((size_t)data->hid, (size_t)data->kvs_cfg.heap_id);
+
+   splinterdb_close(&data->kvs);
+
+   // As we created the heap externally, in this test, close should not
+   // have destroyed the heap. Exercise interfaces which will seg-fault
+   // otherwise.
+   if (data->kvs_cfg.use_shmem) {
+      ASSERT_EQUAL(data->shmem_size, platform_shmsize(data->hid));
+   }
+}
+
+/*
+ * Test create, close followed by re-open of SplinterDB. Re-use the previously
+ * setup splinterdb_config{} struct, which should have a handle to the platform
+ * heap. The same (shared memory) heap should be re-used.
+ */
+CTEST2(splinterdb_heap_id_mgmt, test_create_close_and_reopen)
+{
+   int rc = splinterdb_create(&data->kvs_cfg, &data->kvs);
+   ASSERT_EQUAL(0, rc);
+
+   splinterdb_close(&data->kvs);
+
+   rc = splinterdb_open(&data->kvs_cfg, &data->kvs);
+
+   // The heap ID should not change.
+   ASSERT_EQUAL((size_t)data->hid, (size_t)data->kvs_cfg.heap_id);
+
+   splinterdb_close(&data->kvs);
+   // Shared memory heap should still be around and accessible.
+   if (data->kvs_cfg.use_shmem) {
+      ASSERT_EQUAL(data->shmem_size, platform_shmsize(data->hid));
+   }
+}
+
+/*
+ * Test error path while creating SplinterDB which can trip-up due to a bad
+ * configuration. Induce such an error and verify that platform heap is not
+ * messed-up due to backout code.
+ */
+CTEST2(splinterdb_heap_id_mgmt, test_failed_init_config)
+{
+   size_t save_cache_size   = data->kvs_cfg.cache_size;
+   data->kvs_cfg.cache_size = 0;
+   int rc                   = splinterdb_create(&data->kvs_cfg, &data->kvs);
+   ASSERT_NOT_EQUAL(0, rc);
+
+   data->kvs_cfg.cache_size = save_cache_size;
+
+   // The heap ID should not change.
+   ASSERT_EQUAL((size_t)data->hid, (size_t)data->kvs_cfg.heap_id);
+
+   // Shared memory heap should still be around and accessible.
+   if (data->kvs_cfg.use_shmem) {
+      ASSERT_EQUAL(data->shmem_size, platform_shmsize(data->hid));
+   }
+}
+
+/*
+ * Helper routine to create a valid Splinter configuration using default
+ * page- and extent-size. Shared-memory usage is OFF by default.
+ */
+static void
+create_default_cfg(splinterdb_config *out_kvs_cfg,
+                   data_config       *default_data_cfg,
+                   bool               use_shmem)
+{
+   *out_kvs_cfg =
+      (splinterdb_config){.filename    = TEST_DB_NAME,
+                          .cache_size  = 64 * Mega,
+                          .disk_size   = 127 * Mega,
+                          .page_size   = TEST_CONFIG_DEFAULT_PAGE_SIZE,
+                          .extent_size = TEST_CONFIG_DEFAULT_EXTENT_SIZE,
+                          .use_shmem   = use_shmem,
+                          .data_cfg    = default_data_cfg};
+}

--- a/tests/unit/splinterdb_quick_test.c
+++ b/tests/unit/splinterdb_quick_test.c
@@ -37,6 +37,7 @@
 #include "test_data.h"
 #include "ctest.h" // This is required for all test-case files.
 #include "btree.h" // for MAX_INLINE_MESSAGE_SIZE
+#include "config.h"
 
 #define TEST_MAX_KEY_SIZE 13
 
@@ -108,6 +109,8 @@ CTEST_SETUP(splinterdb_quick)
 {
    default_data_config_init(TEST_MAX_KEY_SIZE, &data->default_data_cfg.super);
    create_default_cfg(&data->cfg, &data->default_data_cfg.super);
+   data->cfg.use_shmem =
+      config_parse_use_shmem(Ctest_argc, (char **)Ctest_argv);
 
    int rc = splinterdb_create(&data->cfg, &data->kvsb);
    ASSERT_EQUAL(0, rc);
@@ -696,7 +699,6 @@ CTEST2(splinterdb_quick, test_close_and_reopen)
    const char  *val      = "some-value";
    const size_t val_len  = strlen(val);
 
-
    int rc = splinterdb_insert(data->kvsb, user_key, slice_create(val_len, val));
    ASSERT_EQUAL(0, rc);
 
@@ -965,6 +967,7 @@ create_default_cfg(splinterdb_config *out_cfg, data_config *default_data_cfg)
    *out_cfg = (splinterdb_config){.filename   = TEST_DB_NAME,
                                   .cache_size = 64 * Mega,
                                   .disk_size  = 127 * Mega,
+                                  .use_shmem  = FALSE,
                                   .data_cfg   = default_data_cfg};
 }
 

--- a/tests/unit/splinterdb_stress_test.c
+++ b/tests/unit/splinterdb_stress_test.c
@@ -16,6 +16,7 @@
 #include "unit_tests.h"
 #include "util.h"
 #include "../functional/random.h"
+#include "config.h"
 #include "ctest.h" // This is required for all test-case files.
 
 #define TEST_KEY_SIZE   20
@@ -56,6 +57,9 @@ CTEST_SETUP(splinterdb_stress)
                                              .num_normal_bg_threads   = 2};
    size_t max_key_size = TEST_KEY_SIZE;
    default_data_config_init(max_key_size, data->cfg.data_cfg);
+
+   data->cfg.use_shmem =
+      config_parse_use_shmem(Ctest_argc, (char **)Ctest_argv);
 
    int rc = splinterdb_create(&data->cfg, &data->kvsb);
    ASSERT_EQUAL(0, rc);

--- a/tests/unit/task_system_test.c
+++ b/tests/unit/task_system_test.c
@@ -80,8 +80,7 @@ exec_user_thread_loop_for_stop(void *arg);
 CTEST_DATA(task_system)
 {
    // Declare heap handles for io allocation.
-   platform_heap_handle hh;
-   platform_heap_id     hid;
+   platform_heap_id hid;
 
    // Config structs required, to exercise task subsystem
    io_config          io_cfg;
@@ -104,11 +103,12 @@ CTEST_DATA(task_system)
 CTEST_SETUP(task_system)
 {
    platform_status rc = STATUS_OK;
+   bool use_shmem     = config_parse_use_shmem(Ctest_argc, (char **)Ctest_argv);
 
    uint64 heap_capacity = (256 * MiB); // small heap is sufficient.
    // Create a heap for io and task system to use.
    rc = platform_heap_create(
-      platform_get_module_id(), heap_capacity, &data->hh, &data->hid);
+      platform_get_module_id(), heap_capacity, use_shmem, &data->hid);
    platform_assert_status_ok(rc);
 
    // Allocate and initialize the IO sub-system.
@@ -127,7 +127,7 @@ CTEST_SETUP(task_system)
                   master_cfg.io_async_queue_depth,
                   master_cfg.io_filename);
 
-   rc = io_handle_init(data->ioh, &data->io_cfg, data->hh, data->hid);
+   rc = io_handle_init(data->ioh, &data->io_cfg, data->hid);
    ASSERT_TRUE(SUCCESS(rc),
                "Failed to init IO handle: %s\n",
                platform_status_to_string(rc));
@@ -161,7 +161,7 @@ CTEST_TEARDOWN(task_system)
 {
    task_system_destroy(data->hid, &data->tasks);
    io_handle_deinit(data->ioh);
-   platform_heap_destroy(&data->hh);
+   platform_heap_destroy(&data->hid);
 }
 
 /*
@@ -321,9 +321,13 @@ CTEST2(task_system, test_max_threads_using_lower_apis)
                 "Before threads start, task_get_max_tid() = %lu",
                 task_get_max_tid(data->tasks));
 
+   // We may have started some background threads, if this test was so
+   // configured. So, start-up all the remaining threads.
+   threadid max_tid_so_far = task_get_max_tid(data->tasks);
+
    // Start-up n-threads, record their expected thread-IDs, which will be
    // validated by the thread's execution function below.
-   for (tctr = 1, thread_cfgp = &thread_cfg[tctr];
+   for (tctr = max_tid_so_far, thread_cfgp = &thread_cfg[tctr];
         tctr < ARRAY_SIZE(thread_cfg);
         tctr++, thread_cfgp++)
    {
@@ -339,7 +343,7 @@ CTEST2(task_system, test_max_threads_using_lower_apis)
    }
 
    // Complete execution of n-threads. Worker fn does the validation.
-   for (tctr = 1, thread_cfgp = &thread_cfg[tctr];
+   for (tctr = max_tid_so_far, thread_cfgp = &thread_cfg[tctr];
         tctr < ARRAY_SIZE(thread_cfg);
         tctr++, thread_cfgp++)
    {


### PR DESCRIPTION
Support to run SplinterDB with shared memory configured for most memory allocation is an -EXPERIMENTAL- feature added with this commit.

This commit brings in basic support to create a shared memory segment and to redirect all memory allocation primitives to shared memory. Currently, we only support a simplistic memory mgmt; i.e. only-allocs, and no frees. With shared segments of 1-2 GiB we can run many functional and unit tests.

The high-points of the changes are:

- External configuration: splinterdb_config{} gains a few new visible fields to configure and troubleshoot shared memory configuration.
   - Boolean: use_shmem: Default is OFF
   - size_t : shmem_size:
   - Few boolean trace options to trace allocs / free from shmem.

- The main driving change is the re-deployment of platform_heap_id 'hid' arg that appears in all memory-related interfaces. If Splinter is configured for shared memory use, 'hid' will be an opaque handle to the shared segment. Most memory allocation will be redirected to new shmem-based alloc() / free() interfaces.

  The default 'hid' remains NULL, labelled as PROCESS_PRIVATE_HEAP_ID.

- Manage handling of heap-ID and heap-handle to platform_get_heap_id() to correctly return the handle to shared memory. (Otherwise, it would return NULL by default.)

- Formalize usages of PROCESS_PRIVATE_HEAP_ID: A small number of clients that wish to repeatedly allocate large chunks of memory tend to cause OOMs. The memory allocated by these clients is not shared across threads / processes. For such usages, introduce PROCESS_PRIVATE_HEAP_ID as an alias to NULL. The known set of clients using this interface now are:

    - merge_iterator_create(), merge_iterator_destroy()
    - trunk_range() - trunk_range_iterator_init(), trunk_range_iterator_deinit()
    - routing_filter_add() - temp array

- BTree pack allocates large fingerprint-array. This also causes large tests to run into OOMs. For threaded execution, it's ok if the memory for this array is allocated from the heap. But for multi-process execution, when one process (thread) allocates this finger print array, another thread may pick up the task to compact a bundle and will try to free this memory. So, this memory has to come from shared memory. To cope with such repeated allocations of large chunks of memory to build fingerprint, a small recycling scheme for "free"-large-memory chunks scheme is now supported by shmem module.

  Use this technique to recycle memory allocated for iterators also. They tend to be big'gish, so can also cause shmem-OOMs.

- Several existing functional and unit-tests have been enhanced to now support "--use-shmem" as the 1st option. This will create Splinter with shared memory configured, and tests run in this mode. This change brings-in quite a good coverage of existing testing for this new feature. Following tests are working with this feature:
     - limitations_test - splinterdb_quick_test - writable_buffer_test - task_system_test - splinter_test - btree_test - splinterdb_stress_test

   - New test: large_inserts_bugs_stress_test -- added to cover the primary use-case of concurrent insert performance benchmarking (that this feature is driving in prior integration effort).

   - test.sh enhanced to run different classes of test with "--use-shmem" option.

- Diagnostis & Troubleshooting:

   - Shmem-based alloc/free interfaces extended to print name of object and other call-site info, to better pinpoint source code-flow leading to memory issues.

   - Add shared memory usage metrics, including for large-fragment handling. Report summary-line of metrics when Splinter is shutdown. Print stats on close.

   - Add various utility diagnostic helper methods to validate that addresses within shared memory are valid. Unit-tests and some asserts use these.