### PR TITLE
Rust wrapper for SplinterDB

### DIFF
--- a/rust/.gitignore
+++ b/rust/.gitignore
@@ -1,0 +1,2 @@
+Cargo.lock
+target

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,0 +1,5 @@
+[workspace]
+members = [
+    "splinterdb-sys",
+    "splinterdb-rs",
+]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -2,4 +2,5 @@
 members = [
     "splinterdb-sys",
     "splinterdb-rs",
+    "splinterdb-cli",
 ]

--- a/rust/README.md
+++ b/rust/README.md
@@ -1,0 +1,36 @@
+# Rust Wrapper for SplinterDB
+
+These docs assume some basic familiarity with the Rust language and tools, particularly the [Rust build tool `cargo`](https://doc.rust-lang.org/book/ch01-03-hello-cargo.html)
+
+## Overview
+Rust may be suitable for developing applications that use SplinterDB, and for writing certain types of tests of SplinterDB.
+
+This directory contains Rust bindings for SplinterDB
+- `splinterdb-sys`: Lowest level, unsafe Rust declarations for a subset of the SplinterDB public API.
+- `splinterdb-rs`: A safe and ergonomic Rust wrapper, intended for use by other Rust libraries and Rust applications.
+
+## Usage
+Ensure you have Rust and Cargo available, e.g. use [rustup](https://rustup.rs/).
+
+Next, [build and install the SplinterDB C library](../../docs/build.md) **using `clang-13`**,
+e.g.:
+```sh
+CC=clang-13 LD=clang-13 make -C .. && make install -C ..
+```
+
+Then from this directory, run
+```sh
+cargo build
+cargo test
+```
+
+Cargo builds into the `target/debug` subdirectory.  For release builds, add `--release` to the above commands and look in `target/release`.
+
+
+## Why does this only build with `clang` and not `gcc`?
+Short answer: because of link time optimization (LTO).
+
+Longer answer:
+To use LTO across languages, e.g. C with Rust, all compilation units must be built using the same toolchain.
+The Rust compiler is based on LLVM, not GCC.  Therefore, SplinterDB must be built with `clang` (or
+without LTO), in order to be usable from Rust.

--- a/rust/README.md
+++ b/rust/README.md
@@ -8,6 +8,8 @@ Rust may be suitable for developing applications that use SplinterDB, and for wr
 This directory contains Rust bindings for SplinterDB
 - `splinterdb-sys`: Lowest level, unsafe Rust declarations for a subset of the SplinterDB public API.
 - `splinterdb-rs`: A safe and ergonomic Rust wrapper, intended for use by other Rust libraries and Rust applications.
+- `splinterdb-cli`: A simple command line utility that provides a limited key/value interface.
+   It serves as an example of how to build a Rust application that uses SplinterDB as a library, and can be used for basic performance testing.
 
 ## Usage
 Ensure you have Rust and Cargo available, e.g. use [rustup](https://rustup.rs/).

--- a/rust/splinterdb-cli/Cargo.toml
+++ b/rust/splinterdb-cli/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "splinterdb-cli"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+clap = { version = "3.0.7", features = ["derive"] }
+crossbeam-utils = "0.8.5"
+rand = "0.8.4"
+rand_pcg = "0.3.1"
+serde = { version = "1.0", optional = true, features = ["derive"] }
+serde_json = "1.0"
+splinterdb-rs = { path = "../splinterdb-rs", features = ["serde"] }

--- a/rust/splinterdb-cli/README.md
+++ b/rust/splinterdb-cli/README.md
@@ -1,0 +1,52 @@
+# SplinterDB Client
+A simple command line utility for SplinterDB.
+
+It also serves as an example of how to build an application using the Rust wrapper for SplinterDB.
+
+For build instructions, see the [README in the parent directory](../README.md).
+
+For usage, run `target/debug/splinterdb-cli --help`:
+
+## Walkthrough
+Initialize a new database file on disk
+```
+$ target/debug/splinterdb-cli --file /tmp/my-db init-db --disk-mb 2000 --key-size 20 --value-size 110
+```
+Note this creates both the named `/tmp/my-db` file and an extra metadata
+file `/tmp/my-db.meta`.  Both files must be present for the other
+commands to work.
+
+List contents (currently empty)
+```
+$ target/debug/splinterdb-cli --file /tmp/my-db list
+```
+
+Add some data
+```
+$ target/debug/splinterdb-cli --file /tmp/my-db insert -k "key1" -v "value1"
+$ target/debug/splinterdb-cli --file /tmp/my-db insert -k "key2" -v "value2"
+$ target/debug/splinterdb-cli --file /tmp/my-db insert -k "key3" -v "value3"
+```
+
+List contents again
+```
+$ target/debug/splinterdb-cli --file /tmp/my-db list
+```
+
+Delete a key/value pair
+```
+$ target/debug/splinterdb-cli --file /tmp/my-db delete --key "key2"
+```
+
+Lookup a single value
+```
+$ target/debug/splinterdb-cli --file /tmp/my-db get -k "key1"
+```
+
+## Performance testing
+The same tool may be used for testing the performance of SplinterDB.
+
+This will overwrite the chosen file or block device with random data, and print results at the end
+```
+$ target/debug/splinterdb-cli --file /tmp/test perf --threads 8 --writes-per-thread 50000
+```

--- a/rust/splinterdb-cli/src/main.rs
+++ b/rust/splinterdb-cli/src/main.rs
@@ -1,0 +1,411 @@
+use clap::Parser;
+
+/// SplinterDB command line tool
+#[derive(Parser)]
+#[clap(name = "splinterdb-cli", version = "0.1")]
+struct Opts {
+    #[clap(short, long)]
+    file: String,
+
+    #[clap(subcommand)]
+    subcmd: SubCommand,
+}
+
+#[derive(Parser)]
+enum SubCommand {
+    InitDB(InitDB),
+    Insert(Insert),
+    Delete(Delete),
+    Get(Get),
+    List(List),
+    Perf(Perf),
+}
+
+/// Insert a key-value pair into an existing database
+#[derive(Parser)]
+struct Insert {
+    /// Key to insert
+    #[clap(short, long)]
+    pub key: String,
+
+    /// Value to insert
+    #[clap(short, long)]
+    pub value: String,
+}
+
+/// Delete a key and its value from an existing database
+#[derive(Parser)]
+struct Delete {
+    /// Key to delete
+    #[clap(short, long)]
+    pub key: String,
+}
+
+/// Get the value for a key from an existing database
+#[derive(Parser)]
+struct Get {
+    /// Key to lookup
+    #[clap(short, long)]
+    pub key: String,
+}
+
+/// List all keys and values in an existing database
+#[derive(Parser)]
+struct List {}
+
+/// Initialize a new database file
+#[derive(Parser)]
+struct InitDB {
+    /// Size of in-memory cache, in MB
+    #[clap(short, long, default_value = "30")]
+    pub cache_mb: u16,
+
+    /// Size of file to use on disk, in MB
+    #[clap(short, long, default_value = "100")]
+    pub disk_mb: u16,
+
+    /// Maximum length of keys, in bytes
+    #[clap(short, long, default_value = "16")]
+    pub key_size: usize,
+
+    /// Maximum length of values, in bytes
+    #[clap(short, long, default_value = "100")]
+    pub value_size: usize,
+}
+
+const MB: usize = 1024 * 1024;
+
+type CLIResult<T> = Result<T, Box<dyn ::std::error::Error>>;
+
+use std::fs::File;
+use std::path::Path;
+use splinterdb_rs::*;
+
+// Simple implementation of some merge behavior for performance testing
+// When an update is performed, simply make the value the larger of the two
+struct SimpleMerge {}
+impl SdbRustDataFuncs for SimpleMerge {
+    // leave all functions but merges as default
+
+    fn merge(_key: &[u8], old_msg: SdbMessage, new_msg: SdbMessage) -> std::io::Result<SdbMessage>
+    {
+        let old_val = old_msg.data;
+        let new_val = new_msg.data;
+
+        let upd_val = if old_val >= new_val {
+            old_val
+        } else {
+            new_val
+        };
+
+        // if old insert and new update -> insert
+        // otherwise -> update
+        match old_msg.msg_type {
+            SdbMessageType::INSERT => Ok(SdbMessage {
+                msg_type: SdbMessageType::INSERT,
+                data: upd_val,
+            }),
+            SdbMessageType::UPDATE => Ok(SdbMessage {
+                msg_type: SdbMessageType::UPDATE,
+                data: upd_val,
+            }),
+            _ => panic!("Expected INSERT or UPDATE"),
+        }
+    }
+    fn merge_final(_key: &[u8], oldest_msg: SdbMessage) -> std::io::Result<SdbMessage>
+    {
+        // Simply label this message as an insertion
+        Ok(SdbMessage {
+            msg_type: SdbMessageType::INSERT,
+            data: oldest_msg.data,
+        })
+    }
+}
+
+fn get_metadata_path(db_path: &str) -> String {
+    format!("{}.meta", db_path)
+}
+
+fn meta_save(db_path: &str, db_config: &splinterdb_rs::DBConfig) -> CLIResult<()> {
+    let meta_file = File::create(Path::new(&get_metadata_path(db_path)))?;
+    ::serde_json::ser::to_writer(meta_file, db_config)?;
+    Ok(())
+}
+
+fn meta_load(db_path: &str) -> CLIResult<splinterdb_rs::DBConfig> {
+    let mut meta_file = File::open(Path::new(&get_metadata_path(db_path)))?;
+    let mut bytes = Vec::new();
+    use std::io::Read;
+    meta_file.read_to_end(&mut bytes)?;
+    let db_config = serde_json::from_slice(&bytes)?;
+    Ok(db_config)
+}
+
+impl InitDB {
+    fn run(&self, opts: &Opts) -> CLIResult<()> {
+        let db_config = splinterdb_rs::DBConfig {
+            cache_size_bytes: (self.cache_mb as usize) * MB,
+            disk_size_bytes: (self.disk_mb as usize) * MB,
+            max_key_size: self.key_size,
+            max_value_size: self.value_size,
+        };
+        meta_save(&opts.file, &db_config)?;
+
+        let mut db = splinterdb_rs::SplinterDB::new::<splinterdb_rs::rust_cfg::DefaultSdb>();
+        db.db_create(&opts.file, &db_config)?;
+        drop(db);
+        Ok(())
+    }
+}
+
+impl Get {
+    fn run(&self, opts: &Opts) -> CLIResult<()> {
+        let db_config = meta_load(&opts.file)?;
+        let mut db = splinterdb_rs::SplinterDB::new::<splinterdb_rs::rust_cfg::DefaultSdb>();
+        db.db_open(&opts.file, &db_config)?;
+        let res = db.lookup(self.key.as_bytes())?;
+        match res {
+            splinterdb_rs::LookupResult::NotFound => Err("key not found".into()),
+            splinterdb_rs::LookupResult::FoundTruncated(_) => {
+                Err("value truncated: this is a bug".into())
+            }
+            splinterdb_rs::LookupResult::Found(v) => {
+                let v = std::str::from_utf8(&v)?;
+                println!("{}", v);
+                Ok(())
+            }
+        }
+    }
+}
+
+impl Insert {
+    fn run(&self, opts: &Opts) -> CLIResult<()> {
+        let db_config = meta_load(&opts.file)?;
+        let mut db = splinterdb_rs::SplinterDB::new::<splinterdb_rs::rust_cfg::DefaultSdb>();
+        db.db_open(&opts.file, &db_config)?;
+        let key = self.key.as_bytes();
+        let val = self.value.as_bytes();
+        db.insert(key, val)?;
+        Ok(())
+    }
+}
+
+impl Delete {
+    fn run(&self, opts: &Opts) -> CLIResult<()> {
+        let db_config = meta_load(&opts.file)?;
+        let mut db = splinterdb_rs::SplinterDB::new::<splinterdb_rs::rust_cfg::DefaultSdb>();
+        db.db_open(&opts.file, &db_config)?;
+        let key = self.key.as_bytes();
+        db.delete(key)?;
+        Ok(())
+    }
+}
+
+impl List {
+    fn run(&self, opts: &Opts) -> CLIResult<()> {
+        let db_config = meta_load(&opts.file)?;
+        let mut db = splinterdb_rs::SplinterDB::new::<splinterdb_rs::rust_cfg::DefaultSdb>();
+        db.db_open(&opts.file, &db_config)?;
+        let mut iter = db.range(None)?;
+        loop {
+            match iter.next() {
+                Ok(Some(&splinterdb_rs::IteratorResult { key, value })) => {
+                    let key = std::str::from_utf8(key)?;
+                    let value = std::str::from_utf8(value)?;
+                    println!("\t{} : {}", key, value)
+                }
+                Ok(None) => {
+                    println!("<end of list>");
+                    break;
+                }
+                Err(e) => {
+                    println!("got error: {:?}", e);
+                    break;
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+use rand::{Rng, SeedableRng};
+use rand_pcg::Pcg64;
+
+use crossbeam_utils::thread;
+use std::time::Instant;
+
+/// Test performance.  Will overwrite the target file with random data.
+#[derive(Parser)]
+pub struct Perf {
+    /// Number of insert threads
+    #[clap(short, long, default_value = "1")]
+    threads: u32,
+
+    /// Number of writes to do on each thread
+    #[clap(short, long, default_value = "10000")]
+    writes_per_thread: u32,
+
+    /// Random seed
+    #[clap(long, default_value = "0")]
+    seed: u64,
+
+    /// Size of in-memory cache, in MB
+    #[clap(long, default_value = "400")]
+    cache_mb: u16,
+
+    /// Size of file to use on disk, in MB
+    #[clap(long, default_value = "9000")]
+    disk_mb: u32,
+}
+
+impl Perf {
+    const KEY_SIZE: usize = 32;
+    const VALUE_SIZE: usize = 64;
+    const REPORT_PERIOD: u32 = 500000;
+
+    pub fn run(&self, file: String) -> CLIResult<()> {
+        let db_config = splinterdb_rs::DBConfig {
+            cache_size_bytes: self.cache_mb as usize * MB,
+            disk_size_bytes: self.disk_mb as usize * MB,
+            max_key_size: Perf::KEY_SIZE,
+            max_value_size: Perf::VALUE_SIZE,
+        };
+        let path = file;
+
+        let mut db = splinterdb_rs::SplinterDB::new::<SimpleMerge>();
+        db.db_create(&path, &db_config)?;
+
+        eprint!("Inserts ");
+
+        let start_time = Instant::now();
+        // spawn several threads within a "scope"
+        // the scope guarantees that all threads have joined before
+        // control leaves the scope
+        thread::scope(|s| {
+            for i in 0..self.threads {
+                let db = &db;
+                let i = i;
+                let num_writes = self.writes_per_thread;
+
+                s.spawn(move |_| {
+                    // closure, work done on this thread
+                    // on each thread, register it with splinterdb
+                    db.register_thread();
+                    let mut rng = Pcg64::seed_from_u64(i as u64);
+
+                    // do num_writes into splinterdb
+                    for count in 0..num_writes {
+                        let mut key = [0u8; Perf::KEY_SIZE as usize];
+                        let mut value = [0u8; Perf::VALUE_SIZE as usize];
+                        Perf::rand_fill_buffer(&mut rng, &mut key);
+                        Perf::rand_fill_buffer(&mut rng, &mut value);
+                        db.insert(&key, &value).unwrap();
+
+                        if (count+1) % Perf::REPORT_PERIOD == 0 {
+                            eprint!(".");
+                        }
+                    }
+                    db.deregister_thread();
+                });
+            }
+        }) // all threads have joined at this point
+        .unwrap();
+        drop(db); // flush all caches to disk
+
+        let write_complete_time = Instant::now();
+        let total_write_time = (write_complete_time - start_time).as_secs_f32();
+
+        eprintln!("");
+        eprint!("Updates ");
+
+        let mut db = splinterdb_rs::SplinterDB::new::<SimpleMerge>();
+        db.db_create(&path, &db_config)?;
+
+        let update_time = Instant::now();
+        thread::scope(|s| {
+            for i in 0..self.threads {
+                let db = &db;
+                let i = i;
+                let num_writes = self.writes_per_thread;
+
+                s.spawn(move |_| {
+                    // closure, work done on this thread
+                    // on each thread, register it with splinterdb
+                    db.register_thread();
+                    let mut rng = Pcg64::seed_from_u64(i as u64);
+
+                    // do num_writes into splinterdb
+                    for count in 0..num_writes {
+                        let mut key = [0u8; Perf::KEY_SIZE as usize];
+                        let mut value = [0u8; Perf::VALUE_SIZE as usize];
+                        Perf::rand_fill_buffer(&mut rng, &mut key);
+                        Perf::rand_fill_buffer(&mut rng, &mut value);
+                        db.update(&key, &value).unwrap();
+
+                        if (count+1) % Perf::REPORT_PERIOD == 0 {
+                            eprint!(".");
+                        }
+                    }
+                    db.deregister_thread();
+                });
+            }
+        }) // all threads have joined at this point
+        .unwrap();
+        drop(db); // flush all caches to disk
+
+        let update_complete_time = Instant::now();
+        let total_update_time = (update_complete_time - update_time).as_secs_f32();
+
+        let total_writes = self.threads as u64 * self.writes_per_thread as u64;
+        let mb_written =
+            total_writes * (Perf::KEY_SIZE as u64 + Perf::VALUE_SIZE as u64) / MB as u64;
+
+        eprintln!(
+            "\n{:>8} {:>12} {:>12} {:>8} {:>8} {:>15}",
+            "threads", "inserts", "MB_inserted", "seconds", "bw_MBps", "inserts/sec"
+        );
+        println!(
+            "{:>8} {:>12} {:>12} {:>8.2} {:>8.2} {:>15.2}",
+            self.threads,
+            total_writes,
+            mb_written,
+            total_write_time,
+            mb_written as f32 / total_write_time,
+            total_writes as f32 / total_write_time,
+        );
+        eprintln!(
+            "\n{:>8} {:>12} {:>12} {:>8} {:>8} {:>15}",
+            "threads", "updates", "MB_updated", "seconds", "bw_MBps", "updates/sec"
+        );
+        println!(
+            "{:>8} {:>12} {:>12} {:>8.2} {:>8.2} {:>15.2}",
+            self.threads,
+            total_writes,
+            mb_written,
+            total_update_time,
+            mb_written as f32 / total_update_time,
+            total_writes as f32 / total_update_time,
+        );
+
+        Ok(())
+    }
+
+    fn rand_fill_buffer(rng: &mut Pcg64, to_fill: &mut [u8]) {
+        for x in to_fill.iter_mut() {
+            *x = rng.gen();
+        }
+    }
+}
+
+fn main() -> CLIResult<()> {
+    let opts: Opts = Opts::parse();
+
+    match opts.subcmd {
+        SubCommand::InitDB(ref init_db) => init_db.run(&opts),
+        SubCommand::Insert(ref insert) => insert.run(&opts),
+        SubCommand::Delete(ref delete) => delete.run(&opts),
+        SubCommand::Get(ref get) => get.run(&opts),
+        SubCommand::List(ref list) => list.run(&opts),
+        SubCommand::Perf(ref perf) => perf.run(opts.file),
+    }
+}

--- a/rust/splinterdb-rs/Cargo.toml
+++ b/rust/splinterdb-rs/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "splinterdb-rs"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+splinterdb-sys = { path = "../splinterdb-sys" }
+serde = { version = "1.0", optional = true, features = ["derive"] }
+
+[dev-dependencies]
+tempfile = "3.2.0"

--- a/rust/splinterdb-rs/Cargo.toml
+++ b/rust/splinterdb-rs/Cargo.toml
@@ -8,6 +8,8 @@ edition = "2021"
 [dependencies]
 splinterdb-sys = { path = "../splinterdb-sys" }
 serde = { version = "1.0", optional = true, features = ["derive"] }
+hex = "0.4"
+xxhash-rust = { version = "0.8.6", features = ["xxh32"] }
 
 [dev-dependencies]
 tempfile = "3.2.0"

--- a/rust/splinterdb-rs/README.md
+++ b/rust/splinterdb-rs/README.md
@@ -1,0 +1,6 @@
+# `splinterdb-rs`
+
+This crate aims to be a safe and ergonomic Rust wrapper SplinterDB's public API.
+
+Currently, it exposes a simple key/value abstraction, by using the `splinterdb` and
+`default_data_config` modules.

--- a/rust/splinterdb-rs/src/lib.rs
+++ b/rust/splinterdb-rs/src/lib.rs
@@ -1,0 +1,299 @@
+use std::io::{Error, Result};
+use std::path::Path;
+
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug)]
+pub struct DBConfig {
+    pub cache_size_bytes: usize,
+    pub disk_size_bytes: usize,
+    pub max_key_size: u8,
+    pub max_value_size: u8,
+}
+
+#[derive(Debug)]
+pub struct SplinterDB {
+    _inner: *mut splinterdb_sys::splinterdb,
+    sdb_cfg: splinterdb_sys::splinterdb_config,
+    data_cfg: splinterdb_sys::data_config,
+}
+
+unsafe impl Sync for SplinterDB {}
+unsafe impl Send for SplinterDB {}
+
+impl Drop for SplinterDB {
+    fn drop(&mut self) {
+        unsafe { splinterdb_sys::splinterdb_close(&mut self._inner) };
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub enum LookupResult {
+    Found(Vec<u8>),
+    FoundTruncated(Vec<u8>),
+    NotFound,
+}
+
+fn as_result(rc: ::std::os::raw::c_int) -> Result<()> {
+    if rc != 0 {
+        Err(Error::from_raw_os_error(rc))
+    } else {
+        Ok(())
+    }
+}
+
+fn create_splinter_slice(ref v: &[u8]) -> splinterdb_sys::slice {
+    unsafe {
+        splinterdb_sys::slice {
+            length: v.len() as u64,
+            data: ::std::mem::transmute(v.as_ptr()),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct IteratorResult<'a> {
+    pub key: &'a [u8],
+    pub value: &'a [u8],
+}
+
+#[derive(Debug)]
+pub struct RangeIterator<'a> {
+    _inner: *mut splinterdb_sys::splinterdb_iterator,
+    _marker: ::std::marker::PhantomData<splinterdb_sys::splinterdb_iterator>,
+    _parent_marker: ::std::marker::PhantomData<&'a splinterdb_sys::splinterdb>,
+    state: Option<IteratorResult<'a>>,
+}
+
+impl<'a> Drop for RangeIterator<'a> {
+    fn drop(&mut self) {
+        unsafe { splinterdb_sys::splinterdb_iterator_deinit(self._inner) }
+    }
+}
+
+impl<'a> RangeIterator<'a> {
+    pub fn new(iter: *mut splinterdb_sys::splinterdb_iterator) -> RangeIterator<'a> {
+        RangeIterator {
+            _inner: iter,
+            _marker: ::std::marker::PhantomData,
+            _parent_marker: ::std::marker::PhantomData,
+            state: None,
+        }
+    }
+
+    // stashes current state of the iterator from the C API
+    fn _stash_current(&mut self) {
+        let mut key_out: splinterdb_sys::slice = splinterdb_sys::slice {
+            length: 0,
+            data: ::std::ptr::null(),
+        };
+        let mut val_out: splinterdb_sys::slice = splinterdb_sys::slice {
+            length: 0,
+            data: ::std::ptr::null(),
+        };
+
+        let (key, value): (&[u8], &[u8]) = unsafe {
+            // get key and value
+            splinterdb_sys::splinterdb_iterator_get_current(
+                self._inner,
+                &mut key_out,
+                &mut val_out,
+            );
+            // parse key and value into rust slices
+            (
+                ::std::slice::from_raw_parts(
+                    ::std::mem::transmute(key_out.data),
+                    key_out.length as usize,
+                ),
+                ::std::slice::from_raw_parts(
+                    ::std::mem::transmute(val_out.data),
+                    val_out.length as usize,
+                ),
+            )
+        };
+        let r = IteratorResult { key, value };
+        self.state = Some(r);
+    }
+
+    fn _inner_advance(&mut self) {
+        unsafe { splinterdb_sys::splinterdb_iterator_next(self._inner) };
+    }
+
+    // almost an iterator, but we need to be able to return errors
+    // and retain ownership of the result
+    #[allow(clippy::should_implement_trait)]
+    pub fn next(&mut self) -> Result<Option<&IteratorResult>> {
+        // Rust iterator expects to start just before the first element
+        // but Splinter iterators start at the first element
+        // so we only call _inner_advance if its our first iteration
+        if self.state.is_some() {
+            self._inner_advance();
+        }
+
+        let valid = unsafe { splinterdb_sys::splinterdb_iterator_valid(self._inner) };
+        if !valid {
+            let rc = unsafe { splinterdb_sys::splinterdb_iterator_status(self._inner) };
+            as_result(rc)?;
+            return Ok(None);
+        }
+
+        self._stash_current();
+        match self.state {
+            None => Ok(None),
+            Some(ref r) => Ok(Some(r)),
+        }
+    }
+}
+
+fn path_as_cstring<P: AsRef<Path>>(path: P) -> std::ffi::CString {
+    let as_os_str = path.as_ref().as_os_str();
+    let as_str = as_os_str.to_str().unwrap();
+    std::ffi::CString::new(as_str).unwrap()
+}
+
+impl SplinterDB {
+    // Create a SplinterDB object. This is uninitialized.
+    pub fn create_uninit_obj() -> SplinterDB {
+        SplinterDB {
+            _inner: std::ptr::null_mut(),
+            sdb_cfg: unsafe { std::mem::zeroed() },
+            data_cfg: unsafe { std::mem::zeroed() },
+        }
+    }
+
+    fn db_create_or_open<P: AsRef<Path>>(
+        &mut self,
+        path: &P,
+        cfg: &DBConfig,
+        open_existing: bool,
+    ) -> Result<()> {
+        let path = path_as_cstring(path); // don't drop until init is done
+
+        self.sdb_cfg.filename = path.as_ptr();
+        self.sdb_cfg.cache_size = cfg.cache_size_bytes as u64;
+        self.sdb_cfg.disk_size = cfg.disk_size_bytes as u64;
+        self.sdb_cfg.data_cfg = &mut self.data_cfg;
+
+        unsafe {
+            splinterdb_sys::default_data_config_init(
+                cfg.max_key_size as u64,
+                self.sdb_cfg.data_cfg,
+            );
+        };
+
+        let rc = if open_existing {
+            unsafe { splinterdb_sys::splinterdb_open(&self.sdb_cfg, &mut self._inner) }
+        } else {
+            unsafe { splinterdb_sys::splinterdb_create(&self.sdb_cfg, &mut self._inner) }
+        };
+        as_result(rc)
+    }
+
+    pub fn db_create<P: AsRef<Path>>(&mut self, path: &P, cfg: &DBConfig) -> Result<()> {
+        self.db_create_or_open(path, cfg, false)
+    }
+
+    pub fn db_open<P: AsRef<Path>>(&mut self, path: &P, cfg: &DBConfig) -> Result<()> {
+        self.db_create_or_open(path, cfg, true)
+    }
+
+    pub fn register_thread(&self) {
+        unsafe { splinterdb_sys::splinterdb_register_thread(self._inner) };
+    }
+
+    pub fn deregister_thread(&self) {
+        unsafe { splinterdb_sys::splinterdb_deregister_thread(self._inner) };
+    }
+
+    pub fn insert(&self, key: &[u8], value: &[u8]) -> Result<()> {
+        let key_slice: splinterdb_sys::slice = create_splinter_slice(key);
+        let val_slice: splinterdb_sys::slice = create_splinter_slice(value);
+
+        let rc = unsafe {
+            splinterdb_sys::splinterdb_insert(
+                self._inner,
+                key_slice,
+                val_slice,
+            )
+        };
+        as_result(rc)
+    }
+
+    pub fn delete(&self, key: &[u8]) -> Result<()> {
+        let rc = unsafe {
+            splinterdb_sys::splinterdb_delete(
+                self._inner,
+                create_splinter_slice(key),
+            )
+        };
+        as_result(rc)
+    }
+
+    pub fn lookup(&self, key: &[u8]) -> Result<LookupResult> {
+        unsafe {
+            let mut lr: splinterdb_sys::splinterdb_lookup_result = std::mem::zeroed();
+            splinterdb_sys::splinterdb_lookup_result_init(
+                self._inner,
+                &mut lr,
+                0,
+                std::ptr::null_mut(),
+            );
+
+            let rc = splinterdb_sys::splinterdb_lookup(
+                self._inner,
+                create_splinter_slice(key),
+                &mut lr,
+            );
+            as_result(rc)?;
+
+            let found = splinterdb_sys::splinterdb_lookup_found(&lr);
+            if !found {
+                return Ok(LookupResult::NotFound);
+            }
+
+            let mut val: splinterdb_sys::slice = splinterdb_sys::slice{
+                length: 0,
+                data: std::mem::zeroed(),
+            };
+            let rc = splinterdb_sys::splinterdb_lookup_result_value(
+                &lr,
+                &mut val,
+            );
+            as_result(rc)?;
+
+            // TODO: Can we avoid this memory init and copy?
+            let mut value: Vec<u8> = vec![0; val.length as usize];
+            std::ptr::copy(
+                val.data,
+                std::mem::transmute(value.as_mut_ptr()),
+                val.length as usize,
+            );
+            Ok(LookupResult::Found(value))
+        }
+    }
+
+    pub fn range(&self, start_key: Option<&[u8]>) -> Result<RangeIterator> {
+        let mut iter: *mut splinterdb_sys::splinterdb_iterator = std::ptr::null_mut();
+
+        let rc = unsafe {
+            let start_slice: splinterdb_sys::slice = match start_key {
+                Some(s) => splinterdb_sys::slice {
+                    length: s.len() as u64,
+                    data: ::std::mem::transmute(s.as_ptr()),
+                },
+                None => splinterdb_sys::slice {
+                    length: 0,
+                    data: ::std::ptr::null(),
+                },
+            };
+            splinterdb_sys::splinterdb_iterator_init(
+                self._inner,
+                &mut iter,
+                start_slice,
+            )
+        };
+        as_result(rc)?;
+        Ok(RangeIterator::new(iter))
+    }
+}
+
+mod tests;

--- a/rust/splinterdb-rs/src/rust_cfg.rs
+++ b/rust/splinterdb-rs/src/rust_cfg.rs
@@ -1,0 +1,240 @@
+use std::io::Result;
+use splinterdb_sys::*;
+use crate::{create_splinter_slice, SdbMessageType, SdbMessage, CompareResult};
+use xxhash_rust::xxh32::xxh32;
+
+fn sdb_slice_to_vec(s: &slice) -> Vec<u8>
+{
+    unsafe {
+        std::slice::from_raw_parts(s.data as *const u8, s.length as usize).to_vec()
+    }
+}
+
+fn raw_to_vec(data: *const ::std::os::raw::c_void, length: usize) -> Vec<u8>
+{
+    unsafe {
+        std::slice::from_raw_parts(data as *const u8, length as usize).to_vec()
+    }
+}
+
+fn int_to_msg_type(i: ::std::os::raw::c_uint) -> SdbMessageType
+{
+    match i {
+        0 => SdbMessageType::INVALID,
+        1 => SdbMessageType::INSERT,
+        2 => SdbMessageType::UPDATE,
+        3 => SdbMessageType::DELETE,
+        _ => SdbMessageType::OTHER,
+    }
+}
+
+fn create_sdb_message(msg: &message) -> SdbMessage
+{
+    SdbMessage {
+        msg_type: int_to_msg_type(msg.type_),
+        data: sdb_slice_to_vec(&msg.data),
+    }
+}
+
+fn sdb_msg_from_acc(ma: &merge_accumulator) -> SdbMessage
+{
+    unsafe {
+        SdbMessage {
+            msg_type: int_to_msg_type(splinterdb_sys::merge_accumulator_message_class(ma)),
+            data: sdb_slice_to_vec(&splinterdb_sys::merge_accumulator_to_slice(ma)),
+        }
+    }
+}
+
+pub trait SdbRustDataFuncs {
+    fn key_comp(key1: &[u8], key2: &[u8]) -> CompareResult
+    {
+        if key1 < key2 {
+            return CompareResult::LESS;
+        } else if key1 == key2 {
+            return CompareResult::EQUAL;
+        }
+        return CompareResult::GREATER;
+    }
+
+    fn key_hash(key: &[u8], seed: u32) -> u32 
+    {
+        xxh32(key, seed)
+    }
+
+    // By default we do not implement merge functionality
+    fn merge(_key: &[u8], _old_msg: SdbMessage, new_msg: SdbMessage) -> Result<SdbMessage>
+    {
+        Ok(new_msg)
+    }
+    fn merge_final(_key: &[u8], oldest_msg: SdbMessage) -> Result<SdbMessage>
+    {
+        Ok(oldest_msg)
+    }
+
+    fn str_key(key: &[u8], dst: &mut [u8]) -> ()
+    {
+        // 2 characters per byte
+        if 2 * key.len() > dst.len() as usize {
+            panic!("Key too long to convert to string!");
+        }
+        let hex_str: String = hex::encode(key);
+        for (i, c) in hex_str.chars().enumerate() {
+            dst[i] = c as u8;
+        }
+    }
+
+    fn str_msg(msg: SdbMessage, dst: &mut [u8]) -> ()
+    {
+        if 2 * msg.data.len() > dst.len() as usize {
+            panic!("Msg too long to convert to string!");
+        }
+        let hex_str: String = hex::encode(msg.data);
+        for (i, c) in hex_str.chars().enumerate() {
+            dst[i] = c as u8;
+        }
+    }
+}
+
+pub fn new_sdb_data_config<T: SdbRustDataFuncs>(key_size: u64) -> data_config
+{
+    data_config {
+        max_key_size: key_size,
+        key_compare: Some(key_compare::<T>),
+        key_hash: Some(key_hash::<T>),
+        merge_tuples: Some(merge_tuples::<T>),
+        merge_tuples_final: Some(merge_tuples_final::<T>),
+        key_to_string: Some(key_to_string::<T>),
+        message_to_string: Some(message_to_string::<T>),
+    }
+}
+
+// Implement all the default data functions
+pub struct DefaultSdb {}
+impl SdbRustDataFuncs for DefaultSdb {}
+
+// These functions are templatized by the SdbRustDataFuncs a structure specified by the 
+// user that implements the key functions in rust.
+//
+// These functions act as a wrapper for the data config functions converting from
+// the SplinterDB C API to a rust friendly API.
+pub extern "C" fn key_compare<T: SdbRustDataFuncs>(
+    _cfg: *const data_config,
+    key1: slice,
+    key2: slice,
+) -> ::std::os::raw::c_int
+{
+    let res: CompareResult = T::key_comp(&sdb_slice_to_vec(&key1), &sdb_slice_to_vec(&key2));
+    match res {
+        CompareResult::LESS => -1,
+        CompareResult::EQUAL => 0,
+        CompareResult::GREATER => 1,
+    }
+}
+
+pub extern "C" fn key_hash<T: SdbRustDataFuncs>(
+    input: *const ::std::os::raw::c_void,
+    length: usize,
+    seed: uint32,
+) -> uint32
+{
+    T::key_hash(&raw_to_vec(input, length), seed)
+}
+
+pub extern "C" fn merge_tuples<T: SdbRustDataFuncs>(
+    _cfg: *const data_config,
+    key: slice,
+    old_message: message,
+    new_message: *mut merge_accumulator,
+) -> ::std::os::raw::c_int
+{
+    // convert the merge_accumulator to a message
+    let new_msg: SdbMessage = unsafe {
+        sdb_msg_from_acc(&*new_message)
+    };
+
+    // pass the old message and new message to user's merge() function
+    let res: SdbMessage = match T::merge(
+        &sdb_slice_to_vec(&key), 
+        create_sdb_message(&old_message), 
+        new_msg
+    ) 
+    {
+        Ok(r) => r,
+        Err(..) => return -1,
+    };
+
+    // update the merge_accumulator with the results of the user's func
+    unsafe {
+        splinterdb_sys::merge_accumulator_copy_message(
+            new_message, 
+            message {
+                type_: res.msg_type as ::std::os::raw::c_uint,
+                data: create_splinter_slice(&res.data),
+            }
+        );
+    }
+
+    return 0;
+}
+
+pub extern "C" fn merge_tuples_final<T: SdbRustDataFuncs>(
+    _cfg: *const data_config,
+    key: slice,
+    oldest_message: *mut merge_accumulator,
+) -> ::std::os::raw::c_int
+{
+    // convert the accumulator to a message
+    let new_msg: SdbMessage = unsafe {
+        sdb_msg_from_acc(&*oldest_message)
+    };
+
+    // call user's merge_final() function
+    let res: SdbMessage = match T::merge_final(
+        &sdb_slice_to_vec(&key),
+        new_msg,
+    ) 
+    {
+        Ok(r) => r,
+        Err(..) => return -1,
+    };
+
+    // update the merge_accumulator with results of merge_final()
+    unsafe {
+        splinterdb_sys::merge_accumulator_copy_message(
+            oldest_message, 
+            message {
+                type_: res.msg_type as ::std::os::raw::c_uint,
+                data: create_splinter_slice(&res.data),
+            }
+        );
+    }
+
+    return 0;
+}
+
+pub extern "C" fn key_to_string<T: SdbRustDataFuncs>(
+    _cfg: *const data_config,
+    key: slice,
+    str_: *mut ::std::os::raw::c_char,
+    max_len: uint64,
+) -> ()
+{
+    T::str_key(
+        &sdb_slice_to_vec(&key), 
+        &mut raw_to_vec(str_ as *const ::std::os::raw::c_void, max_len as usize)
+    );
+}
+
+pub extern "C" fn message_to_string<T: SdbRustDataFuncs>(
+    _cfg: *const data_config,
+    msg: message,
+    str_: *mut ::std::os::raw::c_char,
+    max_len: uint64,
+) -> ()
+{
+    T::str_msg(
+        create_sdb_message(&msg), 
+        &mut raw_to_vec(str_ as *const ::std::os::raw::c_void, max_len as usize)
+    );
+}

--- a/rust/splinterdb-rs/src/tests.rs
+++ b/rust/splinterdb-rs/src/tests.rs
@@ -1,0 +1,220 @@
+// Tests of the splinterdb-rs library
+//
+// If you add a new function to the public API of this library, add a test here
+// (or extend an existing test) to demonstrate how to use it.
+
+#[cfg(test)]
+mod tests {
+
+    // Test of performing two insertions and lookup
+    #[test]
+    fn ins_test() -> std::io::Result<()> {
+        use splinterdb_sys::slice;
+        use tempfile::tempdir;
+        println!("BEGINNING TEST!");
+
+        let mut sdb = crate::SplinterDB::create_uninit_obj();
+
+        let data_dir = tempdir()?; // is removed on drop
+        let data_file = data_dir.path().join("db.splinterdb");
+
+        sdb.db_create(
+            &data_file,
+            &crate::DBConfig {
+                cache_size_bytes: 1024 * 1024,
+                disk_size_bytes: 30 * 1024 * 1024,
+                max_key_size: 23,
+                max_value_size: 100,
+            },
+        )?;
+
+        println!("SUCCESSFULLY CREATED DB!");
+
+        let key = b"some-key-0".to_vec();
+        let value = b"some-value-0".to_vec();
+
+        // verify that we can correctly create a splinter-slice from these keys and values
+        let ks: slice = crate::create_splinter_slice(&key);
+        let vs: slice = crate::create_splinter_slice(&value);
+        assert_eq!(ks.length, key.len() as u64);
+        assert_eq!(vs.length, value.len() as u64);
+        unsafe {
+            for i in 0..key.len() {
+                assert_eq!(*((ks.data as *const u8).offset(i as isize)), key[i]);
+            }
+            for i in 0..value.len() {
+                assert_eq!(*((vs.data as *const u8).offset(i as isize)), value[i]);
+            }
+        }
+
+        sdb.insert(&key, &value)?;
+        sdb.insert(&(b"some-key-4".to_vec()), &(b"some-value-4".to_vec()))?;
+        println!("SUCCESSFULLY INSERTED TO DB!");
+
+        let res = sdb.lookup(&key)?;
+        match res {
+            crate::LookupResult::NotFound => panic!("inserted key not found"),
+            crate::LookupResult::FoundTruncated(_) => panic!("inserted key found but truncated"),
+            crate::LookupResult::Found(v) => assert_eq!(v, value),
+        }
+
+        println!("SUCCESSFULLY PERFORMED LOOKUP!");
+
+        println!("Dropping SplinterDB!");
+        drop(sdb);
+        println!("Drop done! Exiting");
+        Ok(())
+    }
+
+    // Insert and delete, then lookup
+    #[test]
+    fn ins_and_del_test() -> std::io::Result<()> {
+        use tempfile::tempdir;
+        println!("BEGINNING TEST!");
+
+        let mut sdb = crate::SplinterDB::create_uninit_obj();
+
+        let data_dir = tempdir()?; // is removed on drop
+        let data_file = data_dir.path().join("db.splinterdb");
+
+        sdb.db_create(
+            &data_file,
+            &crate::DBConfig {
+                cache_size_bytes: 1024 * 1024,
+                disk_size_bytes: 30 * 1024 * 1024,
+                max_key_size: 23,
+                max_value_size: 100,
+            },
+        )?;
+
+        println!("SUCCESSFULLY CREATED DB!");
+
+        let key = b"some-key-0".to_vec();
+        let value = b"some-value-0".to_vec();
+        sdb.insert(&key, &value)?;
+        sdb.insert(&(b"some-key-1".to_vec()), &(b"some-value-1".to_vec()))?;
+        sdb.insert(&(b"some-key-2".to_vec()), &(b"some-value-2".to_vec()))?;
+        println!("SUCCESSFULLY PERFORMED INSERTIONS!");
+
+        sdb.delete(&(b"some-key-1".to_vec()))?;
+        sdb.delete(&(b"some-key-2".to_vec()))?;
+
+        // lookup key that should not be present
+        let res = sdb.lookup(&(b"some-key-1".to_vec()))?;
+        match res {
+            crate::LookupResult::NotFound => println!("Good!"),
+            crate::LookupResult::FoundTruncated(_) => panic!("Should not have found this key!"),
+            crate::LookupResult::Found(_) => panic!("Should not have found this key!"),
+        }
+
+        // lookup key that should still be present
+        let res = sdb.lookup(&key)?;
+        match res {
+            crate::LookupResult::NotFound => panic!("inserted key not found"),
+            crate::LookupResult::FoundTruncated(_) => panic!("inserted key found but truncated"),
+            crate::LookupResult::Found(v) => assert_eq!(v, value),
+        }
+
+        println!("SUCCESSFULLY PERFORMED LOOKUPS!");
+
+        println!("Dropping SplinterDB!");
+        drop(sdb);
+        println!("Drop done! Exiting");
+        Ok(())
+    }
+
+    #[test]
+    fn overwrite_test() -> std::io::Result<()> {
+        use tempfile::tempdir;
+        println!("BEGINNING TEST!");
+
+        let mut sdb = crate::SplinterDB::create_uninit_obj();
+
+        let data_dir = tempdir()?; // is removed on drop
+        let data_file = data_dir.path().join("db.splinterdb");
+
+        sdb.db_create(
+            &data_file,
+            &crate::DBConfig {
+                cache_size_bytes: 1024 * 1024,
+                disk_size_bytes: 30 * 1024 * 1024,
+                max_key_size: 23,
+                max_value_size: 100,
+            },
+        )?;
+        println!("SUCCESSFULLY CREATED DB!");
+
+        let key = b"some-key-0".to_vec();
+        let value = b"some-value-0".to_vec();
+        let nval = b"some-value-1".to_vec();
+        sdb.insert(&key, &value)?;
+        sdb.insert(&key, &nval)?;
+
+        // lookup key
+        let res = sdb.lookup(&key)?;
+        match res {
+            crate::LookupResult::NotFound => panic!("inserted key not found"),
+            crate::LookupResult::FoundTruncated(_) => panic!("inserted key found but truncated"),
+            crate::LookupResult::Found(v) => {
+                assert_eq!(v, nval);
+            },
+        }
+        println!("SUCCESSFULLY PERFORMED LOOKUP!");
+
+        println!("Dropping SplinterDB!");
+        drop(sdb);
+        println!("Drop done! Exiting");
+        Ok(())
+    }
+
+    #[test]
+    fn range_lookup_test() -> std::io::Result<()> {
+        use tempfile::tempdir;
+        println!("BEGINNING TEST!");
+
+        let mut sdb = crate::SplinterDB::create_uninit_obj();
+
+        let data_dir = tempdir()?; // is removed on drop
+        let data_file = data_dir.path().join("db.splinterdb");
+
+        sdb.db_create(
+            &data_file,
+            &crate::DBConfig {
+                cache_size_bytes: 1024 * 1024,
+                disk_size_bytes: 30 * 1024 * 1024,
+                max_key_size: 23,
+                max_value_size: 100,
+            },
+        )?;
+        println!("SUCCESSFULLY CREATED DB!");
+
+        sdb.insert(&(b"some-key-0".to_vec()), &(b"some-value-0".to_vec()))?;
+        sdb.insert(&(b"some-key-3".to_vec()), &(b"some-value-3".to_vec()))?;
+        sdb.insert(&(b"some-key-5".to_vec()), &(b"some-value-5".to_vec()))?;
+        sdb.insert(&(b"some-key-6".to_vec()), &(b"some-value-6".to_vec()))?;
+
+        let mut found: Vec<(Vec<u8>, Vec<u8>)> = Vec::new(); // to collect results
+        let mut iter = sdb.range(None)?;
+        loop {
+            match iter.next() {
+                Ok(Some(r)) => found.push((r.key.to_vec(), r.value.to_vec())),
+                Ok(None) => break,
+                Err(e) => return Err(e),
+            }
+        }
+
+        println!("Found {} results", found.len());
+
+        assert_eq!(found[0], (b"some-key-0".to_vec(), b"some-value-0".to_vec()));
+        assert_eq!(found[1], (b"some-key-3".to_vec(), b"some-value-3".to_vec()));
+        assert_eq!(found[2], (b"some-key-5".to_vec(), b"some-value-5".to_vec()));
+        assert_eq!(found[3], (b"some-key-6".to_vec(), b"some-value-6".to_vec()));
+
+        drop(iter);
+
+        println!("Dropping SplinterDB!");
+        drop(sdb);
+        println!("Drop done! Exiting");
+        Ok(())
+    }
+}

--- a/rust/splinterdb-sys/Cargo.toml
+++ b/rust/splinterdb-sys/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "splinterdb-sys"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[build-dependencies]
+bindgen = "0.65.1"
+
+[dependencies]
+tempfile = "3.2.0"

--- a/rust/splinterdb-sys/README.md
+++ b/rust/splinterdb-sys/README.md
@@ -1,0 +1,21 @@
+# `splinterdb-sys`
+
+Lowest level, unsafe Rust declarations for (some of) the C functions exported from SplinterDB.
+
+The exported headers are listed in `wrapper.h`. In order to build, the splinterdb shared libraries must be built and present at `\usr\local\lib`. The location where the shared libraries are found can be changed by modifying `build.rs`.
+
+If the shared libraries change, `cargo build` should automatically detect the change and rebuild this package.
+
+## Generating the Wrapper
+The wrapper code is generated automatically upon a call to `cargo build` based upon the files listed in `wrapper.h`.
+
+If it is necessary to expand the functionality of `splinterdb-sys` simply add more files to `wrapper.h` and build again.
+
+## Verifying the Wrapper
+From this directory run
+```sh
+cargo build
+cargo test
+```
+
+This runs the smoke test for this library, ensuring that the C bindings are created successfully. If errors occur ensure that `\usr\local\lib` is in `LD_LIBRARY_PATH` and the shared libraries have been successfully installed at that location.

--- a/rust/splinterdb-sys/build.rs
+++ b/rust/splinterdb-sys/build.rs
@@ -23,6 +23,7 @@ fn main() {
         .allowlist_type("splinterdb.*")
         .allowlist_function("splinterdb.*")
         .allowlist_function("default_data_config.*")
+        .allowlist_function("merge.*")
         .allowlist_var("SPLINTERDB.*")
         .allowlist_var(".*_SIZE")
         .clang_arg("-DSPLINTERDB_PLATFORM_DIR=platform_linux")

--- a/rust/splinterdb-sys/build.rs
+++ b/rust/splinterdb-sys/build.rs
@@ -1,0 +1,39 @@
+extern crate bindgen;
+
+use std::env;
+use std::path::PathBuf;
+
+fn main() {
+    // Tell cargo to look for shared libraries in the specified directory
+    println!("cargo:rustc-link-search=/usr/local/lib");
+
+    // Tell cargo to tell rustc to link to splinterdb shared lib
+    println!("cargo:rustc-link-lib=splinterdb");
+
+    // Tell cargo to invalidate the built crate whenever the wrapper changes
+    println!("cargo:rerun-if-changed=wrapper.h");
+
+    // The bindgen::Builder is the main entry point
+    // to bindgen, and lets you build up options for
+    // the resulting bindings.
+    let bindings = bindgen::Builder::default()
+        .no_copy("splinterdb.*")
+        .no_copy("writable_buffer")
+        .no_copy("data_config")
+        .allowlist_type("splinterdb.*")
+        .allowlist_function("splinterdb.*")
+        .allowlist_function("default_data_config.*")
+        .allowlist_var("SPLINTERDB.*")
+        .allowlist_var(".*_SIZE")
+        .clang_arg("-DSPLINTERDB_PLATFORM_DIR=platform_linux")
+        .header("wrapper.h")
+        .parse_callbacks(Box::new(bindgen::CargoCallbacks))
+        .generate()
+        .expect("Unable to generate bindings");
+
+    // Write the bindings to the $OUT_DIR/bindings.rs file.
+    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+    bindings
+        .write_to_file(out_path.join("bindings.rs"))
+        .expect("Couldn't write bindings!");
+}

--- a/rust/splinterdb-sys/src/lib.rs
+++ b/rust/splinterdb-sys/src/lib.rs
@@ -1,0 +1,60 @@
+#![allow(non_upper_case_globals)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
+
+#[cfg(test)]
+mod tests {
+
+	fn path_as_cstring<P: AsRef<std::path::Path>>(path: P) -> std::ffi::CString {
+        let as_os_str = path.as_ref().as_os_str();
+        let as_str = as_os_str.to_str().unwrap();
+        std::ffi::CString::new(as_str).unwrap()
+    }
+
+    // Really basic "smoke" test of the generated code, just to see that the
+    // C library actually links.
+    #[test]
+    fn invoke_things() {
+        use tempfile::tempdir;
+
+        let data_dir = tempdir().unwrap(); // is removed on drop
+        let data_file = data_dir.path().join("db.splinterdb");
+        let path = path_as_cstring(data_file); // don't drop until init is done
+
+        println!("path = {:?}", path);
+
+        let mut data_config: super::data_config = unsafe { std::mem::zeroed() };
+        let mut cfg: super::splinterdb_config = unsafe { std::mem::zeroed() };
+        cfg.filename = path.as_ptr();
+        cfg.cache_size = 200 * 1024 * 1024;
+        cfg.disk_size = 400 * 1024 * 1024;
+        cfg.data_cfg = &mut data_config;
+
+        println!("CONFIG CREATED!");
+
+        let mut splinterdb: *mut super::splinterdb = std::ptr::null_mut();
+
+        println!("SPLINTER POINTER CREATED!");
+
+        unsafe {
+            super::default_data_config_init(
+                32,
+                cfg.data_cfg,
+            )
+        };
+
+        println!("CONFIG INIT!");
+
+        let rc = unsafe {
+            super::splinterdb_create(&cfg, &mut splinterdb)
+        };
+        assert_eq!(rc, 0);
+
+        println!("SPLINTER CREATED!");
+
+        unsafe { super::splinterdb_close(&mut splinterdb) };
+
+        println!("SPLINTER CLOSED!");
+    }
+}

--- a/rust/splinterdb-sys/wrapper.h
+++ b/rust/splinterdb-sys/wrapper.h
@@ -1,0 +1,6 @@
+// This file lists the C headers that bindgen will process
+// when creating the rust interface to splinterdb
+// See regenerate.sh for details
+
+#include <splinterdb/splinterdb.h>
+#include <splinterdb/default_data_config.h>

--- a/rust/splinterdb-sys/wrapper.h
+++ b/rust/splinterdb-sys/wrapper.h
@@ -1,6 +1,5 @@
 // This file lists the C headers that bindgen will process
 // when creating the rust interface to splinterdb
-// See regenerate.sh for details
 
 #include <splinterdb/splinterdb.h>
 #include <splinterdb/default_data_config.h>

--- a/rust/splinterdb-sys/wrapper.h
+++ b/rust/splinterdb-sys/wrapper.h
@@ -3,3 +3,4 @@
 
 #include <splinterdb/splinterdb.h>
 #include <splinterdb/default_data_config.h>
+#include <splinterdb/data.h>


### PR DESCRIPTION
A rust wrapper for SplinterDB. Implements simple key/value operations by default and allows for more complicated update behavior with user defined rust functions.

The wrapper is an iterative improvement to a previous version created by @rosenhouse.

Changes from the previous version of the wrapper:
- Automatic splinter binding (`splinterdb-sys`) generation when building the rust library.
- More tests of the rust wrapper (`splinterdb-rs`).
- Support for new data_config layout and other changes to SplinterDB.
- Ability to callback to rust functions via the SplinterDB data_config. These callbacks are defined by the `SdbRustDataFuncs` trait.