### PR TITLE
Rust wrapper

### DIFF
--- a/rust/.gitignore
+++ b/rust/.gitignore
@@ -1,0 +1,2 @@
+Cargo.lock
+target

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,0 +1,5 @@
+[workspace]
+members = [
+    "splinterdb-sys",
+    "splinterdb-rs",
+]

--- a/rust/README.md
+++ b/rust/README.md
@@ -1,0 +1,36 @@
+# Rust Wrapper for SplinterDB
+
+These docs assume some basic familiarity with the Rust language and tools, particularly the [Rust build tool `cargo`](https://doc.rust-lang.org/book/ch01-03-hello-cargo.html)
+
+## Overview
+Rust may be suitable for developing applications that use SplinterDB, and for writing certain types of tests of SplinterDB.
+
+This directory contains Rust bindings for SplinterDB
+- `splinterdb-sys`: Lowest level, unsafe Rust declarations for a subset of the SplinterDB public API.
+- `splinterdb-rs`: A safe and ergonomic Rust wrapper, intended for use by other Rust libraries and Rust applications.
+
+## Usage
+Ensure you have Rust and Cargo available, e.g. use [rustup](https://rustup.rs/).
+
+Next, [build and install the SplinterDB C library](../../docs/build.md) **using `clang-13`**,
+e.g.:
+```sh
+CC=clang-13 LD=clang-13 make -C .. && make install -C ..
+```
+
+Then from this directory, run
+```sh
+cargo build
+cargo test
+```
+
+Cargo builds into the `target/debug` subdirectory.  For release builds, add `--release` to the above commands and look in `target/release`.
+
+
+## Why does this only build with `clang` and not `gcc`?
+Short answer: because of link time optimization (LTO).
+
+Longer answer:
+To use LTO across languages, e.g. C with Rust, all compilation units must be built using the same toolchain.
+The Rust compiler is based on LLVM, not GCC.  Therefore, SplinterDB must be built with `clang` (or
+without LTO), in order to be usable from Rust.

--- a/rust/splinterdb-rs/Cargo.toml
+++ b/rust/splinterdb-rs/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "splinterdb-rs"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+splinterdb-sys = { path = "../splinterdb-sys" }
+serde = { version = "1.0", optional = true, features = ["derive"] }
+
+[dev-dependencies]
+tempfile = "3.2.0"

--- a/rust/splinterdb-rs/README.md
+++ b/rust/splinterdb-rs/README.md
@@ -1,0 +1,6 @@
+# `splinterdb-rs`
+
+This crate aims to be a safe and ergonomic Rust wrapper SplinterDB's public API.
+
+Currently, it exposes a simple key/value abstraction, by using the `splinterdb` and
+`default_data_config` modules.

--- a/rust/splinterdb-rs/src/lib.rs
+++ b/rust/splinterdb-rs/src/lib.rs
@@ -1,0 +1,299 @@
+use std::io::{Error, Result};
+use std::path::Path;
+
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug)]
+pub struct DBConfig {
+    pub cache_size_bytes: usize,
+    pub disk_size_bytes: usize,
+    pub max_key_size: u8,
+    pub max_value_size: u8,
+}
+
+#[derive(Debug)]
+pub struct SplinterDB {
+    _inner: *mut splinterdb_sys::splinterdb,
+    sdb_cfg: splinterdb_sys::splinterdb_config,
+    data_cfg: splinterdb_sys::data_config,
+}
+
+unsafe impl Sync for SplinterDB {}
+unsafe impl Send for SplinterDB {}
+
+impl Drop for SplinterDB {
+    fn drop(&mut self) {
+        unsafe { splinterdb_sys::splinterdb_close(&mut self._inner) };
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub enum LookupResult {
+    Found(Vec<u8>),
+    FoundTruncated(Vec<u8>),
+    NotFound,
+}
+
+fn as_result(rc: ::std::os::raw::c_int) -> Result<()> {
+    if rc != 0 {
+        Err(Error::from_raw_os_error(rc))
+    } else {
+        Ok(())
+    }
+}
+
+fn create_splinter_slice(ref v: &[u8]) -> splinterdb_sys::slice {
+    unsafe {
+        splinterdb_sys::slice {
+            length: v.len() as u64,
+            data: ::std::mem::transmute(v.as_ptr()),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct IteratorResult<'a> {
+    pub key: &'a [u8],
+    pub value: &'a [u8],
+}
+
+#[derive(Debug)]
+pub struct RangeIterator<'a> {
+    _inner: *mut splinterdb_sys::splinterdb_iterator,
+    _marker: ::std::marker::PhantomData<splinterdb_sys::splinterdb_iterator>,
+    _parent_marker: ::std::marker::PhantomData<&'a splinterdb_sys::splinterdb>,
+    state: Option<IteratorResult<'a>>,
+}
+
+impl<'a> Drop for RangeIterator<'a> {
+    fn drop(&mut self) {
+        unsafe { splinterdb_sys::splinterdb_iterator_deinit(self._inner) }
+    }
+}
+
+impl<'a> RangeIterator<'a> {
+    pub fn new(iter: *mut splinterdb_sys::splinterdb_iterator) -> RangeIterator<'a> {
+        RangeIterator {
+            _inner: iter,
+            _marker: ::std::marker::PhantomData,
+            _parent_marker: ::std::marker::PhantomData,
+            state: None,
+        }
+    }
+
+    // stashes current state of the iterator from the C API
+    fn _stash_current(&mut self) {
+        let mut key_out: splinterdb_sys::slice = splinterdb_sys::slice {
+            length: 0,
+            data: ::std::ptr::null(),
+        };
+        let mut val_out: splinterdb_sys::slice = splinterdb_sys::slice {
+            length: 0,
+            data: ::std::ptr::null(),
+        };
+
+        let (key, value): (&[u8], &[u8]) = unsafe {
+            // get key and value
+            splinterdb_sys::splinterdb_iterator_get_current(
+                self._inner,
+                &mut key_out,
+                &mut val_out,
+            );
+            // parse key and value into rust slices
+            (
+                ::std::slice::from_raw_parts(
+                    ::std::mem::transmute(key_out.data),
+                    key_out.length as usize,
+                ),
+                ::std::slice::from_raw_parts(
+                    ::std::mem::transmute(val_out.data),
+                    val_out.length as usize,
+                ),
+            )
+        };
+        let r = IteratorResult { key, value };
+        self.state = Some(r);
+    }
+
+    fn _inner_advance(&mut self) {
+        unsafe { splinterdb_sys::splinterdb_iterator_next(self._inner) };
+    }
+
+    // almost an iterator, but we need to be able to return errors
+    // and retain ownership of the result
+    #[allow(clippy::should_implement_trait)]
+    pub fn next(&mut self) -> Result<Option<&IteratorResult>> {
+        // Rust iterator expects to start just before the first element
+        // but Splinter iterators start at the first element
+        // so we only call _inner_advance if its our first iteration
+        if self.state.is_some() {
+            self._inner_advance();
+        }
+
+        let valid = unsafe { splinterdb_sys::splinterdb_iterator_valid(self._inner) };
+        if !valid {
+            let rc = unsafe { splinterdb_sys::splinterdb_iterator_status(self._inner) };
+            as_result(rc)?;
+            return Ok(None);
+        }
+
+        self._stash_current();
+        match self.state {
+            None => Ok(None),
+            Some(ref r) => Ok(Some(r)),
+        }
+    }
+}
+
+fn path_as_cstring<P: AsRef<Path>>(path: P) -> std::ffi::CString {
+    let as_os_str = path.as_ref().as_os_str();
+    let as_str = as_os_str.to_str().unwrap();
+    std::ffi::CString::new(as_str).unwrap()
+}
+
+impl SplinterDB {
+    // Create a SplinterDB object. This is uninitialized.
+    pub fn create_uninit_obj() -> SplinterDB {
+        SplinterDB {
+            _inner: std::ptr::null_mut(),
+            sdb_cfg: unsafe { std::mem::zeroed() },
+            data_cfg: unsafe { std::mem::zeroed() },
+        }
+    }
+
+    fn db_create_or_open<P: AsRef<Path>>(
+        &mut self,
+        path: &P,
+        cfg: &DBConfig,
+        open_existing: bool,
+    ) -> Result<()> {
+        let path = path_as_cstring(path); // don't drop until init is done
+
+        self.sdb_cfg.filename = path.as_ptr();
+        self.sdb_cfg.cache_size = cfg.cache_size_bytes as u64;
+        self.sdb_cfg.disk_size = cfg.disk_size_bytes as u64;
+        self.sdb_cfg.data_cfg = &mut self.data_cfg;
+
+        unsafe {
+            splinterdb_sys::default_data_config_init(
+                cfg.max_key_size as u64,
+                self.sdb_cfg.data_cfg,
+            );
+        };
+
+        let rc = if open_existing {
+            unsafe { splinterdb_sys::splinterdb_open(&self.sdb_cfg, &mut self._inner) }
+        } else {
+            unsafe { splinterdb_sys::splinterdb_create(&self.sdb_cfg, &mut self._inner) }
+        };
+        as_result(rc)
+    }
+
+    pub fn db_create<P: AsRef<Path>>(&mut self, path: &P, cfg: &DBConfig) -> Result<()> {
+        self.db_create_or_open(path, cfg, false)
+    }
+
+    pub fn db_open<P: AsRef<Path>>(&mut self, path: &P, cfg: &DBConfig) -> Result<()> {
+        self.db_create_or_open(path, cfg, true)
+    }
+
+    pub fn register_thread(&self) {
+        unsafe { splinterdb_sys::splinterdb_register_thread(self._inner) };
+    }
+
+    pub fn deregister_thread(&self) {
+        unsafe { splinterdb_sys::splinterdb_deregister_thread(self._inner) };
+    }
+
+    pub fn insert(&self, key: &[u8], value: &[u8]) -> Result<()> {
+        let key_slice: splinterdb_sys::slice = create_splinter_slice(key);
+        let val_slice: splinterdb_sys::slice = create_splinter_slice(value);
+
+        let rc = unsafe {
+            splinterdb_sys::splinterdb_insert(
+                self._inner,
+                key_slice,
+                val_slice,
+            )
+        };
+        as_result(rc)
+    }
+
+    pub fn delete(&self, key: &[u8]) -> Result<()> {
+        let rc = unsafe {
+            splinterdb_sys::splinterdb_delete(
+                self._inner,
+                create_splinter_slice(key),
+            )
+        };
+        as_result(rc)
+    }
+
+    pub fn lookup(&self, key: &[u8]) -> Result<LookupResult> {
+        unsafe {
+            let mut lr: splinterdb_sys::splinterdb_lookup_result = std::mem::zeroed();
+            splinterdb_sys::splinterdb_lookup_result_init(
+                self._inner,
+                &mut lr,
+                0,
+                std::ptr::null_mut(),
+            );
+
+            let rc = splinterdb_sys::splinterdb_lookup(
+                self._inner,
+                create_splinter_slice(key),
+                &mut lr,
+            );
+            as_result(rc)?;
+
+            let found = splinterdb_sys::splinterdb_lookup_found(&lr);
+            if !found {
+                return Ok(LookupResult::NotFound);
+            }
+
+            let mut val: splinterdb_sys::slice = splinterdb_sys::slice{
+                length: 0,
+                data: std::mem::zeroed(),
+            };
+            let rc = splinterdb_sys::splinterdb_lookup_result_value(
+                &lr,
+                &mut val,
+            );
+            as_result(rc)?;
+
+            // TODO: Can we avoid this memory init and copy?
+            let mut value: Vec<u8> = vec![0; val.length as usize];
+            std::ptr::copy(
+                val.data,
+                std::mem::transmute(value.as_mut_ptr()),
+                val.length as usize,
+            );
+            Ok(LookupResult::Found(value))
+        }
+    }
+
+    pub fn range(&self, start_key: Option<&[u8]>) -> Result<RangeIterator> {
+        let mut iter: *mut splinterdb_sys::splinterdb_iterator = std::ptr::null_mut();
+
+        let rc = unsafe {
+            let start_slice: splinterdb_sys::slice = match start_key {
+                Some(s) => splinterdb_sys::slice {
+                    length: s.len() as u64,
+                    data: ::std::mem::transmute(s.as_ptr()),
+                },
+                None => splinterdb_sys::slice {
+                    length: 0,
+                    data: ::std::ptr::null(),
+                },
+            };
+            splinterdb_sys::splinterdb_iterator_init(
+                self._inner,
+                &mut iter,
+                start_slice,
+            )
+        };
+        as_result(rc)?;
+        Ok(RangeIterator::new(iter))
+    }
+}
+
+mod tests;

--- a/rust/splinterdb-rs/src/tests.rs
+++ b/rust/splinterdb-rs/src/tests.rs
@@ -1,0 +1,220 @@
+// Tests of the splinterdb-rs library
+//
+// If you add a new function to the public API of this library, add a test here
+// (or extend an existing test) to demonstrate how to use it.
+
+#[cfg(test)]
+mod tests {
+
+    // Test of performing two insertions and lookup
+    #[test]
+    fn ins_test() -> std::io::Result<()> {
+        use splinterdb_sys::slice;
+        use tempfile::tempdir;
+        println!("BEGINNING TEST!");
+
+        let mut sdb = crate::SplinterDB::create_uninit_obj();
+
+        let data_dir = tempdir()?; // is removed on drop
+        let data_file = data_dir.path().join("db.splinterdb");
+
+        sdb.db_create(
+            &data_file,
+            &crate::DBConfig {
+                cache_size_bytes: 1024 * 1024,
+                disk_size_bytes: 30 * 1024 * 1024,
+                max_key_size: 23,
+                max_value_size: 100,
+            },
+        )?;
+
+        println!("SUCCESSFULLY CREATED DB!");
+
+        let key = b"some-key-0".to_vec();
+        let value = b"some-value-0".to_vec();
+
+        // verify that we can correctly create a splinter-slice from these keys and values
+        let ks: slice = crate::create_splinter_slice(&key);
+        let vs: slice = crate::create_splinter_slice(&value);
+        assert_eq!(ks.length, key.len() as u64);
+        assert_eq!(vs.length, value.len() as u64);
+        unsafe {
+            for i in 0..key.len() {
+                assert_eq!(*((ks.data as *const u8).offset(i as isize)), key[i]);
+            }
+            for i in 0..value.len() {
+                assert_eq!(*((vs.data as *const u8).offset(i as isize)), value[i]);
+            }
+        }
+
+        sdb.insert(&key, &value)?;
+        sdb.insert(&(b"some-key-4".to_vec()), &(b"some-value-4".to_vec()))?;
+        println!("SUCCESSFULLY INSERTED TO DB!");
+
+        let res = sdb.lookup(&key)?;
+        match res {
+            crate::LookupResult::NotFound => panic!("inserted key not found"),
+            crate::LookupResult::FoundTruncated(_) => panic!("inserted key found but truncated"),
+            crate::LookupResult::Found(v) => assert_eq!(v, value),
+        }
+
+        println!("SUCCESSFULLY PERFORMED LOOKUP!");
+
+        println!("Dropping SplinterDB!");
+        drop(sdb);
+        println!("Drop done! Exiting");
+        Ok(())
+    }
+
+    // Insert and delete, then lookup
+    #[test]
+    fn ins_and_del_test() -> std::io::Result<()> {
+        use tempfile::tempdir;
+        println!("BEGINNING TEST!");
+
+        let mut sdb = crate::SplinterDB::create_uninit_obj();
+
+        let data_dir = tempdir()?; // is removed on drop
+        let data_file = data_dir.path().join("db.splinterdb");
+
+        sdb.db_create(
+            &data_file,
+            &crate::DBConfig {
+                cache_size_bytes: 1024 * 1024,
+                disk_size_bytes: 30 * 1024 * 1024,
+                max_key_size: 23,
+                max_value_size: 100,
+            },
+        )?;
+
+        println!("SUCCESSFULLY CREATED DB!");
+
+        let key = b"some-key-0".to_vec();
+        let value = b"some-value-0".to_vec();
+        sdb.insert(&key, &value)?;
+        sdb.insert(&(b"some-key-1".to_vec()), &(b"some-value-1".to_vec()))?;
+        sdb.insert(&(b"some-key-2".to_vec()), &(b"some-value-2".to_vec()))?;
+        println!("SUCCESSFULLY PERFORMED INSERTIONS!");
+
+        sdb.delete(&(b"some-key-1".to_vec()))?;
+        sdb.delete(&(b"some-key-2".to_vec()))?;
+
+        // lookup key that should not be present
+        let res = sdb.lookup(&(b"some-key-1".to_vec()))?;
+        match res {
+            crate::LookupResult::NotFound => println!("Good!"),
+            crate::LookupResult::FoundTruncated(_) => panic!("Should not have found this key!"),
+            crate::LookupResult::Found(_) => panic!("Should not have found this key!"),
+        }
+
+        // lookup key that should still be present
+        let res = sdb.lookup(&key)?;
+        match res {
+            crate::LookupResult::NotFound => panic!("inserted key not found"),
+            crate::LookupResult::FoundTruncated(_) => panic!("inserted key found but truncated"),
+            crate::LookupResult::Found(v) => assert_eq!(v, value),
+        }
+
+        println!("SUCCESSFULLY PERFORMED LOOKUPS!");
+
+        println!("Dropping SplinterDB!");
+        drop(sdb);
+        println!("Drop done! Exiting");
+        Ok(())
+    }
+
+    #[test]
+    fn overwrite_test() -> std::io::Result<()> {
+        use tempfile::tempdir;
+        println!("BEGINNING TEST!");
+
+        let mut sdb = crate::SplinterDB::create_uninit_obj();
+
+        let data_dir = tempdir()?; // is removed on drop
+        let data_file = data_dir.path().join("db.splinterdb");
+
+        sdb.db_create(
+            &data_file,
+            &crate::DBConfig {
+                cache_size_bytes: 1024 * 1024,
+                disk_size_bytes: 30 * 1024 * 1024,
+                max_key_size: 23,
+                max_value_size: 100,
+            },
+        )?;
+        println!("SUCCESSFULLY CREATED DB!");
+
+        let key = b"some-key-0".to_vec();
+        let value = b"some-value-0".to_vec();
+        let nval = b"some-value-1".to_vec();
+        sdb.insert(&key, &value)?;
+        sdb.insert(&key, &nval)?;
+
+        // lookup key
+        let res = sdb.lookup(&key)?;
+        match res {
+            crate::LookupResult::NotFound => panic!("inserted key not found"),
+            crate::LookupResult::FoundTruncated(_) => panic!("inserted key found but truncated"),
+            crate::LookupResult::Found(v) => {
+                assert_eq!(v, nval);
+            },
+        }
+        println!("SUCCESSFULLY PERFORMED LOOKUP!");
+
+        println!("Dropping SplinterDB!");
+        drop(sdb);
+        println!("Drop done! Exiting");
+        Ok(())
+    }
+
+    #[test]
+    fn range_lookup_test() -> std::io::Result<()> {
+        use tempfile::tempdir;
+        println!("BEGINNING TEST!");
+
+        let mut sdb = crate::SplinterDB::create_uninit_obj();
+
+        let data_dir = tempdir()?; // is removed on drop
+        let data_file = data_dir.path().join("db.splinterdb");
+
+        sdb.db_create(
+            &data_file,
+            &crate::DBConfig {
+                cache_size_bytes: 1024 * 1024,
+                disk_size_bytes: 30 * 1024 * 1024,
+                max_key_size: 23,
+                max_value_size: 100,
+            },
+        )?;
+        println!("SUCCESSFULLY CREATED DB!");
+
+        sdb.insert(&(b"some-key-0".to_vec()), &(b"some-value-0".to_vec()))?;
+        sdb.insert(&(b"some-key-3".to_vec()), &(b"some-value-3".to_vec()))?;
+        sdb.insert(&(b"some-key-5".to_vec()), &(b"some-value-5".to_vec()))?;
+        sdb.insert(&(b"some-key-6".to_vec()), &(b"some-value-6".to_vec()))?;
+
+        let mut found: Vec<(Vec<u8>, Vec<u8>)> = Vec::new(); // to collect results
+        let mut iter = sdb.range(None)?;
+        loop {
+            match iter.next() {
+                Ok(Some(r)) => found.push((r.key.to_vec(), r.value.to_vec())),
+                Ok(None) => break,
+                Err(e) => return Err(e),
+            }
+        }
+
+        println!("Found {} results", found.len());
+
+        assert_eq!(found[0], (b"some-key-0".to_vec(), b"some-value-0".to_vec()));
+        assert_eq!(found[1], (b"some-key-3".to_vec(), b"some-value-3".to_vec()));
+        assert_eq!(found[2], (b"some-key-5".to_vec(), b"some-value-5".to_vec()));
+        assert_eq!(found[3], (b"some-key-6".to_vec(), b"some-value-6".to_vec()));
+
+        drop(iter);
+
+        println!("Dropping SplinterDB!");
+        drop(sdb);
+        println!("Drop done! Exiting");
+        Ok(())
+    }
+}

--- a/rust/splinterdb-sys/Cargo.toml
+++ b/rust/splinterdb-sys/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "splinterdb-sys"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[build-dependencies]
+bindgen = "0.65.1"
+
+[dependencies]
+tempfile = "3.2.0"

--- a/rust/splinterdb-sys/README.md
+++ b/rust/splinterdb-sys/README.md
@@ -1,0 +1,21 @@
+# `splinterdb-sys`
+
+Lowest level, unsafe Rust declarations for (some of) the C functions exported from SplinterDB.
+
+The exported headers are listed in `wrapper.h`. In order to build, the splinterdb shared libraries must be built and present at `\usr\local\lib`. The location where the shared libraries are found can be changed by modifying `build.rs`.
+
+If the shared libraries change, `cargo build` should automatically detect the change and rebuild this package.
+
+## Generating the Wrapper
+The wrapper code is generated automatically upon a call to `cargo build` based upon the files listed in `wrapper.h`.
+
+If it is necessary to expand the functionality of `splinterdb-sys` simply add more files to `wrapper.h` and build again.
+
+## Verifying the Wrapper
+From this directory run
+```sh
+cargo build
+cargo test
+```
+
+This runs the smoke test for this library, ensuring that the C bindings are created successfully. If errors occur ensure that `\usr\local\lib` is in `LD_LIBRARY_PATH` and the shared libraries have been successfully installed at that location.

--- a/rust/splinterdb-sys/build.rs
+++ b/rust/splinterdb-sys/build.rs
@@ -1,0 +1,39 @@
+extern crate bindgen;
+
+use std::env;
+use std::path::PathBuf;
+
+fn main() {
+    // Tell cargo to look for shared libraries in the specified directory
+    println!("cargo:rustc-link-search=/usr/local/lib");
+
+    // Tell cargo to tell rustc to link to splinterdb shared lib
+    println!("cargo:rustc-link-lib=splinterdb");
+
+    // Tell cargo to invalidate the built crate whenever the wrapper changes
+    println!("cargo:rerun-if-changed=wrapper.h");
+
+    // The bindgen::Builder is the main entry point
+    // to bindgen, and lets you build up options for
+    // the resulting bindings.
+    let bindings = bindgen::Builder::default()
+        .no_copy("splinterdb.*")
+        .no_copy("writable_buffer")
+        .no_copy("data_config")
+        .allowlist_type("splinterdb.*")
+        .allowlist_function("splinterdb.*")
+        .allowlist_function("default_data_config.*")
+        .allowlist_var("SPLINTERDB.*")
+        .allowlist_var(".*_SIZE")
+        .clang_arg("-DSPLINTERDB_PLATFORM_DIR=platform_linux")
+        .header("wrapper.h")
+        .parse_callbacks(Box::new(bindgen::CargoCallbacks))
+        .generate()
+        .expect("Unable to generate bindings");
+
+    // Write the bindings to the $OUT_DIR/bindings.rs file.
+    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+    bindings
+        .write_to_file(out_path.join("bindings.rs"))
+        .expect("Couldn't write bindings!");
+}

--- a/rust/splinterdb-sys/src/lib.rs
+++ b/rust/splinterdb-sys/src/lib.rs
@@ -1,0 +1,60 @@
+#![allow(non_upper_case_globals)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
+
+#[cfg(test)]
+mod tests {
+
+	fn path_as_cstring<P: AsRef<std::path::Path>>(path: P) -> std::ffi::CString {
+        let as_os_str = path.as_ref().as_os_str();
+        let as_str = as_os_str.to_str().unwrap();
+        std::ffi::CString::new(as_str).unwrap()
+    }
+
+    // Really basic "smoke" test of the generated code, just to see that the
+    // C library actually links.
+    #[test]
+    fn invoke_things() {
+        use tempfile::tempdir;
+
+        let data_dir = tempdir().unwrap(); // is removed on drop
+        let data_file = data_dir.path().join("db.splinterdb");
+        let path = path_as_cstring(data_file); // don't drop until init is done
+
+        println!("path = {:?}", path);
+
+        let mut data_config: super::data_config = unsafe { std::mem::zeroed() };
+        let mut cfg: super::splinterdb_config = unsafe { std::mem::zeroed() };
+        cfg.filename = path.as_ptr();
+        cfg.cache_size = 200 * 1024 * 1024;
+        cfg.disk_size = 400 * 1024 * 1024;
+        cfg.data_cfg = &mut data_config;
+
+        println!("CONFIG CREATED!");
+
+        let mut splinterdb: *mut super::splinterdb = std::ptr::null_mut();
+
+        println!("SPLINTER POINTER CREATED!");
+
+        unsafe {
+            super::default_data_config_init(
+                32,
+                cfg.data_cfg,
+            )
+        };
+
+        println!("CONFIG INIT!");
+
+        let rc = unsafe {
+            super::splinterdb_create(&cfg, &mut splinterdb)
+        };
+        assert_eq!(rc, 0);
+
+        println!("SPLINTER CREATED!");
+
+        unsafe { super::splinterdb_close(&mut splinterdb) };
+
+        println!("SPLINTER CLOSED!");
+    }
+}

--- a/rust/splinterdb-sys/wrapper.h
+++ b/rust/splinterdb-sys/wrapper.h
@@ -1,0 +1,6 @@
+// This file lists the C headers that bindgen will process
+// when creating the rust interface to splinterdb
+// See regenerate.sh for details
+
+#include <splinterdb/splinterdb.h>
+#include <splinterdb/default_data_config.h>

--- a/rust/splinterdb-sys/wrapper.h
+++ b/rust/splinterdb-sys/wrapper.h
@@ -1,6 +1,5 @@
 // This file lists the C headers that bindgen will process
 // when creating the rust interface to splinterdb
-// See regenerate.sh for details
 
 #include <splinterdb/splinterdb.h>
 #include <splinterdb/default_data_config.h>


### PR DESCRIPTION
A rust wrapper for splinterDB for using splinter in rust applications. Implements simple key/value operations using the `default_data_config`.

Wrapper based upon a previous version written by @rosenhouse.

Changes from the previous version of the wrapper:
- Automatic splinter binding (`splinterdb-sys`) generation when building the rust library
- More tests of the rust wrapper (`splinterdb-rs`)
- Support for new data_config layout and other changes to SplinterDB