### PR TITLE
(#581) Resolve a segmentation fault on trunk_unmount()

### DIFF
--- a/src/trunk.c
+++ b/src/trunk.c
@@ -931,8 +931,13 @@ trunk_set_super_block(trunk_handle *spl,
    super->root_addr = spl->root_addr;
    super->meta_tail = mini_meta_tail(&spl->mini);
    if (spl->cfg.use_log) {
-      super->log_addr      = log_addr(spl->log);
-      super->log_meta_addr = log_meta_addr(spl->log);
+      if (spl->log) {
+         super->log_addr      = log_addr(spl->log);
+         super->log_meta_addr = log_meta_addr(spl->log);
+      } else {
+         super->log_addr      = 0;
+         super->log_meta_addr = 0;
+      }
    }
    super->timestamp    = platform_get_real_time();
    super->checkpointed = is_checkpoint;


### PR DESCRIPTION
`trunk_set_super_block()` is used when both creating and closing the splinterdb. However, `spl->log` is already freed and becomes NULL when it gets to this function. This causes a segmentation fault because `spl->log` is referenced when it stores the log addresses into the super block.  As a fix, it sets `super->log_addr` and `super->log_meta_addr` if `spl->log` is valid. Otherwise, they are set to 0.