### PR TITLE
Fix the compile error on platform_open_log_file()

### DIFF
--- a/src/platform_linux/platform_inline.h
+++ b/src/platform_linux/platform_inline.h
@@ -317,14 +317,14 @@ platform_log_stream_to_string(platform_stream_handle *stream)
 
 #define platform_open_log_file(path, mode)                                     \
    ({                                                                          \
-      platform_log_handle lh = fopen(path, mode);                              \
+      platform_log_handle *lh = fopen(path, mode);                             \
       platform_assert(lh);                                                     \
       lh;                                                                      \
    })
 
-#define platform_close_log_file(path)                                          \
+#define platform_close_log_file(log_handle)                                    \
    do {                                                                        \
-      fclose(path);                                                            \
+      fclose(log_handle);                                                      \
    } while (0)
 
 #define platform_thread_cleanup_push(func, arg)                                \


### PR DESCRIPTION
This PR fixes #595 about a compile error when using `platform_open_log_file()` and a wrong parameter name for `platform_close_log_file()`.