### PR TITLE
Robj/memtable race fix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,4 +26,4 @@ and follow [testing](docs/testing.md) for instructions on testing your changes.
         ln -s -f ../../format-check.sh .git/hooks/pre-commit
         ```
 
-3. Then open a [Pull Request](https://github.com/vmware/splinterdb/pulls).  Our continuous integration (CI) system will run additional checks, which can take a couple hours.  If you have not signed our Contributor License Agreement (CLA), a "CLA-bot" will take you through the process and update the issue.  If you have questions about the CLA process, see our CLA [FAQ](https://cla.vmware.com/faq) or just ask for help on your pull request.
+3. Then open a [Pull Request](https://github.com/vmware/splinterdb/pulls).  You'll need to wait for a project maintainer to add the `ok-to-test` label to your PR.  Then our continuous integration (CI) system will run checks, which can take a couple hours.  Also, if you have not signed our Contributor License Agreement (CLA), a "CLA-bot" will take you through the process and update the issue.  If you have questions about the CLA process, see our CLA [FAQ](https://cla.vmware.com/faq) or just ask for help on your pull request.

--- a/src/memtable.c
+++ b/src/memtable.c
@@ -129,7 +129,7 @@ memtable_maybe_rotate_and_get_insert_lock(memtable_context *ctxt,
       memtable_get_insert_lock(ctxt);
       uint64    current_generation = ctxt->generation;
       uint64    current_mt_no = current_generation % ctxt->cfg.max_memtables;
-      memtable *current_mt         = &ctxt->mt[current_mt_no];
+      memtable *current_mt    = &ctxt->mt[current_mt_no];
       if (current_mt->state != MEMTABLE_STATE_READY) {
          // The next memtable is not ready yet, back off and wait.
          memtable_unget_insert_lock(ctxt);

--- a/src/memtable.h
+++ b/src/memtable.h
@@ -140,23 +140,23 @@ typedef struct memtable_context {
 } memtable_context;
 
 platform_status
-memtable_maybe_rotate_and_get_insert_lock(memtable_context *ctxt,
-                                          uint64           *generation);
+memtable_maybe_rotate_and_begin_insert(memtable_context *ctxt,
+                                       uint64           *generation);
 
 void
-memtable_unget_insert_lock(memtable_context *ctxt);
+memtable_end_insert(memtable_context *ctxt);
 
 void
-memtable_get_lookup_lock(memtable_context *ctxt);
+memtable_begin_lookup(memtable_context *ctxt);
 
 void
-memtable_unget_lookup_lock(memtable_context *ctxt);
+memtable_end_lookup(memtable_context *ctxt);
 
 void
-memtable_lock_lookup_lock(memtable_context *ctxt);
+memtable_block_lookups(memtable_context *ctxt);
 
 void
-memtable_unlock_lookup_lock(memtable_context *ctxt);
+memtable_unblock_lookups(memtable_context *ctxt);
 
 platform_status
 memtable_insert(memtable_context *ctxt,

--- a/src/platform_linux/platform_types.h
+++ b/src/platform_linux/platform_types.h
@@ -129,9 +129,10 @@ platform_batch_rwlock_unget(platform_batch_rwlock *lock, uint64 lock_idx);
 bool
 platform_batch_rwlock_try_claim(platform_batch_rwlock *lock, uint64 lock_idx);
 
-/* no lock -> claim */
+/* shared-lock -> claim, BUT(!) may temporarily release the shared-lock in the
+ * process. */
 void
-platform_batch_rwlock_claim(platform_batch_rwlock *lock, uint64 lock_idx);
+platform_batch_rwlock_claim_loop(platform_batch_rwlock *lock, uint64 lock_idx);
 
 /* claim -> shared lock */
 void
@@ -144,6 +145,10 @@ platform_batch_rwlock_lock(platform_batch_rwlock *lock, uint64 lock_idx);
 /* exclusive lock -> claim */
 void
 platform_batch_rwlock_unlock(platform_batch_rwlock *lock, uint64 lock_idx);
+
+/* exclusive-lock -> unlocked */
+void
+platform_batch_rwlock_full_unlock(platform_batch_rwlock *lock, uint64 lock_idx);
 
 
 // Buffer handle

--- a/src/trunk.c
+++ b/src/trunk.c
@@ -1196,9 +1196,10 @@ error:
  */
 
 static inline void
-trunk_root_claim(trunk_handle *spl)
+trunk_root_full_claim(trunk_handle *spl)
 {
-   platform_batch_rwlock_claim(&spl->trunk_root_lock, TRUNK_ROOT_LOCK_IDX);
+   platform_batch_rwlock_get(&spl->trunk_root_lock, TRUNK_ROOT_LOCK_IDX);
+   platform_batch_rwlock_claim_loop(&spl->trunk_root_lock, TRUNK_ROOT_LOCK_IDX);
 }
 
 static inline void
@@ -1214,7 +1215,7 @@ trunk_root_unlock(trunk_handle *spl)
 }
 
 static inline void
-trunk_root_unclaim(trunk_handle *spl)
+trunk_root_full_unclaim(trunk_handle *spl)
 {
    platform_batch_rwlock_unclaim(&spl->trunk_root_lock, TRUNK_ROOT_LOCK_IDX);
    platform_batch_rwlock_unget(&spl->trunk_root_lock, TRUNK_ROOT_LOCK_IDX);
@@ -1233,7 +1234,7 @@ trunk_claim_and_copy_root(trunk_handle *spl,      // IN
                           trunk_node   *new_root, // OUT
                           uint64       *old_root_addr)  // OUT
 {
-   trunk_root_claim(spl);
+   trunk_root_full_claim(spl);
    trunk_node root;
    // Safe because we have the claim
    trunk_node_get(spl->cc, spl->root_addr, &root);
@@ -1258,7 +1259,7 @@ trunk_update_claimed_root(trunk_handle *spl,    // IN
    trunk_root_lock(spl);
    spl->root_addr = new_root->addr;
    trunk_root_unlock(spl);
-   trunk_root_unclaim(spl);
+   trunk_root_full_unclaim(spl);
 }
 
 /*
@@ -3374,12 +3375,12 @@ trunk_memtable_insert(trunk_handle *spl, key tuple_key, message msg)
    uint64 generation;
 
    platform_status rc =
-      memtable_maybe_rotate_and_get_insert_lock(spl->mt_ctxt, &generation);
+      memtable_maybe_rotate_and_begin_insert(spl->mt_ctxt, &generation);
    while (STATUS_IS_EQ(rc, STATUS_BUSY)) {
       // Memtable isn't ready, do a task if available; may be required to
       // incorporate memtable that we're waiting on
       task_perform_one_if_needed(spl->ts, 0);
-      rc = memtable_maybe_rotate_and_get_insert_lock(spl->mt_ctxt, &generation);
+      rc = memtable_maybe_rotate_and_begin_insert(spl->mt_ctxt, &generation);
    }
    if (!SUCCESS(rc)) {
       goto out;
@@ -3402,7 +3403,7 @@ trunk_memtable_insert(trunk_handle *spl, key tuple_key, message msg)
    }
 
 unlock_insert_lock:
-   memtable_unget_insert_lock(spl->mt_ctxt);
+   memtable_end_insert(spl->mt_ctxt);
 out:
    return rc;
 }
@@ -3709,7 +3710,7 @@ trunk_memtable_incorporate_and_flush(trunk_handle  *spl,
     * Transition memtable state and increment memtable generation (blocks
     * lookups from accessing the memtable that's being incorporated).
     */
-   memtable_lock_lookup_lock(spl->mt_ctxt);
+   memtable_block_lookups(spl->mt_ctxt);
    memtable *mt = trunk_get_memtable(spl, generation);
    // Normally need to hold incorp_mutex, but debug code and also guaranteed no
    // one is changing gen_to_incorp (we are the only thread that would try)
@@ -3722,7 +3723,7 @@ trunk_memtable_incorporate_and_flush(trunk_handle  *spl,
 
    // Switch in the new root and release all locks
    trunk_update_claimed_root_and_unlock(spl, &new_root);
-   memtable_unlock_lookup_lock(spl->mt_ctxt);
+   memtable_unblock_lookups(spl->mt_ctxt);
 
    // Enqueue the filter building task.
    trunk_log_stream_if_enabled(
@@ -4285,7 +4286,7 @@ trunk_bundle_build_filters(void *arg, void *scratch)
          if (trunk_build_filter_should_abort(compact_req, &node)) {
             trunk_log_stream_if_enabled(
                spl, &stream, "replace_filter abort leaf split\n");
-            trunk_root_unclaim(spl);
+            trunk_root_full_unclaim(spl);
             trunk_node_unlock(spl->cc, &node);
             trunk_node_unclaim(spl->cc, &node);
             trunk_node_unget(spl->cc, &node);
@@ -6052,7 +6053,7 @@ trunk_range_iterator_init(trunk_handle         *spl,
    ZERO_ARRAY(range_itor->compacted);
 
    // grab the lookup lock
-   memtable_get_lookup_lock(spl->mt_ctxt);
+   memtable_begin_lookup(spl->mt_ctxt);
 
    // memtables
    ZERO_ARRAY(range_itor->branch);
@@ -6090,7 +6091,7 @@ trunk_range_iterator_init(trunk_handle         *spl,
 
    trunk_node node;
    trunk_node_get(spl->cc, spl->root_addr, &node);
-   memtable_unget_lookup_lock(spl->mt_ctxt);
+   memtable_end_lookup(spl->mt_ctxt);
 
    // index btrees
    uint16 height = trunk_node_height(&node);
@@ -6727,7 +6728,7 @@ trunk_lookup(trunk_handle *spl, key target, merge_accumulator *result)
 
    merge_accumulator_set_to_null(result);
 
-   memtable_get_lookup_lock(spl->mt_ctxt);
+   memtable_begin_lookup(spl->mt_ctxt);
    bool   found_in_memtable = FALSE;
    uint64 mt_gen_start      = memtable_generation(spl->mt_ctxt);
    uint64 mt_gen_end        = memtable_generation_retired(spl->mt_ctxt);
@@ -6747,7 +6748,7 @@ trunk_lookup(trunk_handle *spl, key target, merge_accumulator *result)
    trunk_root_get(spl, &node);
 
    // release memtable lookup lock
-   memtable_unget_lookup_lock(spl->mt_ctxt);
+   memtable_end_lookup(spl->mt_ctxt);
 
    // look in index nodes
    uint16 height = trunk_node_height(&node);
@@ -6784,7 +6785,7 @@ found_final_answer_early:
 
    if (found_in_memtable) {
       // release memtable lookup lock
-      memtable_unget_lookup_lock(spl->mt_ctxt);
+      memtable_end_lookup(spl->mt_ctxt);
    } else {
       trunk_node_unget(spl->cc, &node);
    }
@@ -6948,7 +6949,7 @@ trunk_lookup_async(trunk_handle      *spl,    // IN
          }
          case async_state_lookup_memtable:
          {
-            memtable_get_lookup_lock(spl->mt_ctxt);
+            memtable_begin_lookup(spl->mt_ctxt);
             uint64 mt_gen_start = memtable_generation(spl->mt_ctxt);
             uint64 mt_gen_end   = memtable_generation_retired(spl->mt_ctxt);
             for (uint64 mt_gen = mt_gen_start; mt_gen != mt_gen_end; mt_gen--) {
@@ -6958,7 +6959,7 @@ trunk_lookup_async(trunk_handle      *spl,    // IN
                if (merge_accumulator_is_definitive(result)) {
                   trunk_async_set_state(ctxt,
                                         async_state_found_final_answer_early);
-                  memtable_unget_lookup_lock(spl->mt_ctxt);
+                  memtable_end_lookup(spl->mt_ctxt);
                   break;
                }
             }
@@ -7000,7 +7001,7 @@ trunk_lookup_async(trunk_handle      *spl,    // IN
                   ctxt->trunk_node.page = ctxt->cache_ctxt.page;
                   ctxt->trunk_node.hdr =
                      (trunk_hdr *)(ctxt->cache_ctxt.page->data);
-                  memtable_unget_lookup_lock(spl->mt_ctxt);
+                  memtable_end_lookup(spl->mt_ctxt);
                   break;
                default:
                   platform_assert(0);

--- a/src/trunk.c
+++ b/src/trunk.c
@@ -3279,13 +3279,13 @@ trunk_get_memtable(trunk_handle *spl, uint64 generation)
 {
    uint64    memtable_idx = generation % TRUNK_NUM_MEMTABLES;
    memtable *mt           = &spl->mt_ctxt->mt[memtable_idx];
-   platform_assert(
-      mt->generation == generation,
-      "mt->generation=%lu, mt_ctxt->generation=%lu, mt_ctxt->generation_retired=%lu, generation=%lu\n",
-      mt->generation,
-      spl->mt_ctxt->generation,
-      spl->mt_ctxt->generation_retired,
-      generation);
+   platform_assert(mt->generation == generation,
+                   "mt->generation=%lu, mt_ctxt->generation=%lu, "
+                   "mt_ctxt->generation_retired=%lu, generation=%lu\n",
+                   mt->generation,
+                   spl->mt_ctxt->generation,
+                   spl->mt_ctxt->generation_retired,
+                   generation);
    return mt;
 }
 
@@ -3371,7 +3371,7 @@ trunk_memtable_iterator_deinit(trunk_handle   *spl,
 platform_status
 trunk_memtable_insert(trunk_handle *spl, key tuple_key, message msg)
 {
-   uint64          generation;
+   uint64 generation;
 
    platform_status rc =
       memtable_maybe_rotate_and_get_insert_lock(spl->mt_ctxt, &generation);
@@ -6728,9 +6728,9 @@ trunk_lookup(trunk_handle *spl, key target, merge_accumulator *result)
    merge_accumulator_set_to_null(result);
 
    memtable_get_lookup_lock(spl->mt_ctxt);
-   bool         found_in_memtable   = FALSE;
-   uint64       mt_gen_start        = memtable_generation(spl->mt_ctxt);
-   uint64       mt_gen_end          = memtable_generation_retired(spl->mt_ctxt);
+   bool   found_in_memtable = FALSE;
+   uint64 mt_gen_start      = memtable_generation(spl->mt_ctxt);
+   uint64 mt_gen_end        = memtable_generation_retired(spl->mt_ctxt);
    platform_assert(mt_gen_start - mt_gen_end <= TRUNK_NUM_MEMTABLES);
 
    for (uint64 mt_gen = mt_gen_start; mt_gen != mt_gen_end; mt_gen--) {

--- a/tests/functional/btree_test.c
+++ b/tests/functional/btree_test.c
@@ -81,7 +81,7 @@ test_btree_insert(test_memtable_context *ctxt, key tuple_key, message data)
 {
    uint64          generation;
    platform_status rc =
-      memtable_maybe_rotate_and_get_insert_lock(ctxt->mt_ctxt, &generation);
+      memtable_maybe_rotate_and_begin_insert(ctxt->mt_ctxt, &generation);
    if (!SUCCESS(rc)) {
       return rc;
    }
@@ -101,7 +101,7 @@ test_btree_insert(test_memtable_context *ctxt, key tuple_key, message data)
                         &dummy_leaf_generation);
 
 out:
-   memtable_unget_insert_lock(ctxt->mt_ctxt);
+   memtable_end_insert(ctxt->mt_ctxt);
    return rc;
 }
 


### PR DESCRIPTION
Fix a race in the memtable where we might accidentally wrap around all memtables if we fall behind.

Also, change the platform_batch_rwlock to support the unlocked---read-locked---claimed---write-locked state machine.
