### PR TITLE
Add Column Families to SplinterDB

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -437,6 +437,11 @@ $(BINDIR)/$(UNITDIR)/splinterdb_quick_test: $(COMMON_TESTOBJ)                   
                                             $(OBJDIR)/$(FUNCTIONAL_TESTSDIR)/test_async.o \
                                             $(LIBDIR)/libsplinterdb.so
 
+$(BINDIR)/$(UNITDIR)/column_family_test: $(COMMON_TESTOBJ)                             \
+                                         $(COMMON_UNIT_TESTOBJ)                        \
+                                         $(OBJDIR)/$(FUNCTIONAL_TESTSDIR)/test_async.o \
+                                         $(LIBDIR)/libsplinterdb.so
+
 $(BINDIR)/$(UNITDIR)/splinterdb_stress_test: $(COMMON_TESTOBJ)                             \
                                              $(COMMON_UNIT_TESTOBJ)                        \
                                              $(OBJDIR)/$(FUNCTIONAL_TESTSDIR)/test_async.o \

--- a/include/splinterdb/column_family.h
+++ b/include/splinterdb/column_family.h
@@ -1,0 +1,127 @@
+/*
+ * column_family.h --
+ *
+ *     The Column Family public API for SplinterDB.
+ *
+ *
+ */
+
+
+#ifndef _SPLINTERDB_COLUMN_FAMILY_H_
+#define _SPLINTERDB_COLUMN_FAMILY_H_
+
+#include "splinterdb/splinterdb.h"
+
+// Maximum size of a key within a column family
+// allows conversion from user key to cf key
+// to be performed upon the stack.
+#define COLUMN_FAMILY_KEY_BYTES 512
+
+typedef uint32 column_family_id;
+
+typedef struct cf_data_config {
+   data_config      general_config;
+   column_family_id num_families;
+   data_config    **config_table;
+   column_family_id table_mem;
+} cf_data_config;
+
+typedef struct splinterdb_column_family {
+   column_family_id id;
+   splinterdb      *kvs;
+} splinterdb_column_family;
+
+typedef struct splinterdb_cf_iterator {
+   column_family_id     id;
+   splinterdb_iterator *iter;
+} splinterdb_cf_iterator;
+
+#define CF_ITER_UNINIT ((splinterdb_cf_iterator){0, NULL})
+
+// Initialize the data_config stored in the cf_data_config
+// this data_config is then passed to SplinterDB to add support for
+// column families
+void
+init_column_family_config(const uint64    max_key_size, // IN
+                          cf_data_config *cf_cfg        // OUT
+);
+
+// Delete the cf_data_config, freeing the memory used by the
+// config table
+void
+deinit_column_family_config(cf_data_config *cf_cfg);
+
+// Create a new column family
+// Returns a new column family struct
+splinterdb_column_family
+create_column_family(splinterdb  *kvs,
+                     const uint64 max_key_size,
+                     data_config *data_cfg);
+
+// Delete the column family cf
+void
+delete_column_family(splinterdb_column_family cf);
+
+// ====== SPLINTERDB Functions ======
+// We wrap these for column family support
+// Column families and standard splinterdb should not be mixed
+int
+splinterdb_cf_insert(const splinterdb_column_family cf, slice key, slice value);
+
+int
+splinterdb_cf_delete(const splinterdb_column_family cf, slice key);
+
+int
+splinterdb_cf_update(const splinterdb_column_family cf, slice key, slice delta);
+
+// column family lookups
+
+void
+splinterdb_cf_lookup_result_init(const splinterdb_column_family cf,    // IN
+                                 splinterdb_lookup_result *result,     // IN/OUT
+                                 uint64                    buffer_len, // IN
+                                 char                     *buffer      // IN
+);
+
+void
+splinterdb_cf_lookup_result_deinit(splinterdb_lookup_result *result); // IN
+
+_Bool
+splinterdb_cf_lookup_found(const splinterdb_lookup_result *); // IN
+
+int
+splinterdb_cf_lookup_result_value(const splinterdb_lookup_result *result, // IN
+                                  slice                          *value   // OUT
+);
+
+int
+splinterdb_cf_lookup(const splinterdb_column_family cf,    // IN
+                     slice                          key,   // IN
+                     splinterdb_lookup_result      *result // IN/OUT
+);
+
+
+// Range iterators for column families
+
+int
+splinterdb_cf_iterator_init(const splinterdb_column_family cf,       // IN
+                            splinterdb_cf_iterator        *cf_iter,  // OUT
+                            slice                          start_key // IN
+);
+
+void
+splinterdb_cf_iterator_deinit(splinterdb_cf_iterator *cf_iter);
+
+void
+splinterdb_cf_iterator_next(splinterdb_cf_iterator *cf_iter);
+
+_Bool
+splinterdb_cf_iterator_get_current(splinterdb_cf_iterator *cf_iter, // IN
+                                   slice                  *key,     // OUT
+                                   slice                  *value    // OUT
+);
+
+int
+splinterdb_cf_iterator_status(const splinterdb_cf_iterator *cf_iter);
+
+#endif // _SPLINTERDB_COLUMN_FAMILY_H_

--- a/src/column_family.c
+++ b/src/column_family.c
@@ -1,0 +1,361 @@
+
+#include "platform.h"
+
+#include "splinterdb/column_family.h"
+#include "splinterdb/splinterdb.h"
+#include "splinterdb_internal.h"
+#include "util.h"
+
+#include <stdbool.h>
+#include <stdlib.h>
+
+// Some helper functions we'll use for managing the column family identifiers
+// and the data config table
+column_family_id
+get_cf_id(slice cf_key)
+{
+   // the cf id is a prefix of the key
+   const void      *data = slice_data(cf_key);
+   column_family_id id;
+   memcpy(&id, data, sizeof(id));
+   return id;
+}
+
+slice
+userkey_to_cf_key(slice            userkey,
+                  column_family_id cf_id,
+                  char            *buf,
+                  uint32           buf_size)
+{
+   uint64      key_len = slice_length(userkey);
+   const void *data    = slice_data(userkey);
+   platform_assert(buf_size >= key_len + sizeof(column_family_id));
+
+   memcpy(buf, &cf_id, sizeof(cf_id));
+   if (key_len > 0)
+      memcpy(buf + sizeof(cf_id), data, key_len);
+   return slice_create(key_len + sizeof(cf_id), buf);
+}
+
+slice
+cf_key_to_userkey(slice cf_key)
+{
+   uint64      key_len = slice_length(cf_key);
+   const void *data    = slice_data(cf_key);
+
+   return slice_create(key_len - sizeof(column_family_id),
+                       data + sizeof(column_family_id));
+}
+
+column_family_id
+cfg_table_insert(cf_data_config *cf_cfg, data_config *data_cfg)
+{
+   column_family_id new_id = cf_cfg->num_families;
+   cf_cfg->num_families += 1;
+
+   // reallocate table memory if necessary
+   if (cf_cfg->table_mem <= new_id) {
+      cf_cfg->config_table = (data_config **)realloc(
+         cf_cfg->config_table, new_id * 2 * sizeof(data_config *));
+   }
+
+   // place new data_config in table
+   cf_cfg->config_table[new_id] = data_cfg;
+
+   return new_id;
+}
+
+void
+cfg_table_delete(cf_data_config *cf_cfg, column_family_id cf_id)
+{
+   // memory is held by user so don't free it
+   // just mark the config_table entry as NULL
+   cf_cfg->config_table[cf_id] = NULL;
+
+   // TODO: Reuse this slot somehow?
+}
+
+// Beginning of column family interface
+
+// Create a new column family
+// Returns a new column family struct
+splinterdb_column_family
+create_column_family(splinterdb  *kvs,
+                     const uint64 max_key_size,
+                     data_config *new_data_cfg)
+{
+   platform_assert(kvs->data_cfg->max_key_size >= max_key_size);
+
+   // convert from data_config to cf_data_config
+   cf_data_config *cf_cfg = (cf_data_config *)kvs->data_cfg;
+
+   column_family_id new_id = cfg_table_insert(cf_cfg, new_data_cfg);
+
+   // return new column family
+   splinterdb_column_family cf;
+   cf.id  = new_id;
+   cf.kvs = kvs;
+
+   return cf;
+}
+
+// Delete the column family cf
+void
+delete_column_family(splinterdb_column_family cf)
+{
+   // convert from data_config to cf_data_config
+   cf_data_config *cf_cfg = (cf_data_config *)cf.kvs->data_cfg;
+
+   cfg_table_delete(cf_cfg, cf.id);
+}
+
+// SplinterDB Functions
+// We wrap these for column family support
+// Column families and standard splinterdb should not be mixed
+int
+splinterdb_cf_insert(const splinterdb_column_family cf, slice key, slice value)
+{
+   // zero len key reserved, negative infinity
+   platform_assert(slice_length(key) > 0);
+
+   // convert to column family key by prefixing the cf id
+   char  key_buf[COLUMN_FAMILY_KEY_BYTES];
+   slice cf_key =
+      userkey_to_cf_key(key, cf.id, key_buf, COLUMN_FAMILY_KEY_BYTES);
+   return splinterdb_insert(cf.kvs, cf_key, value);
+}
+
+int
+splinterdb_cf_delete(const splinterdb_column_family cf, slice key)
+{
+   char  key_buf[COLUMN_FAMILY_KEY_BYTES];
+   slice cf_key =
+      userkey_to_cf_key(key, cf.id, key_buf, COLUMN_FAMILY_KEY_BYTES);
+   return splinterdb_delete(cf.kvs, cf_key);
+}
+
+int
+splinterdb_cf_update(const splinterdb_column_family cf, slice key, slice delta)
+{
+   char  key_buf[COLUMN_FAMILY_KEY_BYTES];
+   slice cf_key =
+      userkey_to_cf_key(key, cf.id, key_buf, COLUMN_FAMILY_KEY_BYTES);
+   return splinterdb_insert(cf.kvs, cf_key, delta);
+}
+
+// column family lookups
+
+void
+splinterdb_cf_lookup_result_init(const splinterdb_column_family cf,    // IN
+                                 splinterdb_lookup_result *result,     // IN/OUT
+                                 uint64                    buffer_len, // IN
+                                 char                     *buffer      // IN
+)
+{
+   splinterdb_lookup_result_init(cf.kvs, result, buffer_len, buffer);
+}
+
+void
+splinterdb_cf_lookup_result_deinit(splinterdb_lookup_result *result) // IN
+{
+   splinterdb_lookup_result_deinit(result);
+}
+
+_Bool
+splinterdb_cf_lookup_found(const splinterdb_lookup_result *result) // IN
+{
+   return splinterdb_lookup_found(result);
+}
+
+int
+splinterdb_cf_lookup_result_value(const splinterdb_lookup_result *result, // IN
+                                  slice                          *value   // OUT
+)
+{
+   return splinterdb_lookup_result_value(result, value);
+}
+
+int
+splinterdb_cf_lookup(const splinterdb_column_family cf,    // IN
+                     slice                          key,   // IN
+                     splinterdb_lookup_result      *result // IN/OUT
+)
+{
+   char  key_buf[COLUMN_FAMILY_KEY_BYTES];
+   slice cf_key =
+      userkey_to_cf_key(key, cf.id, key_buf, COLUMN_FAMILY_KEY_BYTES);
+   return splinterdb_lookup(cf.kvs, cf_key, result);
+}
+
+
+// Range iterators for column families
+
+int
+splinterdb_cf_iterator_init(const splinterdb_column_family cf,       // IN
+                            splinterdb_cf_iterator        *cf_iter,  // OUT
+                            slice                          start_key // IN
+)
+{
+   // The minimum key contains no key data only consists of
+   // the column id so this is what a NULL key will become
+   char  key_buf[COLUMN_FAMILY_KEY_BYTES];
+   slice cf_key =
+      userkey_to_cf_key(start_key, cf.id, key_buf, COLUMN_FAMILY_KEY_BYTES);
+   cf_iter->id = cf.id;
+   return splinterdb_iterator_init(cf.kvs, &cf_iter->iter, cf_key);
+}
+
+void
+splinterdb_cf_iterator_deinit(splinterdb_cf_iterator *cf_iter)
+{
+   splinterdb_iterator_deinit(cf_iter->iter);
+}
+
+_Bool
+splinterdb_cf_iterator_get_current(splinterdb_cf_iterator *cf_iter, // IN
+                                   slice                  *key,     // OUT
+                                   slice                  *value    // OUT
+)
+{
+   _Bool valid = splinterdb_iterator_valid(cf_iter->iter);
+
+   if (!valid)
+      return false;
+
+   // if valid, check the key to ensure it's within this column family
+   splinterdb_iterator_get_current(cf_iter->iter, key, value);
+   column_family_id key_cf = get_cf_id(*key);
+
+   if (key_cf != cf_iter->id)
+      return false;
+
+   *key = cf_key_to_userkey(*key);
+   return true;
+}
+
+void
+splinterdb_cf_iterator_next(splinterdb_cf_iterator *cf_iter)
+{
+   return splinterdb_iterator_next(cf_iter->iter);
+}
+
+int
+splinterdb_cf_iterator_status(const splinterdb_cf_iterator *cf_iter)
+{
+   return splinterdb_iterator_status(cf_iter->iter);
+}
+
+
+static int
+cf_key_compare(const data_config *cfg, slice key1, slice key2)
+{
+   // sort first by the column family ids
+   column_family_id cf_id1 = get_cf_id(key1);
+   column_family_id cf_id2 = get_cf_id(key2);
+
+   if (cf_id1 < cf_id2)
+      return -1;
+   if (cf_id1 > cf_id2)
+      return 1;
+
+   // Now we are comparing two keys from the same column family
+   // so we will use the user defined func for this cf
+   slice userkey1 = cf_key_to_userkey(key1);
+   slice userkey2 = cf_key_to_userkey(key2);
+
+   // empty keys are defined to be the minimum among the column family
+   if (slice_length(userkey1) == 0) return -1;
+   if (slice_length(userkey2) == 0) return 1;
+
+   // get the data_config for this column family and call its function
+   data_config *cf_cfg = ((cf_data_config *)cfg)->config_table[cf_id1];
+   return cf_cfg->key_compare(cf_cfg, userkey1, userkey2);
+}
+
+static int
+cf_merge_tuples(const data_config *cfg,
+                slice              key,
+                message            old_raw_message,
+                merge_accumulator *new_data)
+{
+   column_family_id cf_id = get_cf_id(key);
+
+   // get the data_config for this column family and call its function
+   data_config *cf_cfg = ((cf_data_config *)cfg)->config_table[cf_id];
+   return cf_cfg->merge_tuples(
+      cf_cfg, cf_key_to_userkey(key), old_raw_message, new_data);
+}
+
+static int
+cf_merge_tuples_final(const data_config *cfg,
+                      slice              key,
+                      merge_accumulator *oldest_data // IN/OUT
+)
+{
+   column_family_id cf_id = get_cf_id(key);
+
+   // get the data_config for this column family and call its function
+   data_config *cf_cfg = ((cf_data_config *)cfg)->config_table[cf_id];
+   return cf_cfg->merge_tuples_final(
+      cf_cfg, cf_key_to_userkey(key), oldest_data);
+}
+
+// These functions we don't allow the column families to overwrite
+
+static void
+cf_key_to_string(const data_config *cfg, slice key, char *str, size_t max_len)
+{
+   debug_hex_encode(str, max_len, slice_data(key), slice_length(key));
+}
+
+static void
+cf_message_to_string(const data_config *cfg,
+                     message            msg,
+                     char              *str,
+                     size_t             max_len)
+{
+   debug_hex_encode(str, max_len, message_data(msg), message_length(msg));
+}
+
+// Initialize the data_config stored in the cf_data_config.
+// Its data_config is then passed to SplinterDB to add support for
+// column families
+//
+// TODO: The key_hash function cannot be overwritten by column families
+//       at this time. This is because we do not have access to the cfg
+//       in the key_hash. So we have no way of accessing a user defined
+//       key_hash for the column family. This should probably be fixed.
+//       Likely requires adding the cfg to the key_hash_fn type.
+void
+init_column_family_config(const uint64    max_key_size, // IN
+                          cf_data_config *cf_cfg        // OUT
+)
+{
+   platform_assert(max_key_size + sizeof(column_family_id)
+                   < COLUMN_FAMILY_KEY_BYTES);
+   data_config cfg = {
+      .max_key_size       = max_key_size + sizeof(column_family_id),
+      .key_compare        = cf_key_compare,
+      .key_hash           = platform_hash32,
+      .merge_tuples       = cf_merge_tuples,
+      .merge_tuples_final = cf_merge_tuples_final,
+      .key_to_string      = cf_key_to_string,
+      .message_to_string  = cf_message_to_string,
+   };
+
+   cf_cfg->general_config = cfg;
+   cf_cfg->num_families   = 0;
+   cf_cfg->config_table   = NULL;
+   cf_cfg->table_mem      = 0;
+}
+
+void
+deinit_column_family_config(cf_data_config *cf_cfg)
+{
+   // we assume that the user will handle deallocating the table entries
+   // we just need to dealloc our array of pointers
+   if (cf_cfg->config_table != NULL)
+      free(cf_cfg->config_table);
+   cf_cfg->config_table = NULL;
+   cf_cfg->table_mem    = 0;
+}

--- a/src/splinterdb.c
+++ b/src/splinterdb.c
@@ -14,12 +14,10 @@
  */
 
 #include "splinterdb/splinterdb.h"
+#include "splinterdb_internal.h"
+
 #include "platform.h"
-#include "clockcache.h"
-#include "rc_allocator.h"
-#include "trunk.h"
 #include "btree_private.h"
-#include "shard_log.h"
 #include "poison.h"
 
 const char *BUILD_VERSION = "splinterdb_build_version " GIT_VERSION;
@@ -28,25 +26,6 @@ splinterdb_get_version()
 {
    return BUILD_VERSION;
 }
-
-typedef struct splinterdb {
-   task_system         *task_sys;
-   io_config            io_cfg;
-   platform_io_handle   io_handle;
-   allocator_config     allocator_cfg;
-   rc_allocator         allocator_handle;
-   clockcache_config    cache_cfg;
-   clockcache           cache_handle;
-   shard_log_config     log_cfg;
-   task_system_config   task_cfg;
-   allocator_root_id    trunk_id;
-   trunk_config         trunk_cfg;
-   trunk_handle        *spl;
-   platform_heap_handle heap_handle; // for platform_buffer_create
-   platform_heap_id     heap_id;
-   data_config         *data_cfg;
-} splinterdb;
-
 
 /*
  * Extract errno.h -style status int from a platform_status

--- a/src/splinterdb_internal.h
+++ b/src/splinterdb_internal.h
@@ -1,0 +1,27 @@
+#ifndef SPLINTERDB_SPLINTERDB_INTERNAL_H_
+#define SPLINTERDB_SPLINTERDB_INTERNAL_H_
+
+#include "trunk.h"
+#include "clockcache.h"
+#include "rc_allocator.h"
+#include "shard_log.h"
+
+typedef struct splinterdb {
+   task_system         *task_sys;
+   io_config            io_cfg;
+   platform_io_handle   io_handle;
+   allocator_config     allocator_cfg;
+   rc_allocator         allocator_handle;
+   clockcache_config    cache_cfg;
+   clockcache           cache_handle;
+   shard_log_config     log_cfg;
+   task_system_config   task_cfg;
+   allocator_root_id    trunk_id;
+   trunk_config         trunk_cfg;
+   trunk_handle        *spl;
+   platform_heap_handle heap_handle; // for platform_buffer_create
+   platform_heap_id     heap_id;
+   data_config         *data_cfg;
+} splinterdb;
+
+#endif // SPLINTERDB_SPLINTERDB_INTERNAL_H_

--- a/test.sh
+++ b/test.sh
@@ -534,6 +534,7 @@ function test_make_run_tests() {
 function run_fast_unit_tests() {
 
    "$BINDIR"/unit/splinterdb_quick_test
+   "$BINDIR"/unit/column_family_test
    "$BINDIR"/unit/btree_test
    "$BINDIR"/unit/util_test
    "$BINDIR"/unit/misc_test

--- a/tests/unit/column_family_test.c
+++ b/tests/unit/column_family_test.c
@@ -1,0 +1,331 @@
+/*
+ * -----------------------------------------------------------------------------
+ * splinter_cf_test.c --
+ *
+ *     Quick test of the Column Family public API for SplinterDB
+ *
+ * -----------------------------------------------------------------------------
+ */
+
+#include "splinterdb/column_family.h"
+#include "splinterdb/data.h"
+#include "splinterdb/public_platform.h"
+#include "splinterdb/default_data_config.h"
+#include "unit_tests.h"
+#include "util.h"
+#include "test_data.h"
+#include "ctest.h" // This is required for all test-case files.
+#include "btree.h" // for MAX_INLINE_MESSAGE_SIZE
+
+#define TEST_MAX_KEY_SIZE   16
+#define TEST_MAX_VALUE_SIZE 32
+
+// Hard-coded format strings to generate key and values
+// static const char key_fmt[] = "key-%04x";
+// static const char val_fmt[] = "val-%04x";
+// #define KEY_FMT_LENGTH (8)
+// #define VAL_FMT_LENGTH (8)
+
+
+CTEST_DATA(column_family)
+{
+   splinterdb       *kvsb;
+   splinterdb_config cfg;
+
+   // the global_data_cfg is used to route to the right data_config
+   // for each column family
+   cf_data_config global_data_cfg;
+
+   // default data config for when we don't want to be special
+   data_config default_data_cfg;
+};
+
+CTEST_SETUP(column_family)
+{
+   default_data_config_init(TEST_MAX_KEY_SIZE, &data->default_data_cfg);
+   init_column_family_config(TEST_MAX_KEY_SIZE, &data->global_data_cfg);
+   data->cfg =
+      (splinterdb_config){.filename   = TEST_DB_NAME,
+                          .cache_size = 64 * Mega,
+                          .disk_size  = 128 * Mega,
+                          .data_cfg   = (data_config *)&data->global_data_cfg};
+
+   int rc = splinterdb_create(&data->cfg, &data->kvsb);
+   ASSERT_EQUAL(0, rc);
+   ASSERT_TRUE(TEST_MAX_VALUE_SIZE
+               < MAX_INLINE_MESSAGE_SIZE(LAIO_DEFAULT_PAGE_SIZE));
+}
+
+CTEST_TEARDOWN(column_family)
+{
+   if (data->kvsb) {
+      splinterdb_close(&data->kvsb);
+   }
+   deinit_column_family_config(&data->global_data_cfg);
+}
+
+/*
+ *
+ * Basic test case that ensures we can create and use a single column family
+ * correctly Tests:
+ *  - create_column_family()
+ *  - delete_column_family()
+ *  - splinterdb_cf_insert()
+ *  - splinterdb_cf_delete()
+ *  - splinterdb_cf_lookup()
+ *
+ * We evaluate that these functions perform as expected and provide the correct
+ * outputs
+ */
+CTEST2(column_family, test_single_column)
+{
+   // create a column family
+   splinterdb_column_family cf = create_column_family(
+      data->kvsb, TEST_MAX_KEY_SIZE, &data->default_data_cfg);
+
+   // create some basic data to insert and lookup
+   char  *key_data = "some-key";
+   size_t key_len  = sizeof("some-key");
+   slice  user_key = slice_create(key_len, key_data);
+
+   splinterdb_lookup_result result;
+   splinterdb_cf_lookup_result_init(cf, &result, 0, NULL);
+
+   int rc = splinterdb_cf_lookup(cf, user_key, &result);
+   ASSERT_EQUAL(0, rc);
+
+   // Lookup of a non-existent key should return not-found.
+   ASSERT_FALSE(splinterdb_cf_lookup_found(&result));
+
+   static char *to_insert_data = "some-value";
+   size_t       to_insert_len  = strlen(to_insert_data);
+   slice        to_insert      = slice_create(to_insert_len, to_insert_data);
+
+   // Basic insert of new key should succeed.
+   rc = splinterdb_cf_insert(cf, user_key, to_insert);
+   ASSERT_EQUAL(0, rc);
+
+   // Lookup of inserted key should succeed.
+   rc = splinterdb_cf_lookup(cf, user_key, &result);
+   ASSERT_EQUAL(0, rc);
+   ASSERT_TRUE(splinterdb_cf_lookup_found(&result));
+
+   // Lookup should return inserted value
+   slice value;
+   rc = splinterdb_cf_lookup_result_value(&result, &value);
+   ASSERT_EQUAL(0, rc);
+   ASSERT_EQUAL(to_insert_len, slice_length(value));
+   ASSERT_STREQN(to_insert_data, slice_data(value), slice_length(value));
+
+   // Delete key
+   rc = splinterdb_cf_delete(cf, user_key);
+   ASSERT_EQUAL(0, rc);
+
+   // Deleted key should not be found
+   rc = splinterdb_cf_lookup(cf, user_key, &result);
+   ASSERT_EQUAL(0, rc);
+   ASSERT_FALSE(splinterdb_cf_lookup_found(&result));
+
+   splinterdb_cf_lookup_result_deinit(&result);
+}
+
+/*
+ * Ensure keys and values of maximum length work
+ * with column families
+ */
+CTEST2(column_family, test_max_length)
+{
+   // create a column family
+   splinterdb_column_family cf = create_column_family(
+      data->kvsb, TEST_MAX_KEY_SIZE, &data->default_data_cfg);
+
+   char   large_key_data[TEST_MAX_KEY_SIZE];
+   size_t large_key_len = TEST_MAX_KEY_SIZE;
+   memset(large_key_data, 'k', TEST_MAX_KEY_SIZE);
+   slice large_key = slice_create(large_key_len, large_key_data);
+
+   char   large_val_data[TEST_MAX_VALUE_SIZE];
+   size_t large_val_len = TEST_MAX_VALUE_SIZE;
+   memset(large_val_data, 'v', TEST_MAX_VALUE_SIZE);
+   slice large_val = slice_create(large_val_len, large_val_data);
+
+   // Insert of large key and value should exceed
+   int rc = splinterdb_cf_insert(cf, large_key, large_val);
+   ASSERT_EQUAL(0, rc);
+
+   splinterdb_lookup_result result;
+   splinterdb_cf_lookup_result_init(cf, &result, 0, NULL);
+
+   // Lookup of inserted key should succeed.
+   rc = splinterdb_cf_lookup(cf, large_key, &result);
+   ASSERT_EQUAL(0, rc);
+   ASSERT_TRUE(splinterdb_cf_lookup_found(&result));
+
+   // Lookup should return inserted value
+   slice value;
+   rc = splinterdb_cf_lookup_result_value(&result, &value);
+   ASSERT_EQUAL(0, rc);
+   ASSERT_EQUAL(large_val_len, slice_length(value));
+   ASSERT_STREQN(large_val_data, slice_data(value), slice_length(value));
+
+   // Delete key
+   rc = splinterdb_cf_delete(cf, large_key);
+   ASSERT_EQUAL(0, rc);
+
+   // Deleted key should not be found
+   rc = splinterdb_cf_lookup(cf, large_key, &result);
+   ASSERT_EQUAL(0, rc);
+   ASSERT_FALSE(splinterdb_cf_lookup_found(&result));
+
+   splinterdb_cf_lookup_result_deinit(&result);
+}
+
+static int
+rev_key_compare(const data_config *cfg, slice key1, slice key2)
+{
+   platform_assert(slice_data(key1) != NULL);
+   platform_assert(slice_data(key2) != NULL);
+
+   return slice_lex_cmp(key2, key1);
+}
+
+/*
+ * Test key/value operations upon multiple column families.
+ * Ensure that the keys can be operated upon independently.
+ */
+CTEST2(column_family, test_multiple_cf_same_key)
+{
+   // create a few column families
+   splinterdb_column_family cf0 = create_column_family(
+      data->kvsb, TEST_MAX_KEY_SIZE, &data->default_data_cfg);
+   splinterdb_column_family cf1 = create_column_family(
+      data->kvsb, TEST_MAX_KEY_SIZE, &data->default_data_cfg);
+   splinterdb_column_family cf2 = create_column_family(
+      data->kvsb, TEST_MAX_KEY_SIZE, &data->default_data_cfg);
+   splinterdb_column_family cf3 = create_column_family(
+      data->kvsb, TEST_MAX_KEY_SIZE, &data->default_data_cfg);
+
+   // Insert a single key to each column family
+   char key_data[] = "key";
+   char val0_data[] = "val0";
+   char val1_data[] = "val1";
+   char val2_data[] = "val2";
+   char val3_data[] = "val3";
+   slice key = slice_create(3, key_data);
+   slice val0 = slice_create(4, val0_data);
+   slice val1 = slice_create(4, val1_data);
+   slice val2 = slice_create(4, val2_data);
+   slice val3 = slice_create(4, val3_data);
+
+   slice values[] = {val0, val1, val2, val3};
+   splinterdb_column_family cfs[] = {cf0, cf1, cf2, cf3};
+
+   // Perform insertions
+   for (int idx = 0; idx < 4; idx++) {
+      splinterdb_cf_insert(cfs[idx], key, values[idx]);
+   }
+
+   // lookup the key from each column family
+   // and ensure the right value is returned
+   for (int idx = 0; idx < 4; idx++) {
+      splinterdb_lookup_result result;
+      splinterdb_cf_lookup_result_init(cfs[idx], &result, 0, NULL);
+
+      int rc = splinterdb_cf_lookup(cfs[idx], key, &result);
+      ASSERT_EQUAL(0, rc);
+      ASSERT_TRUE(splinterdb_cf_lookup_found(&result));
+
+      // Lookup should return correct values
+      slice value;
+      rc = splinterdb_cf_lookup_result_value(&result, &value);
+      ASSERT_EQUAL(0, rc);
+      ASSERT_EQUAL(slice_length(values[idx]), slice_length(value));
+      ASSERT_STREQN(slice_data(values[idx]), slice_data(value), slice_length(value));
+   }
+}
+
+/* Test multiple column families with range iterators
+ * ensure that keys are found in the order defined by their
+ * custom key comparison functions
+ */
+CTEST2(column_family, test_multiple_cf_range)
+{
+   // create the default column family
+   splinterdb_column_family cf_default = create_column_family(
+      data->kvsb, TEST_MAX_KEY_SIZE, &data->default_data_cfg);
+
+   // create a config with a reversed key compare function
+   // and create a column family that will reverse the keys
+   data_config rev_data_config;
+   default_data_config_init(TEST_MAX_KEY_SIZE, &rev_data_config);
+   rev_data_config.key_compare = rev_key_compare;
+
+   splinterdb_column_family cf_reverse =
+      create_column_family(data->kvsb, TEST_MAX_KEY_SIZE, &rev_data_config);
+
+   // Insert a few key/value pairs to each cf
+   char key1_data[] = "aaaa";
+   char key2_data[] = "bbbb";
+   char key3_data[] = "cccc";
+   char key4_data[] = "dddd";
+   char cf1_value[] = "val-in-cf1";
+   char cf2_value[] = "val-in-cf2";
+
+   slice key1 = slice_create(4, key1_data);
+   slice key2 = slice_create(4, key2_data);
+   slice key3 = slice_create(4, key3_data);
+   slice key4 = slice_create(4, key4_data);
+   slice val1 = slice_create(10, cf1_value);
+   slice val2 = slice_create(10, cf2_value);
+
+   ASSERT_EQUAL(0, splinterdb_cf_insert(cf_default, key1, val1));
+   ASSERT_EQUAL(0, splinterdb_cf_insert(cf_default, key2, val1));
+   ASSERT_EQUAL(0, splinterdb_cf_insert(cf_default, key3, val1));
+   ASSERT_EQUAL(0, splinterdb_cf_insert(cf_default, key4, val1));
+
+   ASSERT_EQUAL(0, splinterdb_cf_insert(cf_reverse, key1, val2));
+   ASSERT_EQUAL(0, splinterdb_cf_insert(cf_reverse, key2, val2));
+   ASSERT_EQUAL(0, splinterdb_cf_insert(cf_reverse, key3, val2));
+   ASSERT_EQUAL(0, splinterdb_cf_insert(cf_reverse, key4, val2));
+
+   // Perform a range query over all cf1 keys
+   splinterdb_cf_iterator *it = &CF_ITER_UNINIT;
+   ASSERT_EQUAL(0, splinterdb_cf_iterator_init(cf_default, it, NULL_SLICE));
+
+   slice keys[] = {key1, key2, key3, key4};
+   slice key;
+   slice val;
+   int   idx = 0;
+   for (; splinterdb_cf_iterator_get_current(it, &key, &val);
+        splinterdb_cf_iterator_next(it))
+   {
+      ASSERT_EQUAL(slice_length(keys[idx]), slice_length(key));
+      ASSERT_STREQN(slice_data(keys[idx]), slice_data(key), slice_length(key));
+
+      ASSERT_EQUAL(slice_length(val1), slice_length(val));
+      ASSERT_STREQN(slice_data(val1), slice_data(val), slice_length(val));
+      ++idx;
+   }
+   ASSERT_EQUAL(4, idx);
+
+   splinterdb_cf_iterator_deinit(it);
+
+   // Perform a range query over all cf2 keys
+   ASSERT_EQUAL(0, splinterdb_cf_iterator_init(cf_reverse, it, NULL_SLICE));
+
+   idx = 0;
+   for (; splinterdb_cf_iterator_get_current(it, &key, &val);
+        splinterdb_cf_iterator_next(it))
+   {
+      ASSERT_EQUAL(slice_length(keys[3 - idx]), slice_length(key));
+      ASSERT_STREQN(
+         slice_data(keys[3 - idx]), slice_data(key), slice_length(key));
+
+      ASSERT_EQUAL(slice_length(val2), slice_length(val));
+      ASSERT_STREQN(slice_data(val2), slice_data(val), slice_length(val));
+      ++idx;
+   }
+   ASSERT_EQUAL(4, idx);
+
+   splinterdb_cf_iterator_deinit(it);
+}


### PR DESCRIPTION
This pull request is a foundational attempt to add support for column families in SplinterDB. 

This is accomplished with the `splinterdb_column_family` struct that wraps `splinterdb`. Each column family has an associated struct and operations upon the family are performed by passing the struct to insert/delete/update/etc functions.

When operations upon keys are performed by a column family the user key is prepended with a 4 byte column family id. These keys are then commingled in a single splinterdb instance (though all key/value pairs for a single column family are stored contiguously in the key space).

The API for column families is defined in the `splinterdb/column_family.h` header.

Limitations:
 - Column families all use xxh32 for the key_hash. There is no support for user defined hash functions.
 - The deletion of column spaces is not well supported. The space in the data_config table is not reclaimed.
 - The onus is on the user to support closing and reopening a splinterdb instance that contains column families. The user must ensure that they create the exact same column families in the same order when reopening the instance.
 - Maximum key size of 512 bytes for column families.
 - Mixing regular splinterdb calls and column families results in undefined behavior.
