### PR TITLE
CI fix: use new version of registry-image resource

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -48,6 +48,14 @@ resource_types:
     #! which is maintained by VMware staff
     repository: harbor-repo.vmware.com/dockerhub-proxy-cache/loggregatorbot/github-pr-resource
 
+#! Attempt to fix a problem with image pulls failing
+#! see: https://vmware.slack.com/archives/CEUC18KQA/p1689754476227109?thread_ts=1689753436.440569&cid=CEUC18KQA
+- name: registry-image
+  type: registry-image
+  source:
+    repository: harbor-repo.vmware.com/dockerhub-proxy-cache/concourse/registry-image-resource
+    tag: 1.8.0
+
 resources:
 
 #! Container images for the build environment


### PR DESCRIPTION
I've applied this configuration already.  It appears to work.