### PR TITLE
Bidirectional Iterators

### DIFF
--- a/include/splinterdb/splinterdb.h
+++ b/include/splinterdb/splinterdb.h
@@ -340,6 +340,11 @@ splinterdb_iterator_valid(splinterdb_iterator *iter);
 void
 splinterdb_iterator_next(splinterdb_iterator *iter);
 
+// Attempts to move the iterator to the previous item.
+// Any error will cause valid() == false and be visible with status()
+void
+splinterdb_iterator_prev(splinterdb_iterator *iter);
+
 // Sets *key and *value to the locations of the current item
 // Callers must not modify that memory pointed to by the slice
 //

--- a/include/splinterdb/splinterdb.h
+++ b/include/splinterdb/splinterdb.h
@@ -330,20 +330,39 @@ splinterdb_iterator_deinit(splinterdb_iterator *iter);
 
 // Checks that the iterator status is OK (no errors) and that get_current()
 // will succeed. If false, there are two possibilities:
-// 1. Iterator has passed the final item.  In this case, status() == 0
+// 1. Iterator is out of bounds.  In this case, status() == 0
 // 2. Iterator has encountered an error.  In this case, status() != 0
 _Bool
 splinterdb_iterator_valid(splinterdb_iterator *iter);
 
-// Attempts to advance the iterator to the next item.
-// Any error will cause valid() == false and be visible with status()
-void
-splinterdb_iterator_next(splinterdb_iterator *iter);
+/*
+ * splinterdb_iterator_can_next --
+ * splinterdb_iterator_can_prev --
+ *
+ * Knowing the iterator is invalid does not provide enough information to
+ * determine if next and prev are safe operations.
+ *
+ * These functions provide granular information on which operations are safe.
+ * splinterdb_iterator_can_next == TRUE <-> splinterdb_iterator_next is safe
+ * splinterdb_iterator_can_prev == TRUE <-> splinterdb_iterator_prev is safe
+ */
+_Bool
+splinterdb_iterator_can_prev(splinterdb_iterator *iter);
 
-// Attempts to move the iterator to the previous item.
+_Bool
+splinterdb_iterator_can_next(splinterdb_iterator *iter);
+
+// Moves the iterator to the previous item.
+// Precondition for calling: splinterdb_iterator_can_prev() returns TRUE
 // Any error will cause valid() == false and be visible with status()
 void
 splinterdb_iterator_prev(splinterdb_iterator *iter);
+
+// Moves the iterator to the next item.
+// Precondition for calling: splinterdb_iterator_can_next() returns TRUE
+// Any error will cause valid() == false and be visible with status()
+void
+splinterdb_iterator_next(splinterdb_iterator *iter);
 
 // Sets *key and *value to the locations of the current item
 // Callers must not modify that memory pointed to by the slice

--- a/src/btree.c
+++ b/src/btree.c
@@ -1329,6 +1329,7 @@ btree_split_child_leaf(cache                 *cc,
             old_next_wait > 2048 ? old_next_wait : 2 * old_next_wait;
          btree_node_get(cc, cfg, &old_next, PAGE_TYPE_MEMTABLE);
       }
+      btree_node_lock(cc, cfg, &old_next);
    }
    /* p: write, c: claim, rc: write, on: write if exists */
 

--- a/src/btree.c
+++ b/src/btree.c
@@ -2875,11 +2875,10 @@ btree_iterator_seek(iterator *base_itor, key seek_key, comparison seek_type)
       itor->idx =
          find_key_in_node(itor, itor->curr.hdr, seek_key, seek_type, &found);
       platform_assert(0 <= itor->idx);
-      return STATUS_OK;
+   } else {
+      // seek key is not within our current leaf. So find the correct leaf
+      find_btree_node_and_get_idx_bounds(itor, seek_key, seek_type);
    }
-
-   // seek key is not within our current leaf. So find the correct leaf
-   find_btree_node_and_get_idx_bounds(itor, seek_key, seek_type);
 
    return STATUS_OK;
 }

--- a/src/btree.c
+++ b/src/btree.c
@@ -2968,7 +2968,7 @@ btree_iterator_init(cache          *cc,
       cache_prefetch(cc, itor->curr.hdr->next_extent_addr, itor->page_type);
    }
 
-   debug_assert(!iterator_can_curr((iterator *) itor)
+   debug_assert(!iterator_can_curr((iterator *)itor)
                 || itor->idx < btree_num_entries(itor->curr.hdr));
 }
 

--- a/src/btree.h
+++ b/src/btree.h
@@ -139,7 +139,8 @@ typedef struct btree_iterator {
 
    uint64     root_addr;
    btree_node curr;
-   uint64     idx;
+   int64      idx;
+   int64      curr_min_idx;
    uint64     end_addr;
    uint64     end_idx;
    uint64     end_generation;

--- a/src/btree.h
+++ b/src/btree.h
@@ -313,13 +313,13 @@ btree_lookup_and_merge_async(cache             *cc,          // IN
 void
 btree_iterator_init(cache          *cc,
                     btree_config   *cfg,
-                    btree_iterator *iterator,
+                    btree_iterator *itor,
                     uint64          root_addr,
                     page_type       page_type,
                     key             min_key,
                     key             max_key,
                     key             start_key,
-                    bool            from_above,
+                    comparison      start_type,
                     bool            do_prefetch,
                     uint32          height);
 

--- a/src/btree.h
+++ b/src/btree.h
@@ -319,6 +319,7 @@ btree_iterator_init(cache          *cc,
                     key             min_key,
                     key             max_key,
                     key             start_key,
+                    bool            from_above,
                     bool            do_prefetch,
                     uint32          height);
 

--- a/src/btree.h
+++ b/src/btree.h
@@ -318,6 +318,7 @@ btree_iterator_init(cache          *cc,
                     page_type       page_type,
                     key             min_key,
                     key             max_key,
+                    key             start_key,
                     bool            do_prefetch,
                     uint32          height);
 

--- a/src/btree_private.h
+++ b/src/btree_private.h
@@ -33,6 +33,7 @@ typedef node_offset table_entry;
  * *************************************************************************
  */
 struct ONDISK btree_hdr {
+   uint64      prev_addr;
    uint64      next_addr;
    uint64      next_extent_addr;
    uint64      generation;

--- a/src/iterator.h
+++ b/src/iterator.h
@@ -8,19 +8,17 @@
 
 typedef struct iterator iterator;
 
-typedef void (*iterator_get_curr_fn)(iterator *itor,
-                                     key      *curr_key,
-                                     message  *msg);
-typedef platform_status (*iterator_at_end_fn)(iterator *itor, bool *at_end);
-typedef platform_status (*iterator_advance_fn)(iterator *itor);
+typedef void (*iterator_curr_fn)(iterator *itor, key *curr_key, message *msg);
+typedef bool (*iterator_valid_fn)(iterator *itor);
+typedef platform_status (*iterator_step_fn)(iterator *itor);
 typedef void (*iterator_print_fn)(iterator *itor);
 
 typedef struct iterator_ops {
    /* Callers should not modify data pointed to by *key or *data */
-   iterator_get_curr_fn get_curr;
-   iterator_at_end_fn   at_end;
-   iterator_advance_fn  advance;
-   iterator_print_fn    print;
+   iterator_curr_fn  curr;
+   iterator_valid_fn valid;
+   iterator_step_fn  next;
+   iterator_print_fn print;
 } iterator_ops;
 
 // To sub-class iterator, make an iterator your first field
@@ -29,21 +27,21 @@ struct iterator {
 };
 
 static inline void
-iterator_get_curr(iterator *itor, key *curr_key, message *msg)
+iterator_curr(iterator *itor, key *curr_key, message *msg)
 {
-   itor->ops->get_curr(itor, curr_key, msg);
+   itor->ops->curr(itor, curr_key, msg);
+}
+
+static inline bool
+iterator_valid(iterator *itor)
+{
+   return itor->ops->valid(itor);
 }
 
 static inline platform_status
-iterator_at_end(iterator *itor, bool *at_end)
+iterator_next(iterator *itor)
 {
-   return itor->ops->at_end(itor, at_end);
-}
-
-static inline platform_status
-iterator_advance(iterator *itor)
-{
-   return itor->ops->advance(itor);
+   return itor->ops->next(itor);
 }
 
 static inline void

--- a/src/iterator.h
+++ b/src/iterator.h
@@ -18,6 +18,7 @@ typedef struct iterator_ops {
    iterator_curr_fn  curr;
    iterator_valid_fn valid;
    iterator_step_fn  next;
+   iterator_step_fn  prev;
    iterator_print_fn print;
 } iterator_ops;
 
@@ -42,6 +43,12 @@ static inline platform_status
 iterator_next(iterator *itor)
 {
    return itor->ops->next(itor);
+}
+
+static inline platform_status
+iterator_prev(iterator *itor)
+{
+   return itor->ops->prev(itor);
 }
 
 static inline void

--- a/src/iterator.h
+++ b/src/iterator.h
@@ -11,6 +11,9 @@ typedef struct iterator iterator;
 typedef void (*iterator_curr_fn)(iterator *itor, key *curr_key, message *msg);
 typedef bool (*iterator_valid_fn)(iterator *itor);
 typedef platform_status (*iterator_step_fn)(iterator *itor);
+typedef platform_status (*iterator_seek_fn)(iterator *itor,
+                                            key       seek_key,
+                                            bool      from_above);
 typedef void (*iterator_print_fn)(iterator *itor);
 
 typedef struct iterator_ops {
@@ -19,6 +22,7 @@ typedef struct iterator_ops {
    iterator_valid_fn valid;
    iterator_step_fn  next;
    iterator_step_fn  prev;
+   iterator_seek_fn  seek;
    iterator_print_fn print;
 } iterator_ops;
 
@@ -49,6 +53,12 @@ static inline platform_status
 iterator_prev(iterator *itor)
 {
    return itor->ops->prev(itor);
+}
+
+static inline platform_status
+iterator_seek(iterator *itor, key seek_key, bool from_above)
+{
+   return itor->ops->seek(itor, seek_key, from_above);
 }
 
 static inline void

--- a/src/iterator.h
+++ b/src/iterator.h
@@ -17,7 +17,7 @@ typedef enum comparison {
 } comparison;
 
 typedef void (*iterator_curr_fn)(iterator *itor, key *curr_key, message *msg);
-typedef bool (*iterator_in_range_fn)(iterator *itor);
+typedef bool (*iterator_bound_fn)(iterator *itor);
 typedef platform_status (*iterator_step_fn)(iterator *itor);
 typedef platform_status (*iterator_seek_fn)(iterator  *itor,
                                             key        seek_key,
@@ -26,12 +26,13 @@ typedef void (*iterator_print_fn)(iterator *itor);
 
 typedef struct iterator_ops {
    /* Callers should not modify data pointed to by *key or *data */
-   iterator_curr_fn     curr;
-   iterator_in_range_fn in_range;
-   iterator_step_fn     next;
-   iterator_step_fn     prev;
-   iterator_seek_fn     seek;
-   iterator_print_fn    print;
+   iterator_curr_fn  curr;
+   iterator_bound_fn can_prev;
+   iterator_bound_fn can_next;
+   iterator_step_fn  next;
+   iterator_step_fn  prev;
+   iterator_seek_fn  seek;
+   iterator_print_fn print;
 } iterator_ops;
 
 // To sub-class iterator, make an iterator your first field
@@ -48,9 +49,21 @@ iterator_curr(iterator *itor, key *curr_key, message *msg)
 }
 
 static inline bool
-iterator_in_range(iterator *itor)
+iterator_can_prev(iterator *itor)
 {
-   return itor->ops->in_range(itor);
+   return itor->ops->can_prev(itor);
+}
+
+static inline bool
+iterator_can_next(iterator *itor)
+{
+   return itor->ops->can_next(itor);
+}
+
+static inline bool
+iterator_can_curr(iterator *itor)
+{
+   return itor->ops->can_next(itor) && itor->ops->can_prev(itor);
 }
 
 static inline platform_status

--- a/src/merge.c
+++ b/src/merge.c
@@ -644,7 +644,7 @@ bool
 merge_in_range(iterator *itor) // IN
 {
    merge_iterator *merge_itor = (merge_iterator *)itor;
-   debug_assert(!merge_itor->in_range == key_is_null(merge_itor->curr_key)
+   debug_assert(merge_itor->in_range != key_is_null(merge_itor->curr_key)
                 || !merge_itor->forwards);
    return merge_itor->in_range;
 }

--- a/src/merge.h
+++ b/src/merge.h
@@ -68,6 +68,8 @@ typedef struct merge_iterator {
    key          curr_key;      // current key
    message      curr_data;     // current data
 
+   bool forwards;
+
    // Padding so ordered_iterators[-1] is valid
    ordered_iterator ordered_iterator_stored_pad;
    ordered_iterator ordered_iterator_stored[MAX_MERGE_ARITY];

--- a/src/merge.h
+++ b/src/merge.h
@@ -62,13 +62,12 @@ typedef struct merge_iterator {
    bool         merge_messages;
    bool         finalize_updates;
    bool         emit_deletes;
-   bool         at_end;
+   bool         in_range;
    int          num_remaining; // number of ritors not at end
    data_config *cfg;           // point message tree data config
    key          curr_key;      // current key
    message      curr_data;     // current data
-
-   bool forwards;
+   bool         forwards;
 
    // Padding so ordered_iterators[-1] is valid
    ordered_iterator ordered_iterator_stored_pad;

--- a/src/merge.h
+++ b/src/merge.h
@@ -97,6 +97,7 @@ platform_status
 merge_iterator_create(platform_heap_id hid,
                       data_config     *cfg,
                       int              num_trees,
+                      bool             forwards,
                       iterator       **itor_arr,
                       merge_behavior   merge_mode,
                       merge_iterator **out_itor);

--- a/src/merge.h
+++ b/src/merge.h
@@ -62,7 +62,8 @@ typedef struct merge_iterator {
    bool         merge_messages;
    bool         finalize_updates;
    bool         emit_deletes;
-   bool         in_range;
+   bool         can_prev;
+   bool         can_next;
    int          num_remaining; // number of ritors not at end
    data_config *cfg;           // point message tree data config
    key          curr_key;      // current key
@@ -96,7 +97,6 @@ platform_status
 merge_iterator_create(platform_heap_id hid,
                       data_config     *cfg,
                       int              num_trees,
-                      bool             forwards,
                       iterator       **itor_arr,
                       merge_behavior   merge_mode,
                       merge_iterator **out_itor);

--- a/src/routing_filter.c
+++ b/src/routing_filter.c
@@ -1215,7 +1215,7 @@ routing_filter_verify(cache          *cc,
                       uint16          value,
                       iterator       *itor)
 {
-   while (iterator_in_range(itor)) {
+   while (iterator_can_next(itor)) {
       key     curr_key;
       message msg;
       iterator_curr(itor, &curr_key, &msg);

--- a/src/routing_filter.c
+++ b/src/routing_filter.c
@@ -1215,20 +1215,18 @@ routing_filter_verify(cache          *cc,
                       uint16          value,
                       iterator       *itor)
 {
-   bool at_end;
-   iterator_at_end(itor, &at_end);
-   while (!at_end) {
+   while (iterator_valid(itor)) {
       key     curr_key;
       message msg;
-      iterator_get_curr(itor, &curr_key, &msg);
+      iterator_curr(itor, &curr_key, &msg);
       debug_assert(key_is_user_key(curr_key));
       uint64          found_values;
       platform_status rc =
          routing_filter_lookup(cc, cfg, filter, curr_key, &found_values);
       platform_assert_status_ok(rc);
       platform_assert(routing_filter_is_value_found(found_values, value));
-      iterator_advance(itor);
-      iterator_at_end(itor, &at_end);
+      rc = iterator_next(itor);
+      platform_assert_status_ok(rc);
    }
 }
 

--- a/src/routing_filter.c
+++ b/src/routing_filter.c
@@ -1215,7 +1215,7 @@ routing_filter_verify(cache          *cc,
                       uint16          value,
                       iterator       *itor)
 {
-   while (iterator_valid(itor)) {
+   while (iterator_in_range(itor)) {
       key     curr_key;
       message msg;
       iterator_curr(itor, &curr_key, &msg);

--- a/src/shard_log.c
+++ b/src/shard_log.c
@@ -40,13 +40,16 @@ static log_ops shard_log_ops = {
 void
 shard_log_iterator_curr(iterator *itor, key *curr_key, message *msg);
 bool
-shard_log_iterator_in_range(iterator *itor);
+shard_log_iterator_can_prev(iterator *itor);
+bool
+shard_log_iterator_can_next(iterator *itor);
 platform_status
 shard_log_iterator_next(iterator *itor);
 
 const static iterator_ops shard_log_iterator_ops = {
    .curr     = shard_log_iterator_curr,
-   .in_range = shard_log_iterator_in_range,
+   .can_prev = shard_log_iterator_can_prev,
+   .can_next = shard_log_iterator_can_next,
    .next     = shard_log_iterator_next,
    .print    = NULL,
 };
@@ -436,10 +439,17 @@ shard_log_iterator_curr(iterator *itorh, key *curr_key, message *msg)
 }
 
 bool
-shard_log_iterator_in_range(iterator *itorh)
+shard_log_iterator_can_prev(iterator *itorh)
+{
+   // this iterator only goes forward so just return TRUE
+   return TRUE;
+}
+
+bool
+shard_log_iterator_can_next(iterator *itorh)
 {
    shard_log_iterator *itor = (shard_log_iterator *)itorh;
-   return itor->pos != itor->num_entries;
+   return itor->pos < itor->num_entries;
 }
 
 platform_status

--- a/src/shard_log.c
+++ b/src/shard_log.c
@@ -442,8 +442,8 @@ shard_log_iterator_curr(iterator *itorh, key *curr_key, message *msg)
 bool32
 shard_log_iterator_can_prev(iterator *itorh)
 {
-   // this iterator only goes forward so just return TRUE
-   return TRUE;
+   shard_log_iterator *itor = (shard_log_iterator *)itorh;
+   return itor->pos >= 0;
 }
 
 bool32

--- a/src/shard_log.c
+++ b/src/shard_log.c
@@ -38,17 +38,17 @@ static log_ops shard_log_ops = {
 };
 
 void
-shard_log_iterator_get_curr(iterator *itor, key *curr_key, message *msg);
+shard_log_iterator_curr(iterator *itor, key *curr_key, message *msg);
+bool
+shard_log_iterator_valid(iterator *itor);
 platform_status
-shard_log_iterator_at_end(iterator *itor, bool *at_end);
-platform_status
-shard_log_iterator_advance(iterator *itor);
+shard_log_iterator_next(iterator *itor);
 
 const static iterator_ops shard_log_iterator_ops = {
-   .get_curr = shard_log_iterator_get_curr,
-   .at_end   = shard_log_iterator_at_end,
-   .advance  = shard_log_iterator_advance,
-   .print    = NULL,
+   .curr  = shard_log_iterator_curr,
+   .valid = shard_log_iterator_valid,
+   .next  = shard_log_iterator_next,
+   .print = NULL,
 };
 
 static inline uint64
@@ -428,24 +428,22 @@ shard_log_iterator_deinit(platform_heap_id hid, shard_log_iterator *itor)
 }
 
 void
-shard_log_iterator_get_curr(iterator *itorh, key *curr_key, message *msg)
+shard_log_iterator_curr(iterator *itorh, key *curr_key, message *msg)
 {
    shard_log_iterator *itor = (shard_log_iterator *)itorh;
    *curr_key                = log_entry_key(itor->entries[itor->pos]);
    *msg                     = log_entry_message(itor->entries[itor->pos]);
 }
 
-platform_status
-shard_log_iterator_at_end(iterator *itorh, bool *at_end)
+bool
+shard_log_iterator_valid(iterator *itorh)
 {
    shard_log_iterator *itor = (shard_log_iterator *)itorh;
-   *at_end                  = itor->pos == itor->num_entries;
-
-   return STATUS_OK;
+   return itor->pos != itor->num_entries;
 }
 
 platform_status
-shard_log_iterator_advance(iterator *itorh)
+shard_log_iterator_next(iterator *itorh)
 {
    shard_log_iterator *itor = (shard_log_iterator *)itorh;
    itor->pos++;

--- a/src/shard_log.c
+++ b/src/shard_log.c
@@ -40,15 +40,15 @@ static log_ops shard_log_ops = {
 void
 shard_log_iterator_curr(iterator *itor, key *curr_key, message *msg);
 bool
-shard_log_iterator_valid(iterator *itor);
+shard_log_iterator_in_range(iterator *itor);
 platform_status
 shard_log_iterator_next(iterator *itor);
 
 const static iterator_ops shard_log_iterator_ops = {
-   .curr  = shard_log_iterator_curr,
-   .valid = shard_log_iterator_valid,
-   .next  = shard_log_iterator_next,
-   .print = NULL,
+   .curr     = shard_log_iterator_curr,
+   .in_range = shard_log_iterator_in_range,
+   .next     = shard_log_iterator_next,
+   .print    = NULL,
 };
 
 static inline uint64
@@ -436,7 +436,7 @@ shard_log_iterator_curr(iterator *itorh, key *curr_key, message *msg)
 }
 
 bool
-shard_log_iterator_valid(iterator *itorh)
+shard_log_iterator_in_range(iterator *itorh)
 {
    shard_log_iterator *itor = (shard_log_iterator *)itorh;
    return itor->pos != itor->num_entries;

--- a/src/splinterdb.c
+++ b/src/splinterdb.c
@@ -617,10 +617,10 @@ splinterdb_iterator_init(const splinterdb     *kvs,           // IN
 
    platform_status rc = trunk_range_iterator_init(kvs->spl,
                                                   range_itor,
-                                                  start_key,
+                                                  NEGATIVE_INFINITY_KEY,
                                                   POSITIVE_INFINITY_KEY,
                                                   start_key,
-                                                  TRUE,
+                                                  greater_than_or_equal,
                                                   UINT64_MAX);
    if (!SUCCESS(rc)) {
       platform_free(kvs->spl->heap_id, *iter);
@@ -649,7 +649,27 @@ splinterdb_iterator_valid(splinterdb_iterator *kvi)
       return FALSE;
    }
    iterator *itor = &(kvi->sri.super);
-   return iterator_in_range(itor);
+   return iterator_can_curr(itor);
+}
+
+_Bool
+splinterdb_iterator_can_prev(splinterdb_iterator *kvi)
+{
+   if (!SUCCESS(kvi->last_rc)) {
+      return FALSE;
+   }
+   iterator *itor = &(kvi->sri.super);
+   return iterator_can_prev(itor);
+}
+
+_Bool
+splinterdb_iterator_can_next(splinterdb_iterator *kvi)
+{
+   if (!SUCCESS(kvi->last_rc)) {
+      return FALSE;
+   }
+   iterator *itor = &(kvi->sri.super);
+   return iterator_can_next(itor);
 }
 
 void

--- a/src/splinterdb.c
+++ b/src/splinterdb.c
@@ -649,7 +649,7 @@ splinterdb_iterator_valid(splinterdb_iterator *kvi)
       return FALSE;
    }
    iterator *itor = &(kvi->sri.super);
-   return iterator_valid(itor);
+   return iterator_in_range(itor);
 }
 
 void

--- a/src/splinterdb.c
+++ b/src/splinterdb.c
@@ -643,20 +643,15 @@ splinterdb_iterator_valid(splinterdb_iterator *kvi)
    if (!SUCCESS(kvi->last_rc)) {
       return FALSE;
    }
-   bool      at_end;
    iterator *itor = &(kvi->sri.super);
-   kvi->last_rc   = iterator_at_end(itor, &at_end);
-   if (!SUCCESS(kvi->last_rc)) {
-      return FALSE;
-   }
-   return !at_end;
+   return iterator_valid(itor);
 }
 
 void
 splinterdb_iterator_next(splinterdb_iterator *kvi)
 {
    iterator *itor = &(kvi->sri.super);
-   kvi->last_rc   = iterator_advance(itor);
+   kvi->last_rc   = iterator_next(itor);
 }
 
 int
@@ -675,7 +670,7 @@ splinterdb_iterator_get_current(splinterdb_iterator *iter,   // IN
    message   msg;
    iterator *itor = &(iter->sri.super);
 
-   iterator_get_curr(itor, &result_key, &msg);
+   iterator_curr(itor, &result_key, &msg);
    *value  = message_slice(msg);
    *outkey = key_slice(result_key);
 }

--- a/src/splinterdb.c
+++ b/src/splinterdb.c
@@ -615,8 +615,13 @@ splinterdb_iterator_init(const splinterdb     *kvs,           // IN
       start_key = key_create_from_slice(user_start_key);
    }
 
-   platform_status rc = trunk_range_iterator_init(
-      kvs->spl, range_itor, start_key, POSITIVE_INFINITY_KEY, UINT64_MAX);
+   platform_status rc = trunk_range_iterator_init(kvs->spl,
+                                                  range_itor,
+                                                  start_key,
+                                                  POSITIVE_INFINITY_KEY,
+                                                  start_key,
+                                                  TRUE,
+                                                  UINT64_MAX);
    if (!SUCCESS(rc)) {
       platform_free(kvs->spl->heap_id, *iter);
       return platform_status_to_int(rc);
@@ -652,6 +657,13 @@ splinterdb_iterator_next(splinterdb_iterator *kvi)
 {
    iterator *itor = &(kvi->sri.super);
    kvi->last_rc   = iterator_next(itor);
+}
+
+void
+splinterdb_iterator_prev(splinterdb_iterator *kvi)
+{
+   iterator *itor = &(kvi->sri.super);
+   kvi->last_rc   = iterator_prev(itor);
 }
 
 int

--- a/src/trunk.c
+++ b/src/trunk.c
@@ -6079,7 +6079,7 @@ trunk_range_iterator_init(trunk_handle         *spl,
    }
    if (trunk_key_compare(spl, max_key, start_key) <= 0) {
       // out of bounds, start at max
-      start_key            = max_key;
+      start_key = max_key;
    }
 
    // copy over global min and max

--- a/src/trunk.c
+++ b/src/trunk.c
@@ -3344,6 +3344,7 @@ trunk_memtable_iterator_init(trunk_handle   *spl,
                        PAGE_TYPE_MEMTABLE,
                        min_key,
                        max_key,
+                       min_key,
                        FALSE,
                        0);
 }
@@ -4828,6 +4829,7 @@ trunk_branch_iterator_init(trunk_handle   *spl,
                        PAGE_TYPE_BRANCH,
                        min_key,
                        max_key,
+                       min_key,
                        do_prefetch,
                        0);
 }
@@ -5719,6 +5721,7 @@ trunk_split_leaf(trunk_handle *spl,
                              PAGE_TYPE_BRANCH,
                              min_key,
                              max_key,
+                             min_key,
                              TRUE,
                              1);
          rough_itor[branch_offset] = &rough_btree_itor[branch_offset].super;

--- a/src/trunk.c
+++ b/src/trunk.c
@@ -6080,10 +6080,7 @@ trunk_range_iterator_init(trunk_handle         *spl,
    if (trunk_key_compare(spl, max_key, start_key) <= 0) {
       // out of bounds, start at max
       start_key            = max_key;
-      range_itor->can_next = FALSE;
    }
-   platform_assert(!key_is_negative_infinity(start_key)
-                   || start_type >= less_than_or_equal);
 
    // copy over global min and max
    key_buffer_init_from_key(&range_itor->min_key, spl->heap_id, min_key);

--- a/src/trunk.c
+++ b/src/trunk.c
@@ -6065,10 +6065,11 @@ trunk_range_iterator_init(trunk_handle         *spl,
    key_buffer_init_from_key(&range_itor->min_key, spl->heap_id, min_key);
    key_buffer_init_from_key(&range_itor->max_key, spl->heap_id, max_key);
 
-   int comp                 = trunk_key_compare(spl, min_key, start_key);
-   range_itor->before_begin = key_is_negative_infinity(min_key) ? comp >= 0 && !forwards : comp > 0;
-   range_itor->after_end    = trunk_key_compare(spl, max_key, start_key) <= 0;
-   range_itor->merge_itor   = NULL;
+   int comp = trunk_key_compare(spl, min_key, start_key);
+   range_itor->before_begin =
+      key_is_negative_infinity(min_key) ? comp >= 0 && !forwards : comp > 0;
+   range_itor->after_end  = trunk_key_compare(spl, max_key, start_key) <= 0;
+   range_itor->merge_itor = NULL;
 
    if ((forwards && range_itor->after_end)
        || (!forwards && range_itor->before_begin))
@@ -6369,11 +6370,13 @@ trunk_range_iterator_prev(iterator *itor)
    range_itor->after_end    = FALSE;
 
    if (range_itor->before_begin) {
-      int  comp      = trunk_key_compare(range_itor->spl,
+      int  comp = trunk_key_compare(range_itor->spl,
                                    key_buffer_key(&range_itor->local_min_key),
                                    key_buffer_key(&range_itor->min_key));
-      bool more_data = key_is_negative_infinity(key_buffer_key(&range_itor->min_key))
-                          ? comp >= 0 : comp > 0;
+      bool more_data =
+         key_is_negative_infinity(key_buffer_key(&range_itor->min_key))
+            ? comp >= 0
+            : comp > 0;
       if (more_data) {
          KEY_CREATE_LOCAL_COPY(rc,
                                min_key,

--- a/src/trunk.h
+++ b/src/trunk.h
@@ -231,7 +231,8 @@ typedef struct trunk_range_iterator {
    uint64          memtable_end_gen;
    bool            compacted[TRUNK_RANGE_ITOR_MAX_BRANCHES];
    merge_iterator *merge_itor;
-   bool            in_range;
+   bool            can_prev;
+   bool            can_next;
    key_buffer      min_key;
    key_buffer      max_key;
    key_buffer      local_min_key;
@@ -351,8 +352,8 @@ trunk_range_iterator_init(trunk_handle         *spl,
                           trunk_range_iterator *range_itor,
                           key                   min_key,
                           key                   max_key,
-                          key                   curr_key,
-                          bool                  forwards,
+                          key                   start_key,
+                          comparison            start_type,
                           uint64                num_tuples);
 void
 trunk_range_iterator_deinit(trunk_range_iterator *range_itor);

--- a/src/trunk.h
+++ b/src/trunk.h
@@ -231,8 +231,7 @@ typedef struct trunk_range_iterator {
    uint64          memtable_end_gen;
    bool            compacted[TRUNK_RANGE_ITOR_MAX_BRANCHES];
    merge_iterator *merge_itor;
-   bool            before_begin;
-   bool            after_end;
+   bool            in_range;
    key_buffer      min_key;
    key_buffer      max_key;
    key_buffer      local_min_key;

--- a/src/trunk.h
+++ b/src/trunk.h
@@ -231,11 +231,12 @@ typedef struct trunk_range_iterator {
    uint64          memtable_end_gen;
    bool            compacted[TRUNK_RANGE_ITOR_MAX_BRANCHES];
    merge_iterator *merge_itor;
-   bool            at_end;
+   bool            before_begin;
+   bool            after_end;
    key_buffer      min_key;
    key_buffer      max_key;
+   key_buffer      local_min_key;
    key_buffer      local_max_key;
-   key_buffer      rebuild_key;
    btree_iterator  btree_itor[TRUNK_RANGE_ITOR_MAX_BRANCHES];
    trunk_branch    branch[TRUNK_RANGE_ITOR_MAX_BRANCHES];
 
@@ -351,6 +352,8 @@ trunk_range_iterator_init(trunk_handle         *spl,
                           trunk_range_iterator *range_itor,
                           key                   min_key,
                           key                   max_key,
+                          key                   curr_key,
+                          bool                  forwards,
                           uint64                num_tuples);
 void
 trunk_range_iterator_deinit(trunk_range_iterator *range_itor);

--- a/src/trunk.h
+++ b/src/trunk.h
@@ -231,8 +231,8 @@ typedef struct trunk_range_iterator {
    uint64          memtable_end_gen;
    bool32          compacted[TRUNK_RANGE_ITOR_MAX_BRANCHES];
    merge_iterator *merge_itor;
-   bool32            can_prev;
-   bool32            can_next;
+   bool32          can_prev;
+   bool32          can_next;
    key_buffer      min_key;
    key_buffer      max_key;
    key_buffer      local_min_key;

--- a/tests/functional/btree_test.c
+++ b/tests/functional/btree_test.c
@@ -665,6 +665,7 @@ test_btree_basic(cache             *cc,
                        NEGATIVE_INFINITY_KEY,
                        POSITIVE_INFINITY_KEY,
                        NEGATIVE_INFINITY_KEY,
+                       TRUE,
                        FALSE,
                        0);
    platform_default_log("btree iterator init time %luns\n",
@@ -840,6 +841,7 @@ test_btree_create_packed_trees(cache             *cc,
                           NEGATIVE_INFINITY_KEY,
                           POSITIVE_INFINITY_KEY,
                           NEGATIVE_INFINITY_KEY,
+                          TRUE,
                           FALSE,
                           0);
 
@@ -889,6 +891,7 @@ test_count_tuples_in_range(cache        *cc,
                           low_key,
                           high_key,
                           low_key,
+                          TRUE,
                           TRUE,
                           0);
       key last_key = NULL_KEY;
@@ -982,6 +985,7 @@ test_btree_print_all_keys(cache        *cc,
                           high_key,
                           low_key,
                           TRUE,
+                          TRUE,
                           0);
       while (iterator_valid(&itor.super)) {
          key     curr_key;
@@ -1058,12 +1062,18 @@ test_btree_merge_basic(cache             *cc,
                              hi,
                              lo,
                              TRUE,
+                             TRUE,
                              0);
          itor_arr[tree_no] = &btree_itor_arr[tree_no].super;
       }
       merge_iterator *merge_itor;
-      rc = merge_iterator_create(
-         hid, btree_cfg->data_cfg, arity, itor_arr, MERGE_FULL, &merge_itor);
+      rc = merge_iterator_create(hid,
+                                 btree_cfg->data_cfg,
+                                 arity,
+                                 TRUE,
+                                 itor_arr,
+                                 MERGE_FULL,
+                                 &merge_itor);
       if (!SUCCESS(rc)) {
          goto destroy_btrees;
       }
@@ -1277,6 +1287,7 @@ test_btree_rough_iterator(cache             *cc,
                           POSITIVE_INFINITY_KEY,
                           NEGATIVE_INFINITY_KEY,
                           TRUE,
+                          TRUE,
                           1);
       if (iterator_valid(&rough_btree_itor[tree_no].super)) {
          key     curr_key;
@@ -1291,6 +1302,7 @@ test_btree_rough_iterator(cache             *cc,
    rc = merge_iterator_create(hid,
                               btree_cfg->data_cfg,
                               num_trees,
+                              TRUE,
                               rough_itor,
                               MERGE_RAW,
                               &rough_merge_itor);
@@ -1436,12 +1448,18 @@ test_btree_merge_perf(cache             *cc,
                                 max_key,
                                 min_key,
                                 TRUE,
+                                TRUE,
                                 0);
             itor_arr[tree_no] = &btree_itor_arr[tree_no].super;
          }
          merge_iterator *merge_itor;
-         rc = merge_iterator_create(
-            hid, btree_cfg->data_cfg, arity, itor_arr, MERGE_FULL, &merge_itor);
+         rc = merge_iterator_create(hid,
+                                    btree_cfg->data_cfg,
+                                    arity,
+                                    TRUE,
+                                    itor_arr,
+                                    MERGE_FULL,
+                                    &merge_itor);
          if (!SUCCESS(rc)) {
             goto destroy_btrees;
          }

--- a/tests/functional/btree_test.c
+++ b/tests/functional/btree_test.c
@@ -664,6 +664,7 @@ test_btree_basic(cache             *cc,
                        PAGE_TYPE_MEMTABLE,
                        NEGATIVE_INFINITY_KEY,
                        POSITIVE_INFINITY_KEY,
+                       NEGATIVE_INFINITY_KEY,
                        FALSE,
                        0);
    platform_default_log("btree iterator init time %luns\n",
@@ -838,6 +839,7 @@ test_btree_create_packed_trees(cache             *cc,
                           PAGE_TYPE_MEMTABLE,
                           NEGATIVE_INFINITY_KEY,
                           POSITIVE_INFINITY_KEY,
+                          NEGATIVE_INFINITY_KEY,
                           FALSE,
                           0);
 
@@ -879,8 +881,16 @@ test_count_tuples_in_range(cache        *cc,
                           PAGE_TYPE_BRANCH);
          platform_assert(0);
       }
-      btree_iterator_init(
-         cc, cfg, &itor, root_addr[i], type, low_key, high_key, TRUE, 0);
+      btree_iterator_init(cc,
+                          cfg,
+                          &itor,
+                          root_addr[i],
+                          type,
+                          low_key,
+                          high_key,
+                          low_key,
+                          TRUE,
+                          0);
       key last_key = NULL_KEY;
       while (iterator_valid(&itor.super)) {
          key     curr_key;
@@ -963,8 +973,16 @@ test_btree_print_all_keys(cache        *cc,
    uint64         i;
    for (i = 0; i < num_trees; i++) {
       platform_default_log("tree number %lu\n", i);
-      btree_iterator_init(
-         cc, cfg, &itor, root_addr[i], type, low_key, high_key, TRUE, 0);
+      btree_iterator_init(cc,
+                          cfg,
+                          &itor,
+                          root_addr[i],
+                          type,
+                          low_key,
+                          high_key,
+                          low_key,
+                          TRUE,
+                          0);
       while (iterator_valid(&itor.super)) {
          key     curr_key;
          message data;
@@ -1038,6 +1056,7 @@ test_btree_merge_basic(cache             *cc,
                              PAGE_TYPE_BRANCH,
                              lo,
                              hi,
+                             lo,
                              TRUE,
                              0);
          itor_arr[tree_no] = &btree_itor_arr[tree_no].super;
@@ -1256,6 +1275,7 @@ test_btree_rough_iterator(cache             *cc,
                           PAGE_TYPE_BRANCH,
                           NEGATIVE_INFINITY_KEY,
                           POSITIVE_INFINITY_KEY,
+                          NEGATIVE_INFINITY_KEY,
                           TRUE,
                           1);
       if (iterator_valid(&rough_btree_itor[tree_no].super)) {
@@ -1414,6 +1434,7 @@ test_btree_merge_perf(cache             *cc,
                                 PAGE_TYPE_BRANCH,
                                 min_key,
                                 max_key,
+                                min_key,
                                 TRUE,
                                 0);
             itor_arr[tree_no] = &btree_itor_arr[tree_no].super;

--- a/tests/functional/btree_test.c
+++ b/tests/functional/btree_test.c
@@ -665,7 +665,7 @@ test_btree_basic(cache             *cc,
                        NEGATIVE_INFINITY_KEY,
                        POSITIVE_INFINITY_KEY,
                        NEGATIVE_INFINITY_KEY,
-                       TRUE,
+                       greater_than_or_equal,
                        FALSE,
                        0);
    platform_default_log("btree iterator init time %luns\n",
@@ -841,7 +841,7 @@ test_btree_create_packed_trees(cache             *cc,
                           NEGATIVE_INFINITY_KEY,
                           POSITIVE_INFINITY_KEY,
                           NEGATIVE_INFINITY_KEY,
-                          TRUE,
+                          greater_than_or_equal,
                           FALSE,
                           0);
 
@@ -891,11 +891,11 @@ test_count_tuples_in_range(cache        *cc,
                           low_key,
                           high_key,
                           low_key,
-                          TRUE,
+                          greater_than_or_equal,
                           TRUE,
                           0);
       key last_key = NULL_KEY;
-      while (iterator_valid(&itor.super)) {
+      while (iterator_in_range(&itor.super)) {
          key     curr_key;
          message data;
          iterator_curr(&itor.super, &curr_key, &data);
@@ -984,10 +984,10 @@ test_btree_print_all_keys(cache        *cc,
                           low_key,
                           high_key,
                           low_key,
-                          TRUE,
+                          greater_than_or_equal,
                           TRUE,
                           0);
-      while (iterator_valid(&itor.super)) {
+      while (iterator_in_range(&itor.super)) {
          key     curr_key;
          message data;
          iterator_curr(&itor.super, &curr_key, &data);
@@ -1061,7 +1061,7 @@ test_btree_merge_basic(cache             *cc,
                              lo,
                              hi,
                              lo,
-                             TRUE,
+                             greater_than_or_equal,
                              TRUE,
                              0);
          itor_arr[tree_no] = &btree_itor_arr[tree_no].super;
@@ -1286,10 +1286,10 @@ test_btree_rough_iterator(cache             *cc,
                           NEGATIVE_INFINITY_KEY,
                           POSITIVE_INFINITY_KEY,
                           NEGATIVE_INFINITY_KEY,
-                          TRUE,
+                          greater_than_or_equal,
                           TRUE,
                           1);
-      if (iterator_valid(&rough_btree_itor[tree_no].super)) {
+      if (iterator_in_range(&rough_btree_itor[tree_no].super)) {
          key     curr_key;
          message msg;
          iterator_curr(&rough_btree_itor[tree_no].super, &curr_key, &msg);
@@ -1310,7 +1310,7 @@ test_btree_rough_iterator(cache             *cc,
    // uint64 target_num_pivots =
    //   cfg->mt_cfg->max_tuples_per_memtable / btree_cfg->tuples_per_leaf;
 
-   bool at_end = !iterator_valid(&rough_merge_itor->super);
+   bool at_end = !iterator_in_range(&rough_merge_itor->super);
 
    uint64 pivot_no;
    for (pivot_no = 0; !at_end; pivot_no++) {
@@ -1447,7 +1447,7 @@ test_btree_merge_perf(cache             *cc,
                                 min_key,
                                 max_key,
                                 min_key,
-                                TRUE,
+                                greater_than_or_equal,
                                 TRUE,
                                 0);
             itor_arr[tree_no] = &btree_itor_arr[tree_no].super;

--- a/tests/functional/btree_test.c
+++ b/tests/functional/btree_test.c
@@ -895,7 +895,7 @@ test_count_tuples_in_range(cache        *cc,
                           TRUE,
                           0);
       key last_key = NULL_KEY;
-      while (iterator_in_range(&itor.super)) {
+      while (iterator_can_curr(&itor.super)) {
          key     curr_key;
          message data;
          iterator_curr(&itor.super, &curr_key, &data);
@@ -987,7 +987,7 @@ test_btree_print_all_keys(cache        *cc,
                           greater_than_or_equal,
                           TRUE,
                           0);
-      while (iterator_in_range(&itor.super)) {
+      while (iterator_can_curr(&itor.super)) {
          key     curr_key;
          message data;
          iterator_curr(&itor.super, &curr_key, &data);
@@ -1067,13 +1067,8 @@ test_btree_merge_basic(cache             *cc,
          itor_arr[tree_no] = &btree_itor_arr[tree_no].super;
       }
       merge_iterator *merge_itor;
-      rc = merge_iterator_create(hid,
-                                 btree_cfg->data_cfg,
-                                 arity,
-                                 TRUE,
-                                 itor_arr,
-                                 MERGE_FULL,
-                                 &merge_itor);
+      rc = merge_iterator_create(
+         hid, btree_cfg->data_cfg, arity, itor_arr, MERGE_FULL, &merge_itor);
       if (!SUCCESS(rc)) {
          goto destroy_btrees;
       }
@@ -1289,7 +1284,7 @@ test_btree_rough_iterator(cache             *cc,
                           greater_than_or_equal,
                           TRUE,
                           1);
-      if (iterator_in_range(&rough_btree_itor[tree_no].super)) {
+      if (iterator_can_curr(&rough_btree_itor[tree_no].super)) {
          key     curr_key;
          message msg;
          iterator_curr(&rough_btree_itor[tree_no].super, &curr_key, &msg);
@@ -1302,7 +1297,6 @@ test_btree_rough_iterator(cache             *cc,
    rc = merge_iterator_create(hid,
                               btree_cfg->data_cfg,
                               num_trees,
-                              TRUE,
                               rough_itor,
                               MERGE_RAW,
                               &rough_merge_itor);
@@ -1310,7 +1304,7 @@ test_btree_rough_iterator(cache             *cc,
    // uint64 target_num_pivots =
    //   cfg->mt_cfg->max_tuples_per_memtable / btree_cfg->tuples_per_leaf;
 
-   bool at_end = !iterator_in_range(&rough_merge_itor->super);
+   bool at_end = !iterator_can_curr(&rough_merge_itor->super);
 
    uint64 pivot_no;
    for (pivot_no = 0; !at_end; pivot_no++) {
@@ -1453,13 +1447,8 @@ test_btree_merge_perf(cache             *cc,
             itor_arr[tree_no] = &btree_itor_arr[tree_no].super;
          }
          merge_iterator *merge_itor;
-         rc = merge_iterator_create(hid,
-                                    btree_cfg->data_cfg,
-                                    arity,
-                                    TRUE,
-                                    itor_arr,
-                                    MERGE_FULL,
-                                    &merge_itor);
+         rc = merge_iterator_create(
+            hid, btree_cfg->data_cfg, arity, itor_arr, MERGE_FULL, &merge_itor);
          if (!SUCCESS(rc)) {
             goto destroy_btrees;
          }

--- a/tests/functional/btree_test.c
+++ b/tests/functional/btree_test.c
@@ -866,8 +866,9 @@ test_count_tuples_in_range(cache        *cc,
                            key           high_key,
                            uint64       *count) // OUTPUT
 {
-   btree_iterator itor;
-   uint64         i;
+   platform_status rc;
+   btree_iterator  itor;
+   uint64          i;
    *count = 0;
    for (i = 0; i < num_trees; i++) {
       if (!btree_verify_tree(cc, cfg, root_addr[i], type)) {
@@ -880,13 +881,11 @@ test_count_tuples_in_range(cache        *cc,
       }
       btree_iterator_init(
          cc, cfg, &itor, root_addr[i], type, low_key, high_key, TRUE, 0);
-      bool at_end;
-      iterator_at_end(&itor.super, &at_end);
       key last_key = NULL_KEY;
-      while (!at_end) {
+      while (iterator_valid(&itor.super)) {
          key     curr_key;
          message data;
-         iterator_get_curr(&itor.super, &curr_key, &data);
+         iterator_curr(&itor.super, &curr_key, &data);
          if (!key_is_null(last_key)
              && data_key_compare(cfg->data_cfg, last_key, curr_key) > 0)
          {
@@ -938,13 +937,17 @@ test_count_tuples_in_range(cache        *cc,
             platform_assert(0);
          }
          (*count)++;
-         iterator_advance(&itor.super);
-         iterator_at_end(&itor.super, &at_end);
+         rc = iterator_next(&itor.super);
+         if (!SUCCESS(rc)) {
+            btree_iterator_deinit(&itor);
+            goto out;
+         }
       }
       btree_iterator_deinit(&itor);
    }
 
-   return STATUS_OK;
+out:
+   return rc;
 }
 
 static inline int
@@ -962,17 +965,18 @@ test_btree_print_all_keys(cache        *cc,
       platform_default_log("tree number %lu\n", i);
       btree_iterator_init(
          cc, cfg, &itor, root_addr[i], type, low_key, high_key, TRUE, 0);
-      bool at_end;
-      iterator_at_end(&itor.super, &at_end);
-      while (!at_end) {
+      while (iterator_valid(&itor.super)) {
          key     curr_key;
          message data;
-         iterator_get_curr(&itor.super, &curr_key, &data);
+         iterator_curr(&itor.super, &curr_key, &data);
          char key_str[128];
          data_key_to_string(cfg->data_cfg, curr_key, key_str, 128);
          platform_default_log("%s\n", key_str);
-         iterator_advance(&itor.super);
-         iterator_at_end(&itor.super, &at_end);
+         platform_status rc = iterator_next(&itor.super);
+         if (!SUCCESS(rc)) {
+            btree_iterator_deinit(&itor);
+            return -1;
+         }
       }
       btree_iterator_deinit(&itor);
    }
@@ -1244,7 +1248,6 @@ test_btree_rough_iterator(cache             *cc,
    iterator **rough_itor = TYPED_ARRAY_MALLOC(hid, rough_itor, num_trees);
    platform_assert(rough_itor);
 
-   bool at_end;
    for (uint64 tree_no = 0; tree_no < num_trees; tree_no++) {
       btree_iterator_init(cc,
                           btree_cfg,
@@ -1255,12 +1258,10 @@ test_btree_rough_iterator(cache             *cc,
                           POSITIVE_INFINITY_KEY,
                           TRUE,
                           1);
-      if (SUCCESS(iterator_at_end(&rough_btree_itor[tree_no].super, &at_end))
-          && !at_end)
-      {
+      if (iterator_valid(&rough_btree_itor[tree_no].super)) {
          key     curr_key;
          message msg;
-         iterator_get_curr(&rough_btree_itor[tree_no].super, &curr_key, &msg);
+         iterator_curr(&rough_btree_itor[tree_no].super, &curr_key, &msg);
          platform_default_log("key size: %lu\n", key_length(curr_key));
       }
       rough_itor[tree_no] = &rough_btree_itor[tree_no].super;
@@ -1277,14 +1278,14 @@ test_btree_rough_iterator(cache             *cc,
    // uint64 target_num_pivots =
    //   cfg->mt_cfg->max_tuples_per_memtable / btree_cfg->tuples_per_leaf;
 
-   iterator_at_end(&rough_merge_itor->super, &at_end);
+   bool at_end = !iterator_valid(&rough_merge_itor->super);
 
    uint64 pivot_no;
    for (pivot_no = 0; !at_end; pivot_no++) {
       // uint64 rough_count_pivots = 0;
       key     curr_key;
       message dummy_data;
-      iterator_get_curr(&rough_merge_itor->super, &curr_key, &dummy_data);
+      iterator_curr(&rough_merge_itor->super, &curr_key, &dummy_data);
       if (key_length(curr_key) != btree_cfg->data_cfg->max_key_size) {
          platform_default_log("Weird key length: %lu should be: %lu\n",
                               key_length(curr_key),

--- a/tests/functional/log_test.c
+++ b/tests/functional/log_test.c
@@ -81,7 +81,7 @@ test_log_crash(clockcache             *cc,
    platform_assert_status_ok(rc);
    itorh = (iterator *)&itor;
 
-   for (i = 0; i < num_entries && iterator_valid(itorh); i++) {
+   for (i = 0; i < num_entries && iterator_in_range(itorh); i++) {
       key skey = test_key(&keybuffer,
                           TEST_RANDOM,
                           i,

--- a/tests/functional/log_test.c
+++ b/tests/functional/log_test.c
@@ -45,7 +45,6 @@ test_log_crash(clockcache             *cc,
    iterator          *itorh = (iterator *)&itor;
    char               key_str[128];
    char               data_str[128];
-   bool               at_end;
    merge_accumulator  msg;
    DECLARE_AUTO_KEY_BUFFER(keybuffer, hid);
 
@@ -82,8 +81,7 @@ test_log_crash(clockcache             *cc,
    platform_assert_status_ok(rc);
    itorh = (iterator *)&itor;
 
-   iterator_at_end(itorh, &at_end);
-   for (i = 0; i < num_entries && !at_end; i++) {
+   for (i = 0; i < num_entries && iterator_valid(itorh); i++) {
       key skey = test_key(&keybuffer,
                           TEST_RANDOM,
                           i,
@@ -93,7 +91,7 @@ test_log_crash(clockcache             *cc,
                           0);
       generate_test_message(gen, i, &msg);
       message mmessage = merge_accumulator_to_message(&msg);
-      iterator_get_curr(itorh, &returned_key, &returned_message);
+      iterator_curr(itorh, &returned_key, &returned_message);
       if (data_key_compare(cfg->data_cfg, skey, returned_key)
           || message_lex_cmp(mmessage, returned_message))
       {
@@ -106,8 +104,8 @@ test_log_crash(clockcache             *cc,
          platform_default_log("actual: %s -- %s\n", key_str, data_str);
          platform_assert(0);
       }
-      iterator_advance(itorh);
-      iterator_at_end(itorh, &at_end);
+      rc = iterator_next(itorh);
+      platform_assert_status_ok(rc);
    }
 
    platform_default_log("log returned %lu of %lu entries\n", i, num_entries);

--- a/tests/functional/log_test.c
+++ b/tests/functional/log_test.c
@@ -81,7 +81,7 @@ test_log_crash(clockcache             *cc,
    platform_assert_status_ok(rc);
    itorh = (iterator *)&itor;
 
-   for (i = 0; i < num_entries && iterator_in_range(itorh); i++) {
+   for (i = 0; i < num_entries && iterator_can_curr(itorh); i++) {
       key skey = test_key(&keybuffer,
                           TEST_RANDOM,
                           i,

--- a/tests/functional/test_functionality.c
+++ b/tests/functional/test_functionality.c
@@ -32,20 +32,20 @@ static void
 search_for_key_via_iterator(trunk_handle *spl, key target)
 {
    trunk_range_iterator iter;
-   bool                 at_end;
 
    trunk_range_iterator_init(
       spl, &iter, NEGATIVE_INFINITY_KEY, POSITIVE_INFINITY_KEY, UINT64_MAX);
    uint64 count = 0;
-   while (SUCCESS(iterator_at_end((iterator *)&iter, &at_end)) && !at_end) {
+   while (iterator_valid((iterator *)&iter)) {
       key     curr_key;
       message value;
-      iterator_get_curr((iterator *)&iter, &curr_key, &value);
+      iterator_curr((iterator *)&iter, &curr_key, &value);
       if (data_key_compare(spl->cfg.data_cfg, target, curr_key) == 0) {
          platform_error_log("Found missing key %s\n",
                             key_string(spl->cfg.data_cfg, target));
       }
-      iterator_advance((iterator *)&iter);
+      platform_status rc = iterator_next((iterator *)&iter);
+      platform_assert_status_ok(rc);
       count++;
    }
    platform_default_log("Saw a total of %lu keys\n", count);
@@ -227,7 +227,6 @@ verify_range_against_shadow(trunk_handle               *spl,
    const data_handle *splinter_data_handle;
    uint64             splinter_key;
    uint64             i;
-   bool               at_end;
 
    platform_assert(start_index <= sharr->nkeys);
    platform_assert(end_index <= sharr->nkeys);
@@ -250,19 +249,13 @@ verify_range_against_shadow(trunk_handle               *spl,
          continue;
       }
 
-      status = iterator_at_end((iterator *)range_itor, &at_end);
-      if (!SUCCESS(status) || at_end) {
-         platform_error_log("ERROR: range itor failed or terminated "
-                            "early (at_end = %d): %s\n",
-                            at_end,
-                            platform_status_to_string(status));
-         if (SUCCESS(status)) {
-            status = STATUS_NO_PERMISSION;
-         }
+      if (!iterator_valid((iterator *)range_itor)) {
+         platform_error_log("ERROR: range itor terminated early\n");
+         status = STATUS_NO_PERMISSION;
          goto destroy;
       }
 
-      iterator_get_curr(
+      iterator_curr(
          (iterator *)range_itor, &splinter_keybuf, &splinter_message);
       splinter_key         = be64toh(*(uint64 *)key_data(splinter_keybuf));
       splinter_data_handle = message_data(splinter_message);
@@ -287,16 +280,15 @@ verify_range_against_shadow(trunk_handle               *spl,
       verify_tuple(
          spl, splinter_keybuf, splinter_message, shadow_refcount, &status);
 
-      status = iterator_advance((iterator *)range_itor);
+      status = iterator_next((iterator *)range_itor);
       if (!SUCCESS(status)) {
          goto destroy;
       }
    }
 
-   while (SUCCESS(iterator_at_end((iterator *)range_itor, &at_end)) && !at_end)
-   {
+   while (iterator_valid((iterator *)range_itor)) {
       status = STATUS_LIMIT_EXCEEDED;
-      iterator_get_curr(
+      iterator_curr(
          (iterator *)range_itor, &splinter_keybuf, &splinter_message);
       splinter_key = be64toh(*(uint64 *)key_data(splinter_keybuf));
 
@@ -304,7 +296,7 @@ verify_range_against_shadow(trunk_handle               *spl,
                            "Tree Refcount %3d\n",
                            splinter_key,
                            splinter_data_handle->ref_count);
-      if (!SUCCESS(iterator_advance((iterator *)range_itor))) {
+      if (!SUCCESS(iterator_next((iterator *)range_itor))) {
          goto destroy;
       }
    }

--- a/tests/functional/test_functionality.c
+++ b/tests/functional/test_functionality.c
@@ -33,8 +33,13 @@ search_for_key_via_iterator(trunk_handle *spl, key target)
 {
    trunk_range_iterator iter;
 
-   trunk_range_iterator_init(
-      spl, &iter, NEGATIVE_INFINITY_KEY, POSITIVE_INFINITY_KEY, UINT64_MAX);
+   trunk_range_iterator_init(spl,
+                             &iter,
+                             NEGATIVE_INFINITY_KEY,
+                             POSITIVE_INFINITY_KEY,
+                             NEGATIVE_INFINITY_KEY,
+                             TRUE,
+                             UINT64_MAX);
    uint64 count = 0;
    while (iterator_valid((iterator *)&iter)) {
       key     curr_key;
@@ -233,8 +238,13 @@ verify_range_against_shadow(trunk_handle               *spl,
 
    trunk_range_iterator *range_itor = TYPED_MALLOC(hid, range_itor);
    platform_assert(range_itor != NULL);
-   status = trunk_range_iterator_init(
-      spl, range_itor, start_key, end_key, end_index - start_index);
+   status = trunk_range_iterator_init(spl,
+                                      range_itor,
+                                      start_key,
+                                      end_key,
+                                      start_key,
+                                      TRUE,
+                                      end_index - start_index);
    if (!SUCCESS(status)) {
       platform_error_log("failed to create range itor: %s\n",
                          platform_status_to_string(status));

--- a/tests/functional/test_functionality.c
+++ b/tests/functional/test_functionality.c
@@ -38,10 +38,10 @@ search_for_key_via_iterator(trunk_handle *spl, key target)
                              NEGATIVE_INFINITY_KEY,
                              POSITIVE_INFINITY_KEY,
                              NEGATIVE_INFINITY_KEY,
-                             TRUE,
+                             greater_than_or_equal,
                              UINT64_MAX);
    uint64 count = 0;
-   while (iterator_in_range((iterator *)&iter)) {
+   while (iterator_can_curr((iterator *)&iter)) {
       key     curr_key;
       message value;
       iterator_curr((iterator *)&iter, &curr_key, &value);
@@ -243,7 +243,7 @@ verify_range_against_shadow(trunk_handle               *spl,
                                       start_key,
                                       end_key,
                                       start_key,
-                                      TRUE,
+                                      greater_than_or_equal,
                                       end_index - start_index);
    if (!SUCCESS(status)) {
       platform_error_log("failed to create range itor: %s\n",
@@ -259,7 +259,7 @@ verify_range_against_shadow(trunk_handle               *spl,
          continue;
       }
 
-      if (!iterator_in_range((iterator *)range_itor)) {
+      if (!iterator_can_curr((iterator *)range_itor)) {
          platform_error_log("ERROR: range itor terminated early\n");
          status = STATUS_NO_PERMISSION;
          goto destroy;
@@ -296,7 +296,7 @@ verify_range_against_shadow(trunk_handle               *spl,
       }
    }
 
-   while (iterator_in_range((iterator *)range_itor)) {
+   while (iterator_can_curr((iterator *)range_itor)) {
       status = STATUS_LIMIT_EXCEEDED;
       iterator_curr(
          (iterator *)range_itor, &splinter_keybuf, &splinter_message);

--- a/tests/functional/test_functionality.c
+++ b/tests/functional/test_functionality.c
@@ -41,7 +41,7 @@ search_for_key_via_iterator(trunk_handle *spl, key target)
                              TRUE,
                              UINT64_MAX);
    uint64 count = 0;
-   while (iterator_valid((iterator *)&iter)) {
+   while (iterator_in_range((iterator *)&iter)) {
       key     curr_key;
       message value;
       iterator_curr((iterator *)&iter, &curr_key, &value);
@@ -259,7 +259,7 @@ verify_range_against_shadow(trunk_handle               *spl,
          continue;
       }
 
-      if (!iterator_valid((iterator *)range_itor)) {
+      if (!iterator_in_range((iterator *)range_itor)) {
          platform_error_log("ERROR: range itor terminated early\n");
          status = STATUS_NO_PERMISSION;
          goto destroy;
@@ -296,7 +296,7 @@ verify_range_against_shadow(trunk_handle               *spl,
       }
    }
 
-   while (iterator_valid((iterator *)range_itor)) {
+   while (iterator_in_range((iterator *)range_itor)) {
       status = STATUS_LIMIT_EXCEEDED;
       iterator_curr(
          (iterator *)range_itor, &splinter_keybuf, &splinter_message);

--- a/tests/unit/btree_stress_test.c
+++ b/tests/unit/btree_stress_test.c
@@ -425,18 +425,17 @@ iterator_tests(cache           *cc,
 
    iterator *iter = (iterator *)&dbiter;
 
-   uint64 seen = 0;
-   bool   at_end;
+   uint64 seen    = 0;
    uint8 *prevbuf = TYPED_MANUAL_MALLOC(hid, prevbuf, btree_page_size(cfg));
    key    prev    = NULL_KEY;
    uint8 *keybuf  = TYPED_MANUAL_MALLOC(hid, keybuf, btree_page_size(cfg));
    uint8 *msgbuf  = TYPED_MANUAL_MALLOC(hid, msgbuf, btree_page_size(cfg));
 
-   while (SUCCESS(iterator_at_end(iter, &at_end)) && !at_end) {
+   while (iterator_valid(iter)) {
       key     curr_key;
       message msg;
 
-      iterator_get_curr(iter, &curr_key, &msg);
+      iterator_curr(iter, &curr_key, &msg);
       uint64 k = ungen_key(curr_key);
       ASSERT_TRUE(k < nkvs);
 
@@ -456,7 +455,7 @@ iterator_tests(cache           *cc,
       prev = key_create(key_length(curr_key), prevbuf);
       key_copy_contents(prevbuf, curr_key);
 
-      if (!SUCCESS(iterator_advance(iter))) {
+      if (!SUCCESS(iterator_next(iter))) {
          break;
       }
    }

--- a/tests/unit/btree_stress_test.c
+++ b/tests/unit/btree_stress_test.c
@@ -518,6 +518,7 @@ iterator_tests(cache           *cc,
                        NEGATIVE_INFINITY_KEY,
                        POSITIVE_INFINITY_KEY,
                        start_key,
+                       TRUE,
                        FALSE,
                        0);
 
@@ -566,6 +567,7 @@ iterator_seek_tests(cache           *cc,
                        NEGATIVE_INFINITY_KEY,
                        POSITIVE_INFINITY_KEY,
                        start_key,
+                       TRUE,
                        FALSE,
                        0);
    iterator *iter = (iterator *)&dbiter;
@@ -607,6 +609,7 @@ pack_tests(cache           *cc,
                        NEGATIVE_INFINITY_KEY,
                        POSITIVE_INFINITY_KEY,
                        NEGATIVE_INFINITY_KEY,
+                       TRUE,
                        FALSE,
                        0);
 

--- a/tests/unit/btree_stress_test.c
+++ b/tests/unit/btree_stress_test.c
@@ -448,7 +448,7 @@ iterator_test(platform_heap_id hid,
    uint8 *keybuf  = TYPED_MANUAL_MALLOC(hid, keybuf, btree_page_size(cfg));
    uint8 *msgbuf  = TYPED_MANUAL_MALLOC(hid, msgbuf, btree_page_size(cfg));
 
-   while (iterator_valid(iter)) {
+   while (iterator_in_range(iter)) {
       key     curr_key;
       message msg;
 
@@ -518,7 +518,7 @@ iterator_tests(cache           *cc,
                        NEGATIVE_INFINITY_KEY,
                        POSITIVE_INFINITY_KEY,
                        start_key,
-                       TRUE,
+                       greater_than_or_equal,
                        FALSE,
                        0);
 
@@ -527,7 +527,7 @@ iterator_tests(cache           *cc,
    if (!start_front) {
       iterator_prev(iter);
    }
-   bool nonempty = iterator_valid(iter);
+   bool nonempty = iterator_in_range(iter);
 
    ASSERT_EQUAL(nkvs, iterator_test(hid, cfg, nkvs, iter, start_front));
    if (nonempty) {
@@ -567,7 +567,7 @@ iterator_seek_tests(cache           *cc,
                        NEGATIVE_INFINITY_KEY,
                        POSITIVE_INFINITY_KEY,
                        start_key,
-                       TRUE,
+                       greater_than_or_equal,
                        FALSE,
                        0);
    iterator *iter = (iterator *)&dbiter;
@@ -609,7 +609,7 @@ pack_tests(cache           *cc,
                        NEGATIVE_INFINITY_KEY,
                        POSITIVE_INFINITY_KEY,
                        NEGATIVE_INFINITY_KEY,
-                       TRUE,
+                       greater_than_or_equal,
                        FALSE,
                        0);
 

--- a/tests/unit/btree_stress_test.c
+++ b/tests/unit/btree_stress_test.c
@@ -448,7 +448,7 @@ iterator_test(platform_heap_id hid,
    uint8 *keybuf  = TYPED_MANUAL_MALLOC(hid, keybuf, btree_page_size(cfg));
    uint8 *msgbuf  = TYPED_MANUAL_MALLOC(hid, msgbuf, btree_page_size(cfg));
 
-   while (iterator_in_range(iter)) {
+   while (iterator_can_curr(iter)) {
       key     curr_key;
       message msg;
 
@@ -527,7 +527,7 @@ iterator_tests(cache           *cc,
    if (!start_front) {
       iterator_prev(iter);
    }
-   bool nonempty = iterator_in_range(iter);
+   bool nonempty = iterator_can_curr(iter);
 
    ASSERT_EQUAL(nkvs, iterator_test(hid, cfg, nkvs, iter, start_front));
    if (nonempty) {

--- a/tests/unit/btree_stress_test.c
+++ b/tests/unit/btree_stress_test.c
@@ -64,7 +64,7 @@ iterator_tests(cache           *cc,
                btree_config    *cfg,
                uint64           root_addr,
                int              nkvs,
-               bool32             start_front,
+               bool32           start_front,
                platform_heap_id hid);
 
 static int
@@ -440,7 +440,7 @@ iterator_test(platform_heap_id hid,
               btree_config    *cfg,
               uint64           nkvs,
               iterator        *iter,
-              bool32             forwards)
+              bool32           forwards)
 {
    uint64 seen    = 0;
    uint8 *prevbuf = TYPED_MANUAL_MALLOC(hid, prevbuf, btree_page_size(cfg));
@@ -499,7 +499,7 @@ iterator_tests(cache           *cc,
                btree_config    *cfg,
                uint64           root_addr,
                int              nkvs,
-               bool32             start_front,
+               bool32           start_front,
                platform_heap_id hid)
 {
    btree_iterator dbiter;

--- a/tests/unit/btree_test.c
+++ b/tests/unit/btree_test.c
@@ -170,7 +170,7 @@ leaf_hdr_tests(btree_config *cfg, btree_scratch *scratch, platform_heap_id hid)
     * or the size of a btree leafy entry, then this number will need
     * to be changed, and that's fine.
     */
-   int nkvs = 209;
+   int nkvs = 208;
 
    btree_init_hdr(cfg, hdr);
 

--- a/tests/unit/splinterdb_quick_test.c
+++ b/tests/unit/splinterdb_quick_test.c
@@ -634,7 +634,7 @@ CTEST2(splinterdb_quick,
    }
 }
 
-CTEST2(splinterdb_quick, test_iterator_prev)
+CTEST2(splinterdb_quick, test_iterator_prev_and_next)
 {
    const int num_inserts = 1 << 14;
    // Should insert keys: 1, 4, 7, 10 13, 16, 19, ...
@@ -1088,10 +1088,11 @@ test_two_step_iterator(splinterdb *kvsb,
    ASSERT_FALSE(is_valid);
    rc = splinterdb_iterator_status(it);
    ASSERT_EQUAL(0, rc);
+   ASSERT_TRUE(splinterdb_iterator_can_prev(it));
 
    // Start going down
    splinterdb_iterator_prev(it);
-   for (int i = num_keys - 1; i >= start_i; i--) {
+   for (int i = num_keys - 1; i >= 0; i--) {
       bool is_valid = splinterdb_iterator_valid(it);
       ASSERT_TRUE(is_valid);
       check_current_tuple(it, i * hop_i + minkey);

--- a/tests/unit/splinterdb_quick_test.c
+++ b/tests/unit/splinterdb_quick_test.c
@@ -66,7 +66,12 @@ static int
 check_current_tuple(splinterdb_iterator *it, const int expected_i);
 
 static int
-test_two_step_iterator(splinterdb *kvsb, slice start_key, int num_keys, int minkey, int start_i, int hop_i);
+test_two_step_iterator(splinterdb *kvsb,
+                       slice       start_key,
+                       int         num_keys,
+                       int         minkey,
+                       int         start_i,
+                       int         hop_i);
 
 static int
 custom_key_comparator(const data_config *cfg, slice key1, slice key2);
@@ -641,18 +646,25 @@ CTEST2(splinterdb_quick, test_iterator_prev)
    char key[TEST_INSERT_KEY_LENGTH];
 
    // test starting with a null key
-   ASSERT_EQUAL(0, test_two_step_iterator(data->kvsb, NULL_SLICE, num_inserts, minkey, 0, hop_amt));
+   ASSERT_EQUAL(0,
+                test_two_step_iterator(
+                   data->kvsb, NULL_SLICE, num_inserts, minkey, 0, hop_amt));
 
    // test starting == minkey
    snprintf(key, sizeof(key), key_fmt, minkey);
    slice start_key = slice_create(strlen(key), key);
-   ASSERT_EQUAL(0, test_two_step_iterator(data->kvsb, start_key, num_inserts, minkey, 0, hop_amt));
+   ASSERT_EQUAL(0,
+                test_two_step_iterator(
+                   data->kvsb, start_key, num_inserts, minkey, 0, hop_amt));
 
    // test starting between two keys
    int start_i = num_inserts / 4;
    snprintf(key, sizeof(key), key_fmt, hop_amt * start_i + minkey - 1);
    start_key = slice_create(strlen(key), key);
-   ASSERT_EQUAL(0, test_two_step_iterator(data->kvsb, start_key, num_inserts, minkey, start_i, hop_amt));
+   ASSERT_EQUAL(
+      0,
+      test_two_step_iterator(
+         data->kvsb, start_key, num_inserts, minkey, start_i, hop_amt));
 }
 
 /*
@@ -1041,11 +1053,16 @@ check_current_tuple(splinterdb_iterator *it, const int expected_i)
 
 // Test moving iterator 2 steps up, 1 step back and then all the way back down
 static int
-test_two_step_iterator(splinterdb *kvsb, slice start_key, int num_keys, int minkey, int start_i, int hop_i)
+test_two_step_iterator(splinterdb *kvsb,
+                       slice       start_key,
+                       int         num_keys,
+                       int         minkey,
+                       int         start_i,
+                       int         hop_i)
 {
-   int rc;
+   int                  rc;
    splinterdb_iterator *it = NULL;
-   rc = splinterdb_iterator_init(kvsb, &it, start_key);
+   rc                      = splinterdb_iterator_init(kvsb, &it, start_key);
    ASSERT_EQUAL(0, rc);
 
    for (int i = start_i; i < num_keys; i++) {

--- a/tests/unit/splinterdb_quick_test.c
+++ b/tests/unit/splinterdb_quick_test.c
@@ -44,10 +44,10 @@
 #define TEST_MAX_VALUE_SIZE 32
 
 // Hard-coded format strings to generate key and values
-static const char key_fmt[] = "key-%08x";
-static const char val_fmt[] = "val-%20x";
-#define KEY_FMT_LENGTH         (12)
-#define VAL_FMT_LENGTH         (24)
+static const char key_fmt[] = "key-%04x";
+static const char val_fmt[] = "val-%04x";
+#define KEY_FMT_LENGTH         (8)
+#define VAL_FMT_LENGTH         (8)
 #define TEST_INSERT_KEY_LENGTH (KEY_FMT_LENGTH + 1)
 #define TEST_INSERT_VAL_LENGTH (VAL_FMT_LENGTH + 1)
 

--- a/tests/unit/splinterdb_stress_test.c
+++ b/tests/unit/splinterdb_stress_test.c
@@ -140,6 +140,82 @@ CTEST2(splinterdb_stress, test_naive_range_delete)
 }
 
 /*
+ * Test case that inserts a large number of KV-pairs and then performs a
+ * range query over them, backwards and then forwards.
+ */
+#define KEY_SIZE 13
+CTEST2(splinterdb_stress, test_iterator_over_many_kvs)
+{
+   char         key_str[KEY_SIZE];
+   char        *value_str = "This is the value string\0";
+   const uint32 inserts   = 1 << 25; // 16 million
+   for (int i = 0; i < inserts; i++) {
+      snprintf(key_str, sizeof(key_str), "key-%08x", i);
+      slice key = slice_create(sizeof(key_str), key_str);
+      slice val = slice_create(sizeof(value_str), value_str);
+      ASSERT_EQUAL(0, splinterdb_insert(data->kvsb, key, val));
+   }
+
+   // create an iterator at end of keys
+   splinterdb_iterator *it = NULL;
+   snprintf(key_str, sizeof(key_str), "key-%08x", inserts);
+   slice start_key = slice_create(sizeof(key_str), key_str);
+   ASSERT_EQUAL(0, splinterdb_iterator_init(data->kvsb, &it, start_key));
+
+   // assert that the iterator is in the state we expect
+   ASSERT_FALSE(splinterdb_iterator_valid(it));
+   ASSERT_FALSE(splinterdb_iterator_can_next(it));
+   ASSERT_TRUE(splinterdb_iterator_can_prev(it));
+   ASSERT_EQUAL(0, splinterdb_iterator_status(it));
+
+   splinterdb_iterator_prev(it);
+
+   // iterate down all the keys
+   for (int i = inserts - 1; i >= 0; i--) {
+      ASSERT_TRUE(splinterdb_iterator_valid(it));
+      slice key;
+      slice val;
+      splinterdb_iterator_get_current(it, &key, &val);
+      snprintf(key_str, sizeof(key_str), "key-%08x", i);
+
+      ASSERT_EQUAL(KEY_SIZE, slice_length(key));
+      int comp = memcmp(slice_data(key), key_str, slice_length(key));
+      ASSERT_EQUAL(0, comp);
+      splinterdb_iterator_prev(it);
+   }
+
+   // assert that the iterator is in the state we expect
+   ASSERT_FALSE(splinterdb_iterator_valid(it));
+   ASSERT_TRUE(splinterdb_iterator_can_next(it));
+   ASSERT_FALSE(splinterdb_iterator_can_prev(it));
+   ASSERT_EQUAL(0, splinterdb_iterator_status(it));
+
+   splinterdb_iterator_next(it);
+
+   // iterate back up all the keys
+   for (int i = 0; i < inserts; i++) {
+      ASSERT_TRUE(splinterdb_iterator_valid(it));
+      slice key;
+      slice val;
+      splinterdb_iterator_get_current(it, &key, &val);
+      snprintf(key_str, sizeof(key_str), "key-%08x", i);
+
+      ASSERT_EQUAL(KEY_SIZE, slice_length(key));
+      int comp = memcmp(slice_data(key), key_str, slice_length(key));
+      ASSERT_EQUAL(0, comp);
+      splinterdb_iterator_next(it);
+   }
+
+   // assert that the iterator is in the state we expect
+   ASSERT_FALSE(splinterdb_iterator_valid(it));
+   ASSERT_FALSE(splinterdb_iterator_can_next(it));
+   ASSERT_TRUE(splinterdb_iterator_can_prev(it));
+   ASSERT_EQUAL(0, splinterdb_iterator_status(it));
+
+   splinterdb_iterator_deinit(it);
+}
+
+/*
  * Test case that inserts large # of KV-pairs, and goes into a code path
  * reported by issue# 458, tripping a debug assert. This test case also
  * triggered the failure(s) reported by issue # 545.


### PR DESCRIPTION
This PR allows splinter iterators to be bidirectional. To do this

- It renames some of the iterator functions to make them more direction-neutral.  For example, "advance" is renamed "next", so that we can add a "prev".  "at_end" becomes 3 functions "can_prev", "can_next", and "can_curr" which allow for more granular bounds checking and inform us of what state the iterator is in.

- It changes the possible states of an iterator to: 
   - `before start`: Allowed to call "next", not allowed to call "get_current" or "prev"
   - `in range`: Allowed to call all operations
   - `after end`: Allowed to call "prev", not allowed to call "get_current" or "next"
   - `empty`: Not allowed to perform any operations.

- It changes which iterator operations can fail:  Now, only the "next" or "prev" method can fail.  Getting the current key/value pair or checking bounds cannot fail.  The rationale for this decision is: the fewer operations that can fail, the easier it is to use the iterator; in practice, all of the bounds implementations never fail; "next" and "prev" _can_ fail; if there is an implementation that can fail on bounds checks, it is easy to move that failure to "next"/"prev" by performing the bounds check at the end of the "next"/"prev"; same for getting the current key/value pair.

- It adds prev pointers in the btree which must be maintained during operations such as splitting leaves. 

- It adds "start_key" and "start_type" parameters to most iterator init functions. These determine the value of the key we are positioning the iterator relative to and where to actually begin relative to the start key, respectively. "start_type" may be one of the following: less_than, less_than_or_equal, greater_than, or greater_than_or_equal.

---------

Co-authored-by: Evan West <evan.ts.west@gmail.com>