### PR TITLE
Robj/update limitation

### DIFF
--- a/include/splinterdb/data.h
+++ b/include/splinterdb/data.h
@@ -162,8 +162,10 @@ struct data_config {
    // FIXME: Planned for deprecation.
    uint64 max_key_size;
 
-   key_compare_fn       key_compare;
-   key_hash_fn          key_hash;
+   key_compare_fn key_compare;
+   key_hash_fn    key_hash;
+   /* The merge functions may be NULL, in which case
+      splinterdb_update() is not allowed. */
    merge_tuple_fn       merge_tuples;
    merge_tuple_final_fn merge_tuples_final;
    key_to_str_fn        key_to_string;

--- a/src/default_data_config.c
+++ b/src/default_data_config.c
@@ -30,29 +30,6 @@ key_compare(const data_config *cfg, slice key1, slice key2)
 }
 
 
-static int
-merge_tuples(const data_config *cfg,
-             slice              key,
-             message            old_raw_message,
-             merge_accumulator *new_data)
-{
-   // we don't implement UPDATEs, so this is a no-op:
-   // new is always left intact
-   return 0;
-}
-
-static int
-merge_tuples_final(const data_config *cfg,
-                   slice              key,
-                   merge_accumulator *oldest_data // IN/OUT
-)
-{
-   // we don't implement UPDATEs, so this is a no-op:
-   // new is always left intact
-   return 0;
-}
-
-
 static void
 key_to_string(const data_config *cfg, slice key, char *str, size_t max_len)
 {
@@ -78,8 +55,8 @@ default_data_config_init(const size_t max_key_size, // IN
       .max_key_size       = max_key_size,
       .key_compare        = key_compare,
       .key_hash           = platform_hash32,
-      .merge_tuples       = merge_tuples,
-      .merge_tuples_final = merge_tuples_final,
+      .merge_tuples       = NULL,
+      .merge_tuples_final = NULL,
       .key_to_string      = key_to_string,
       .message_to_string  = message_to_string,
    };

--- a/src/splinterdb.c
+++ b/src/splinterdb.c
@@ -488,6 +488,7 @@ int
 splinterdb_update(const splinterdb *kvsb, slice user_key, slice update)
 {
    message msg = message_create(MESSAGE_TYPE_UPDATE, update);
+   platform_assert(kvsb->data_cfg->merge_tuples);
    return splinterdb_insert_message(kvsb, user_key, msg);
 }
 

--- a/src/splinterdb.c
+++ b/src/splinterdb.c
@@ -112,8 +112,6 @@ splinterdb_validate_app_data_config(const data_config *cfg)
    platform_assert(cfg->max_key_size > 0);
    platform_assert(cfg->key_compare != NULL);
    platform_assert(cfg->key_hash != NULL);
-   /* platform_assert(cfg->merge_tuples != NULL); */
-   /* platform_assert(cfg->merge_tuples_final != NULL); */
    platform_assert(cfg->key_to_string != NULL);
    platform_assert(cfg->message_to_string != NULL);
 

--- a/src/splinterdb.c
+++ b/src/splinterdb.c
@@ -112,8 +112,8 @@ splinterdb_validate_app_data_config(const data_config *cfg)
    platform_assert(cfg->max_key_size > 0);
    platform_assert(cfg->key_compare != NULL);
    platform_assert(cfg->key_hash != NULL);
-   platform_assert(cfg->merge_tuples != NULL);
-   platform_assert(cfg->merge_tuples_final != NULL);
+   /* platform_assert(cfg->merge_tuples != NULL); */
+   /* platform_assert(cfg->merge_tuples_final != NULL); */
    platform_assert(cfg->key_to_string != NULL);
    platform_assert(cfg->message_to_string != NULL);
 


### PR DESCRIPTION
This change allows data_configs to set the merge_tuple functions to NULL.

If they do so, then calling splinter_update will throw an assertion.

This also changes the default_data_config to leave these functions as NULL.

This fixes a bug where the default_data_config merge functions were not correctly handling updates.
