### PR TITLE
test.sh: Enable running by named-function w/o shared memory.

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -42,6 +42,9 @@ INCLUDE_SLOW_TESTS="${INCLUDE_SLOW_TESTS:-false}"
 RUN_NIGHTLY_TESTS="${RUN_NIGHTLY_TESTS:-false}"
 RUN_MAKE_TESTS="${RUN_MAKE_TESTS:-false}"
 
+# Global variable to control memory config. Default is off => Use heap memory
+Use_shmem=""
+
 # Name of /tmp file to record test-execution times
 test_exec_log_file="/tmp/${Me}.$$.log"
 
@@ -59,13 +62,14 @@ function usage() {
    echo "To run CI-regression tests       : INCLUDE_SLOW_TESTS=true ./${Me}"
    echo "To run nightly regression tests  : RUN_NIGHTLY_TESTS=true ./${Me}"
    echo "To run make build-and-test tests : RUN_MAKE_TESTS=true ./${Me}"
-   echo
+   echo " "
    echo "To run a smaller collection of slow running tests,
 name the function that drives the test execution.
 Examples:"
    echo "  INCLUDE_SLOW_TESTS=true ./test.sh run_btree_tests"
-   echo "  INCLUDE_SLOW_TESTS=true ./test.sh run_splinter_functionality_tests"
+   echo "  INCLUDE_SLOW_TESTS=true ./test.sh run_btree_tests --use-shmem"
    echo "  INCLUDE_SLOW_TESTS=true ./test.sh nightly_cache_perf_tests"
+   echo "  INCLUDE_SLOW_TESTS=true ./test.sh run_splinter_functionality_tests"
    echo "  INCLUDE_SLOW_TESTS=true ./test.sh run_splinter_functionality_tests --use-shmem"
    echo "  INCLUDE_SLOW_TESTS=true ./test.sh run_tests_with_shared_memory"
 }
@@ -113,7 +117,7 @@ function run_with_timing() {
 
    # Starting a new test batch. So inject blank link for this chunk of output
    start_seconds=$SECONDS
-   echo
+   echo " "
    set -x
    "$@"
    set +x
@@ -129,7 +133,7 @@ function cat_exec_log_file() {
         cat "${test_exec_log_file}"
         rm -f "${test_exec_log_file}"
    fi
-   echo
+   echo " "
    echo "$(TZ="America/Los_Angeles" date) End SplinterDB Test Suite Execution."
 }
 
@@ -232,8 +236,6 @@ function nightly_functionality_stress_tests() {
 # of execution, especially to shake out AIO / thread registration issues.
 # #############################################################################
 function nightly_unit_stress_tests() {
-    local use_shmem=$1
-
     local n_mills=10
     local num_rows=$((n_mills * 1000 * 1000))
     local nrows_h="${n_mills} mil"
@@ -248,10 +250,10 @@ function nightly_unit_stress_tests() {
     # with this configuration. The config-params listed below -should- work but
     # this combination has never been exercised successfully due to lack of hw.
     echo "$Me: Run ${test_name} with ${n_mills} million rows, ${n_threads} threads"
-    # RESOLVE: Revert: shell_check disable=SC2086
+    # RESOLVE: Revert: shellcheck disable=SC2086
     # run_with_timing "Large Inserts Stress test ${test_descr}" \
     #         "$BINDIR"/unit/${test_name} \
-    #                            $use_shmem \
+    #                            $Use_shmem \
     #                            --shmem-capacity-gib 8 \
     #                            --num-inserts ${num_rows} \
     #                            --num-threads ${n_threads} \
@@ -265,8 +267,8 @@ function nightly_unit_stress_tests() {
 function run_nightly_stress_tests() {
 
     nightly_functionality_stress_tests
-    nightly_unit_stress_tests ""
-    nightly_unit_stress_tests "--use-shmem"
+    Use_shmem=""            nightly_unit_stress_tests
+    Use_shmem="--use-shmem" nightly_unit_stress_tests
 }
 
 # #############################################################################
@@ -277,9 +279,8 @@ function run_nightly_stress_tests() {
 # Async-systems are a bit unstable now, so will online them shortly in future.
 # #############################################################################
 function nightly_sync_perf_tests() {
-    local use_shmem=$1
     local use_msg=
-    if [ "$use_shmem" != "" ]; then
+    if [ "$Use_shmem" != "" ]; then
         use_msg=", using shared memory"
    fi
 
@@ -305,7 +306,7 @@ function nightly_sync_perf_tests() {
                                                 --db-capacity-gib 60 \
                                                 --db-location ${dbname} \
                                                 --verbose-progress
-                                                ${use_shmem}
+                                                ${Use_shmem}
     rm ${dbname}
 
     local npthreads=8
@@ -322,7 +323,7 @@ function nightly_sync_perf_tests() {
                                                 --tree-size-gib ${tree_size} \
                                                 --db-capacity-gib 60 \
                                                 --db-location ${dbname} \
-                                                ${use_shmem}
+                                                ${Use_shmem}
     rm ${dbname}
 
     # Exercise a case with max # of insert-threads which tripped an assertion
@@ -339,7 +340,7 @@ function nightly_sync_perf_tests() {
                                                 --num-range-lookup-threads ${nrange_lookup_t} \
                                                 --tree-size-gib 1 \
                                                 --db-location ${dbname} \
-                                                ${use_shmem}
+                                                ${Use_shmem}
     rm ${dbname}
 }
 
@@ -347,10 +348,8 @@ function nightly_sync_perf_tests() {
 # Nightly Cache Performance tests with async disabled
 # #############################################################################
 function nightly_cache_perf_tests() {
-
-    local use_shmem=$1
     local use_msg=
-    if [ "$use_shmem" != "" ]; then
+    if [ "$Use_shmem" != "" ]; then
         use_msg=", using shared memory"
    fi
 
@@ -360,7 +359,7 @@ function nightly_cache_perf_tests() {
     run_with_timing "Cache Performance test, ${test_descr}${use_msg}" \
             "$BINDIR"/driver_test cache_test --perf \
                                              --db-location ${dbname} \
-                                             ${use_msg}
+                                             ${Use_shmem}
 
     cache_size=6  # GiB
     test_descr="${cache_size} GiB cache"
@@ -370,7 +369,7 @@ function nightly_cache_perf_tests() {
                                              --db-location ${dbname} \
                                              --cache-capacity-gib ${cache_size} \
                                              --db-capacity-gib 60 \
-                                             ${use_msg}
+                                             ${Use_shmem}
     rm ${dbname}
 }
 
@@ -401,22 +400,17 @@ function nightly_async_perf_tests() {
 # Run through collection of nightly Performance-oriented tests
 # #############################################################################
 function run_nightly_perf_tests() {
-    local use_shmem=$1
+    nightly_sync_perf_tests
 
-    # shellcheck disable=SC2086
-    nightly_sync_perf_tests ${use_shmem}
-
-    # shellcheck disable=SC2086
-    nightly_cache_perf_tests ${use_shmem}
+    nightly_cache_perf_tests
 
     # nightly_async_perf_tests
-
 }
 
 # #############################################################################
 # Method to check that the command actually does fail; Otherwise it's an error.
 function run_check_rc() {
-    echo
+    echo " "
     set +e
     "$@"
     local rc=$?
@@ -596,25 +590,25 @@ function test_make_run_tests() {
 # This can be invoked w/ or w/o the "--use-shmem" arg.
 # ##################################################################
 function run_fast_unit_tests() {
-   local use_shmem=$1
 
-   "$BINDIR"/unit/splinterdb_quick_test "$use_shmem"
-   "$BINDIR"/unit/btree_test "$use_shmem"
-   "$BINDIR"/unit/util_test "$use_shmem"
-   "$BINDIR"/unit/misc_test "$use_shmem"
-   "$BINDIR"/unit/limitations_test "$use_shmem"
-   "$BINDIR"/unit/task_system_test "$use_shmem"
-   "$BINDIR"/unit/splinterdb_heap_id_mgmt_test "$use_shmem"
+   "$BINDIR"/unit/splinterdb_quick_test "$Use_shmem"
+   "$BINDIR"/unit/btree_test "$Use_shmem"
+   "$BINDIR"/unit/util_test "$Use_shmem"
+   "$BINDIR"/unit/misc_test "$Use_shmem"
+   "$BINDIR"/unit/limitations_test "$Use_shmem"
+   "$BINDIR"/unit/task_system_test "$Use_shmem"
+   "$BINDIR"/unit/splinterdb_heap_id_mgmt_test "$Use_shmem"
+   "$BINDIR"/unit/platform_apis_test "$Use_shmem"
 
-   echo
+   echo " "
    # Just exercise with some combination of background threads to ensure
    # that basic usage of background threads still works.
    # shellcheck disable=SC2086
-   "$BINDIR"/unit/task_system_test $use_shmem
+   "$BINDIR"/unit/task_system_test $Use_shmem
 
-   echo
+   echo " "
    # shellcheck disable=SC2086
-   "$BINDIR"/driver_test io_apis_test $use_shmem
+   "$BINDIR"/driver_test io_apis_test $Use_shmem
 }
 
 # ##################################################################
@@ -625,10 +619,8 @@ function run_fast_unit_tests() {
 # Execute this set w/ and w/o the "--use-shmem" arg.
 # ##################################################################
 function run_slower_unit_tests() {
-    local use_shmem=$1
-
     local use_msg=
-    if [ "$use_shmem" != "" ]; then
+    if [ "$Use_shmem" != "" ]; then
         use_msg="using shared memory"
    fi
 
@@ -638,11 +630,11 @@ function run_slower_unit_tests() {
     VERBOSE=7
                export VERBOSE
 
-    # Allow $use_shmem to come w/o quotes. Otherwise for default execution, we
+    # Allow $Use_shmem to come w/o quotes. Otherwise for default execution, we
     # end up with empty '' parameter, which causes the argument parsing routine
     # in the program to cough-up an error.
     # shellcheck disable=SC2086
-    run_with_timing "${msg}" "$BINDIR"/unit/splinter_test ${use_shmem} test_inserts
+    run_with_timing "${msg}" "$BINDIR"/unit/splinter_test ${Use_shmem} test_inserts
 
     # Use fewer rows for this case, to keep elapsed times of MSAN runs reasonable.
     msg="Splinter lookups test ${use_msg}"
@@ -650,14 +642,14 @@ function run_slower_unit_tests() {
     local num_rows=$((n_mills * 1000 * 1000))
     # shellcheck disable=SC2086
     run_with_timing "${msg}" \
-          "$BINDIR"/unit/splinter_test ${use_shmem} --num-inserts ${num_rows} test_lookups
+          "$BINDIR"/unit/splinter_test ${Use_shmem} --num-inserts ${num_rows} test_lookups
 
     unset VERBOSE
 
     msg="Splinter print diagnostics test ${use_msg}"
     # shellcheck disable=SC2086
     run_with_timing "${msg}" \
-          "$BINDIR"/unit/splinter_test ${use_shmem} test_splinter_print_diags
+          "$BINDIR"/unit/splinter_test ${Use_shmem} test_splinter_print_diags
 
     # Test runs w/ default of 1M rows for --num-inserts
     n_mills=1
@@ -674,7 +666,7 @@ function run_slower_unit_tests() {
 
     # shellcheck disable=SC2086
     run_with_timing "${msg}" \
-            "$BINDIR"/unit/large_inserts_stress_test ${use_shmem} --num-inserts ${num_rows}
+            "$BINDIR"/unit/large_inserts_stress_test ${Use_shmem} --num-inserts ${num_rows}
 
     # Test runs w/ more inserts and enable bg-threads
     n_mills=2
@@ -683,7 +675,7 @@ function run_slower_unit_tests() {
     #
     # shellcheck disable=SC2086
     run_with_timing "${msg}" \
-            "$BINDIR"/unit/large_inserts_stress_test ${use_shmem} \
+            "$BINDIR"/unit/large_inserts_stress_test ${Use_shmem} \
                                                         --num-inserts ${num_rows} \
                                                         --num-normal-bg-threads 4 \
                                                         --num-memtable-bg-threads 3
@@ -735,9 +727,9 @@ function run_slower_forked_process_tests() {
 # Execute this set w/ and w/o the "--use-shmem" arg.
 # ##################################################################
 function run_splinter_functionality_tests() {
-    local use_shmem=$1
+
     local use_msg=
-    if [ "$use_shmem" != "" ]; then
+    if [ "$Use_shmem" != "" ]; then
         use_msg=", using shared memory"
    fi
 
@@ -745,19 +737,19 @@ function run_splinter_functionality_tests() {
     # shellcheck disable=SC2086
     run_with_timing "Functionality test, key size=${key_size} bytes${use_msg}" \
         "$BINDIR"/driver_test splinter_test --functionality 1000000 100 \
-                                            $use_shmem \
+                                            $Use_shmem \
                                             --key-size ${key_size} --seed "$SEED"
 
     # shellcheck disable=SC2086
     run_with_timing "Functionality test, with default key size${use_msg}" \
         "$BINDIR"/driver_test splinter_test --functionality 1000000 100 \
-                                            $use_shmem \
+                                            $Use_shmem \
                                             --seed "$SEED"
 
     # shellcheck disable=SC2086
     run_with_timing "Functionality test, default key size, with background threads${use_msg}" \
         "$BINDIR"/driver_test splinter_test --functionality 1000000 100 \
-                                            $use_shmem \
+                                            $Use_shmem \
                                             --num-normal-bg-threads 4 --num-memtable-bg-threads 2 \
                                             --seed "$SEED"
 
@@ -765,7 +757,7 @@ function run_splinter_functionality_tests() {
     # shellcheck disable=SC2086
     run_with_timing "Functionality test, key size=maximum (${max_key_size} bytes)${use_msg}" \
         "$BINDIR"/driver_test splinter_test --functionality 1000000 100 \
-                                            $use_shmem \
+                                            $Use_shmem \
                                             --key-size ${max_key_size} --seed "$SEED"
 }
 
@@ -774,9 +766,8 @@ function run_splinter_functionality_tests() {
 # Execute this set w/ and w/o the "--use-shmem" arg.
 # ##################################################################
 function run_splinter_perf_tests() {
-    local use_shmem=$1
     local use_msg=
-    if [ "$use_shmem" != "" ]; then
+    if [ "$Use_shmem" != "" ]; then
         use_msg=", using shared memory"
    fi
    # Validate use of small # of --num-inserts, and --verbose-progress
@@ -784,7 +775,7 @@ function run_splinter_perf_tests() {
    # shellcheck disable=SC2086
    run_with_timing "Very quick Performance test${use_msg}" \
         "$BINDIR"/driver_test splinter_test --perf \
-                                            $use_shmem \
+                                            $Use_shmem \
                                             --max-async-inflight 0 \
                                             --num-insert-threads 4 \
                                             --num-lookup-threads 4 \
@@ -799,7 +790,7 @@ function run_splinter_perf_tests() {
    # shellcheck disable=SC2086
    run_with_timing "Quick Performance test with background threads${use_msg}" \
         "$BINDIR"/driver_test splinter_test --perf \
-                                            $use_shmem \
+                                            $Use_shmem \
                                             --num-insert-threads 4 \
                                             --num-lookup-threads 4 \
                                             --num-inserts 10000 \
@@ -810,7 +801,7 @@ function run_splinter_perf_tests() {
    # shellcheck disable=SC2086
    run_with_timing "Performance test${use_msg}" \
         "$BINDIR"/driver_test splinter_test --perf \
-                                            $use_shmem \
+                                            $Use_shmem \
                                             --max-async-inflight 0 \
                                             --num-insert-threads 4 \
                                             --num-lookup-threads 4 \
@@ -823,26 +814,25 @@ function run_splinter_perf_tests() {
 # Execute BTree tests, including BTree perf test case
 # ##################################################################
 function run_btree_tests() {
-    local use_shmem=$1
     local use_msg=
-    if [ "$use_shmem" != "" ]; then
+    if [ "$Use_shmem" != "" ]; then
         use_msg=", using shared memory"
    fi
     key_size=8
     # shellcheck disable=SC2086
     run_with_timing "BTree test, key size=${key_size} bytes${use_msg}" \
         "$BINDIR"/driver_test btree_test --key-size ${key_size} \
-                                         $use_shmem \
+                                         $Use_shmem \
                                          --seed "$SEED"
 
     # shellcheck disable=SC2086
     run_with_timing "BTree test, with default key size${use_msg}" \
-        "$BINDIR"/driver_test btree_test $use_shmem --seed "$SEED"
+        "$BINDIR"/driver_test btree_test $Use_shmem --seed "$SEED"
 
     key_size=100
     # shellcheck disable=SC2086
     run_with_timing "BTree test, key size=${key_size} bytes${use_msg}" \
-        "$BINDIR"/driver_test btree_test $use_shmem \
+        "$BINDIR"/driver_test btree_test $Use_shmem \
                                           --key-size ${key_size} --seed "$SEED"
 
     # shellcheck disable=SC2086
@@ -850,26 +840,28 @@ function run_btree_tests() {
         "$BINDIR"/driver_test btree_test --perf \
                                          --cache-capacity-gib 4 \
                                          --seed "$SEED" \
-                                         $use_shmem
+                                         $Use_shmem
 }
 
 # ##################################################################
 # Run remaining functionality-related tests from driver_test
 # ##################################################################
 function run_other_driver_tests() {
-    local use_shmem=$1
     local use_msg=
-    if [ "$use_shmem" != "" ]; then
+    if [ "$Use_shmem" != "" ]; then
         use_msg=", using shared memory"
    fi
+    # shellcheck disable=SC2086
     run_with_timing "Cache test${use_msg}" \
-        "$BINDIR"/driver_test cache_test --seed "$SEED"
+        "$BINDIR"/driver_test cache_test --seed "$SEED" $Use_shmem
 
+    # shellcheck disable=SC2086
     run_with_timing "Log test${use_msg}" \
-        "$BINDIR"/driver_test log_test --seed "$SEED"
+        "$BINDIR"/driver_test log_test --seed "$SEED" $Use_shmem
 
+    # shellcheck disable=SC2086
     run_with_timing "Filter test${use_msg}" \
-        "$BINDIR"/driver_test filter_test --seed "$SEED"
+        "$BINDIR"/driver_test filter_test --seed "$SEED" $Use_shmem
 }
 
 # #######################################################################
@@ -880,6 +872,13 @@ function run_other_driver_tests() {
 # remaining tests when they can run successfully in this mode.
 # #######################################################################
 function run_tests_with_shared_memory() {
+   {
+      echo " "
+      echo "-- Tests with shared memory configured --" >> "${test_exec_log_file}"
+      echo " "
+   } >> "${test_exec_log_file}"
+
+   shmem_tests_run_start=$SECONDS
 
    # Run all the unit-tests first, to get basic coverage of shared-memory support.
    run_with_timing "Fast unit tests using shared memory" "$BINDIR"/unit_test "--use-shmem"
@@ -890,18 +889,21 @@ function run_tests_with_shared_memory() {
                    "$BINDIR"/driver_test io_apis_test \
                    --use-shmem --fork-child
 
-   run_slower_unit_tests "--use-shmem"
+   Use_shmem="--use-shmem" run_slower_unit_tests
    if [ -f "${UNIT_TESTS_DB_DEV}" ]; then rm "${UNIT_TESTS_DB_DEV}"; fi
 
-   run_splinter_functionality_tests "--use-shmem"
-   run_splinter_perf_tests "--use-shmem"
-   run_btree_tests "--use-shmem"
-   run_other_driver_tests "--use-shmem"
+   Use_shmem="--use-shmem"
+   run_splinter_functionality_tests
+   run_splinter_perf_tests
+   run_btree_tests
+   run_other_driver_tests
 
    # These are written to always create shared segment, so --use-shmem arg is
    # not needed when invoking them. These tests will fork one or more child
    # processes.
    run_slower_forked_process_tests
+
+   record_elapsed_time ${shmem_tests_run_start} "Tests with shared memory configured"
 }
 
 # ##################################################################
@@ -940,8 +942,8 @@ if [ "$RUN_NIGHTLY_TESTS" == "true" ]; then
 
     run_nightly_stress_tests
 
-    run_nightly_perf_tests ""
-    run_nightly_perf_tests "--use-shmem"
+    Use_shmem=""            run_nightly_perf_tests
+    Use_shmem="--use-shmem" run_nightly_perf_tests
     set -e
 
     record_elapsed_time ${testRunStartSeconds} "Nightly Stress & Performance Tests"
@@ -961,10 +963,10 @@ if [ "$INCLUDE_SLOW_TESTS" != "true" ]; then
    "$BINDIR"/unit/splinterdb_quick_test --list
    set +x
 
-   echo
+   echo " "
    echo "NOTE: **** Only running fast unit tests ****"
    echo "To run all tests, set the env var, and re-run: $ INCLUDE_SLOW_TESTS=true ./$Me"
-   echo
+   echo " "
 
    # Exercise config-parsing test case. Here, we feed-in a set of
    # --config-params that the test code knows to "expect" and validates.
@@ -983,7 +985,9 @@ if [ "$INCLUDE_SLOW_TESTS" != "true" ]; then
    start_seconds=$SECONDS
 
    run_with_timing "Smoke tests" run_fast_unit_tests ""
-   run_with_timing "Smoke tests using shared memory" run_fast_unit_tests "--use-shmem"
+
+   Use_shmem="--use-shmem"
+   run_with_timing "Smoke tests using shared memory" run_fast_unit_tests
 
    if [ "$RUN_MAKE_TESTS" == "true" ]; then
       run_with_timing "Basic build-and-test tests" test_make_run_tests
@@ -1003,36 +1007,35 @@ UNIT_TESTS_DB_DEV="unit_tests_db"
 # can debug script changes to ensure that test-execution still works.
 #
 # Examples:
+#  Run BTree functional tests w/default memory configuration:
 #      INCLUDE_SLOW_TESTS=true ./test.sh run_btree_tests
-#      INCLUDE_SLOW_TESTS=true ./test.sh run_tests_with_shared_memory
-#      INCLUDE_SLOW_TESTS=true ./test.sh run_tests_with_shared_memory
+#
+#  Run BTree functional tests w/shared memory configuration:
+#      INCLUDE_SLOW_TESTS=true ./test.sh run_btree_tests --use-shmem
+#
+#  Run slower unit-tests w/default memory configuration:
+#      INCLUDE_SLOW_TESTS=true ./test.sh run_slower_unit_tests
+#
+#  Run slower unit-tests & nightly stress tests w/shared memory configuration:
 #      INCLUDE_SLOW_TESTS=true ./test.sh run_slower_unit_tests --use-shmem
 #      INCLUDE_SLOW_TESTS=true ./test.sh nightly_unit_stress_tests --use-shmem
-# ------------------------------------------------------------------------
-if [ $# -ge 1 ]; then
-
-   # shellcheck disable=SC2048
-   $*
-   record_elapsed_time ${testRunStartSeconds} "All Tests"
-   cat_exec_log_file
-   exit 0
-fi
-
-# ------------------------------------------------------------------------
-# Fast-path execution support. You can invoke this script specifying the
-# name of one of the functions to execute a specific set of tests. If the
-# function takes arguments, pass them on the command-line. This way, one
-# can debug script changes to ensure that test-execution still works.
 #
-# Examples:
-#  INCLUDE_SLOW_TESTS=true ./test.sh run_btree_tests
-#  INCLUDE_SLOW_TESTS=true ./test.sh run_splinter_functionality_tests --use-shmem
+#  Run collection of tests designed to exercise shared memory support:
+#      INCLUDE_SLOW_TESTS=true ./test.sh run_tests_with_shared_memory
 # ------------------------------------------------------------------------
 if [ $# -ge 1 ]; then
 
+   execMsg="Test $1"
+   # Parse memory config arg, if supplied, expecting it will only always be
+   # '--use-shmem'. Anything else, will trip an execution error.
+   if [ $# -eq 2 ]; then
+       Use_shmem="$2"
+       execMsg="${execMsg}, using shared memory"
+   fi
+
    # shellcheck disable=SC2048
    $*
-   record_elapsed_time ${testRunStartSeconds} "All Tests"
+   record_elapsed_time ${testRunStartSeconds} "${execMsg}"
    cat_exec_log_file
    exit 0
 fi
@@ -1043,21 +1046,23 @@ run_with_timing "Fast unit tests" "$BINDIR"/unit_test
 # ------------------------------------------------------------------------
 # Run mini-unit-tests that were excluded from bin/unit_test binary:
 # ------------------------------------------------------------------------
-run_slower_unit_tests ""
+Use_shmem=""
+run_slower_unit_tests
 
 if [ -f ${UNIT_TESTS_DB_DEV} ]; then rm ${UNIT_TESTS_DB_DEV}; fi
 
-run_splinter_functionality_tests ""
+run_splinter_functionality_tests
 
-run_splinter_perf_tests ""
+run_splinter_perf_tests
 
-run_btree_tests ""
+run_btree_tests
 
-run_other_driver_tests ""
+run_other_driver_tests
 
+record_elapsed_time ${testRunStartSeconds} "Tests without shared memory configured"
 # ------------------------------------------------------------------------
 # Re-run a collection of tests using shared-memory.
-run_tests_with_shared_memory
+Use_shmem="--use-shmem" run_tests_with_shared_memory
 
 record_elapsed_time ${testRunStartSeconds} "All Tests"
 echo ALL PASSED


### PR DESCRIPTION
This commit adds minor improvements / bug-fixes to test.sh:

- The capability to run individual test-function(s) by name was only working with the "--use-shmem" flag but was not working when `test.sh` is invoked with just the `test-execution-fn-name`. We would get a bash parameter parsing error.

 Rework the parameter parsing in all test-functions so that we can now invoke this driver script as:

    $ INCLUDE_SLOW_TESTS=true ./test.sh run_slower_unit_tests

  This will run individually named test-functions with default memory configuration.

- run_other_driver_tests() had a bug where tests run by this function were not honoring '--use-shmem' arg. Fix this so that cache_test, log_test, filter_test can now also be run with "--use-shmem" enabled.

- Update elapsed-time tracking to separately track the test execution run-times w/o and w/ shared memory configured.

- Other minor cleanup of comments, usage() info etc.

--- NOTE ---

In `main`, without this fix, the following invocation will result in a bash-script parsing error:

```
cc-sdb-vm:[130] $ INCLUDE_SLOW_TESTS=true ./test.sh run_slower_unit_tests

test.sh: build_dir='build/release', BINDIR='build/release/bin'
test.sh: Sun Dec 10 13:24:29 PST 2023 Start SplinterDB Test Suite Execution.
+ SEED=135
+ run_type=' '
+ '[' false == true ']'
+ set +x
./test.sh: line 628: $1: unbound variable
```

With this fix, this usage will now be supported and will run the named test-execution function, `run_slower_unit_tests()`, without the use of shared memory configuration.

---
The improved test summary output can be seen in any of the CI jobs run for this PR.
For example, see [this one](https://runway-ci.eng.vmware.com/builds/4022376220):

```
Sun Dec 10 21:28:25 America 2023 **** SplinterDB Test Suite Execution Times **** 

Fast unit tests                                                                      :  105s [  0h  1m 45s ]
[...]
Filter test                                                                          :    3s [  0h  0m  3s ]
Tests without shared memory configured                                               : 1269s [  0h 21m  9s ]
 
-- Tests with shared memory configured --
 
Fast unit tests using shared memory                                                  :  121s [  0h  2m  1s ]
[...]

Splinter large inserts test using shared memory, 1 forked child                      :    2s [  0h  0m  2s ]
Tests with shared memory configured                                                  : 1536s [  0h 25m 36s ]
All Tests                                                                            : 2805s [  0h 46m 45s ]
```