### PR TITLE
(#604) Cache page-size in local variables to reduce multiple lookups.

### DIFF
--- a/src/btree_private.h
+++ b/src/btree_private.h
@@ -223,11 +223,11 @@ btree_get_leaf_entry(const btree_config *cfg,
     */
    debug_assert(diff_ptr(hdr, &hdr->offsets[hdr->num_entries])
                 <= hdr->offsets[k]);
-   debug_assert(hdr->offsets[k] + sizeof(leaf_entry) <= btree_page_size(cfg));
+   debug_code(uint64 bt_page_size = btree_page_size(cfg));
+   debug_assert(hdr->offsets[k] + sizeof(leaf_entry) <= bt_page_size);
    leaf_entry *entry =
       (leaf_entry *)const_pointer_byte_offset(hdr, hdr->offsets[k]);
-   debug_assert(hdr->offsets[k] + sizeof_leaf_entry(entry)
-                <= btree_page_size(cfg));
+   debug_assert(hdr->offsets[k] + sizeof_leaf_entry(entry) <= bt_page_size);
    return entry;
 }
 
@@ -270,27 +270,27 @@ btree_get_index_entry(const btree_config *cfg,
     */
    debug_assert(diff_ptr(hdr, &hdr->offsets[hdr->num_entries])
                 <= hdr->offsets[k]);
-   debug_assert(hdr->offsets[k] + sizeof(index_entry) <= btree_page_size(cfg),
+   debug_code(uint64 bt_page_size = btree_page_size(cfg));
+   debug_assert((hdr->offsets[k] + sizeof(index_entry) <= bt_page_size),
                 "k=%d, offsets[k]=%d, sizeof(index_entry)=%lu"
                 ", btree_page_size=%lu.",
                 k,
                 hdr->offsets[k],
                 sizeof(index_entry),
-                btree_page_size(cfg));
+                bt_page_size);
 
    index_entry *entry =
       (index_entry *)const_pointer_byte_offset(hdr, hdr->offsets[k]);
 
    /* Now ensure that the entire entry fits in the page. */
-   debug_assert(hdr->offsets[k] + sizeof_index_entry(entry)
-                   <= btree_page_size(cfg),
+   debug_assert((hdr->offsets[k] + sizeof_index_entry(entry) <= bt_page_size),
                 "Offsets entry at index k=%d does not fit in the page."
                 " offsets[k]=%d, sizeof_index_entry()=%lu"
                 ", btree_page_size=%lu.",
                 k,
                 hdr->offsets[k],
                 sizeof_index_entry(entry),
-                btree_page_size(cfg));
+                bt_page_size);
    return entry;
 }
 

--- a/src/mini_allocator.c
+++ b/src/mini_allocator.c
@@ -377,18 +377,18 @@ mini_keyed_append_entry(mini_allocator *mini,
                         uint64          extent_addr,
                         key             start_key)
 {
+   uint64 page_size = cache_page_size(mini->cc);
    debug_assert(mini->keyed);
    debug_assert(batch < mini->num_batches);
    debug_assert(!key_is_null(start_key));
    debug_assert(extent_addr != 0);
    debug_assert(extent_addr == TERMINAL_EXTENT_ADDR
-                || extent_addr % cache_page_size(mini->cc) == 0);
+                || (extent_addr % page_size) == 0);
 
    mini_meta_hdr *hdr = (mini_meta_hdr *)meta_page->data;
 
-   if (!entry_fits_in_page(cache_page_size(mini->cc),
-                           hdr->pos,
-                           keyed_meta_entry_required_capacity(start_key)))
+   if (!entry_fits_in_page(
+          page_size, hdr->pos, keyed_meta_entry_required_capacity(start_key)))
    {
       return FALSE;
    }
@@ -409,15 +409,14 @@ mini_unkeyed_append_entry(mini_allocator *mini,
                           page_handle    *meta_page,
                           uint64          extent_addr)
 {
+   uint64 page_size = cache_page_size(mini->cc);
    debug_assert(!mini->keyed);
    debug_assert(extent_addr != 0);
-   debug_assert(extent_addr % cache_page_size(mini->cc) == 0);
+   debug_assert((extent_addr % page_size) == 0);
 
    mini_meta_hdr *hdr = (mini_meta_hdr *)meta_page->data;
 
-   if (!entry_fits_in_page(
-          cache_page_size(mini->cc), hdr->pos, sizeof(unkeyed_meta_entry)))
-   {
+   if (!entry_fits_in_page(page_size, hdr->pos, sizeof(unkeyed_meta_entry))) {
       return FALSE;
    }
 

--- a/src/routing_filter.c
+++ b/src/routing_filter.c
@@ -173,17 +173,14 @@ routing_get_header(cache          *cc,
                    uint64          index,
                    page_handle   **filter_page)
 {
-   uint64 addrs_per_page =
-      cache_config_page_size(cfg->cache_cfg) / sizeof(uint64);
+   uint64 page_size      = cache_config_page_size(cfg->cache_cfg);
+   uint64 addrs_per_page = page_size / sizeof(uint64);
    debug_assert(index / addrs_per_page < 32);
-   uint64 index_addr =
-      filter_addr
-      + cache_config_page_size(cfg->cache_cfg) * (index / addrs_per_page);
+   uint64       index_addr = filter_addr + page_size * (index / addrs_per_page);
    page_handle *index_page = cache_get(cc, index_addr, TRUE, PAGE_TYPE_FILTER);
    uint64 hdr_raw_addr = ((uint64 *)index_page->data)[index % addrs_per_page];
    platform_assert(hdr_raw_addr != 0);
-   uint64 header_addr =
-      hdr_raw_addr - (hdr_raw_addr % cache_config_page_size(cfg->cache_cfg));
+   uint64 header_addr      = hdr_raw_addr - (hdr_raw_addr % page_size);
    *filter_page            = cache_get(cc, header_addr, TRUE, PAGE_TYPE_FILTER);
    uint64       header_off = hdr_raw_addr - header_addr;
    routing_hdr *hdr        = (routing_hdr *)((*filter_page)->data + header_off);
@@ -1004,6 +1001,7 @@ routing_filter_lookup_async(cache              *cc,
 
    debug_assert(key_is_user_key(target));
 
+   uint64 page_size = cache_config_page_size(cfg->cache_cfg);
    do {
       switch (ctxt->state) {
          case routing_async_state_start:
@@ -1031,11 +1029,9 @@ routing_filter_lookup_async(cache              *cc,
                                             index_remainder_and_value_size);
             ctxt->remainder       = fp & remainder_mask;
 
-            uint64 addrs_per_page =
-               cache_config_page_size(cfg->cache_cfg) / sizeof(uint64);
-            ctxt->page_addr = filter->addr
-                              + cache_config_page_size(cfg->cache_cfg)
-                                   * (ctxt->index / addrs_per_page);
+            uint64 addrs_per_page = (page_size / sizeof(uint64));
+            ctxt->page_addr =
+               filter->addr + page_size * (ctxt->index / addrs_per_page);
             routing_async_set_state(ctxt, routing_async_state_get_index);
             // fallthrough;
          }
@@ -1096,13 +1092,11 @@ routing_filter_lookup_async(cache              *cc,
             if (ctxt->was_async) {
                cache_async_done(cc, PAGE_TYPE_FILTER, cache_ctxt);
             }
-            uint64 *index_arr = ((uint64 *)cache_ctxt->page->data);
-            uint64  addrs_per_page =
-               cache_config_page_size(cfg->cache_cfg) / sizeof(uint64);
-            ctxt->header_addr = index_arr[ctxt->index % addrs_per_page];
+            uint64 *index_arr      = ((uint64 *)cache_ctxt->page->data);
+            uint64  addrs_per_page = (page_size / sizeof(uint64));
+            ctxt->header_addr      = index_arr[ctxt->index % addrs_per_page];
             ctxt->page_addr =
-               ctxt->header_addr
-               - (ctxt->header_addr % cache_config_page_size(cfg->cache_cfg));
+               ctxt->header_addr - (ctxt->header_addr % page_size);
             cache_unget(cc, cache_ctxt->page);
             routing_async_set_state(ctxt, routing_async_state_get_filter);
             break;
@@ -1117,8 +1111,7 @@ routing_filter_lookup_async(cache              *cc,
             }
             routing_hdr *hdr =
                (routing_hdr *)(cache_ctxt->page->data
-                               + (ctxt->header_addr
-                                  % cache_config_page_size(cfg->cache_cfg)));
+                               + (ctxt->header_addr % page_size));
             uint64 encoding_size =
                (hdr->num_remainders + cfg->index_size - 1) / 8 + 4;
             uint64 header_length = encoding_size + sizeof(routing_hdr);
@@ -1276,12 +1269,10 @@ routing_filter_print_index(cache          *cc,
    platform_default_log("***   filter_addr: %lu\n", filter_addr);
    platform_default_log("------------------------------------------------------"
                         "--------------------------\n");
+   uint64 page_size = cache_config_page_size(cfg->cache_cfg);
    for (i = 0; i < num_indices; i++) {
-      uint64 addrs_per_page =
-         cache_config_page_size(cfg->cache_cfg) / sizeof(uint64);
-      uint64 index_addr =
-         filter_addr
-         + cache_config_page_size(cfg->cache_cfg) * (i / addrs_per_page);
+      uint64 addrs_per_page = (page_size / sizeof(uint64));
+      uint64 index_addr     = filter_addr + (page_size * (i / addrs_per_page));
       page_handle *index_page =
          cache_get(cc, index_addr, TRUE, PAGE_TYPE_FILTER);
       platform_default_log("index 0x%lx: %lu\n",

--- a/src/trunk.c
+++ b/src/trunk.c
@@ -5862,6 +5862,7 @@ trunk_split_leaf(trunk_handle *spl,
    uint16 bundle_no = trunk_leaf_rebundle_all_branches(
       spl, leaf, leaf0_num_tuples, leaf0_kv_bytes, FALSE);
 
+   uint64 page_size = trunk_page_size(&spl->cfg);
    for (uint16 leaf_no = 0; leaf_no < num_leaves; leaf_no++) {
       /*
        * 4. Create new leaf, adjust min/max keys and other metadata
@@ -5883,8 +5884,7 @@ trunk_split_leaf(trunk_handle *spl,
          trunk_alloc(spl->cc, &spl->mini, 0, &new_leaf);
 
          // copy leaf to new leaf
-         memmove(
-            new_leaf.page->data, leaf->page->data, trunk_page_size(&spl->cfg));
+         memmove(new_leaf.page->data, leaf->page->data, page_size);
       } else {
          // just going to edit the min/max keys, etc. of original leaf
          new_leaf = *leaf;

--- a/tests/unit/btree_stress_test.c
+++ b/tests/unit/btree_stress_test.c
@@ -340,10 +340,11 @@ insert_tests(cache           *cc,
    uint64 generation;
    bool32 was_unique;
 
-   int    keybuf_size = btree_page_size(cfg);
-   int    msgbuf_size = btree_page_size(cfg);
-   uint8 *keybuf      = TYPED_MANUAL_MALLOC(hid, keybuf, keybuf_size);
-   uint8 *msgbuf      = TYPED_MANUAL_MALLOC(hid, msgbuf, msgbuf_size);
+   uint64 bt_page_size = btree_page_size(cfg);
+   int    keybuf_size  = bt_page_size;
+   int    msgbuf_size  = bt_page_size;
+   uint8 *keybuf       = TYPED_MANUAL_MALLOC(hid, keybuf, keybuf_size);
+   uint8 *msgbuf       = TYPED_MANUAL_MALLOC(hid, msgbuf, msgbuf_size);
 
    for (uint64 i = start; i < end; i++) {
       if (!SUCCESS(btree_insert(cc,
@@ -409,9 +410,10 @@ query_tests(cache           *cc,
             uint64           root_addr,
             int              nkvs)
 {
-   uint8 *keybuf = TYPED_MANUAL_MALLOC(hid, keybuf, btree_page_size(cfg));
-   uint8 *msgbuf = TYPED_MANUAL_MALLOC(hid, msgbuf, btree_page_size(cfg));
-   memset(msgbuf, 0, btree_page_size(cfg));
+   uint64 bt_page_size = btree_page_size(cfg);
+   uint8 *keybuf       = TYPED_MANUAL_MALLOC(hid, keybuf, bt_page_size);
+   uint8 *msgbuf       = TYPED_MANUAL_MALLOC(hid, msgbuf, bt_page_size);
+   memset(msgbuf, 0, bt_page_size);
 
    merge_accumulator result;
    merge_accumulator_init(&result, hid);
@@ -421,11 +423,11 @@ query_tests(cache           *cc,
                    cfg,
                    root_addr,
                    type,
-                   gen_key(cfg, i, keybuf, btree_page_size(cfg)),
+                   gen_key(cfg, i, keybuf, bt_page_size),
                    &result);
       if (!btree_found(&result)
           || message_lex_cmp(merge_accumulator_to_message(&result),
-                             gen_msg(cfg, i, msgbuf, btree_page_size(cfg))))
+                             gen_msg(cfg, i, msgbuf, bt_page_size)))
       {
          ASSERT_TRUE(FALSE, "Failure on lookup %lu\n", i);
       }
@@ -444,11 +446,12 @@ iterator_test(platform_heap_id hid,
               iterator        *iter,
               bool32           forwards)
 {
-   uint64 seen    = 0;
-   uint8 *prevbuf = TYPED_MANUAL_MALLOC(hid, prevbuf, btree_page_size(cfg));
-   key    prev    = NULL_KEY;
-   uint8 *keybuf  = TYPED_MANUAL_MALLOC(hid, keybuf, btree_page_size(cfg));
-   uint8 *msgbuf  = TYPED_MANUAL_MALLOC(hid, msgbuf, btree_page_size(cfg));
+   uint64 seen         = 0;
+   uint64 bt_page_size = btree_page_size(cfg);
+   uint8 *prevbuf      = TYPED_MANUAL_MALLOC(hid, prevbuf, bt_page_size);
+   key    prev         = NULL_KEY;
+   uint8 *keybuf       = TYPED_MANUAL_MALLOC(hid, keybuf, bt_page_size);
+   uint8 *msgbuf       = TYPED_MANUAL_MALLOC(hid, msgbuf, bt_page_size);
 
    while (iterator_can_curr(iter)) {
       key     curr_key;
@@ -459,12 +462,11 @@ iterator_test(platform_heap_id hid,
       ASSERT_TRUE(k < nkvs);
 
       int rc = 0;
-      rc     = data_key_compare(cfg->data_cfg,
-                            curr_key,
-                            gen_key(cfg, k, keybuf, btree_page_size(cfg)));
+      rc     = data_key_compare(
+         cfg->data_cfg, curr_key, gen_key(cfg, k, keybuf, bt_page_size));
       ASSERT_EQUAL(0, rc);
 
-      rc = message_lex_cmp(msg, gen_msg(cfg, k, msgbuf, btree_page_size(cfg)));
+      rc = message_lex_cmp(msg, gen_msg(cfg, k, msgbuf, bt_page_size));
       ASSERT_EQUAL(0, rc);
 
       if (forwards) {

--- a/tests/unit/btree_test.c
+++ b/tests/unit/btree_test.c
@@ -302,12 +302,10 @@ leaf_hdr_search_tests(btree_config *cfg, platform_heap_id hid)
 static int
 index_hdr_tests(btree_config *cfg, btree_scratch *scratch, platform_heap_id hid)
 {
-
    char *index_buffer =
       TYPED_MANUAL_MALLOC(hid, index_buffer, btree_page_size(cfg));
    btree_hdr *hdr  = (btree_hdr *)index_buffer;
    int        nkvs = 100;
-
 
    bool32 rv     = FALSE;
    int    cmp_rv = 0;
@@ -406,18 +404,17 @@ leaf_split_tests(btree_config    *cfg,
                  int              nkvs,
                  platform_heap_id hid)
 {
-   char *leaf_buffer =
-      TYPED_MANUAL_MALLOC(hid, leaf_buffer, btree_page_size(cfg));
-   char *msg_buffer =
-      TYPED_MANUAL_MALLOC(hid, msg_buffer, btree_page_size(cfg));
+   uint64 bt_page_size = btree_page_size(cfg);
+   char  *leaf_buffer  = TYPED_MANUAL_MALLOC(hid, leaf_buffer, bt_page_size);
+   char  *msg_buffer   = TYPED_MANUAL_MALLOC(hid, msg_buffer, bt_page_size);
 
-   memset(msg_buffer, 0, btree_page_size(cfg));
+   memset(msg_buffer, 0, bt_page_size);
 
    btree_hdr *hdr = (btree_hdr *)leaf_buffer;
 
    btree_init_hdr(cfg, hdr);
 
-   int     msgsize = btree_page_size(cfg) / (nkvs + 1);
+   int     msgsize = bt_page_size / (nkvs + 1);
    message msg =
       message_create(MESSAGE_TYPE_INSERT, slice_create(msgsize, msg_buffer));
    message bigger_msg = message_create(


### PR DESCRIPTION
In debug-build test runs, profiling shows interfaces like clockcache_page_size(), clockcache_config_page_size() bubbling up to top of 'perf top' output. This commit attempts to reduce multiple calls to lookup functions to retrieve the page-size, by caching the page-size once per function where it's used multiple times.

The affected interfaces are: btree_page_size(), clockcache_page_size(), cache_page_size(), cache_config_page_size(), trunk_page_size() and few similar ones.

These changes add up to saving few seconds of test-execution (out of few mins of run-time) in debug-build mode, esp for BTree-related tests.

---
## Empirical performance test results: Running slow tests using `test.sh` on Nimbus-VM:

### With `/main`:

```
cc-sdb-vm:[7] $ tail -100 /home/agurajada/tmp/test.nightly.dbg.main.out | grep BTree
BTree test, key size=8 bytes                                                         :  710s [  0h 11m 50s ]
BTree test, with default key size                                                    :  607s [  0h 10m  7s ]
BTree test, key size=100 bytes                                                       :  336s [  0h  5m 36s ]
BTree Perf test                                                                      :  198s [  0h  3m 18s ]
BTree test, key size=8 bytes, using shared memory                                    :  702s [  0h 11m 42s ]
BTree test, with default key size, using shared memory                               :  590s [  0h  9m 50s ]
BTree test, key size=100 bytes, using shared memory                                  :  319s [  0h  5m 19s ]
BTree Perf test, using shared memory                                                 :  192s [  0h  3m 12s ]

All Tests                                                                            : 6905s [  1h 55m  5s ]
```

### With this fix:

```
cc-sdb-vm:[8] $ tail -100 /home/agurajada/tmp/test.clockcache.dbg.fix.3.out | grep BTree
BTree test, key size=8 bytes                                                         :  698s [  0h 11m 38s ]
BTree test, with default key size                                                    :  553s [  0h  9m 13s ]
BTree test, key size=100 bytes                                                       :  330s [  0h  5m 30s ]
BTree Perf test                                                                      :  197s [  0h  3m 17s ]
BTree test, key size=8 bytes, using shared memory                                    :  640s [  0h 10m 40s ]
BTree test, with default key size, using shared memory                               :  487s [  0h  8m  7s ]
BTree test, key size=100 bytes, using shared memory                                  :  291s [  0h  4m 51s ]
BTree Perf test, using shared memory                                                 :  185s [  0h  3m  5s ]

All Tests                                                                            : 6537s [  1h 48m 57s ]
```
 
 There is no earth-shattering gains to be had, but we knock-off about several 10s of seconds of execution times in a test-run taking about 10 mins (for example).
 
 Overall test-execution run-time drops by about 6-7 mins, gain of about 5% overall. 
