### PR TITLE
Robj/deadlock fix

### DIFF
--- a/src/clockcache.c
+++ b/src/clockcache.c
@@ -1697,7 +1697,7 @@ clockcache_get_internal(clockcache   *cc,       // IN
    refcount extent_ref_count = allocator_get_refcount(cc->al, base_addr);
 
    // Dump allocated extents info for deeper debugging.
-   if (extent_ref_count AL_FREE) {
+   if (extent_ref_count == AL_FREE) {
       allocator_print_allocated(cc->al);
    }
    debug_assert((extent_ref_count != AL_FREE),

--- a/src/core.c
+++ b/src/core.c
@@ -1259,8 +1259,6 @@ core_lookup(core_handle *spl, key target, merge_accumulator *result)
 
    rc = trunk_merge_lookup(
       &spl->trunk_context, &root_handle, target, result, NULL);
-   // Release the node handle before handling any errors
-   trunk_ondisk_node_handle_deinit(&root_handle);
    if (!SUCCESS(rc)) {
       return rc;
    }
@@ -1340,9 +1338,6 @@ core_lookup_async(core_lookup_async_state *state)
                     state->callback,
                     state->callback_arg);
    rc = async_result(&state->trunk_node_state);
-
-   // Release the node handle before handling any errors
-   trunk_ondisk_node_handle_deinit(&state->root_handle);
    if (!SUCCESS(rc)) {
       async_return(state, rc);
    }
@@ -1911,7 +1906,6 @@ core_print_lookup(core_handle *spl, key target, platform_log_handle *log_handle)
    trunk_ondisk_node_handle handle;
    trunk_init_root_handle(&spl->trunk_context, &handle);
    trunk_merge_lookup(&spl->trunk_context, &handle, target, &data, log_handle);
-   trunk_ondisk_node_handle_deinit(&handle);
 }
 
 void

--- a/src/core.c
+++ b/src/core.c
@@ -156,8 +156,11 @@ core_set_super_block(core_handle *spl,
    super                = (core_super_block *)super_page->data;
    uint64 old_root_addr = super->root_addr;
 
-   if (spl->trunk_context.root != NULL) {
-      super->root_addr = spl->trunk_context.root->addr;
+   trunk_ondisk_node_handle root_handle;
+   trunk_init_root_handle(&spl->trunk_context, &root_handle);
+   uint64 root_addr = trunk_ondisk_node_handle_addr(&root_handle);
+   if (root_addr != 0) {
+      super->root_addr = root_addr;
       rc               = trunk_inc_ref(spl->cfg.trunk_node_cfg,
                          spl->heap_id,
                          spl->cc,
@@ -169,6 +172,8 @@ core_set_super_block(core_handle *spl,
    } else {
       super->root_addr = 0;
    }
+   trunk_ondisk_node_handle_deinit(&root_handle);
+
    if (spl->cfg.use_log) {
       if (spl->log) {
          super->log_addr      = log_addr(spl->log);

--- a/src/core.c
+++ b/src/core.c
@@ -1259,6 +1259,7 @@ core_lookup(core_handle *spl, key target, merge_accumulator *result)
 
    rc = trunk_merge_lookup(
       &spl->trunk_context, &root_handle, target, result, NULL);
+   trunk_ondisk_node_handle_deinit(&root_handle);
    if (!SUCCESS(rc)) {
       return rc;
    }
@@ -1337,6 +1338,7 @@ core_lookup_async(core_lookup_async_state *state)
                     NULL,
                     state->callback,
                     state->callback_arg);
+   trunk_ondisk_node_handle_deinit(&state->root_handle);
    rc = async_result(&state->trunk_node_state);
    if (!SUCCESS(rc)) {
       async_return(state, rc);
@@ -1906,6 +1908,7 @@ core_print_lookup(core_handle *spl, key target, platform_log_handle *log_handle)
    trunk_ondisk_node_handle handle;
    trunk_init_root_handle(&spl->trunk_context, &handle);
    trunk_merge_lookup(&spl->trunk_context, &handle, target, &data, log_handle);
+   trunk_ondisk_node_handle_deinit(&handle);
 }
 
 void

--- a/src/trunk.c
+++ b/src/trunk.c
@@ -5762,6 +5762,8 @@ trunk_context_init(trunk_context      *context,
                    task_system        *ts,
                    uint64              root_addr)
 {
+   memset(context, 0, sizeof(trunk_context));
+
    if (root_addr != 0) {
       context->root =
          trunk_ondisk_node_ref_create(hid, NEGATIVE_INFINITY_KEY, root_addr);
@@ -5791,7 +5793,6 @@ trunk_context_init(trunk_context      *context,
 
    trunk_pivot_state_map_init(&context->pivot_states);
    platform_batch_rwlock_init(&context->root_lock);
-
 
    return STATUS_OK;
 }

--- a/src/trunk.c
+++ b/src/trunk.c
@@ -1027,7 +1027,7 @@ trunk_ondisk_node_handle_setup_content_page(trunk_ondisk_node_handle *handle,
 
 /*
  * IN Parameters:
- * - state->handle: the ondisk_node_handle
+ * - state->handlep: the ondisk_node_handle
  * - state->offset: the offset of the page to get
  *
  * IN/OUT Parameters:
@@ -1046,37 +1046,37 @@ trunk_ondisk_node_handle_setup_content_page_async(
 {
    async_begin(state, depth);
 
-   uint64 page_size = cache_page_size(state->handle.cc);
+   uint64 page_size = cache_page_size(state->handlep->cc);
 
-   if (offset_is_in_content_page(&state->handle, *state->page, state->offset)) {
+   if (offset_is_in_content_page(state->handlep, *state->page, state->offset)) {
       state->rc = STATUS_OK;
       async_return(state);
    }
 
-   if (*state->page != NULL && *state->page != state->handle.header_page) {
-      cache_unget(state->handle.cc, *state->page);
+   if (*state->page != NULL && *state->page != state->handlep->header_page) {
+      cache_unget(state->handlep->cc, *state->page);
    }
 
    if (state->offset < page_size) {
-      *state->page = state->handle.header_page;
+      *state->page = state->handlep->header_page;
       state->rc    = STATUS_OK;
       async_return(state);
    } else {
-      uint64 addr = state->handle.header_page->disk_addr + state->offset;
+      uint64 addr = state->handlep->header_page->disk_addr + state->offset;
       addr -= (addr % page_size);
       cache_get_async_state_init(state->cache_get_state,
-                                 state->handle.cc,
+                                 state->handlep->cc,
                                  addr,
                                  PAGE_TYPE_TRUNK,
                                  state->callback,
                                  state->callback_arg);
-      while (cache_get_async(state->handle.cc, state->cache_get_state)
+      while (cache_get_async(state->handlep->cc, state->cache_get_state)
              != ASYNC_STATUS_DONE)
       {
          async_yield(state);
       }
-      *state->page =
-         cache_get_async_state_result(state->handle.cc, state->cache_get_state);
+      *state->page = cache_get_async_state_result(state->handlep->cc,
+                                                  state->cache_get_state);
       if (*state->page == NULL) {
          platform_error_log("%s():%d: cache_get() failed", __func__, __LINE__);
          state->rc = STATUS_IO_ERROR;
@@ -1123,7 +1123,7 @@ trunk_ondisk_node_get_pivot(trunk_ondisk_node_handle *handle, uint64 pivot_num)
 
 /*
  * IN Parameters:
- * - state->handle: the ondisk_node_handle
+ * - state->handlep: the ondisk_node_handle
  * - state->pivot_num: the pivot number to get
  *
  * OUT Parameters:
@@ -1142,9 +1142,9 @@ trunk_ondisk_node_get_pivot_async(trunk_merge_lookup_async_state *state,
    async_begin(state, depth);
 
    trunk_ondisk_node *header =
-      (trunk_ondisk_node *)state->handle.header_page->data;
+      (trunk_ondisk_node *)state->handlep->header_page->data;
    state->offset = header->pivot_offsets[state->pivot_num];
-   state->page   = &state->handle.pivot_page;
+   state->page   = &state->handlep->pivot_page;
    async_await_subroutine(state,
                           trunk_ondisk_node_handle_setup_content_page_async);
    if (!SUCCESS(state->rc)) {
@@ -1157,9 +1157,9 @@ trunk_ondisk_node_get_pivot_async(trunk_merge_lookup_async_state *state,
       async_return(state);
    }
    state->pivot =
-      (trunk_ondisk_pivot *)(state->handle.pivot_page->data + state->offset
-                             - content_page_offset(&state->handle,
-                                                   state->handle.pivot_page));
+      (trunk_ondisk_pivot *)(state->handlep->pivot_page->data + state->offset
+                             - content_page_offset(state->handlep,
+                                                   state->handlep->pivot_page));
    state->rc = STATUS_OK;
    async_return(state);
 }
@@ -1245,7 +1245,7 @@ trunk_ondisk_node_bundle_at_offset(trunk_ondisk_node_handle *handle,
 
 /*
  * IN Parameters:
- * - state->handle: the ondisk_node_handle
+ * - state->handlep: the ondisk_node_handle
  * - state->offset: the offset of the bundle
  *
  * OUT Parameters:
@@ -1260,7 +1260,7 @@ static async_status
 trunk_ondisk_node_bundle_at_offset_async(trunk_merge_lookup_async_state *state,
                                          uint64                          depth)
 {
-   uint64 page_size = cache_page_size(state->handle.cc);
+   uint64 page_size = cache_page_size(state->handlep->cc);
 
    async_begin(state, depth);
 
@@ -1270,7 +1270,7 @@ trunk_ondisk_node_bundle_at_offset_async(trunk_merge_lookup_async_state *state,
       state->offset += page_size - (state->offset % page_size);
    }
 
-   state->page = &state->handle.inflight_bundle_page;
+   state->page = &state->handlep->inflight_bundle_page;
    async_await_subroutine(state,
                           trunk_ondisk_node_handle_setup_content_page_async);
    if (!SUCCESS(state->rc)) {
@@ -1283,17 +1283,17 @@ trunk_ondisk_node_bundle_at_offset_async(trunk_merge_lookup_async_state *state,
       async_return(state);
    }
    state->bndl =
-      (trunk_ondisk_bundle *)(state->handle.inflight_bundle_page->data
+      (trunk_ondisk_bundle *)(state->handlep->inflight_bundle_page->data
                               + state->offset
                               - content_page_offset(
-                                 &state->handle,
-                                 state->handle.inflight_bundle_page));
+                                 state->handlep,
+                                 state->handlep->inflight_bundle_page));
 
    /* If there wasn't enough room for this bundle on this page, then we would
     * have zeroed the remaining bytes and put the bundle on the next page. */
    if (state->bndl->num_branches == 0) {
       state->offset += page_size - (state->offset % page_size);
-      state->page = &state->handle.inflight_bundle_page;
+      state->page = &state->handlep->inflight_bundle_page;
       async_await_subroutine(state,
                              trunk_ondisk_node_handle_setup_content_page_async);
       if (!SUCCESS(state->rc)) {
@@ -1306,11 +1306,11 @@ trunk_ondisk_node_bundle_at_offset_async(trunk_merge_lookup_async_state *state,
          async_return(state);
       }
       state->bndl =
-         (trunk_ondisk_bundle *)(state->handle.inflight_bundle_page->data
+         (trunk_ondisk_bundle *)(state->handlep->inflight_bundle_page->data
                                  + state->offset
                                  - content_page_offset(
-                                    &state->handle,
-                                    state->handle.inflight_bundle_page));
+                                    state->handlep,
+                                    state->handlep->inflight_bundle_page));
    }
    async_return(state);
 }
@@ -1331,7 +1331,7 @@ trunk_ondisk_node_get_first_inflight_bundle(trunk_ondisk_node_handle *handle,
 
 /*
  * IN Parameters:
- * - state->handle: the ondisk_node_handle
+ * - state->handlep: the ondisk_node_handle
  *
  * OUT Parameters:
  * - state->bndl: the bundle
@@ -1350,7 +1350,7 @@ trunk_ondisk_node_get_first_inflight_bundle_async(
    async_begin(state, depth);
 
    trunk_ondisk_node *header =
-      (trunk_ondisk_node *)state->handle.header_page->data;
+      (trunk_ondisk_node *)state->handlep->header_page->data;
    if (header->num_inflight_bundles == 0) {
       state->bndl = NULL;
       state->rc   = STATUS_OK;
@@ -1374,7 +1374,7 @@ trunk_ondisk_node_get_next_inflight_bundle(trunk_ondisk_node_handle *handle,
 
 /*
  * IN Parameters:
- * - state->handle: the ondisk_node_handle
+ * - state->handlep: the ondisk_node_handle
  *
  * IN/OUT Parameters:
  * - state->bndl: the bundle
@@ -1393,10 +1393,11 @@ trunk_ondisk_node_get_next_inflight_bundle_async(
    uint64                          depth)
 {
    async_begin(state, depth);
-   state->offset =
-      ((char *)state->bndl) - state->handle.inflight_bundle_page->data
-      + content_page_offset(&state->handle, state->handle.inflight_bundle_page)
-      + sizeof_trunk_ondisk_bundle(state->bndl);
+   state->offset = ((char *)state->bndl)
+                   - state->handlep->inflight_bundle_page->data
+                   + content_page_offset(state->handlep,
+                                         state->handlep->inflight_bundle_page)
+                   + sizeof_trunk_ondisk_bundle(state->bndl);
    async_await_subroutine(state, trunk_ondisk_node_bundle_at_offset_async);
    async_return(state);
 }
@@ -4961,7 +4962,7 @@ trunk_ondisk_node_find_pivot(const trunk_context      *context,
 /*
  * IN Parameters:
  * state->context: the trunk node context
- * state->handle: the ondisk node handle
+ * state->handlep: the ondisk node handle
  * state->tgt: the target key
  * //state->cmp: the comparison to use
  *
@@ -4987,7 +4988,7 @@ trunk_ondisk_node_find_pivot_async(trunk_merge_lookup_async_state *state,
    async_begin(state, depth);
 
    state->min = 0;
-   state->max = trunk_ondisk_node_num_pivots(&state->handle) - 1;
+   state->max = trunk_ondisk_node_num_pivots(state->handlep) - 1;
 
    // invariant: pivot[min] <= tgt < pivot[max]
    state->min_pivot = NULL;
@@ -5018,12 +5019,12 @@ trunk_ondisk_node_find_pivot_async(trunk_merge_lookup_async_state *state,
    */
    // if (0 < state->min && state->last_cmp == 0 && state->cmp == less_than) {
    //    state->min--;
-   //    state->min_pivot = ondisk_node_get_pivot(&state->handle, state->min);
+   //    state->min_pivot = ondisk_node_get_pivot(state->handlep, state->min);
    // }
 
    if (state->min_pivot == NULL) {
       state->min_pivot =
-         trunk_ondisk_node_get_pivot(&state->handle, state->min);
+         trunk_ondisk_node_get_pivot(state->handlep, state->min);
    }
 
    state->pivot = state->min_pivot;
@@ -5247,36 +5248,31 @@ trunk_merge_lookup(trunk_context            *context,
 {
    platform_status rc = STATUS_OK;
 
-   trunk_ondisk_node_handle handle;
-   rc = trunk_ondisk_node_handle_clone(&handle, inhandle);
-   if (!SUCCESS(rc)) {
-      platform_error_log("trunk_merge_lookup: "
-                         "trunk_ondisk_node_handle_clone failed: %d\n",
-                         rc.r);
-      return rc;
-   }
+   trunk_ondisk_node_handle  handle;
+   trunk_ondisk_node_handle *handlep;
+   handlep = inhandle;
 
-   while (handle.header_page) {
-      uint64 height = trunk_ondisk_node_height(&handle);
+   while (handlep && handlep->header_page) {
+      uint64 height = trunk_ondisk_node_height(handlep);
 
       if (log) {
          trunk_node node;
          rc = trunk_node_deserialize(
-            context, handle.header_page->disk_addr, &node);
+            context, handlep->header_page->disk_addr, &node);
          if (!SUCCESS(rc)) {
             platform_error_log("trunk_merge_lookup: "
                                "node_deserialize failed: %d\n",
                                rc.r);
             goto cleanup;
          }
-         platform_log(log, "addr: %lu\n", handle.header_page->disk_addr);
+         platform_log(log, "addr: %lu\n", handlep->header_page->disk_addr);
          trunk_node_print(&node, log, context->cfg->data_cfg, 0);
          trunk_node_deinit(&node, context);
       }
 
       trunk_ondisk_pivot *pivot;
       rc = trunk_ondisk_node_find_pivot(
-         context, &handle, tgt, less_than_or_equal, &pivot);
+         context, handlep, tgt, less_than_or_equal, &pivot);
       if (!SUCCESS(rc)) {
          platform_error_log(
             "trunk_merge_lookup: ondisk_node_find_pivot failed: "
@@ -5294,7 +5290,7 @@ trunk_merge_lookup(trunk_context            *context,
 
       // Search the inflight bundles
       trunk_ondisk_bundle *bndl;
-      rc = trunk_ondisk_node_get_first_inflight_bundle(&handle, &bndl);
+      rc = trunk_ondisk_node_get_first_inflight_bundle(handlep, &bndl);
       if (!SUCCESS(rc)) {
          platform_error_log("trunk_merge_lookup: "
                             "ondisk_node_get_first_inflight_bundle failed\n");
@@ -5313,7 +5309,7 @@ trunk_merge_lookup(trunk_context            *context,
             goto cleanup;
          }
          if (i < pivot->num_live_inflight_bundles - 1) {
-            bndl = trunk_ondisk_node_get_next_inflight_bundle(&handle, bndl);
+            bndl = trunk_ondisk_node_get_next_inflight_bundle(handlep, bndl);
          }
       }
 
@@ -5342,16 +5338,18 @@ trunk_merge_lookup(trunk_context            *context,
                                rc.r);
             goto cleanup;
          }
-         trunk_ondisk_node_handle_deinit(&handle);
-         handle = child_handle;
+         trunk_ondisk_node_handle_deinit(handlep);
+         handle  = child_handle;
+         handlep = &handle;
       } else {
-         trunk_ondisk_node_handle_deinit(&handle);
+         trunk_ondisk_node_handle_deinit(handlep);
+         handlep = NULL;
       }
    }
 
 cleanup:
-   if (handle.header_page) {
-      trunk_ondisk_node_handle_deinit(&handle);
+   if (handlep) {
+      trunk_ondisk_node_handle_deinit(handlep);
    }
    return rc;
 }
@@ -5361,24 +5359,16 @@ trunk_merge_lookup_async(trunk_merge_lookup_async_state *state)
 {
    async_begin(state, 0);
 
-   // We don't need to perform the clone asynchronously because the header page
-   // is guaranteed to be in memory.
-   state->rc = trunk_ondisk_node_handle_clone(&state->handle, state->inhandle);
-   if (!SUCCESS(state->rc)) {
-      platform_error_log("trunk_merge_lookup_async: "
-                         "trunk_ondisk_node_handle_clone failed: %d\n",
-                         state->rc.r);
-      async_return(state, state->rc);
-   }
+   state->handlep = state->inhandle;
 
-   while (state->handle.header_page) {
-      state->height = trunk_ondisk_node_height(&state->handle);
+   while (state->handlep && state->handlep->header_page) {
+      state->height = trunk_ondisk_node_height(state->handlep);
 
       if (state->log) {
          // Sorry, but we're not going to perform the logging asynchronously.
          trunk_node node;
          state->rc = trunk_node_deserialize(
-            state->context, state->handle.header_page->disk_addr, &node);
+            state->context, state->handlep->header_page->disk_addr, &node);
          if (!SUCCESS(state->rc)) {
             platform_error_log("trunk_merge_lookup_async: "
                                "node_deserialize failed: %d\n",
@@ -5386,7 +5376,7 @@ trunk_merge_lookup_async(trunk_merge_lookup_async_state *state)
             goto cleanup;
          }
          platform_log(
-            state->log, "addr: %lu\n", state->handle.header_page->disk_addr);
+            state->log, "addr: %lu\n", state->handlep->header_page->disk_addr);
          trunk_node_print(&node, state->log, state->context->cfg->data_cfg, 0);
          trunk_node_deinit(&node, state->context);
       }
@@ -5469,16 +5459,18 @@ trunk_merge_lookup_async(trunk_merge_lookup_async_state *state)
                                state->rc.r);
             goto cleanup;
          }
-         trunk_ondisk_node_handle_deinit(&state->handle);
-         state->handle = state->child_handle;
+         trunk_ondisk_node_handle_deinit(state->handlep);
+         state->handle  = state->child_handle;
+         state->handlep = &state->handle;
       } else {
-         trunk_ondisk_node_handle_deinit(&state->handle);
+         trunk_ondisk_node_handle_deinit(state->handlep);
+         state->handlep = NULL;
       }
    }
 
 cleanup:
-   if (state->handle.header_page) {
-      trunk_ondisk_node_handle_deinit(&state->handle);
+   if (state->handlep) {
+      trunk_ondisk_node_handle_deinit(state->handlep);
    }
    async_return(state, state->rc);
 }

--- a/src/trunk.c
+++ b/src/trunk.c
@@ -5423,6 +5423,7 @@ trunk_merge_lookup_async(trunk_merge_lookup_async_state *state)
 {
    async_begin(state, 0);
 
+   state->rc      = STATUS_OK;
    state->handlep = state->inhandle;
 
    while (state->handlep && state->handlep->header_page) {

--- a/src/trunk.c
+++ b/src/trunk.c
@@ -5338,17 +5338,21 @@ trunk_merge_lookup(trunk_context            *context,
                                rc.r);
             goto cleanup;
          }
-         trunk_ondisk_node_handle_deinit(handlep);
+         if (handlep != inhandle) {
+            trunk_ondisk_node_handle_deinit(handlep);
+         }
          handle  = child_handle;
          handlep = &handle;
       } else {
-         trunk_ondisk_node_handle_deinit(handlep);
+         if (handlep != inhandle) {
+            trunk_ondisk_node_handle_deinit(handlep);
+         }
          handlep = NULL;
       }
    }
 
 cleanup:
-   if (handlep) {
+   if (handlep && handlep != inhandle) {
       trunk_ondisk_node_handle_deinit(handlep);
    }
    return rc;
@@ -5459,17 +5463,21 @@ trunk_merge_lookup_async(trunk_merge_lookup_async_state *state)
                                state->rc.r);
             goto cleanup;
          }
-         trunk_ondisk_node_handle_deinit(state->handlep);
+         if (state->handlep != state->inhandle) {
+            trunk_ondisk_node_handle_deinit(state->handlep);
+         }
          state->handle  = state->child_handle;
          state->handlep = &state->handle;
       } else {
-         trunk_ondisk_node_handle_deinit(state->handlep);
+         if (state->handlep != state->inhandle) {
+            trunk_ondisk_node_handle_deinit(state->handlep);
+         }
          state->handlep = NULL;
       }
    }
 
 cleanup:
-   if (state->handlep) {
+   if (state->handlep && state->handlep != state->inhandle) {
       trunk_ondisk_node_handle_deinit(state->handlep);
    }
    async_return(state, state->rc);

--- a/src/trunk.h
+++ b/src/trunk.h
@@ -275,8 +275,6 @@ trunk_init_root_handle(trunk_context            *context,
 void
 trunk_ondisk_node_handle_deinit(trunk_ondisk_node_handle *handle);
 
-/* Note: consumes handle, i.e. calls deinit on handle, even if the lookup
- * otherwise encounters an error. */
 platform_status
 trunk_merge_lookup(trunk_context            *context,
                    trunk_ondisk_node_handle *handle,
@@ -303,8 +301,6 @@ trunk_collect_branches(const trunk_context            *context,
 typedef struct trunk_ondisk_pivot  trunk_ondisk_pivot;
 typedef struct trunk_ondisk_bundle trunk_ondisk_bundle;
 
-/* As with trunk_merge_lookup, trunk_merge_lookup_async always deinits inhandle.
- */
 // clang-format off
 DEFINE_ASYNC_STATE(trunk_merge_lookup_async_state, 4,
    param, trunk_context *,            context,

--- a/src/trunk.h
+++ b/src/trunk.h
@@ -153,6 +153,8 @@ typedef struct incorporation_tasks {
    trunk_node_vector node_compactions;
 } incorporation_tasks;
 
+typedef struct pending_gc pending_gc;
+
 typedef struct trunk_context {
    const trunk_config    *cfg;
    platform_heap_id       hid;
@@ -165,6 +167,9 @@ typedef struct trunk_context {
    trunk_ondisk_node_ref *root;
    trunk_ondisk_node_ref *post_incorporation_root;
    trunk_ondisk_node_ref *pre_incorporation_root;
+   uint64                 pending_gcs_lock;
+   pending_gc            *pending_gcs;
+   pending_gc            *pending_gcs_tail;
    incorporation_tasks    tasks;
 } trunk_context;
 
@@ -207,7 +212,6 @@ trunk_context_init(trunk_context      *context,
                    allocator          *al,
                    task_system        *ts,
                    uint64              root_addr);
-
 
 platform_status
 trunk_inc_ref(const trunk_config *cfg,
@@ -271,6 +275,9 @@ trunk_modification_end(trunk_context *context);
 platform_status
 trunk_init_root_handle(trunk_context            *context,
                        trunk_ondisk_node_handle *handle);
+
+uint64
+trunk_ondisk_node_handle_addr(const trunk_ondisk_node_handle *handle);
 
 void
 trunk_ondisk_node_handle_deinit(trunk_ondisk_node_handle *handle);

--- a/src/trunk.h
+++ b/src/trunk.h
@@ -275,6 +275,8 @@ trunk_init_root_handle(trunk_context            *context,
 void
 trunk_ondisk_node_handle_deinit(trunk_ondisk_node_handle *handle);
 
+/* Note: consumes handle, i.e. calls deinit on handle, even if the lookup
+ * otherwise encounters an error. */
 platform_status
 trunk_merge_lookup(trunk_context            *context,
                    trunk_ondisk_node_handle *handle,
@@ -301,6 +303,8 @@ trunk_collect_branches(const trunk_context            *context,
 typedef struct trunk_ondisk_pivot  trunk_ondisk_pivot;
 typedef struct trunk_ondisk_bundle trunk_ondisk_bundle;
 
+/* As with trunk_merge_lookup, trunk_merge_lookup_async always deinits inhandle.
+ */
 // clang-format off
 DEFINE_ASYNC_STATE(trunk_merge_lookup_async_state, 4,
    param, trunk_context *,            context,
@@ -313,6 +317,7 @@ DEFINE_ASYNC_STATE(trunk_merge_lookup_async_state, 4,
    local, platform_status,            __async_result,
    local, platform_status,            rc,
    local, trunk_ondisk_node_handle,   handle,
+   local, trunk_ondisk_node_handle *, handlep,
    local, uint64,                     height,
    local, trunk_ondisk_pivot *,       pivot,
    local, uint64,                     inflight_bundle_num,

--- a/test.sh
+++ b/test.sh
@@ -974,7 +974,6 @@ if [ "$INCLUDE_SLOW_TESTS" != "true" ]; then
    set -x
    run_with_timing "Config-params parsing test"
             "$BINDIR"/unit/config_parse_test --log \
-                                             --max-branches-per-node 42 \
                                              --num-inserts 20 \
                                              --rough-count-height 11 \
                                              --stats \


### PR DESCRIPTION
This patch fixes two deadlocks, also enabling threads to perform updates to splinterdb while also performing asynchronous queries.

The first deadlock was caused by trunk_merge_lookup acquiring two locks on the root.  This deadlock prone because, if another thread begins to GC the root, it will set the writer bit on the root lock and then wait for the readers to clear out.  But, if the query code has already acquired its first read lock on the root and attempts to acquire its second read lock after the writer bit is set, then it will deadlock with the GC thread.

The fix is to acquire a lock on the root only once.

The second deadlock could occur when a thread performing asynchronous queries performs an update which results in a GC.  In this case, one of the thread's async queries may hold a read lock on a node-to-be-GCed, but the GC code will wait forever for that read lock to be released, causing the thread to deadlock with itself.

The fix in this case is to defer GC until there are no more readers.  So there's now a queue of GC tasks in the trunk context.  Any time GC reaches a node with a read lock, it stops and puts that node on the queue.  Every trunk modification checks the queue and processes any GCs that are now available to perform.

Fixes #314 .