### PR TITLE
(#599) Replace calls to getpid() with  platform_getpid()

### DIFF
--- a/src/platform_linux/laio.c
+++ b/src/platform_linux/laio.c
@@ -24,7 +24,6 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-#include <unistd.h>
 #include <errno.h>
 #include <string.h>
 
@@ -433,7 +432,7 @@ laio_read_async(io_handle     *ioh,
          platform_error_log("%s(): OS-pid=%d, tid=%lu, req=%p"
                             ", io_submit errorno=%d: %s\n",
                             __func__,
-                            getpid(),
+                            platform_getpid(),
                             tid,
                             req,
                             -status,
@@ -471,7 +470,7 @@ laio_write_async(io_handle     *ioh,
          platform_error_log("%s(): OS-pid=%d, tid=%lu, req=%p"
                             ", io_submit errorno=%d: %s\n",
                             __func__,
-                            getpid(),
+                            platform_getpid(),
                             tid,
                             req,
                             -status,
@@ -509,7 +508,7 @@ laio_cleanup(io_handle *ioh, uint64 count)
             "%s(): OS-pid=%d, tid=%lu, io_getevents[%lu], count=%lu, "
             "failed with errorno=%d: %s\n",
             __func__,
-            getpid(),
+            platform_getpid(),
             tid,
             i,
             count,

--- a/src/platform_linux/platform.c
+++ b/src/platform_linux/platform.c
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <stdarg.h>
-#include <unistd.h>
 #include <sys/mman.h>
 #include "platform.h"
 #include "shmem.h"
@@ -660,7 +659,7 @@ platform_assert_msg(platform_log_handle *log_handle,
                                   "Assertion failed at %s:%d:%s(): \"%s\". ";
    platform_log(log_handle,
                 assert_msg_fmt,
-                getpid(),
+                platform_getpid(),
                 gettid(),
                 platform_get_tid(), // SplinterDB's thread-ID (index)
                 filename,

--- a/src/platform_linux/platform_inline.h
+++ b/src/platform_linux/platform_inline.h
@@ -4,6 +4,7 @@
 #ifndef PLATFORM_LINUX_INLINE_H
 #define PLATFORM_LINUX_INLINE_H
 
+#include <unistd.h>
 #include <laio.h>
 #include <string.h> // for memcpy, strerror
 #include <time.h>   // for nanosecond sleep api.
@@ -222,6 +223,12 @@ platform_set_tid(threadid t)
 {
    extern __thread threadid xxxtid;
    xxxtid = t;
+}
+
+static inline int
+platform_getpid()
+{
+   return getpid();
 }
 
 static inline void

--- a/src/platform_linux/shmem.c
+++ b/src/platform_linux/shmem.c
@@ -7,8 +7,6 @@
  * This file contains the implementation for managing shared memory created
  * for use by SplinterDB and all its innards.
  */
-#include <unistd.h>
-
 #include "platform.h"
 #include "shmem.h"
 #include "util.h"
@@ -832,7 +830,7 @@ platform_shm_track_large_alloc(shmem_heap *shm, void *addr, size_t size)
       frag->frag_addr = addr;
       frag->frag_size = size;
 
-      frag->frag_allocated_to_pid = getpid();
+      frag->frag_allocated_to_pid = platform_getpid();
       frag->frag_allocated_to_tid = platform_get_tid();
 
       // The freed_by_pid/freed_by_tid == 0 means fragment is still allocated.
@@ -898,7 +896,7 @@ platform_shm_track_free(shmem_heap *shm,
 
       // Mark the fragment as in-use by recording the process/thread that's
       // doing the free.
-      frag->frag_freed_by_pid = getpid();
+      frag->frag_freed_by_pid = platform_getpid();
       frag->frag_freed_by_tid = platform_get_tid();
 
       if (trace_shmem) {
@@ -922,7 +920,7 @@ platform_shm_track_free(shmem_heap *shm,
    if (!found_tracked_frag && trace_shmem) {
       platform_default_log("[OS-pid=%d, ThreadID=%lu, %s:%d::%s()] "
                            ", Fragment %p for object '%s' is not tracked\n",
-                           getpid(),
+                           platform_getpid(),
                            platform_get_tid(),
                            file,
                            lineno,
@@ -988,7 +986,7 @@ platform_shm_find_large(shmem_heap *shm,
       found_at_fctr      = fctr;
 
       // Record the process/thread to which free fragment is being allocated
-      frag->frag_allocated_to_pid = getpid();
+      frag->frag_allocated_to_pid = platform_getpid();
       frag->frag_allocated_to_tid = platform_get_tid();
 
       shm->usage.nlarge_frags_inuse++;
@@ -1299,7 +1297,7 @@ platform_shm_trace_allocs(shmem_heap  *shm,
                         "-> %s: %s size=%lu bytes (%s)"
                         " for object '%s', at %p, "
                         "free bytes=%lu (%s).\n",
-                        getpid(),
+                        platform_getpid(),
                         platform_get_tid(),
                         file,
                         lineno,

--- a/src/routing_filter.c
+++ b/src/routing_filter.c
@@ -8,7 +8,6 @@
  *     This file contains the implementation for a routing filter
  *----------------------------------------------------------------------
  */
-#include <unistd.h>
 #include "platform.h"
 #include "routing_filter.h"
 #include "PackedArray.h"
@@ -104,7 +103,7 @@ RadixSort(uint32 *pData,
          platform_assert((mIndex[j][c] < count),
                          "OS-pid=%d, thread-ID=%lu, i=%u, j=%u, c=%d"
                          ", mIndex[j][c]=%d, count=%u\n",
-                         getpid(),
+                         platform_getpid(),
                          platform_get_tid(),
                          i,
                          j,

--- a/tests/functional/io_apis_test.c
+++ b/tests/functional/io_apis_test.c
@@ -32,7 +32,6 @@
  *  Hence, there is no separate lower-level API exerciser unit-test.
  * ----------------------------------------------------------------------------
  */
-#include <unistd.h>
 #include <sys/wait.h>
 
 #include "platform.h"
@@ -230,7 +229,7 @@ splinter_io_apis_test(int argc, char *argv[])
                   master_cfg.io_async_queue_depth,
                   "splinterdb_io_apis_test_db");
 
-   int pid = getpid();
+   int pid = platform_getpid();
    platform_default_log("Parent OS-pid=%d, Exercise IO sub-system test on"
                         " device '%s'"
                         ", page_size=%lu, extent_size=%lu, async_queue_size=%lu"
@@ -347,7 +346,7 @@ splinter_io_apis_test(int argc, char *argv[])
                                  "Child execution wait() completed."
                                  " Resuming parent ...\n",
                                  platform_get_tid(),
-                                 getpid());
+                                 platform_getpid());
          }
       }
    }
@@ -369,7 +368,7 @@ splinter_io_apis_test(int argc, char *argv[])
                                  ", Parent io_handle=%p, io_hdl=%p"
                                  ", IO context[%lu]: "
                                  "%p\n",
-                                 getpid(),
+                                 platform_getpid(),
                                  this_thread_idx,
                                  whoami,
                                  Parent_io_handle,
@@ -393,7 +392,7 @@ splinter_io_apis_test(int argc, char *argv[])
          platform_default_log("After  fork()'ing: %s OS-pid=%d"
                               ", ThreadID=%lu",
                               whoami,
-                              getpid(),
+                              platform_getpid(),
                               this_thread_idx);
 
          if (Verbose_progress) {
@@ -441,7 +440,7 @@ heap_destroy:
       platform_default_log("%s: OS-pid=%d, Thread-ID=%lu"
                            " execution completed.\n",
                            whoami,
-                           getpid(),
+                           platform_getpid(),
                            platform_get_tid());
    }
    return (SUCCESS(rc) ? 0 : -1);
@@ -507,7 +506,7 @@ test_sync_writes(platform_heap_id    hid,
          "  %s(): OS-pid=%d, Thread %lu performed %lu %dK page write IOs "
          "from start addr=%lu through end addr=%lu\n",
          __func__,
-         getpid(),
+         platform_getpid(),
          this_thread,
          num_IOs,
          (int)(page_size / KiB),
@@ -618,7 +617,7 @@ test_sync_reads(platform_heap_id    hid,
          "  %s(): OS-pid=%d, Thread %lu performed %lu %dK page read  IOs "
          "from start addr=%lu through end addr=%lu\n",
          __func__,
-         getpid(),
+         platform_getpid(),
          this_thread,
          num_IOs,
          (int)(page_size / KiB),
@@ -693,7 +692,7 @@ test_sync_write_reads_by_threads(io_test_fn_args *io_test_param,
       "\n%s(): %s process, OS-pid=%d, creates %d threads, %lu pages/thread \n",
       __func__,
       whoami,
-      getpid(),
+      platform_getpid(),
       nthreads,
       npages);
 

--- a/tests/test_common.c
+++ b/tests/test_common.c
@@ -8,7 +8,6 @@
  * Module contains functions shared between functional/ and unit/ test sources.
  * -----------------------------------------------------------------------------
  */
-#include <unistd.h>
 #include "splinterdb/public_platform.h"
 #include "trunk.h"
 #include "functional/test.h"
@@ -148,7 +147,7 @@ trace_wait_for_gdb(void)
       if (!gdb_msg_printed) {
          platform_default_log(
             "Looping ... Attach gdb to OS-pid=%d; Set breakpoint in %s_hook\n",
-            getpid(),
+            platform_getpid(),
             __func__);
          gdb_msg_printed = TRUE;
       }

--- a/tests/unit/btree_stress_test.c
+++ b/tests/unit/btree_stress_test.c
@@ -9,7 +9,6 @@
  * -----------------------------------------------------------------------------
  */
 #include <string.h>
-#include <unistd.h>
 #include <fcntl.h>
 #include <pthread.h>
 

--- a/tests/unit/large_inserts_stress_test.c
+++ b/tests/unit/large_inserts_stress_test.c
@@ -11,7 +11,6 @@
  * -----------------------------------------------------------------------------
  */
 #include <fcntl.h>
-#include <unistd.h>
 #include <string.h>
 #include <sys/wait.h>
 
@@ -101,7 +100,7 @@ CTEST_SETUP(large_inserts_stress)
 {
    // First, register that main() is being run as a parent process
    data->am_parent = TRUE;
-   data->this_pid  = getpid();
+   data->this_pid  = platform_getpid();
 
    platform_status rc;
    uint64          heap_capacity = (64 * MiB); // small heap is sufficient.
@@ -314,7 +313,7 @@ CTEST2(large_inserts_stress, test_seq_key_seq_values_inserts_forked)
    wcfg.master_cfg  = &data->master_cfg;
    wcfg.num_inserts = data->num_inserts;
 
-   int pid = getpid();
+   int pid = platform_getpid();
 
    if (wcfg.master_cfg->fork_child) {
       pid = fork();
@@ -325,7 +324,7 @@ CTEST2(large_inserts_stress, test_seq_key_seq_values_inserts_forked)
       } else if (pid) {
          platform_default_log("OS-pid=%d, Thread-ID=%lu: "
                               "Waiting for child pid=%d to complete ...\n",
-                              getpid(),
+                              platform_getpid(),
                               platform_get_tid(),
                               pid);
 
@@ -335,13 +334,13 @@ CTEST2(large_inserts_stress, test_seq_key_seq_values_inserts_forked)
                               "Child execution wait() completed."
                               " Resuming parent ...\n",
                               platform_get_tid(),
-                              getpid());
+                              platform_getpid());
       }
    }
    if (pid == 0) {
       // Record in global data that we are now running as a child.
       data->am_parent = FALSE;
-      data->this_pid  = getpid();
+      data->this_pid  = platform_getpid();
 
       platform_default_log(
          "OS-pid=%d Running as %s process ...\n",
@@ -682,7 +681,7 @@ exec_worker_thread(void *w)
                platform_default_log("OS-pid=%d, Thread-ID=%lu"
                                     ", Insert random value of "
                                     "fixed-length=%lu bytes.\n",
-                                    getpid(),
+                                    platform_getpid(),
                                     thread_idx,
                                     val_len);
                val_length_msg_printed = TRUE;
@@ -696,7 +695,7 @@ exec_worker_thread(void *w)
                platform_default_log("OS-pid=%d, Thread-ID=%lu"
                                     ", Insert small-width sequential values of "
                                     "different lengths.\n",
-                                    getpid(),
+                                    platform_getpid(),
                                     thread_idx);
                val_length_msg_printed = TRUE;
             }
@@ -705,7 +704,7 @@ exec_worker_thread(void *w)
                platform_default_log("OS-pid=%d, Thread-ID=%lu"
                                     ", Insert fully-packed fixed value of "
                                     "length=%lu bytes.\n",
-                                    getpid(),
+                                    platform_getpid(),
                                     thread_idx,
                                     val_len);
                val_length_msg_printed = TRUE;

--- a/tests/unit/main.c
+++ b/tests/unit/main.c
@@ -15,7 +15,6 @@
 #include <stdarg.h>
 #include <string.h>
 #include <sys/time.h>
-#include <unistd.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <wchar.h>
@@ -144,7 +143,7 @@ sighandler(int signum)
     * so it can terminate as expected
     */
    signal(signum, SIG_DFL);
-   kill(getpid(), signum);
+   kill(platform_getpid(), signum);
 }
 #endif // CTEST_SEGFAULT
 

--- a/tests/unit/splinterdb_forked_child_test.c
+++ b/tests/unit/splinterdb_forked_child_test.c
@@ -13,7 +13,6 @@
  * functional usages in this multi-process configuration.
  * -----------------------------------------------------------------------------
  */
-#include <unistd.h>
 #include <sys/wait.h>
 
 #include "platform.h"
@@ -119,7 +118,7 @@ CTEST2(splinterdb_forked_child, test_data_structures_handles)
    int         rc = splinterdb_create(&splinterdb_cfg, &spl_handle);
    ASSERT_EQUAL(0, rc);
 
-   int pid = getpid();
+   int pid = platform_getpid();
 
    // Parent / main() process is always at tid==0.
    ASSERT_EQUAL(0, platform_get_tid());
@@ -233,7 +232,7 @@ CTEST2(splinterdb_forked_child, test_one_insert_then_close_bug)
    int         rc = splinterdb_create(&splinterdb_cfg, &spl_handle);
    ASSERT_EQUAL(0, rc);
 
-   int pid = getpid();
+   int pid = platform_getpid();
 
    platform_default_log(
       "Parent OS-pid=%d, ThreadID=%lu\n", pid, platform_get_tid());
@@ -248,7 +247,7 @@ CTEST2(splinterdb_forked_child, test_one_insert_then_close_bug)
 
       platform_default_log("OS-pid=%d, ThreadID=%lu: "
                            "Child execution started ...\n",
-                           getpid(),
+                           platform_getpid(),
                            platform_get_tid());
 
       char   key_data[30];
@@ -277,7 +276,7 @@ CTEST2(splinterdb_forked_child, test_one_insert_then_close_bug)
    if (pid) {
       platform_default_log("OS-pid=%d, ThreadID=%lu: "
                            "Waiting for child pid=%d to complete ...\n",
-                           getpid(),
+                           platform_getpid(),
                            platform_get_tid(),
                            pid);
 
@@ -286,7 +285,7 @@ CTEST2(splinterdb_forked_child, test_one_insert_then_close_bug)
       platform_default_log("OS-pid=%d, ThreadID=%lu: "
                            "Child execution wait() completed."
                            " Resuming parent ...\n",
-                           getpid(),
+                           platform_getpid(),
                            platform_get_tid());
 
       // We would get assertions tripping from BTree iterator code here,
@@ -353,7 +352,7 @@ CTEST2(splinterdb_forked_child,
    int         rc = splinterdb_create(&splinterdb_cfg, &spl_handle);
    ASSERT_EQUAL(0, rc);
 
-   int pid = getpid();
+   int pid = platform_getpid();
 
    platform_default_log(
       "Parent OS-pid=%d, ThreadID=%lu\n", pid, platform_get_tid());
@@ -369,7 +368,7 @@ CTEST2(splinterdb_forked_child,
       platform_default_log(
          "OS-pid=%d, ThreadID=%lu: "
          "Child execution started: Test cache-flush before deregister ...\n",
-         getpid(),
+         platform_getpid(),
          platform_get_tid());
 
       do_many_inserts(spl_handle, data->num_inserts);
@@ -383,7 +382,7 @@ CTEST2(splinterdb_forked_child,
 
       platform_default_log(
          "OS-pid=%d, ThreadID=%lu, Test cache-flush after deregister:\n",
-         getpid(),
+         platform_getpid(),
          platform_get_tid());
 
       do_many_inserts(spl_handle, data->num_inserts);
@@ -404,7 +403,7 @@ CTEST2(splinterdb_forked_child,
    if (pid) {
       platform_default_log("OS-pid=%d, ThreadID=%lu: "
                            "Waiting for child pid=%d to complete ...\n",
-                           getpid(),
+                           platform_getpid(),
                            platform_get_tid(),
                            pid);
 
@@ -413,7 +412,7 @@ CTEST2(splinterdb_forked_child,
       platform_default_log("OS-pid=%d, ThreadID=%lu: "
                            "Child execution wait() completed."
                            " Resuming parent ...\n",
-                           getpid(),
+                           platform_getpid(),
                            platform_get_tid());
       splinterdb_close(&spl_handle);
    } else {
@@ -459,7 +458,7 @@ CTEST2(splinterdb_forked_child, test_multiple_forked_process_doing_IOs)
    int         rc = splinterdb_create(&splinterdb_cfg, &spl_handle);
    ASSERT_EQUAL(0, rc);
 
-   int pid = getpid();
+   int pid = platform_getpid();
 
    platform_default_log(
       "Parent OS-pid=%d, ThreadID=%lu, fork %lu child processes.\n",
@@ -497,7 +496,7 @@ CTEST2(splinterdb_forked_child, test_multiple_forked_process_doing_IOs)
             "OS-pid=%d, ThreadID=%lu:"
             "Child execution started: Perform %lu (%d million) inserts ..."
             " Test cache-flush before deregister ...\n",
-            getpid(),
+            platform_getpid(),
             platform_get_tid(),
             data->num_inserts,
             (int)(data->num_inserts / MILLION));
@@ -522,7 +521,7 @@ CTEST2(splinterdb_forked_child, test_multiple_forked_process_doing_IOs)
    if (data->am_parent && pid) {
       platform_default_log("OS-pid=%d, ThreadID=%lu: "
                            "Waiting for child pid=%d to complete ...\n",
-                           getpid(),
+                           platform_getpid(),
                            platform_get_tid(),
                            pid);
 
@@ -540,7 +539,7 @@ CTEST2(splinterdb_forked_child, test_multiple_forked_process_doing_IOs)
       platform_default_log("OS-pid=%d, ThreadID=%lu: "
                            "Child execution wait() completed."
                            " Resuming parent ...\n",
-                           getpid(),
+                           platform_getpid(),
                            platform_get_tid());
 
       splinterdb_close(&spl_handle);


### PR DESCRIPTION
This commit cleans-up the `#include <unistd.h>` from several .c files that needed access to get pid(). Instead, change the code to invoke platform_getpid(), now defined in platform_inline.h