### PR TITLE
Fix several bugs in cache_test

### DIFF
--- a/src/clockcache.c
+++ b/src/clockcache.c
@@ -2499,12 +2499,19 @@ clockcache_validate_page(clockcache *cc, page_handle *page, uint64 addr)
 void
 clockcache_assert_ungot(clockcache *cc, uint64 addr)
 {
-   uint32         entry_number = clockcache_lookup(cc, addr);
-   const threadid tid          = platform_get_tid();
+   uint32 entry_number = clockcache_lookup(cc, addr);
 
    if (entry_number != CC_UNMAPPED_ENTRY) {
-      debug_only uint16 ref_count = clockcache_get_ref(cc, entry_number, tid);
-      debug_assert(ref_count == 0);
+      for (threadid tid = 0; tid < CC_RC_WIDTH; tid++) {
+         debug_only uint16 ref_count =
+            clockcache_get_ref(cc, entry_number, tid);
+         debug_assert(ref_count == 0,
+                      "Entry %u addr %lu has ref count %u for thread %lu",
+                      entry_number,
+                      addr,
+                      ref_count,
+                      tid);
+      }
    }
 }
 


### PR DESCRIPTION
`test_wait_inflight` did not match how it was used from `test_do_read_batch`.

Also, `cache_assert_ungot` was attempting to implement an impossible check and the test was attempting to use that check.

`clockcache_assert_ungot` was trying to check only that the current thread did not hold a read lock on the specificied page.  But, since CC_RC_WIDTH is only 4, multiple threads may share the same read counter and hence, even if one thread holds no locks, the read counter for a page may be non-zero.  So I changed `clockcache_assert_ungot` to check that no thread has a read lock on the page, which matches its description.

I then modified `cache_test` to use the corrected `cache_assert_ungot`.
