### PR TITLE
rc_allocator: fix refcount I/O size (use bytes not elements)

### DIFF
--- a/src/rc_allocator.c
+++ b/src/rc_allocator.c
@@ -459,8 +459,8 @@ rc_allocator_mount(rc_allocator      *al,
    }
 
    // load the ref counts from disk.
-   uint32 io_size =
-      ROUNDUP(al->cfg->extent_capacity, al->cfg->io_cfg->page_size);
+   uint64 bytes   = (uint64)al->cfg->extent_capacity * sizeof(refcount);
+   uint64 io_size = ROUNDUP(bytes, al->cfg->io_cfg->page_size);
    status = io_read(io, al->ref_count, io_size, cfg->io_cfg->extent_size);
    platform_assert_status_ok(status);
 
@@ -479,8 +479,8 @@ rc_allocator_unmount(rc_allocator *al)
    platform_status status;
 
    // persist the ref counts upon unmount.
-   uint32 io_size =
-      ROUNDUP(al->cfg->extent_capacity, al->cfg->io_cfg->page_size);
+   uint64 bytes   = (uint64)al->cfg->extent_capacity * sizeof(refcount);
+   uint64 io_size = ROUNDUP(bytes, al->cfg->io_cfg->page_size);
    status =
       io_write(al->io, al->ref_count, io_size, al->cfg->io_cfg->extent_size);
    platform_assert_status_ok(status);


### PR DESCRIPTION
**Summary**
io_size for the refcount array was computed from the element count, so only part of the array was persisted/loaded. This left high-index refcounts as zero under long workloads.

**Root cause**
`io_size = ROUNDUP(extent_capacity, page_size);`
used the number of elements. Each refcount is 4 bytes, so the code read/wrote extent_capacity bytes instead of extent_capacity * sizeof(refcount) bytes.

**Fix**
Compute in bytes in both mount and unmount:
```
uint32 io_size =
    ROUNDUP(cfg->extent_capacity * sizeof(refcount), cfg->io_cfg->page_size);
```
Buffer allocation already used sizeof(refcount), so this makes the logic consistent end-to-end.

