### PR TITLE
Rename large_inserts_bugs_stress_test.c -> large_inserts_stress_test.c

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ TESTSRC := $(COMMON_TESTSRC) $(FUNCTIONAL_TESTSRC) $(UNIT_TESTSRC)
 # Construct a list of fast unit-tests that will be linked into unit_test binary,
 # eliminating a sequence of slow-running unit-test programs.
 ALL_UNIT_TESTSRC := $(call rwildcard, $(UNIT_TESTSDIR), *.c)
-SLOW_UNIT_TESTSRC = splinter_test.c config_parse_test.c large_inserts_bugs_stress_test.c splinterdb_forked_child_test.c
+SLOW_UNIT_TESTSRC = splinter_test.c config_parse_test.c large_inserts_stress_test.c splinterdb_forked_child_test.c
 SLOW_UNIT_TESTSRC_FILTER := $(foreach slowf,$(SLOW_UNIT_TESTSRC), $(UNIT_TESTSDIR)/$(slowf))
 FAST_UNIT_TESTSRC := $(sort $(filter-out $(SLOW_UNIT_TESTSRC_FILTER), $(ALL_UNIT_TESTSRC)))
 
@@ -485,10 +485,10 @@ $(BINDIR)/$(UNITDIR)/splinterdb_forked_child_test: $(OBJDIR)/$(TESTS_DIR)/config
                                                    $(OBJDIR)/$(FUNCTIONAL_TESTSDIR)/test_async.o \
                                                    $(LIBDIR)/libsplinterdb.so
 
-$(BINDIR)/$(UNITDIR)/large_inserts_bugs_stress_test: $(UTIL_SYS)                      \
-                                                     $(OBJDIR)/$(TESTS_DIR)/config.o  \
-                                                     $(COMMON_UNIT_TESTOBJ)           \
-                                                     $(LIBDIR)/libsplinterdb.so
+$(BINDIR)/$(UNITDIR)/large_inserts_stress_test: $(UTIL_SYS)                      \
+                                                $(OBJDIR)/$(TESTS_DIR)/config.o  \
+                                                $(COMMON_UNIT_TESTOBJ)           \
+                                                $(LIBDIR)/libsplinterdb.so
 
 $(BINDIR)/$(UNITDIR)/splinterdb_heap_id_mgmt_test: $(COMMON_TESTOBJ)         \
                                                    $(COMMON_UNIT_TESTOBJ)    \

--- a/test.sh
+++ b/test.sh
@@ -241,7 +241,7 @@ function nightly_unit_stress_tests() {
     # ----
     local n_threads=32
     local test_descr="${nrows_h} rows, ${n_threads} threads"
-    local test_name=large_inserts_bugs_stress_test
+    local test_name=large_inserts_stress_test
 
     # FIXME: This stress test is currently unstable. We run into shmem-OOMs
     # Also, we need a big machine with large # of cores to be able to run
@@ -674,7 +674,7 @@ function run_slower_unit_tests() {
 
     # shellcheck disable=SC2086
     run_with_timing "${msg}" \
-            "$BINDIR"/unit/large_inserts_bugs_stress_test ${use_shmem} --num-inserts ${num_rows}
+            "$BINDIR"/unit/large_inserts_stress_test ${use_shmem} --num-inserts ${num_rows}
 
     # Test runs w/ more inserts and enable bg-threads
     n_mills=2
@@ -683,7 +683,7 @@ function run_slower_unit_tests() {
     #
     # shellcheck disable=SC2086
     run_with_timing "${msg}" \
-            "$BINDIR"/unit/large_inserts_bugs_stress_test ${use_shmem} \
+            "$BINDIR"/unit/large_inserts_stress_test ${use_shmem} \
                                                         --num-inserts ${num_rows} \
                                                         --num-normal-bg-threads 4 \
                                                         --num-memtable-bg-threads 3
@@ -718,12 +718,12 @@ function run_slower_forked_process_tests() {
     # run_with_timing "${msg}" "$BINDIR"/unit/splinterdb_forked_child_test \
     #                                     --num-processes ${num_forked_procs}
 
-    # ---- Run large_inserts_bugs_stress_test with small configuration as a quick check
+    # ---- Run large_inserts_stress_test with small configuration as a quick check
     # using forked child process execution.
     msg="Splinter large inserts test using shared memory, 1 forked child"
     local num_rows=$((2 * 1000 * 1000))
     # shellcheck disable=SC2086
-    run_with_timing "${msg}" "$BINDIR"/unit/large_inserts_bugs_stress_test \
+    run_with_timing "${msg}" "$BINDIR"/unit/large_inserts_stress_test \
                                         --use-shmem \
                                         --fork-child \
                                         --num-inserts ${num_rows} \

--- a/tests/unit/large_inserts_stress_test.c
+++ b/tests/unit/large_inserts_stress_test.c
@@ -3,7 +3,7 @@
 
 /*
  * -----------------------------------------------------------------------------
- * large_inserts_bugs_stress_test.c --
+ * large_inserts_stress_test.c --
  *
  * This test exercises simple very large #s of inserts which have found to
  * trigger some bugs in some code paths. This is just a miscellaneous collection
@@ -81,7 +81,7 @@ do_inserts_n_threads(splinterdb      *kvsb,
 /*
  * Global data declaration macro:
  */
-CTEST_DATA(large_inserts_bugs_stress)
+CTEST_DATA(large_inserts_stress)
 {
    // Declare heap handles for on-stack buffer allocations
    platform_heap_id hid;
@@ -97,7 +97,7 @@ CTEST_DATA(large_inserts_bugs_stress)
 };
 
 // Optional setup function for suite, called before every test in suite
-CTEST_SETUP(large_inserts_bugs_stress)
+CTEST_SETUP(large_inserts_stress)
 {
    // First, register that main() is being run as a parent process
    data->am_parent = TRUE;
@@ -155,7 +155,7 @@ CTEST_SETUP(large_inserts_bugs_stress)
 }
 
 // Optional teardown function for suite, called after every test in suite
-CTEST_TEARDOWN(large_inserts_bugs_stress)
+CTEST_TEARDOWN(large_inserts_stress)
 {
    // Only parent process should tear down Splinter.
    if (data->am_parent) {
@@ -168,7 +168,7 @@ CTEST_TEARDOWN(large_inserts_bugs_stress)
  * Test case that inserts large # of KV-pairs, and goes into a code path
  * reported by issue# 458, tripping a debug assert.
  */
-CTEST2_SKIP(large_inserts_bugs_stress,
+CTEST2_SKIP(large_inserts_stress,
             test_issue_458_mini_destroy_unused_debug_assert)
 {
    char key_data[TEST_KEY_SIZE];
@@ -217,7 +217,7 @@ CTEST2_SKIP(large_inserts_bugs_stress,
  *  - sequential keys, random values
  *  - random keys, random values
  */
-CTEST2(large_inserts_bugs_stress, test_seq_key_seq_values_inserts)
+CTEST2(large_inserts_stress, test_seq_key_seq_values_inserts)
 {
    worker_config wcfg;
    ZERO_STRUCT(wcfg);
@@ -230,7 +230,7 @@ CTEST2(large_inserts_bugs_stress, test_seq_key_seq_values_inserts)
    exec_worker_thread(&wcfg);
 }
 
-CTEST2(large_inserts_bugs_stress, test_random_key_seq_values_inserts)
+CTEST2(large_inserts_stress, test_random_key_seq_values_inserts)
 {
    worker_config wcfg;
    ZERO_STRUCT(wcfg);
@@ -246,7 +246,7 @@ CTEST2(large_inserts_bugs_stress, test_random_key_seq_values_inserts)
    close(wcfg.random_key_fd);
 }
 
-CTEST2(large_inserts_bugs_stress, test_seq_key_random_values_inserts)
+CTEST2(large_inserts_stress, test_seq_key_random_values_inserts)
 {
    worker_config wcfg;
    ZERO_STRUCT(wcfg);
@@ -262,7 +262,7 @@ CTEST2(large_inserts_bugs_stress, test_seq_key_random_values_inserts)
    close(wcfg.random_val_fd);
 }
 
-CTEST2(large_inserts_bugs_stress, test_random_key_random_values_inserts)
+CTEST2(large_inserts_stress, test_random_key_random_values_inserts)
 {
    worker_config wcfg;
    ZERO_STRUCT(wcfg);
@@ -304,7 +304,7 @@ safe_wait()
  * shutdown the instance.
  * ----------------------------------------------------------------------------
  */
-CTEST2(large_inserts_bugs_stress, test_seq_key_seq_values_inserts_forked)
+CTEST2(large_inserts_stress, test_seq_key_seq_values_inserts_forked)
 {
    worker_config wcfg;
    ZERO_STRUCT(wcfg);
@@ -375,7 +375,7 @@ CTEST2(large_inserts_bugs_stress, test_seq_key_seq_values_inserts_forked)
  * clockcache_try_get_read() -> memtable_maybe_rotate_and_get_insert_lock()
  * This problem will probably occur in /main as well.
  */
-CTEST2_SKIP(large_inserts_bugs_stress, test_seq_key_seq_values_inserts_threaded)
+CTEST2_SKIP(large_inserts_stress, test_seq_key_seq_values_inserts_threaded)
 {
    // Run n-threads with sequential key and sequential values inserted
    do_inserts_n_threads(data->kvsb,
@@ -394,7 +394,7 @@ CTEST2_SKIP(large_inserts_bugs_stress, test_seq_key_seq_values_inserts_threaded)
  * With --num-threads 63, hangs in
  *  clockcache_get_read() -> memtable_maybe_rotate_and_get_insert_lock()
  */
-CTEST2(large_inserts_bugs_stress,
+CTEST2(large_inserts_stress,
        test_seq_key_seq_values_inserts_threaded_same_start_keyid)
 {
    // Run n-threads with sequential key and sequential values inserted
@@ -412,7 +412,7 @@ CTEST2(large_inserts_bugs_stress,
  * KV-pairs, with all threads inserting from same start-value, using a fixed
  * fully-packed value.
  */
-CTEST2(large_inserts_bugs_stress,
+CTEST2(large_inserts_stress,
        test_seq_key_fully_packed_value_inserts_threaded_same_start_keyid)
 {
    // Run n-threads with sequential key and sequential values inserted
@@ -425,7 +425,7 @@ CTEST2(large_inserts_bugs_stress,
                         data->num_insert_threads);
 }
 
-CTEST2(large_inserts_bugs_stress, test_random_keys_seq_values_threaded)
+CTEST2(large_inserts_stress, test_random_keys_seq_values_threaded)
 {
    int random_key_fd = open("/dev/urandom", O_RDONLY);
    ASSERT_TRUE(random_key_fd > 0);
@@ -442,7 +442,7 @@ CTEST2(large_inserts_bugs_stress, test_random_keys_seq_values_threaded)
    close(random_key_fd);
 }
 
-CTEST2(large_inserts_bugs_stress, test_seq_keys_random_values_threaded)
+CTEST2(large_inserts_stress, test_seq_keys_random_values_threaded)
 {
    int random_val_fd = open("/dev/urandom", O_RDONLY);
    ASSERT_TRUE(random_val_fd > 0);
@@ -459,7 +459,7 @@ CTEST2(large_inserts_bugs_stress, test_seq_keys_random_values_threaded)
    close(random_val_fd);
 }
 
-CTEST2(large_inserts_bugs_stress,
+CTEST2(large_inserts_stress,
        test_seq_keys_random_values_threaded_same_start_keyid)
 {
    int random_val_fd = open("/dev/urandom", O_RDONLY);
@@ -477,7 +477,7 @@ CTEST2(large_inserts_bugs_stress,
    close(random_val_fd);
 }
 
-CTEST2(large_inserts_bugs_stress, test_random_keys_random_values_threaded)
+CTEST2(large_inserts_stress, test_random_keys_random_values_threaded)
 {
    int random_key_fd = open("/dev/urandom", O_RDONLY);
    ASSERT_TRUE(random_key_fd > 0);


### PR DESCRIPTION
Upcoming PR #569 is overhauling large-inserts stress test. To simplify examining the diffs of this test case as part of that review, this commit is renaming the test file to large_inserts_stress_test.c, with appropriate changes to the build-and-test files.

No new tests / changes are added as part of this commit.