### PR TITLE
Robj/max key size elimination

### DIFF
--- a/examples/splinterdb_custom_ipv4_addr_sortcmp_example.c
+++ b/examples/splinterdb_custom_ipv4_addr_sortcmp_example.c
@@ -43,7 +43,6 @@
 
 #define IP4_MIN_KEY_SIZE ((1 * IPV4_NUM_FIELDS) + IPV4_NUM_DOTS)
 
-// Application declares the limit of key-sizes it intends to use
 #define IP4_MAX_KEY_SIZE ((3 * IPV4_NUM_FIELDS) + IPV4_NUM_DOTS)
 
 // Max # of chars in a well-formed IP4 address, including null-terminator byte
@@ -133,7 +132,7 @@ main()
 
    // Initialize data configuration, describing your key-value properties
    data_config splinter_data_cfg;
-   default_data_config_init(IP4_MAX_KEY_SIZE, &splinter_data_cfg);
+   default_data_config_init(&splinter_data_cfg);
 
    // -- ACTION IS HERE --
    // Customize key-comparison with our implementation for IP4 addresses

--- a/examples/splinterdb_intro_example.c
+++ b/examples/splinterdb_intro_example.c
@@ -16,9 +16,6 @@
 #define DB_FILE_SIZE_MB 1024 // Size of SplinterDB device; Fixed when created
 #define CACHE_SIZE_MB   64   // Size of cache; can be changed across boots
 
-/* Application declares the limit of key-sizes it intends to use */
-#define USER_MAX_KEY_SIZE ((int)100)
-
 /*
  * -------------------------------------------------------------------------------
  * We, intentionally, do not check for errors or show error handling, as this is
@@ -32,7 +29,7 @@ main()
 
    // Initialize data configuration, using default key-comparison handling.
    data_config splinter_data_cfg;
-   default_data_config_init(USER_MAX_KEY_SIZE, &splinter_data_cfg);
+   default_data_config_init(&splinter_data_cfg);
 
    // Basic configuration of a SplinterDB instance
    splinterdb_config splinterdb_cfg;

--- a/examples/splinterdb_iterators_example.c
+++ b/examples/splinterdb_iterators_example.c
@@ -14,9 +14,6 @@
 #define DB_FILE_SIZE_MB 1024 // Size of SplinterDB device; Fixed when created
 #define CACHE_SIZE_MB   64   // Size of cache; can be changed across boots
 
-/* Application declares the limit of key-sizes it intends to use */
-#define USER_MAX_KEY_SIZE ((int)100)
-
 // Declare a struct to build a key/value pair
 typedef struct kv_pair {
    char *kv_key;
@@ -63,7 +60,7 @@ main()
 
    // Initialize data configuration, using default key-comparison handling.
    data_config splinter_data_cfg;
-   default_data_config_init(USER_MAX_KEY_SIZE, &splinter_data_cfg);
+   default_data_config_init(&splinter_data_cfg);
 
    // Basic configuration of a SplinterDB instance
    splinterdb_config splinterdb_cfg;

--- a/examples/splinterdb_wide_values_example.c
+++ b/examples/splinterdb_wide_values_example.c
@@ -14,8 +14,8 @@
 #define DB_FILE_SIZE_MB 1024 // Size of SplinterDB device; Fixed when created
 #define CACHE_SIZE_MB   64   // Size of cache; can be changed across boots
 
-/* Application declares the limit of key-sizes it intends to use */
-#define USER_MAX_KEY_SIZE ((int)100)
+/* Largest key buffer used by this example. */
+#define USER_KEY_BUF_SIZE ((int)100)
 
 /* Avg value size and max value sizes we expect to deal with in this program */
 #define USER_AVG_VALUE_SIZE ((int)128)
@@ -33,7 +33,7 @@ main()
 
    // Initialize data configuration, using default key-comparison handling.
    data_config splinter_data_cfg;
-   default_data_config_init(USER_MAX_KEY_SIZE, &splinter_data_cfg);
+   default_data_config_init(&splinter_data_cfg);
 
    // Basic configuration of a SplinterDB instance
    splinterdb_config splinterdb_cfg;
@@ -49,7 +49,7 @@ main()
    printf("Created SplinterDB instance, dbname '%s'.\n\n", DB_FILE_NAME);
 
    // -- ACTION IS HERE --
-   char key_buf[USER_MAX_KEY_SIZE];
+   char key_buf[USER_KEY_BUF_SIZE];
    char val_buf[USER_MAX_VALUE_SIZE];
 
    int nrows = 0;
@@ -88,7 +88,7 @@ main()
         val_len <<= 1, nrows++)
    {
 
-      char key_buf[USER_MAX_KEY_SIZE];
+      char key_buf[USER_KEY_BUF_SIZE];
       snprintf(key_buf, sizeof(key_buf), "Key with val_len=%d", val_len);
       size_t key_len = strlen(key_buf);
 

--- a/include/splinterdb/data.h
+++ b/include/splinterdb/data.h
@@ -180,9 +180,6 @@ typedef void (*message_to_str_fn)(const data_config *cfg,
  * to do something differently, it has to provide these implementations.
  */
 struct data_config {
-   // FIXME: Planned for deprecation.
-   uint64 max_key_size;
-
    key_compare_fn key_compare;
    key_hash_fn    key_hash;
    /* The merge functions may be NULL, in which case

--- a/include/splinterdb/default_data_config.h
+++ b/include/splinterdb/default_data_config.h
@@ -16,8 +16,7 @@ extern "C" {
 #endif
 
 void
-default_data_config_init(const uint64 max_key_size, // IN
-                         data_config *out_cfg       // OUT
+default_data_config_init(data_config *out_cfg // OUT
 );
 
 #ifdef __cplusplus

--- a/src/core.c
+++ b/src/core.c
@@ -1420,10 +1420,6 @@ core_insert(core_handle   *spl,
       ts = platform_get_timestamp();
    }
 
-   if (core_max_key_size(spl) < key_length(tuple_key)) {
-      return STATUS_BAD_PARAM;
-   }
-
    if (message_class(data) == MESSAGE_TYPE_DELETE) {
       data = DELETE_MESSAGE;
    }

--- a/src/core.h
+++ b/src/core.h
@@ -255,12 +255,6 @@ core_print_extent_counts(platform_log_handle *log_handle, core_handle *spl);
 void
 core_print_space_use(platform_log_handle *log_handle, core_handle *spl);
 
-static inline uint64
-core_max_key_size(core_handle *spl)
-{
-   return spl->cfg.data_cfg->max_key_size;
-}
-
 static inline int
 core_key_compare(core_handle *spl, key key1, key key2)
 {

--- a/src/default_data_config.c
+++ b/src/default_data_config.c
@@ -55,12 +55,10 @@ message_to_string(const data_config *cfg,
  * with default values.
  */
 void
-default_data_config_init(const size_t max_key_size, // IN
-                         data_config *out_cfg       // OUT
+default_data_config_init(data_config *out_cfg // OUT
 )
 {
    data_config cfg = {
-      .max_key_size       = max_key_size,
       .key_compare        = key_compare,
       .key_hash           = key_hash,
       .merge_tuples       = NULL,

--- a/src/splinterdb.c
+++ b/src/splinterdb.c
@@ -132,7 +132,6 @@ splinterdb_config_set_defaults(splinterdb_config *cfg)
 static platform_status
 splinterdb_validate_app_data_config(const data_config *cfg)
 {
-   platform_assert(cfg->max_key_size > 0);
    platform_assert(cfg->key_compare != NULL);
    platform_assert(cfg->key_hash != NULL);
    platform_assert(cfg->key_to_string != NULL);

--- a/tests/config.c
+++ b/tests/config.c
@@ -98,7 +98,7 @@ config_set_defaults(master_config *cfg)
      .wait_for_gdb              = FALSE,
 
       .log_handle               = NULL,
-      .max_key_size             = TEST_CONFIG_DEFAULT_KEY_SIZE,
+      .key_size                 = TEST_CONFIG_DEFAULT_KEY_SIZE,
       .message_size             = TEST_CONFIG_DEFAULT_MESSAGE_SIZE,
       .num_inserts              = TEST_CONFIG_DEFAULT_NUM_INSERTS,
       .seed                     = TEST_CONFIG_DEFAULT_SEED,
@@ -370,7 +370,7 @@ config_parse(master_config *cfg, const uint8 num_config, int argc, char *argv[])
             }
          }
 
-         config_set_uint64("key-size", cfg, max_key_size) {}
+         config_set_uint64("key-size", cfg, key_size) {}
          config_set_uint64("data-size", cfg, message_size) {}
 
          // Test-execution configuration parameters
@@ -412,9 +412,9 @@ config_parse(master_config *cfg, const uint8 num_config, int argc, char *argv[])
                                (MAX_PAGES_PER_EXTENT * cfg[cfg_idx].page_size));
             return STATUS_BAD_PARAM;
          }
-         if (cfg[cfg_idx].max_key_size < TEST_CONFIG_MIN_KEY_SIZE) {
+         if (cfg[cfg_idx].key_size < TEST_CONFIG_MIN_KEY_SIZE) {
             platform_error_log("Configured key-size, %lu.\n",
-                               cfg[cfg_idx].max_key_size);
+                               cfg[cfg_idx].key_size);
             return STATUS_BAD_PARAM;
          }
       }

--- a/tests/config.h
+++ b/tests/config.h
@@ -97,7 +97,7 @@ typedef struct master_config {
    platform_log_handle *log_handle;
 
    // data
-   uint64 max_key_size;
+   uint64 key_size;
    uint64 message_size;
 
    // Test-execution configuration parameters

--- a/tests/functional/btree_test.c
+++ b/tests/functional/btree_test.c
@@ -1035,9 +1035,7 @@ test_btree_merge_basic(cache             *cc,
    for (uint64 pivot_no = 0; pivot_no < arity; pivot_no++) {
       key_buffer_init(&pivot_key[pivot_no], hid);
       pivot[pivot_no] = pivot_no * (max_key / arity + 1);
-      test_int_to_key(&pivot_key[pivot_no],
-                      pivot[pivot_no],
-                      cfg->key_size);
+      test_int_to_key(&pivot_key[pivot_no], pivot[pivot_no], cfg->key_size);
    }
    key_buffer_init_from_key(&pivot_key[arity], hid, POSITIVE_INFINITY_KEY);
 
@@ -1189,20 +1187,8 @@ test_btree_count_in_range(cache             *cc,
 
    platform_status rc = STATUS_OK;
    for (uint64 i = 0; i < iterations; i++) {
-      test_key(&bound_key[0],
-               TEST_RANDOM,
-               2 * i,
-               0,
-               0,
-               cfg->key_size,
-               0);
-      test_key(&bound_key[1],
-               TEST_RANDOM,
-               2 * i + 1,
-               0,
-               0,
-               cfg->key_size,
-               0);
+      test_key(&bound_key[0], TEST_RANDOM, 2 * i, 0, 0, cfg->key_size, 0);
+      test_key(&bound_key[1], TEST_RANDOM, 2 * i + 1, 0, 0, cfg->key_size, 0);
 
       btree_pivot_stats stats;
       key               min_key = key_buffer_key(&bound_key[0]);
@@ -1429,9 +1415,7 @@ test_btree_merge_perf(cache             *cc,
    for (uint64 pivot_no = 0; pivot_no < arity; pivot_no++) {
       key_buffer_init(&pivot_key[pivot_no], hid);
       pivot[pivot_no] = pivot_no * (max_key / arity + 1);
-      test_int_to_key(&pivot_key[pivot_no],
-                      pivot[pivot_no],
-                      cfg->key_size);
+      test_int_to_key(&pivot_key[pivot_no], pivot[pivot_no], cfg->key_size);
    }
    key_buffer_init_from_key(&pivot_key[arity], hid, POSITIVE_INFINITY_KEY);
 
@@ -1574,7 +1558,7 @@ btree_test(int argc, char *argv[])
       platform_get_module_id(), 512 * MiB, use_shmem, &hid);
    platform_assert_status_ok(rc);
 
-   uint64 num_bg_threads[NUM_TASK_TYPES] = {0}; // no bg threads
+   uint64               num_bg_threads[NUM_TASK_TYPES] = {0}; // no bg threads
    test_workload_config workload_cfg;
 
    rc = test_parse_args(&system_cfg,
@@ -1588,12 +1572,11 @@ btree_test(int argc, char *argv[])
 
    memtable_config *mt_cfg    = &system_cfg.splinter_cfg.mt_cfg;
    mt_cfg->max_memtables      = 128;
-   test_btree_config test_cfg = {
-      .mt_cfg        = mt_cfg,
-      .type          = TEST_RANDOM,
-      .semiseq_freq  = 0,
-      .key_size      = workload_cfg.key_size,
-      .msggen        = &gen};
+   test_btree_config test_cfg = {.mt_cfg       = mt_cfg,
+                                 .type         = TEST_RANDOM,
+                                 .semiseq_freq = 0,
+                                 .key_size     = workload_cfg.key_size,
+                                 .msggen       = &gen};
    if (!SUCCESS(rc)) {
       platform_error_log("btree_test: failed to parse config: %s\n",
                          platform_status_to_string(rc));

--- a/tests/functional/btree_test.c
+++ b/tests/functional/btree_test.c
@@ -1575,8 +1575,10 @@ btree_test(int argc, char *argv[])
    platform_assert_status_ok(rc);
 
    uint64 num_bg_threads[NUM_TASK_TYPES] = {0}; // no bg threads
+   test_workload_config workload_cfg;
 
    rc = test_parse_args(&system_cfg,
+                        &workload_cfg,
                         &seed,
                         &gen,
                         &num_bg_threads[TASK_TYPE_MEMTABLE],
@@ -1590,7 +1592,7 @@ btree_test(int argc, char *argv[])
       .mt_cfg        = mt_cfg,
       .type          = TEST_RANDOM,
       .semiseq_freq  = 0,
-      .key_size      = system_cfg.key_size,
+      .key_size      = workload_cfg.key_size,
       .msggen        = &gen};
    if (!SUCCESS(rc)) {
       platform_error_log("btree_test: failed to parse config: %s\n",
@@ -1652,7 +1654,7 @@ btree_test(int argc, char *argv[])
    uint64 max_tuples_per_memtable =
       test_cfg.mt_cfg->max_extents_per_memtable
       * cache_config_extent_size((cache_config *)&system_cfg.cache_cfg) / 3
-      / (system_cfg.key_size + generator_average_message_size(&gen));
+      / (workload_cfg.key_size + generator_average_message_size(&gen));
    if (run_perf_test) {
       uint64 total_inserts = 64 * max_tuples_per_memtable;
 

--- a/tests/functional/btree_test.c
+++ b/tests/functional/btree_test.c
@@ -29,6 +29,7 @@ typedef struct test_btree_config {
    test_key_type           type;
    uint64                  semiseq_freq;
    uint64                  period;
+   uint64                  key_size;
    test_message_generator *msggen;
 } test_btree_config;
 
@@ -161,13 +162,13 @@ test_btree_tuple(test_memtable_context *ctxt,
                  uint64                 thread_id)
 {
    test_btree_config *cfg = ctxt->cfg;
-   key_buffer_resize(keybuf, cfg->mt_cfg->btree_cfg->data_cfg->max_key_size);
+   key_buffer_resize(keybuf, cfg->key_size);
    test_key(keybuf,
             cfg->type,
             seq,
             thread_id,
             cfg->semiseq_freq,
-            cfg->mt_cfg->btree_cfg->data_cfg->max_key_size,
+            cfg->key_size,
             cfg->period);
 
    if (data != NULL) {
@@ -1036,7 +1037,7 @@ test_btree_merge_basic(cache             *cc,
       pivot[pivot_no] = pivot_no * (max_key / arity + 1);
       test_int_to_key(&pivot_key[pivot_no],
                       pivot[pivot_no],
-                      btree_cfg->data_cfg->max_key_size);
+                      cfg->key_size);
    }
    key_buffer_init_from_key(&pivot_key[arity], hid, POSITIVE_INFINITY_KEY);
 
@@ -1193,14 +1194,14 @@ test_btree_count_in_range(cache             *cc,
                2 * i,
                0,
                0,
-               btree_cfg->data_cfg->max_key_size,
+               cfg->key_size,
                0);
       test_key(&bound_key[1],
                TEST_RANDOM,
                2 * i + 1,
                0,
                0,
-               btree_cfg->data_cfg->max_key_size,
+               cfg->key_size,
                0);
 
       btree_pivot_stats stats;
@@ -1326,10 +1327,10 @@ test_btree_rough_iterator(cache             *cc,
       key     curr_key;
       message dummy_data;
       iterator_curr(&rough_merge_itor->super, &curr_key, &dummy_data);
-      if (key_length(curr_key) != btree_cfg->data_cfg->max_key_size) {
+      if (key_length(curr_key) != cfg->key_size) {
          platform_default_log("Weird key length: %lu should be: %lu\n",
                               key_length(curr_key),
-                              btree_cfg->data_cfg->max_key_size);
+                              cfg->key_size);
       }
       if (message_length(dummy_data) != sizeof(btree_pivot_data)) {
          platform_default_log("Weird data length: %lu should be == "
@@ -1430,7 +1431,7 @@ test_btree_merge_perf(cache             *cc,
       pivot[pivot_no] = pivot_no * (max_key / arity + 1);
       test_int_to_key(&pivot_key[pivot_no],
                       pivot[pivot_no],
-                      btree_cfg->data_cfg->max_key_size);
+                      cfg->key_size);
    }
    key_buffer_init_from_key(&pivot_key[arity], hid, POSITIVE_INFINITY_KEY);
 
@@ -1586,7 +1587,11 @@ btree_test(int argc, char *argv[])
    memtable_config *mt_cfg    = &system_cfg.splinter_cfg.mt_cfg;
    mt_cfg->max_memtables      = 128;
    test_btree_config test_cfg = {
-      .mt_cfg = mt_cfg, .type = TEST_RANDOM, .semiseq_freq = 0, .msggen = &gen};
+      .mt_cfg        = mt_cfg,
+      .type          = TEST_RANDOM,
+      .semiseq_freq  = 0,
+      .key_size      = system_cfg.key_size,
+      .msggen        = &gen};
    if (!SUCCESS(rc)) {
       platform_error_log("btree_test: failed to parse config: %s\n",
                          platform_status_to_string(rc));
@@ -1647,8 +1652,7 @@ btree_test(int argc, char *argv[])
    uint64 max_tuples_per_memtable =
       test_cfg.mt_cfg->max_extents_per_memtable
       * cache_config_extent_size((cache_config *)&system_cfg.cache_cfg) / 3
-      / (system_cfg.data_cfg->max_key_size
-         + generator_average_message_size(&gen));
+      / (system_cfg.key_size + generator_average_message_size(&gen));
    if (run_perf_test) {
       uint64 total_inserts = 64 * max_tuples_per_memtable;
 

--- a/tests/functional/cache_test.c
+++ b/tests/functional/cache_test.c
@@ -941,6 +941,7 @@ cache_test(int argc, char *argv[])
    core_config *splinter_cfg = TYPED_MALLOC(hid, splinter_cfg);
 
    rc = test_parse_args(&system_cfg,
+                        NULL,
                         &seed,
                         &gen,
                         &num_bg_threads[TASK_TYPE_MEMTABLE],

--- a/tests/functional/filter_test.c
+++ b/tests/functional/filter_test.c
@@ -310,8 +310,8 @@ filter_test(int argc, char *argv[])
       platform_get_module_id(), 512 * MiB, use_shmem, &hid);
    platform_assert_status_ok(rc);
 
-   uint64 num_memtable_bg_threads_unused = 0;
-   uint64 num_normal_bg_threads_unused   = 0;
+   uint64               num_memtable_bg_threads_unused = 0;
+   uint64               num_normal_bg_threads_unused   = 0;
    test_workload_config workload_cfg;
 
    rc = test_parse_args(&system_cfg,

--- a/tests/functional/filter_test.c
+++ b/tests/functional/filter_test.c
@@ -23,13 +23,13 @@ static platform_status
 test_filter_basic(cache           *cc,
                   routing_config  *cfg,
                   platform_heap_id hid,
+                  uint64           key_size,
                   uint64           num_fingerprints,
                   uint64           num_values)
 {
    platform_default_log("filter_test: routing filter basic test started\n");
    platform_status rc = STATUS_OK;
 
-   const uint64 key_size = cfg->data_cfg->max_key_size;
    if (key_size < sizeof(uint64)) {
       platform_default_log("key_size %lu too small\n", key_size);
       return STATUS_BAD_PARAM;
@@ -144,6 +144,7 @@ static platform_status
 test_filter_perf(cache           *cc,
                  routing_config  *cfg,
                  platform_heap_id hid,
+                 uint64           key_size,
                  uint64           num_fingerprints,
                  uint64           num_values,
                  uint64           num_trees)
@@ -151,7 +152,6 @@ test_filter_perf(cache           *cc,
    platform_default_log("filter_test: routing filter perf test started\n");
    platform_status rc = STATUS_OK;
 
-   const uint64 key_size = cfg->data_cfg->max_key_size;
    if (key_size < sizeof(uint64)) {
       platform_default_log("key_size %lu too small\n", key_size);
       return STATUS_BAD_PARAM;
@@ -365,6 +365,7 @@ filter_test(int argc, char *argv[])
       rc = test_filter_perf((cache *)cc,
                             &system_cfg.filter_cfg,
                             hid,
+                            system_cfg.key_size,
                             rflimit / system_cfg.trunk_node_cfg.target_fanout,
                             system_cfg.trunk_node_cfg.target_fanout,
                             100);
@@ -373,24 +374,28 @@ filter_test(int argc, char *argv[])
       rc = test_filter_basic((cache *)cc,
                              &system_cfg.filter_cfg,
                              hid,
+                             system_cfg.key_size,
                              rflimit / system_cfg.trunk_node_cfg.target_fanout,
                              system_cfg.trunk_node_cfg.target_fanout);
       platform_assert(SUCCESS(rc));
       rc = test_filter_basic((cache *)cc,
                              &system_cfg.filter_cfg,
                              hid,
+                             system_cfg.key_size,
                              100,
                              system_cfg.trunk_node_cfg.target_fanout);
       platform_assert(SUCCESS(rc));
       rc = test_filter_basic((cache *)cc,
                              &system_cfg.filter_cfg,
                              hid,
+                             system_cfg.key_size,
                              1,
                              system_cfg.trunk_node_cfg.target_fanout);
       platform_assert(SUCCESS(rc));
       rc = test_filter_basic((cache *)cc,
                              &system_cfg.filter_cfg,
                              hid,
+                             system_cfg.key_size,
                              1,
                              2 * system_cfg.trunk_node_cfg.target_fanout);
       platform_assert(SUCCESS(rc));

--- a/tests/functional/filter_test.c
+++ b/tests/functional/filter_test.c
@@ -312,8 +312,10 @@ filter_test(int argc, char *argv[])
 
    uint64 num_memtable_bg_threads_unused = 0;
    uint64 num_normal_bg_threads_unused   = 0;
+   test_workload_config workload_cfg;
 
    rc = test_parse_args(&system_cfg,
+                        &workload_cfg,
                         &seed,
                         &gen,
                         &num_memtable_bg_threads_unused,
@@ -365,7 +367,7 @@ filter_test(int argc, char *argv[])
       rc = test_filter_perf((cache *)cc,
                             &system_cfg.filter_cfg,
                             hid,
-                            system_cfg.key_size,
+                            workload_cfg.key_size,
                             rflimit / system_cfg.trunk_node_cfg.target_fanout,
                             system_cfg.trunk_node_cfg.target_fanout,
                             100);
@@ -374,28 +376,28 @@ filter_test(int argc, char *argv[])
       rc = test_filter_basic((cache *)cc,
                              &system_cfg.filter_cfg,
                              hid,
-                             system_cfg.key_size,
+                             workload_cfg.key_size,
                              rflimit / system_cfg.trunk_node_cfg.target_fanout,
                              system_cfg.trunk_node_cfg.target_fanout);
       platform_assert(SUCCESS(rc));
       rc = test_filter_basic((cache *)cc,
                              &system_cfg.filter_cfg,
                              hid,
-                             system_cfg.key_size,
+                             workload_cfg.key_size,
                              100,
                              system_cfg.trunk_node_cfg.target_fanout);
       platform_assert(SUCCESS(rc));
       rc = test_filter_basic((cache *)cc,
                              &system_cfg.filter_cfg,
                              hid,
-                             system_cfg.key_size,
+                             workload_cfg.key_size,
                              1,
                              system_cfg.trunk_node_cfg.target_fanout);
       platform_assert(SUCCESS(rc));
       rc = test_filter_basic((cache *)cc,
                              &system_cfg.filter_cfg,
                              hid,
-                             system_cfg.key_size,
+                             workload_cfg.key_size,
                              1,
                              2 * system_cfg.trunk_node_cfg.target_fanout);
       platform_assert(SUCCESS(rc));

--- a/tests/functional/log_test.c
+++ b/tests/functional/log_test.c
@@ -59,13 +59,8 @@ test_log_crash(clockcache             *cc,
    merge_accumulator_init(&msg, hid);
 
    for (i = 0; i < num_entries; i++) {
-      key skey = test_key(&keybuffer,
-                          TEST_RANDOM,
-                          i,
-                          0,
-                          0,
-                          1 + (i % key_size),
-                          0);
+      key skey =
+         test_key(&keybuffer, TEST_RANDOM, i, 0, 0, 1 + (i % key_size), 0);
       generate_test_message(gen, i, &msg);
       log_write(logh, skey, merge_accumulator_to_message(&msg), i);
    }
@@ -82,13 +77,8 @@ test_log_crash(clockcache             *cc,
    itorh = (iterator *)&itor;
 
    for (i = 0; i < num_entries && iterator_can_curr(itorh); i++) {
-      key skey = test_key(&keybuffer,
-                          TEST_RANDOM,
-                          i,
-                          0,
-                          0,
-                          1 + (i % key_size),
-                          0);
+      key skey =
+         test_key(&keybuffer, TEST_RANDOM, i, 0, 0, 1 + (i % key_size), 0);
       generate_test_message(gen, i, &msg);
       message mmessage = merge_accumulator_to_message(&msg);
       iterator_curr(itorh, &returned_key, &returned_message);
@@ -331,8 +321,8 @@ log_test(int argc, char *argv[])
       platform_get_module_id(), 512 * MiB, use_shmem, &hid);
    platform_assert_status_ok(status);
 
-   core_config *cfg                            = TYPED_MALLOC(hid, cfg);
-   uint64       num_bg_threads[NUM_TASK_TYPES] = {0}; // no bg threads
+   core_config         *cfg                            = TYPED_MALLOC(hid, cfg);
+   uint64               num_bg_threads[NUM_TASK_TYPES] = {0}; // no bg threads
    test_workload_config workload_cfg;
 
    status = test_parse_args(&system_cfg,

--- a/tests/functional/log_test.c
+++ b/tests/functional/log_test.c
@@ -29,6 +29,7 @@ test_log_crash(clockcache             *cc,
                task_system            *ts,
                platform_heap_id        hid,
                test_message_generator *gen,
+               uint64                  key_size,
                uint64                  num_entries,
                bool32                  crash)
 
@@ -63,7 +64,7 @@ test_log_crash(clockcache             *cc,
                           i,
                           0,
                           0,
-                          1 + (i % cfg->data_cfg->max_key_size),
+                          1 + (i % key_size),
                           0);
       generate_test_message(gen, i, &msg);
       log_write(logh, skey, merge_accumulator_to_message(&msg), i);
@@ -86,7 +87,7 @@ test_log_crash(clockcache             *cc,
                           i,
                           0,
                           0,
-                          1 + (i % cfg->data_cfg->max_key_size),
+                          1 + (i % key_size),
                           0);
       generate_test_message(gen, i, &msg);
       message mmessage = merge_accumulator_to_message(&msg);
@@ -186,6 +187,7 @@ typedef struct test_log_thread_params {
    platform_thread         thread;
    int                     thread_id;
    test_message_generator *gen;
+   uint64                  key_size;
    uint64                  num_entries;
 } test_log_thread_params;
 
@@ -199,6 +201,7 @@ test_log_thread(void *arg)
    int                     thread_id   = params->thread_id;
    uint64                  num_entries = params->num_entries;
    test_message_generator *gen         = params->gen;
+   uint64                  key_size    = params->key_size;
    uint64                  i;
    merge_accumulator       msg;
    DECLARE_AUTO_KEY_BUFFER(keybuf, hid);
@@ -206,8 +209,7 @@ test_log_thread(void *arg)
    merge_accumulator_init(&msg, hid);
 
    for (i = thread_id * num_entries; i < (thread_id + 1) * num_entries; i++) {
-      key skey = test_key(
-         &keybuf, TEST_RANDOM, i, 0, 0, log->cfg->data_cfg->max_key_size, 0);
+      key skey = test_key(&keybuf, TEST_RANDOM, i, 0, 0, key_size, 0);
       generate_test_message(gen, i, &msg);
       log_write(logh, skey, merge_accumulator_to_message(&msg), i);
    }
@@ -221,6 +223,7 @@ test_log_perf(cache                  *cc,
               shard_log              *log,
               uint64                  num_entries,
               test_message_generator *gen,
+              uint64                  key_size,
               uint64                  num_threads,
               task_system            *ts,
               platform_heap_id        hid)
@@ -239,6 +242,7 @@ test_log_perf(cache                  *cc,
       params[i].log         = log;
       params[i].thread_id   = i;
       params[i].gen         = gen;
+      params[i].key_size    = key_size;
       params[i].num_entries = num_entries / num_threads;
    }
 
@@ -385,8 +389,15 @@ log_test(int argc, char *argv[])
    platform_assert(rc == 0);
 
    if (run_perf_test) {
-      ret = test_log_perf(
-         (cache *)cc, &system_cfg.log_cfg, log, 200000000, &gen, 16, &ts, hid);
+      ret = test_log_perf((cache *)cc,
+                          &system_cfg.log_cfg,
+                          log,
+                          200000000,
+                          &gen,
+                          system_cfg.key_size,
+                          16,
+                          &ts,
+                          hid);
       platform_assert_status_ok(ret);
       rc = 0;
    } else if (run_crash_test) {
@@ -399,6 +410,7 @@ log_test(int argc, char *argv[])
                           &ts,
                           hid,
                           &gen,
+                          system_cfg.key_size,
                           500000,
                           TRUE /* crash */);
       platform_assert(rc == 0);
@@ -412,6 +424,7 @@ log_test(int argc, char *argv[])
                           &ts,
                           hid,
                           &gen,
+                          system_cfg.key_size,
                           500000,
                           FALSE /* don't crash */);
       platform_assert(rc == 0);

--- a/tests/functional/log_test.c
+++ b/tests/functional/log_test.c
@@ -333,8 +333,10 @@ log_test(int argc, char *argv[])
 
    core_config *cfg                            = TYPED_MALLOC(hid, cfg);
    uint64       num_bg_threads[NUM_TASK_TYPES] = {0}; // no bg threads
+   test_workload_config workload_cfg;
 
    status = test_parse_args(&system_cfg,
+                            &workload_cfg,
                             &seed,
                             &gen,
                             &num_bg_threads[TASK_TYPE_MEMTABLE],
@@ -394,7 +396,7 @@ log_test(int argc, char *argv[])
                           log,
                           200000000,
                           &gen,
-                          system_cfg.key_size,
+                          workload_cfg.key_size,
                           16,
                           &ts,
                           hid);
@@ -410,7 +412,7 @@ log_test(int argc, char *argv[])
                           &ts,
                           hid,
                           &gen,
-                          system_cfg.key_size,
+                          workload_cfg.key_size,
                           500000,
                           TRUE /* crash */);
       platform_assert(rc == 0);
@@ -424,7 +426,7 @@ log_test(int argc, char *argv[])
                           &ts,
                           hid,
                           &gen,
-                          system_cfg.key_size,
+                          workload_cfg.key_size,
                           500000,
                           FALSE /* don't crash */);
       platform_assert(rc == 0);

--- a/tests/functional/scan_benchmark.c
+++ b/tests/functional/scan_benchmark.c
@@ -773,7 +773,7 @@ scan_benchmark(int argc, char *argv[])
       goto out;
    }
 
-   if (master_cfg.max_key_size < SCAN_BENCHMARK_KEY_SIZE) {
+   if (master_cfg.key_size < SCAN_BENCHMARK_KEY_SIZE) {
       platform_error_log("scan_benchmark: key-size must be at least %u bytes\n",
                          SCAN_BENCHMARK_KEY_SIZE);
       rc = EINVAL;
@@ -795,7 +795,7 @@ scan_benchmark(int argc, char *argv[])
       goto out;
    }
 
-   default_data_config_init(master_cfg.max_key_size, &default_data_cfg);
+   default_data_config_init(&default_data_cfg);
 
    platform_default_log(
       "scan_benchmark: db=%s mode=%d num_inserts=%lu "

--- a/tests/functional/scan_benchmark.c
+++ b/tests/functional/scan_benchmark.c
@@ -748,6 +748,7 @@ scan_benchmark(int argc, char *argv[])
    int                    config_argc = 0;
    char                 **config_argv = NULL;
    master_config          master_cfg;
+   test_workload_config   workload_cfg;
    data_config            default_data_cfg;
    splinterdb_config      cfg;
    int                    rc = 0;
@@ -772,8 +773,9 @@ scan_benchmark(int argc, char *argv[])
       rc = scan_benchmark_status_to_int(status);
       goto out;
    }
+   test_workload_config_init(&workload_cfg, &master_cfg);
 
-   if (master_cfg.key_size < SCAN_BENCHMARK_KEY_SIZE) {
+   if (workload_cfg.key_size < SCAN_BENCHMARK_KEY_SIZE) {
       platform_error_log("scan_benchmark: key-size must be at least %u bytes\n",
                          SCAN_BENCHMARK_KEY_SIZE);
       rc = EINVAL;
@@ -807,7 +809,7 @@ scan_benchmark(int argc, char *argv[])
       master_cfg.num_inserts,
       master_cfg.cache_capacity,
       master_cfg.extent_size,
-      master_cfg.message_size,
+      workload_cfg.message_size,
       options.random_load_order,
       options.splinter_random_keys,
       options.scan_length,
@@ -820,7 +822,7 @@ scan_benchmark(int argc, char *argv[])
       scan_benchmark_make_config(&master_cfg, &default_data_cfg, &cfg, FALSE);
       rc = scan_benchmark_load_database(&cfg,
                                         master_cfg.num_inserts,
-                                        master_cfg.message_size,
+                                        workload_cfg.message_size,
                                         options.random_load_order,
                                         options.splinter_random_keys,
                                         master_cfg.seed);

--- a/tests/functional/splinter_test.c
+++ b/tests/functional/splinter_test.c
@@ -847,7 +847,7 @@ compute_per_table_inserts(uint64        *per_table_inserts, // OUT
 
    for (uint8 i = 0; i < num_tables; i++) {
       tuple_size =
-         cfg[i].key_size + generator_average_message_size(test_cfg->gen);
+         test_cfg[i].key_size + generator_average_message_size(test_cfg->gen);
       num_inserts = (num_inserts_cfg ? num_inserts_cfg
                                      : test_cfg[i].tree_size / tuple_size);
       if (test_cfg[i].key_type == TEST_PERIODIC) {
@@ -1515,7 +1515,7 @@ test_splinter_periodic(system_config   *cfg,
 
    for (uint8 i = 0; i < num_tables; i++) {
       tuple_size =
-         cfg[i].key_size + generator_average_message_size(test_cfg->gen);
+         test_cfg[i].key_size + generator_average_message_size(test_cfg->gen);
       num_inserts = test_cfg[i].tree_size / tuple_size;
       if (test_cfg[i].key_type == TEST_PERIODIC) {
          test_cfg[i].period = num_inserts;
@@ -2167,7 +2167,7 @@ test_splinter_delete(system_config   *cfg,
 
    for (uint8 i = 0; i < num_tables; i++) {
       tuple_size =
-         cfg[i].key_size + generator_average_message_size(test_cfg->gen);
+         test_cfg[i].key_size + generator_average_message_size(test_cfg->gen);
       num_inserts          = test_cfg[i].tree_size / tuple_size;
       per_table_inserts[i] = ROUNDUP(num_inserts, TEST_INSERT_GRANULARITY);
       total_inserts += per_table_inserts[i];
@@ -2678,9 +2678,16 @@ splinter_test(int argc, char *argv[])
     * 3. Parse trunk_config options, see config_usage()
     */
    system_config *system_cfg = TYPED_ARRAY_MALLOC(hid, system_cfg, num_tables);
+   test_workload_config *workload_cfg =
+      TYPED_ARRAY_MALLOC(hid, workload_cfg, num_tables);
 
-   rc = test_parse_args_n(
-      system_cfg, &test_exec_cfg, &gen, num_tables, config_argc, config_argv);
+   rc = test_parse_args_n(system_cfg,
+                          &test_exec_cfg,
+                          workload_cfg,
+                          &gen,
+                          num_tables,
+                          config_argc,
+                          config_argv);
 
    // if there are multiple cache capacity, cache_per_table needs to be TRUE
    bool32 multi_cap = FALSE;
@@ -2705,7 +2712,7 @@ splinter_test(int argc, char *argv[])
    }
 
    for (uint8 i = 0; i < num_tables; i++) {
-      test_cfg[i].key_size = system_cfg[i].key_size;
+      test_cfg[i].key_size = workload_cfg[i].key_size;
    }
 
    seed = test_exec_cfg.seed;
@@ -2879,6 +2886,7 @@ splinter_test(int argc, char *argv[])
                                  io,
                                  caches,
                                  system_cfg,
+                                 workload_cfg,
                                  seed,
                                  test_ops,
                                  correctness_check_frequency,
@@ -2913,6 +2921,7 @@ splinter_test(int argc, char *argv[])
 handle_destroy:
    io_handle_destroy(io);
 cfg_free:
+   platform_free(hid, workload_cfg);
    platform_free(hid, system_cfg);
    platform_free(hid, test_cfg);
 heap_destroy:

--- a/tests/functional/splinter_test.c
+++ b/tests/functional/splinter_test.c
@@ -178,7 +178,7 @@ test_trunk_insert_thread(void *arg)
                      insert_num,
                      thread_number,
                      test_cfg[spl_idx].semiseq_freq,
-                     core_max_key_size(spl),
+                     test_cfg[spl_idx].key_size,
                      test_cfg[spl_idx].period);
             generate_test_message(test_cfg->gen, insert_num, &msg);
             platform_status rc = core_insert(spl,
@@ -291,7 +291,7 @@ test_trunk_lookup_thread(void *arg)
                         lookup_num,
                         thread_number,
                         test_cfg[spl_idx].semiseq_freq,
-                        core_max_key_size(spl),
+                        test_cfg[spl_idx].key_size,
                         test_cfg[spl_idx].period);
                ts = platform_get_timestamp();
                lookup_result_set_data_config(&data, spl->cfg.data_cfg);
@@ -315,7 +315,7 @@ test_trunk_lookup_thread(void *arg)
                         lookup_num,
                         thread_number,
                         test_cfg[spl_idx].semiseq_freq,
-                        core_max_key_size(spl),
+                        test_cfg[spl_idx].key_size,
                         test_cfg[spl_idx].period);
                ctxt->lookup_num = lookup_num;
                async_ctxt_submit(spl,
@@ -441,7 +441,7 @@ test_trunk_range_thread(void *arg)
                      range_num,
                      thread_number,
                      test_cfg[spl_idx].semiseq_freq,
-                     core_max_key_size(spl),
+                     test_cfg[spl_idx].key_size,
                      test_cfg[spl_idx].period);
             uint64 range_tuples =
                test_range(range_num, min_range_length, max_range_length);
@@ -604,7 +604,7 @@ do_operation(test_splinter_thread_params *params,
                      op_num,
                      thread_number,
                      test_cfg[spl_idx].semiseq_freq,
-                     core_max_key_size(spl),
+                     test_cfg[spl_idx].key_size,
                      test_cfg[spl_idx].period);
             generate_test_message(test_cfg->gen, op_num, &msg);
             ts                 = platform_get_timestamp();
@@ -630,7 +630,7 @@ do_operation(test_splinter_thread_params *params,
                         op_num,
                         thread_number,
                         test_cfg[spl_idx].semiseq_freq,
-                        core_max_key_size(spl),
+                        test_cfg[spl_idx].key_size,
                         test_cfg[spl_idx].period);
                ts = platform_get_timestamp();
                lookup_result_set_data_config(&lookup, spl->cfg.data_cfg);
@@ -653,7 +653,7 @@ do_operation(test_splinter_thread_params *params,
                         op_num,
                         thread_number,
                         test_cfg[spl_idx].semiseq_freq,
-                        core_max_key_size(spl),
+                        test_cfg[spl_idx].key_size,
                         test_cfg[spl_idx].period);
                ctxt->lookup_num = op_num;
                async_ctxt_submit(spl,
@@ -846,8 +846,8 @@ compute_per_table_inserts(uint64        *per_table_inserts, // OUT
    uint64 total_inserts   = 0;
 
    for (uint8 i = 0; i < num_tables; i++) {
-      tuple_size = cfg[i].data_cfg->max_key_size
-                   + generator_average_message_size(test_cfg->gen);
+      tuple_size =
+         cfg[i].key_size + generator_average_message_size(test_cfg->gen);
       num_inserts = (num_inserts_cfg ? num_inserts_cfg
                                      : test_cfg[i].tree_size / tuple_size);
       if (test_cfg[i].key_type == TEST_PERIODIC) {
@@ -1514,8 +1514,8 @@ test_splinter_periodic(system_config   *cfg,
    uint64  total_inserts = 0;
 
    for (uint8 i = 0; i < num_tables; i++) {
-      tuple_size = cfg[i].data_cfg->max_key_size
-                   + generator_average_message_size(test_cfg->gen);
+      tuple_size =
+         cfg[i].key_size + generator_average_message_size(test_cfg->gen);
       num_inserts = test_cfg[i].tree_size / tuple_size;
       if (test_cfg[i].key_type == TEST_PERIODIC) {
          test_cfg[i].period = num_inserts;
@@ -2166,8 +2166,8 @@ test_splinter_delete(system_config   *cfg,
    uint64  total_inserts = 0;
 
    for (uint8 i = 0; i < num_tables; i++) {
-      tuple_size = cfg[i].data_cfg->max_key_size
-                   + generator_average_message_size(test_cfg->gen);
+      tuple_size =
+         cfg[i].key_size + generator_average_message_size(test_cfg->gen);
       num_inserts          = test_cfg[i].tree_size / tuple_size;
       per_table_inserts[i] = ROUNDUP(num_inserts, TEST_INSERT_GRANULARITY);
       total_inserts += per_table_inserts[i];
@@ -2702,6 +2702,10 @@ splinter_test(int argc, char *argv[])
                          argv[0],
                          platform_status_to_string(rc));
       goto cfg_free;
+   }
+
+   for (uint8 i = 0; i < num_tables; i++) {
+      test_cfg[i].key_size = system_cfg[i].key_size;
    }
 
    seed = test_exec_cfg.seed;

--- a/tests/functional/splinter_test.h
+++ b/tests/functional/splinter_test.h
@@ -31,6 +31,7 @@ typedef struct test_config {
    uint64        period;       // if TEST_PERIODIC then repeat sequence after
                                // this many keys
    uint64 num_periods;         // if TEST_PERIODIC then repeat this many times
+   uint64 key_size;
    test_message_generator *gen;
    test_exec_config       *test_exec_cfg; // Describes test's exec parameters
 } test_config;

--- a/tests/functional/test.h
+++ b/tests/functional/test.h
@@ -227,7 +227,7 @@ test_workload_config_init(test_workload_config *workload_cfg,
 }
 
 static inline void
-test_message_generator_init(test_message_generator      *gen,
+test_message_generator_init(test_message_generator     *gen,
                             const test_workload_config *workload_cfg)
 {
    gen->type             = MESSAGE_TYPE_INSERT;
@@ -338,17 +338,17 @@ typedef struct test_exec_config {
  * Not all tests may need these, so this arg is optional, and can be NULL.
  */
 static inline platform_status
-test_parse_args_n(system_config          system_cfg[],    // OUT
-                  test_exec_config      *test_exec_cfg,   // OUT
-                  test_workload_config  *workload_cfg,    // OUT
-                  test_message_generator *gen,            // OUT
-                  uint8                  num_config,      // IN
-                  int                    argc,            // IN
-                  char                  *argv[]           // IN
+test_parse_args_n(system_config           system_cfg[],  // OUT
+                  test_exec_config       *test_exec_cfg, // OUT
+                  test_workload_config   *workload_cfg,  // OUT
+                  test_message_generator *gen,           // OUT
+                  uint8                   num_config,    // IN
+                  int                     argc,          // IN
+                  char                   *argv[]         // IN
 )
 {
-   platform_status rc;
-   uint8           i;
+   platform_status      rc;
+   uint8                i;
    test_workload_config local_workload_cfg;
 
    // Allocate memory and setup default configs for up to n-instances

--- a/tests/functional/test.h
+++ b/tests/functional/test.h
@@ -207,6 +207,7 @@ typedef struct system_config {
    routing_config     filter_cfg;
    shard_log_config   log_cfg;
    data_config       *data_cfg;
+   uint64             key_size;
    task_system_config task_cfg;
    clockcache_config  cache_cfg;
    allocator_config   allocator_cfg;
@@ -226,8 +227,8 @@ test_config_init(system_config          *system_cfg, // OUT
                  master_config          *master_cfg // IN
 )
 {
-   system_cfg->data_cfg               = test_data_config;
-   system_cfg->data_cfg->max_key_size = master_cfg->max_key_size;
+   system_cfg->data_cfg = test_data_config;
+   system_cfg->key_size = master_cfg->key_size;
 
    io_config_init(&system_cfg->io_cfg,
                   master_cfg->page_size,
@@ -307,6 +308,7 @@ test_config_init(system_config          *system_cfg, // OUT
 typedef struct test_exec_config {
    uint64 seed;
    uint64 num_inserts;
+   uint64 key_size;
    bool32 verbose_progress; // --verbose-progress: During test execution
 } test_exec_config;
 
@@ -357,6 +359,7 @@ test_parse_args_n(system_config           system_cfg[],  // OUT
    if (test_exec_cfg) {
       test_exec_cfg->seed             = master_cfg[0].seed;
       test_exec_cfg->num_inserts      = master_cfg[0].num_inserts;
+      test_exec_cfg->key_size         = master_cfg[0].key_size;
       test_exec_cfg->verbose_progress = master_cfg[0].verbose_progress;
    }
 

--- a/tests/functional/test.h
+++ b/tests/functional/test.h
@@ -207,12 +207,33 @@ typedef struct system_config {
    routing_config     filter_cfg;
    shard_log_config   log_cfg;
    data_config       *data_cfg;
-   uint64             key_size;
    task_system_config task_cfg;
    clockcache_config  cache_cfg;
    allocator_config   allocator_cfg;
    io_config          io_cfg;
 } system_config;
+
+typedef struct test_workload_config {
+   uint64 key_size;
+   uint64 message_size;
+} test_workload_config;
+
+static inline void
+test_workload_config_init(test_workload_config *workload_cfg,
+                          const master_config  *master_cfg)
+{
+   workload_cfg->key_size     = master_cfg->key_size;
+   workload_cfg->message_size = master_cfg->message_size;
+}
+
+static inline void
+test_message_generator_init(test_message_generator      *gen,
+                            const test_workload_config *workload_cfg)
+{
+   gen->type             = MESSAGE_TYPE_INSERT;
+   gen->min_payload_size = GENERATOR_MIN_PAYLOAD_SIZE;
+   gen->max_payload_size = workload_cfg->message_size;
+}
 
 /*
  * test_config_init() --
@@ -222,13 +243,11 @@ typedef struct system_config {
  * may have been used to setup master_cfg beyond its initial defaults.
  */
 static inline platform_status
-test_config_init(system_config          *system_cfg, // OUT
-                 test_message_generator *gen,
-                 master_config          *master_cfg // IN
+test_config_init(system_config *system_cfg, // OUT
+                 master_config *master_cfg  // IN
 )
 {
    system_cfg->data_cfg = test_data_config;
-   system_cfg->key_size = master_cfg->key_size;
 
    io_config_init(&system_cfg->io_cfg,
                   master_cfg->page_size,
@@ -294,9 +313,6 @@ test_config_init(system_config          *system_cfg, // OUT
       return rc;
    }
 
-   gen->type             = MESSAGE_TYPE_INSERT;
-   gen->min_payload_size = GENERATOR_MIN_PAYLOAD_SIZE;
-   gen->max_payload_size = master_cfg->message_size;
    return rc;
 }
 
@@ -308,7 +324,6 @@ test_config_init(system_config          *system_cfg, // OUT
 typedef struct test_exec_config {
    uint64 seed;
    uint64 num_inserts;
-   uint64 key_size;
    bool32 verbose_progress; // --verbose-progress: During test execution
 } test_exec_config;
 
@@ -323,16 +338,18 @@ typedef struct test_exec_config {
  * Not all tests may need these, so this arg is optional, and can be NULL.
  */
 static inline platform_status
-test_parse_args_n(system_config           system_cfg[],  // OUT
-                  test_exec_config       *test_exec_cfg, // OUT
-                  test_message_generator *gen,           // OUT
-                  uint8                   num_config,    // IN
-                  int                     argc,          // IN
-                  char                   *argv[]         // IN
+test_parse_args_n(system_config          system_cfg[],    // OUT
+                  test_exec_config      *test_exec_cfg,   // OUT
+                  test_workload_config  *workload_cfg,    // OUT
+                  test_message_generator *gen,            // OUT
+                  uint8                  num_config,      // IN
+                  int                    argc,            // IN
+                  char                  *argv[]           // IN
 )
 {
    platform_status rc;
    uint8           i;
+   test_workload_config local_workload_cfg;
 
    // Allocate memory and setup default configs for up to n-instances
    master_config *master_cfg =
@@ -348,9 +365,15 @@ test_parse_args_n(system_config           system_cfg[],  // OUT
    }
 
    for (i = 0; i < num_config; i++) {
-      rc = test_config_init(&system_cfg[i], gen, &master_cfg[i]);
+      rc = test_config_init(&system_cfg[i], &master_cfg[i]);
       if (!SUCCESS(rc)) {
          goto out;
+      }
+      test_workload_config *curr_workload_cfg =
+         workload_cfg ? &workload_cfg[i] : &local_workload_cfg;
+      test_workload_config_init(curr_workload_cfg, &master_cfg[i]);
+      if (gen) {
+         test_message_generator_init(gen, curr_workload_cfg);
       }
    }
 
@@ -359,7 +382,6 @@ test_parse_args_n(system_config           system_cfg[],  // OUT
    if (test_exec_cfg) {
       test_exec_cfg->seed             = master_cfg[0].seed;
       test_exec_cfg->num_inserts      = master_cfg[0].num_inserts;
-      test_exec_cfg->key_size         = master_cfg[0].key_size;
       test_exec_cfg->verbose_progress = master_cfg[0].verbose_progress;
    }
 
@@ -377,6 +399,7 @@ out:
  */
 static inline platform_status
 test_parse_args(system_config          *system_cfg,
+                test_workload_config   *workload_cfg,
                 uint64                 *seed,
                 test_message_generator *gen,
                 uint64                 *num_memtable_bg_threads,
@@ -388,7 +411,8 @@ test_parse_args(system_config          *system_cfg,
    ZERO_STRUCT(test_exec_cfg);
 
    platform_status rc;
-   rc = test_parse_args_n(system_cfg, &test_exec_cfg, gen, 1, argc, argv);
+   rc = test_parse_args_n(
+      system_cfg, &test_exec_cfg, workload_cfg, gen, 1, argc, argv);
    if (!SUCCESS(rc)) {
       return rc;
    }

--- a/tests/functional/test_functionality.c
+++ b/tests/functional/test_functionality.c
@@ -340,7 +340,7 @@ choose_key(uint64                      key_size,    // IN
            key                         startkey,    // IN
            int                         start_index, // IN
            int                        *index,       // OUT
-           key_buffer                 *keybuf)      // OUT
+           key_buffer                 *keybuf)                      // OUT
 {
    uint64 num_keys = sharr->nkeys;
 
@@ -420,14 +420,14 @@ verify_range_against_shadow_all_types(core_handle                *spl,
                                 &start_index,
                                 &startkey_buf);
          end_key   = choose_key(key_size,
-                                sharr,
-                                prg,
-                                end_type,
-                                0,
-                                start_key,
-                                start_index,
-                                &end_index,
-                                &endkey_buf);
+                              sharr,
+                              prg,
+                              end_type,
+                              0,
+                              start_key,
+                              start_index,
+                              &end_index,
+                              &endkey_buf);
          if (do_it) {
             rc = verify_range_against_shadow(
                spl, sharr, start_key, end_key, hid, start_index, end_index);
@@ -453,14 +453,14 @@ verify_range_against_shadow_all_types(core_handle                *spl,
                              &start_index,
                              &startkey_buf);
       end_key   = choose_key(key_size,
-                             sharr,
-                             prg,
-                             end_type,
-                             0,
-                             start_key,
-                             start_index,
-                             &end_index,
-                             &endkey_buf);
+                           sharr,
+                           prg,
+                           end_type,
+                           0,
+                           start_key,
+                           start_index,
+                           &end_index,
+                           &endkey_buf);
       if (do_it) {
          rc = verify_range_against_shadow(
             spl, sharr, start_key, end_key, hid, start_index, end_index);

--- a/tests/functional/test_functionality.c
+++ b/tests/functional/test_functionality.c
@@ -640,18 +640,19 @@ cmp_ptrs(const void *a, const void *b)
  *-----------------------------------------------------------------------------
  */
 platform_status
-test_functionality(allocator       *al,
-                   io_handle       *io,
-                   cache           *cc[],
-                   system_config   *cfg,
-                   uint64           seed,
-                   uint64           num_inserts,
-                   uint64           correctness_check_frequency,
-                   task_system     *state,
-                   platform_heap_id hid,
-                   uint8            num_tables,
-                   uint8            num_caches,
-                   uint32           max_async_inflight)
+test_functionality(allocator            *al,
+                   io_handle            *io,
+                   cache                *cc[],
+                   system_config        *cfg,
+                   test_workload_config *workload_cfg,
+                   uint64                seed,
+                   uint64                num_inserts,
+                   uint64                correctness_check_frequency,
+                   task_system          *state,
+                   platform_heap_id      hid,
+                   uint8                 num_tables,
+                   uint8                 num_caches,
+                   uint32                max_async_inflight)
 {
    platform_error_log("Functional test started with %d tables\n", num_tables);
    platform_assert(cc != NULL);
@@ -710,8 +711,13 @@ test_functionality(allocator       *al,
    for (uint8 idx = 0; idx < num_tables; idx++) {
       core_handle               *spl    = &spl_tables[idx];
       test_splinter_shadow_tree *shadow = shadows[idx];
-      status                            = validate_tree_against_shadow(
-         spl, &prg, shadow, hid, cfg[idx].key_size, TRUE, async_lookup);
+      status                            = validate_tree_against_shadow(spl,
+                                            &prg,
+                                            shadow,
+                                            hid,
+                                            workload_cfg[idx].key_size,
+                                            TRUE,
+                                            async_lookup);
       if (!SUCCESS(status)) {
          platform_error_log("Failed to validate empty tree against shadow: \
                             %s\n",
@@ -791,7 +797,7 @@ test_functionality(allocator       *al,
          status = insert_random_messages(spl,
                                          shadow,
                                          &prg,
-                                         cfg[idx].key_size,
+                                         workload_cfg[idx].key_size,
                                          num_messages,
                                          op,
                                          minkey,
@@ -809,7 +815,7 @@ test_functionality(allocator       *al,
             &prg,
             shadow,
             hid,
-            cfg[idx].key_size,
+            workload_cfg[idx].key_size,
             correctness_check_frequency
                && (i % correctness_check_frequency) == 0,
             async_lookup);
@@ -856,7 +862,7 @@ test_functionality(allocator       *al,
          &prg,
          shadow,
          hid,
-         cfg[idx].key_size,
+         workload_cfg[idx].key_size,
          correctness_check_frequency
             && ((i - 1) % correctness_check_frequency) != 0,
          async_lookup);

--- a/tests/functional/test_functionality.c
+++ b/tests/functional/test_functionality.c
@@ -156,10 +156,9 @@ verify_tuple_callback(core_handle *spl, test_async_ctxt *ctxt, void *arg)
 platform_status
 verify_against_shadow(core_handle                *spl,
                       test_splinter_shadow_array *sharr,
+                      uint64                      key_size,
                       test_async_lookup          *async_lookup)
 {
-   uint64 key_size = spl->cfg.data_cfg->max_key_size;
-
    platform_assert(key_size >= sizeof(uint64));
    platform_assert(sizeof(data_handle) <= sizeof(void *));
 
@@ -333,7 +332,7 @@ out:
 #define VERIFY_RANGE_ENDPOINT_LESS  (6)
 
 static key
-choose_key(data_config                *cfg,         // IN
+choose_key(uint64                      key_size,    // IN
            test_splinter_shadow_array *sharr,       // IN
            random_state               *prg,         // IN/OUT
            int                         type,        // IN
@@ -341,7 +340,7 @@ choose_key(data_config                *cfg,         // IN
            key                         startkey,    // IN
            int                         start_index, // IN
            int                        *index,       // OUT
-           key_buffer                 *keybuf)                      // OUT
+           key_buffer                 *keybuf)      // OUT
 {
    uint64 num_keys = sharr->nkeys;
 
@@ -365,7 +364,7 @@ choose_key(data_config                *cfg,         // IN
             pos++;
          }
          *index = pos;
-         test_int_to_key(keybuf, int_key, cfg->max_key_size);
+         test_int_to_key(keybuf, int_key, key_size);
          break;
       }
       case VERIFY_RANGE_ENDPOINT_EQUAL:
@@ -376,7 +375,7 @@ choose_key(data_config                *cfg,         // IN
       case VERIFY_RANGE_ENDPOINT_LESS:
          platform_assert(!is_start && !key_is_null(startkey));
          *index = start_index ? (random_next_uint64(prg) % start_index) : 0;
-         test_int_to_key(keybuf, sharr->keys[*index], cfg->max_key_size);
+         test_int_to_key(keybuf, sharr->keys[*index], key_size);
          break;
       default:
          platform_assert(0);
@@ -390,6 +389,7 @@ verify_range_against_shadow_all_types(core_handle                *spl,
                                       random_state               *prg,
                                       test_splinter_shadow_array *sharr,
                                       platform_heap_id            hid,
+                                      uint64                      key_size,
                                       bool32                      do_it)
 {
    int             begin_type;
@@ -410,7 +410,7 @@ verify_range_against_shadow_all_types(core_handle                *spl,
            end_type <= VERIFY_RANGE_ENDPOINT_RAND;
            end_type++)
       {
-         start_key = choose_key(spl->cfg.data_cfg,
+         start_key = choose_key(key_size,
                                 sharr,
                                 prg,
                                 begin_type,
@@ -419,15 +419,15 @@ verify_range_against_shadow_all_types(core_handle                *spl,
                                 0,
                                 &start_index,
                                 &startkey_buf);
-         end_key   = choose_key(spl->cfg.data_cfg,
-                              sharr,
-                              prg,
-                              end_type,
-                              0,
-                              start_key,
-                              start_index,
-                              &end_index,
-                              &endkey_buf);
+         end_key   = choose_key(key_size,
+                                sharr,
+                                prg,
+                                end_type,
+                                0,
+                                start_key,
+                                start_index,
+                                &end_index,
+                                &endkey_buf);
          if (do_it) {
             rc = verify_range_against_shadow(
                spl, sharr, start_key, end_key, hid, start_index, end_index);
@@ -443,7 +443,7 @@ verify_range_against_shadow_all_types(core_handle                *spl,
         end_type <= VERIFY_RANGE_ENDPOINT_LESS;
         end_type++)
    {
-      start_key = choose_key(spl->cfg.data_cfg,
+      start_key = choose_key(key_size,
                              sharr,
                              prg,
                              begin_type,
@@ -452,15 +452,15 @@ verify_range_against_shadow_all_types(core_handle                *spl,
                              0,
                              &start_index,
                              &startkey_buf);
-      end_key   = choose_key(spl->cfg.data_cfg,
-                           sharr,
-                           prg,
-                           end_type,
-                           0,
-                           start_key,
-                           start_index,
-                           &end_index,
-                           &endkey_buf);
+      end_key   = choose_key(key_size,
+                             sharr,
+                             prg,
+                             end_type,
+                             0,
+                             start_key,
+                             start_index,
+                             &end_index,
+                             &endkey_buf);
       if (do_it) {
          rc = verify_range_against_shadow(
             spl, sharr, start_key, end_key, hid, start_index, end_index);
@@ -478,6 +478,7 @@ validate_tree_against_shadow(core_handle               *spl,
                              random_state              *prg,
                              test_splinter_shadow_tree *shadow,
                              platform_heap_id           hid,
+                             uint64                     key_size,
                              bool32                     do_it,
                              test_async_lookup         *async_lookup)
 {
@@ -503,7 +504,7 @@ validate_tree_against_shadow(core_handle               *spl,
       memcpy(&sharr, &dry_run_sharr, sizeof(sharr));
    }
 
-   rc = verify_against_shadow(spl, &sharr, async_lookup);
+   rc = verify_against_shadow(spl, &sharr, key_size, async_lookup);
    if (!SUCCESS(rc)) {
       platform_free(hid, async_lookup);
       platform_error_log("Failed to verify inserted items in Splinter: %s\n",
@@ -511,7 +512,8 @@ validate_tree_against_shadow(core_handle               *spl,
       goto cleanup;
    }
 
-   rc = verify_range_against_shadow_all_types(spl, prg, &sharr, hid, do_it);
+   rc = verify_range_against_shadow_all_types(
+      spl, prg, &sharr, hid, key_size, do_it);
    if (!SUCCESS(rc)) {
       platform_error_log("Failed to verify range iteration over inserted items "
                          "in Splinter: %s\n",
@@ -543,6 +545,7 @@ static platform_status
 insert_random_messages(core_handle               *spl,
                        test_splinter_shadow_tree *shadow,
                        random_state              *prg,
+                       uint64                     key_size,
                        int                        num_messages,
                        message_type               op,
                        uint64                     minkey,
@@ -550,8 +553,6 @@ insert_random_messages(core_handle               *spl,
                        int64                      mindelta,
                        int64                      maxdelta)
 {
-   uint64 key_size = spl->cfg.data_cfg->max_key_size;
-
    platform_assert(key_size >= sizeof(uint64));
    platform_assert(sizeof(data_handle) <= sizeof(void *));
 
@@ -710,7 +711,7 @@ test_functionality(allocator       *al,
       core_handle               *spl    = &spl_tables[idx];
       test_splinter_shadow_tree *shadow = shadows[idx];
       status                            = validate_tree_against_shadow(
-         spl, &prg, shadow, hid, TRUE, async_lookup);
+         spl, &prg, shadow, hid, cfg[idx].key_size, TRUE, async_lookup);
       if (!SUCCESS(status)) {
          platform_error_log("Failed to validate empty tree against shadow: \
                             %s\n",
@@ -790,6 +791,7 @@ test_functionality(allocator       *al,
          status = insert_random_messages(spl,
                                          shadow,
                                          &prg,
+                                         cfg[idx].key_size,
                                          num_messages,
                                          op,
                                          minkey,
@@ -807,6 +809,7 @@ test_functionality(allocator       *al,
             &prg,
             shadow,
             hid,
+            cfg[idx].key_size,
             correctness_check_frequency
                && (i % correctness_check_frequency) == 0,
             async_lookup);
@@ -853,6 +856,7 @@ test_functionality(allocator       *al,
          &prg,
          shadow,
          hid,
+         cfg[idx].key_size,
          correctness_check_frequency
             && ((i - 1) % correctness_check_frequency) != 0,
          async_lookup);

--- a/tests/functional/test_functionality.h
+++ b/tests/functional/test_functionality.h
@@ -8,15 +8,16 @@
 #include "platform.h"
 
 platform_status
-test_functionality(allocator       *al,
-                   io_handle       *io,
-                   cache           *cc[],
-                   system_config   *cfg,
-                   uint64           seed,
-                   uint64           num_inserts,
-                   uint64           correctness_check_frequency,
-                   task_system     *ts,
-                   platform_heap_id hid,
-                   uint8            num_tables,
-                   uint8            num_caches,
-                   uint32           max_async_inflight);
+test_functionality(allocator            *al,
+                   io_handle            *io,
+                   cache                *cc[],
+                   system_config        *cfg,
+                   test_workload_config *workload_cfg,
+                   uint64                seed,
+                   uint64                num_inserts,
+                   uint64                correctness_check_frequency,
+                   task_system          *ts,
+                   platform_heap_id      hid,
+                   uint8                 num_tables,
+                   uint8                 num_caches,
+                   uint32                max_async_inflight);

--- a/tests/functional/ycsb_test.c
+++ b/tests/functional/ycsb_test.c
@@ -1185,8 +1185,10 @@ ycsb_test(int argc, char *argv[])
 
    system_config *system_cfg = TYPED_MALLOC(hid, system_cfg);
    uint64         num_bg_threads[NUM_TASK_TYPES] = {0}; // no bg threads
+   test_workload_config workload_cfg;
 
    rc = test_parse_args(system_cfg,
+                        &workload_cfg,
                         &seed,
                         &gen,
                         &num_bg_threads[TASK_TYPE_MEMTABLE],
@@ -1199,7 +1201,7 @@ ycsb_test(int argc, char *argv[])
       goto cleanup;
    }
 
-   if (system_cfg->key_size != YCSB_KEY_SIZE) {
+   if (workload_cfg.key_size != YCSB_KEY_SIZE) {
       rc = STATUS_BAD_PARAM;
       platform_error_log("ycsb: key size configuration does not match\n");
       goto cleanup;

--- a/tests/functional/ycsb_test.c
+++ b/tests/functional/ycsb_test.c
@@ -1183,8 +1183,8 @@ ycsb_test(int argc, char *argv[])
    rc = platform_heap_create(platform_get_module_id(), 512 * MiB, FALSE, &hid);
    platform_assert_status_ok(rc);
 
-   system_config *system_cfg = TYPED_MALLOC(hid, system_cfg);
-   uint64         num_bg_threads[NUM_TASK_TYPES] = {0}; // no bg threads
+   system_config       *system_cfg = TYPED_MALLOC(hid, system_cfg);
+   uint64               num_bg_threads[NUM_TASK_TYPES] = {0}; // no bg threads
    test_workload_config workload_cfg;
 
    rc = test_parse_args(system_cfg,

--- a/tests/functional/ycsb_test.c
+++ b/tests/functional/ycsb_test.c
@@ -1199,7 +1199,7 @@ ycsb_test(int argc, char *argv[])
       goto cleanup;
    }
 
-   if (system_cfg->data_cfg->max_key_size != YCSB_KEY_SIZE) {
+   if (system_cfg->key_size != YCSB_KEY_SIZE) {
       rc = STATUS_BAD_PARAM;
       platform_error_log("ycsb: key size configuration does not match\n");
       goto cleanup;

--- a/tests/test_data.c
+++ b/tests/test_data.c
@@ -132,7 +132,6 @@ test_data_message_to_string(const data_config *cfg,
 static data_test_config data_test_config_internal = {
    .super =
       {
-         .max_key_size       = 24,
          .key_compare        = test_data_key_cmp,
          .key_hash           = test_data_key_hash,
          .key_to_string      = test_data_key_to_string,

--- a/tests/unit/btree_test_common.c
+++ b/tests/unit/btree_test_common.c
@@ -10,7 +10,8 @@ int
 init_data_config_from_master_config(data_config   *data_cfg,
                                     master_config *master_cfg)
 {
-   data_cfg->max_key_size = master_cfg->max_key_size;
+   (void)data_cfg;
+   (void)master_cfg;
    return 1;
 }
 

--- a/tests/unit/btree_test_common.c
+++ b/tests/unit/btree_test_common.c
@@ -10,8 +10,6 @@ int
 init_data_config_from_master_config(data_config   *data_cfg,
                                     master_config *master_cfg)
 {
-   (void)data_cfg;
-   (void)master_cfg;
    return 1;
 }
 

--- a/tests/unit/config_parse_test.c
+++ b/tests/unit/config_parse_test.c
@@ -57,17 +57,20 @@ CTEST2(config_parse, test_basic_parsing)
 {
    // Following get setup pointing to allocated memory
    system_config         *system_cfg = NULL;
+   test_workload_config  *workload_cfg = NULL;
    test_message_generator gen;
 
    int num_tables = 1;
 
    // Allocate memory for global config structures
    system_cfg = TYPED_ARRAY_MALLOC(data->hid, system_cfg, num_tables);
+   workload_cfg = TYPED_ARRAY_MALLOC(data->hid, workload_cfg, num_tables);
 
    platform_status rc;
 
    rc = test_parse_args_n(system_cfg,
                           &data->test_exec_cfg,
+                          workload_cfg,
                           &gen,
                           num_tables,
                           Ctest_argc, // argc/argv globals setup by CTests
@@ -94,4 +97,5 @@ CTEST2(config_parse, test_basic_parsing)
                "--verbose-progress");
 
    platform_free(data->hid, system_cfg);
+   platform_free(data->hid, workload_cfg);
 }

--- a/tests/unit/config_parse_test.c
+++ b/tests/unit/config_parse_test.c
@@ -56,14 +56,14 @@ CTEST_TEARDOWN(config_parse)
 CTEST2(config_parse, test_basic_parsing)
 {
    // Following get setup pointing to allocated memory
-   system_config         *system_cfg = NULL;
+   system_config         *system_cfg   = NULL;
    test_workload_config  *workload_cfg = NULL;
    test_message_generator gen;
 
    int num_tables = 1;
 
    // Allocate memory for global config structures
-   system_cfg = TYPED_ARRAY_MALLOC(data->hid, system_cfg, num_tables);
+   system_cfg   = TYPED_ARRAY_MALLOC(data->hid, system_cfg, num_tables);
    workload_cfg = TYPED_ARRAY_MALLOC(data->hid, workload_cfg, num_tables);
 
    platform_status rc;

--- a/tests/unit/large_inserts_stress_test.c
+++ b/tests/unit/large_inserts_stress_test.c
@@ -150,9 +150,7 @@ CTEST_SETUP(large_inserts_stress)
    data->cfg.num_memtable_bg_threads = data->master_cfg.num_memtable_bg_threads;
    data->cfg.num_normal_bg_threads   = data->master_cfg.num_normal_bg_threads;
 
-
-   size_t max_key_size = TEST_KEY_SIZE;
-   default_data_config_init(max_key_size, data->cfg.data_cfg);
+   default_data_config_init(data->cfg.data_cfg);
 
    int rv = splinterdb_create(&data->cfg, &data->kvsb);
    ASSERT_EQUAL(0, rv);

--- a/tests/unit/limitations_test.c
+++ b/tests/unit/limitations_test.c
@@ -98,6 +98,7 @@ CTEST2(limitations, test_io_init_invalid_page_size)
 
    rc = test_parse_args_n(data->system_cfg,
                           &data->test_exec_cfg,
+                          NULL,
                           &data->gen,
                           num_tables,
                           Ctest_argc, // argc/argv globals setup by CTests
@@ -152,6 +153,7 @@ CTEST2(limitations, test_io_init_invalid_extent_size)
 
    rc = test_parse_args_n(data->system_cfg,
                           &data->test_exec_cfg,
+                          NULL,
                           &data->gen,
                           num_tables,
                           Ctest_argc, // argc/argv globals setup by CTests

--- a/tests/unit/limitations_test.c
+++ b/tests/unit/limitations_test.c
@@ -21,8 +21,6 @@
 #include "ctest.h" // This is required for all test-case files.
 #include "platform_units.h"
 
-#define TEST_MAX_KEY_SIZE 13
-
 static void
 create_default_cfg(splinterdb_config *out_cfg,
                    data_config       *default_data_cfg,
@@ -208,7 +206,7 @@ CTEST2(limitations, test_splinterdb_create_invalid_task_system_config)
    splinterdb_config cfg;
    data_config       default_data_cfg;
 
-   default_data_config_init(TEST_MAX_KEY_SIZE, &default_data_cfg);
+   default_data_config_init(&default_data_cfg);
    create_default_cfg(&cfg, &default_data_cfg, data->use_shmem);
 
    // Cannot use up all possible threads for just bg-threads.
@@ -229,7 +227,7 @@ CTEST2(limitations, test_splinterdb_create_invalid_page_size)
    splinterdb_config cfg;
    data_config       default_data_cfg;
 
-   default_data_config_init(TEST_MAX_KEY_SIZE, &default_data_cfg);
+   default_data_config_init(&default_data_cfg);
    create_default_cfg(&cfg, &default_data_cfg, data->use_shmem);
 
    uint64 page_size_configured = cfg.page_size;
@@ -250,7 +248,7 @@ CTEST2(limitations, test_splinterdb_create_invalid_extent_size)
    splinterdb_config cfg;
    data_config       default_data_cfg;
 
-   default_data_config_init(TEST_MAX_KEY_SIZE, &default_data_cfg);
+   default_data_config_init(&default_data_cfg);
    create_default_cfg(&cfg, &default_data_cfg, data->use_shmem);
 
    uint64 extent_size_configured = cfg.extent_size;
@@ -276,7 +274,7 @@ CTEST2(limitations, test_create_zero_disk_size)
    splinterdb_config cfg;
    data_config       default_data_cfg;
 
-   default_data_config_init(TEST_MAX_KEY_SIZE, &default_data_cfg);
+   default_data_config_init(&default_data_cfg);
    create_default_cfg(&cfg, &default_data_cfg, data->use_shmem);
 
    // Hard-fix this, to see if an error is raised.
@@ -292,7 +290,7 @@ CTEST2(limitations, test_create_zero_extent_capacity)
    splinterdb_config cfg;
    data_config       default_data_cfg;
 
-   default_data_config_init(TEST_MAX_KEY_SIZE, &default_data_cfg);
+   default_data_config_init(&default_data_cfg);
    create_default_cfg(&cfg, &default_data_cfg, data->use_shmem);
 
    // Hard-fix this to some non-zero value, to see if an error is raised.
@@ -308,7 +306,7 @@ CTEST2(limitations, test_disk_size_not_integral_multiple_of_page_size)
    splinterdb_config cfg;
    data_config       default_data_cfg;
 
-   default_data_config_init(TEST_MAX_KEY_SIZE, &default_data_cfg);
+   default_data_config_init(&default_data_cfg);
    create_default_cfg(&cfg, &default_data_cfg, data->use_shmem);
 
    // Hard-fix this to some non-integral multiple of configured page-size.
@@ -326,7 +324,7 @@ CTEST2(limitations, test_disk_size_not_integral_multiple_of_extents)
    splinterdb_config cfg;
    data_config       default_data_cfg;
 
-   default_data_config_init(TEST_MAX_KEY_SIZE, &default_data_cfg);
+   default_data_config_init(&default_data_cfg);
    create_default_cfg(&cfg, &default_data_cfg, data->use_shmem);
 
    // Hard-fix this to some non-integral multiple of configured extent-size.
@@ -346,7 +344,7 @@ CTEST2(limitations, test_zero_cache_size)
    splinterdb_config cfg;
    data_config       default_data_cfg;
 
-   default_data_config_init(TEST_MAX_KEY_SIZE, &default_data_cfg);
+   default_data_config_init(&default_data_cfg);
    create_default_cfg(&cfg, &default_data_cfg, data->use_shmem);
 
    // Hard-fix this to an illegal value.
@@ -369,7 +367,7 @@ CTEST2(limitations, test_file_error_returns)
    splinterdb_config cfg;
    data_config       default_data_cfg;
 
-   default_data_config_init(TEST_MAX_KEY_SIZE, &default_data_cfg);
+   default_data_config_init(&default_data_cfg);
    create_default_cfg(&cfg, &default_data_cfg, data->use_shmem);
 
    cfg.filename = "/dev/null/this-file-cannot-possibly-be-opened";

--- a/tests/unit/splinter_test.c
+++ b/tests/unit/splinter_test.c
@@ -89,6 +89,7 @@ CTEST_DATA(splinter)
 
    // Following get setup pointing to allocated memory
    system_config         *system_cfg;
+   test_workload_config  *workload_cfg;
    io_handle             *io;
    clockcache            *clock_cache;
    task_system            tasks;
@@ -130,11 +131,14 @@ CTEST_SETUP(splinter)
    // Allocate memory for global config structures
    data->system_cfg = TYPED_ARRAY_MALLOC(data->hid, data->system_cfg,
                                           num_tables);
+   data->workload_cfg =
+      TYPED_ARRAY_MALLOC(data->hid, data->workload_cfg, num_tables);
 
    ZERO_STRUCT(data->test_exec_cfg);
 
    rc = test_parse_args_n(data->system_cfg,
                           &data->test_exec_cfg,
+                          data->workload_cfg,
                           &data->gen,
                           num_tables,
                           Ctest_argc,   // argc/argv globals setup by CTests
@@ -204,6 +208,9 @@ CTEST_TEARDOWN(splinter)
 
    if (data->system_cfg) {
       platform_free(data->hid, data->system_cfg);
+   }
+   if (data->workload_cfg) {
+      platform_free(data->hid, data->workload_cfg);
    }
 
    platform_heap_destroy(&data->hid);
@@ -421,7 +428,7 @@ CTEST2(splinter, test_lookups)
    lookup_result_init(
       &qdata, spl.cfg.data_cfg, SPLINTERDB_LOOKUP_VALUE, 0, NULL);
    DECLARE_AUTO_KEY_BUFFER(keybuf, data->hid);
-   const size_t key_size = data->system_cfg->key_size;
+   const size_t key_size = data->workload_cfg->key_size;
 
    platform_status rc;
 
@@ -708,7 +715,7 @@ splinter_do_inserts(void         *datap,
    uint64 start_time = platform_get_timestamp();
    uint64 insert_num;
    DECLARE_AUTO_KEY_BUFFER(keybuf, spl->heap_id);
-   const size_t key_size = data->system_cfg->key_size;
+   const size_t key_size = data->workload_cfg->key_size;
 
    // Allocate a large array for copying over shadow copies of rows
    // inserted, if user has asked to return such an array.
@@ -825,7 +832,7 @@ test_lookup_by_range(void         *datap,
 {
    struct CTEST_IMPL_DATA_SNAME(splinter) *data =
       (struct CTEST_IMPL_DATA_SNAME(splinter) *)datap;
-   const size_t key_size = data->system_cfg->key_size;
+   const size_t key_size = data->workload_cfg->key_size;
 
    uint64 start_time = platform_get_timestamp();
 

--- a/tests/unit/splinter_test.c
+++ b/tests/unit/splinter_test.c
@@ -421,7 +421,7 @@ CTEST2(splinter, test_lookups)
    lookup_result_init(
       &qdata, spl.cfg.data_cfg, SPLINTERDB_LOOKUP_VALUE, 0, NULL);
    DECLARE_AUTO_KEY_BUFFER(keybuf, data->hid);
-   const size_t key_size = core_max_key_size(&spl);
+   const size_t key_size = data->system_cfg->key_size;
 
    platform_status rc;
 
@@ -708,7 +708,7 @@ splinter_do_inserts(void         *datap,
    uint64 start_time = platform_get_timestamp();
    uint64 insert_num;
    DECLARE_AUTO_KEY_BUFFER(keybuf, spl->heap_id);
-   const size_t key_size = core_max_key_size(spl);
+   const size_t key_size = data->system_cfg->key_size;
 
    // Allocate a large array for copying over shadow copies of rows
    // inserted, if user has asked to return such an array.
@@ -823,7 +823,9 @@ test_lookup_by_range(void         *datap,
                      trunk_shadow *shadow,
                      uint64        num_ranges)
 {
-   const size_t key_size = core_max_key_size(spl);
+   struct CTEST_IMPL_DATA_SNAME(splinter) *data =
+      (struct CTEST_IMPL_DATA_SNAME(splinter) *)datap;
+   const size_t key_size = data->system_cfg->key_size;
 
    uint64 start_time = platform_get_timestamp();
 

--- a/tests/unit/splinterdb_forked_child_test.c
+++ b/tests/unit/splinterdb_forked_child_test.c
@@ -100,7 +100,7 @@ CTEST2(splinterdb_forked_child, test_data_structures_handles)
 
    // Setup global data_config for Splinter's use.
    memset(splinter_data_cfgp, 0, sizeof(*splinter_data_cfgp));
-   default_data_config_init(30, splinter_data_cfgp);
+   default_data_config_init(splinter_data_cfgp);
 
    splinterdb_config splinterdb_cfg;
 
@@ -171,7 +171,7 @@ CTEST2(splinterdb_forked_child, test_one_insert_then_close_bug)
 
    // Setup global data_config for Splinter's use.
    memset(splinter_data_cfgp, 0, sizeof(*splinter_data_cfgp));
-   default_data_config_init(30, splinter_data_cfgp);
+   default_data_config_init(splinter_data_cfgp);
 
    splinterdb_config splinterdb_cfg;
 
@@ -288,7 +288,7 @@ CTEST2(splinterdb_forked_child,
 
    // Setup global data_config for Splinter's use.
    memset(splinter_data_cfgp, 0, sizeof(*splinter_data_cfgp));
-   default_data_config_init(30, splinter_data_cfgp);
+   default_data_config_init(splinter_data_cfgp);
 
    splinterdb_config splinterdb_cfg;
 
@@ -386,7 +386,7 @@ CTEST2(splinterdb_forked_child, test_multiple_forked_process_doing_IOs)
 
    // Setup global data_config for Splinter's use.
    memset(splinter_data_cfgp, 0, sizeof(*splinter_data_cfgp));
-   default_data_config_init(30, splinter_data_cfgp);
+   default_data_config_init(splinter_data_cfgp);
 
    splinterdb_config splinterdb_cfg;
 

--- a/tests/unit/splinterdb_quick_test.c
+++ b/tests/unit/splinterdb_quick_test.c
@@ -320,7 +320,7 @@ CTEST2(splinterdb_quick, test_apis_for_large_key)
  */
 CTEST2(splinterdb_quick, test_key_size_gt_max_inline_key_size)
 {
-   char too_large_key_data[MAX_INLINE_KEY_SIZE(IO_DEFAULT_PAGE_SIZE) + 1];
+   char   too_large_key_data[MAX_INLINE_KEY_SIZE(IO_DEFAULT_PAGE_SIZE) + 1];
    size_t too_large_key_len = sizeof(too_large_key_data);
    memset(too_large_key_data, 'a', too_large_key_len);
    slice too_large_key = slice_create(too_large_key_len, too_large_key_data);
@@ -483,8 +483,8 @@ CTEST2(splinterdb_quick, test_iterator_survives_memtable_recycle)
  */
 CTEST2(splinterdb_quick, test_variable_length_values)
 {
-   slice      key_empty = slice_create(sizeof("empty"), "empty");
-   const char empty_string[0];
+   slice      key_empty      = slice_create(sizeof("empty"), "empty");
+   const char empty_string[] = "";
 
    slice      key_short       = slice_create(sizeof("short"), "short");
    const char short_string[1] = "v";
@@ -498,10 +498,8 @@ CTEST2(splinterdb_quick, test_variable_length_values)
    memset(max_length_string, 'b', TEST_MAX_VALUE_SIZE);
 
    // Insert keys with different value (lengths)
-   int rc = splinterdb_insert(data->kvsb,
-                              key_empty,
-                              slice_create(sizeof(empty_string), empty_string),
-                              NULL);
+   int rc = splinterdb_insert(
+      data->kvsb, key_empty, slice_create(0, empty_string), NULL);
    ASSERT_EQUAL(0, rc);
 
    rc = splinterdb_insert(data->kvsb,
@@ -1239,7 +1237,7 @@ CTEST2(splinterdb_quick, test_custom_data_config)
    // Tear down default instance, and create a new one.
    splinterdb_close(&data->kvsb);
    data->cfg.data_cfg = test_data_config;
-   int rc = splinterdb_create(&data->cfg, &data->kvsb);
+   int rc             = splinterdb_create(&data->cfg, &data->kvsb);
    ASSERT_EQUAL(0, rc);
 
    const size_t key_len   = 3;
@@ -1451,7 +1449,7 @@ CTEST2(splinterdb_quick, test_write_api_old_result_custom_merge_semantics)
 {
    splinterdb_close(&data->kvsb);
    data->cfg.data_cfg = test_data_config;
-   int rc = splinterdb_create(&data->cfg, &data->kvsb);
+   int rc             = splinterdb_create(&data->cfg, &data->kvsb);
    ASSERT_EQUAL(0, rc);
 
    slice       user_key  = slice_create(strlen("merge-key"), "merge-key");
@@ -1500,7 +1498,7 @@ CTEST2(splinterdb_quick, test_write_api_old_result_merges_memtable_and_trunk)
 {
    splinterdb_close(&data->kvsb);
    data->cfg.data_cfg = test_data_config;
-   int rc = splinterdb_create(&data->cfg, &data->kvsb);
+   int rc             = splinterdb_create(&data->cfg, &data->kvsb);
    ASSERT_EQUAL(0, rc);
 
    slice user_key  = slice_create(strlen("trunk-merge-key"), "trunk-merge-key");

--- a/tests/unit/splinterdb_quick_test.c
+++ b/tests/unit/splinterdb_quick_test.c
@@ -41,7 +41,7 @@
 #include "config.h"
 #include "splinterdb_tests_private.h"
 
-#define TEST_MAX_KEY_SIZE 23
+#define TEST_LARGE_KEY_SIZE 23
 
 /* -1 for message encoding overhead */
 #define TEST_MAX_VALUE_SIZE 32
@@ -163,7 +163,7 @@ CTEST_DATA(splinterdb_quick)
 // Optional setup function for suite, called before every test in suite
 CTEST_SETUP(splinterdb_quick)
 {
-   default_data_config_init(TEST_MAX_KEY_SIZE, &data->default_data_cfg.super);
+   default_data_config_init(&data->default_data_cfg.super);
    create_default_cfg(&data->cfg, &data->default_data_cfg.super);
    data->cfg.use_shmem =
       config_parse_use_shmem(Ctest_argc, (char **)Ctest_argv);
@@ -268,20 +268,20 @@ CTEST2(splinterdb_quick, test_pthread_auto_registration)
 
 /*
  * Basic test case that exercises and validates the basic flow of the
- * Splinter APIs for key of max-key-length.
+ * Splinter APIs for a larger key.
  */
-CTEST2(splinterdb_quick, test_apis_for_max_key_length)
+CTEST2(splinterdb_quick, test_apis_for_large_key)
 {
-   char   large_key_data[TEST_MAX_KEY_SIZE];
-   size_t large_key_len = TEST_MAX_KEY_SIZE;
-   memset(large_key_data, 'a', TEST_MAX_KEY_SIZE);
+   char   large_key_data[TEST_LARGE_KEY_SIZE];
+   size_t large_key_len = TEST_LARGE_KEY_SIZE;
+   memset(large_key_data, 'a', TEST_LARGE_KEY_SIZE);
    slice large_key = slice_create(large_key_len, large_key_data);
 
    static char *to_insert_data = "a-value";
    size_t       to_insert_len  = strlen(to_insert_data);
    slice        to_insert      = slice_create(to_insert_len, to_insert_data);
 
-   // **** Insert of a max-size key should succeed.
+   // **** Insert of a larger key should succeed.
    int rc = splinterdb_insert(data->kvsb, large_key, to_insert, NULL);
    ASSERT_EQUAL(0, rc);
 
@@ -316,11 +316,11 @@ CTEST2(splinterdb_quick, test_apis_for_max_key_length)
 }
 
 /*
- * Test case to verify core interfaces when key-size is > max key-size.
+ * Test case to verify core interfaces when key-size is too large.
  */
-CTEST2(splinterdb_quick, test_key_size_gt_max_key_size)
+CTEST2(splinterdb_quick, test_key_size_gt_max_inline_key_size)
 {
-   char   too_large_key_data[TEST_MAX_KEY_SIZE + 1];
+   char too_large_key_data[MAX_INLINE_KEY_SIZE(IO_DEFAULT_PAGE_SIZE) + 1];
    size_t too_large_key_len = sizeof(too_large_key_data);
    memset(too_large_key_data, 'a', too_large_key_len);
    slice too_large_key = slice_create(too_large_key_len, too_large_key_data);
@@ -1239,7 +1239,6 @@ CTEST2(splinterdb_quick, test_custom_data_config)
    // Tear down default instance, and create a new one.
    splinterdb_close(&data->kvsb);
    data->cfg.data_cfg = test_data_config;
-   // data->cfg.data_cfg->max_key_size = 20;
    int rc = splinterdb_create(&data->cfg, &data->kvsb);
    ASSERT_EQUAL(0, rc);
 
@@ -1452,7 +1451,6 @@ CTEST2(splinterdb_quick, test_write_api_old_result_custom_merge_semantics)
 {
    splinterdb_close(&data->kvsb);
    data->cfg.data_cfg = test_data_config;
-   // data->cfg.data_cfg->max_key_size = 20;
    int rc = splinterdb_create(&data->cfg, &data->kvsb);
    ASSERT_EQUAL(0, rc);
 
@@ -1502,7 +1500,6 @@ CTEST2(splinterdb_quick, test_write_api_old_result_merges_memtable_and_trunk)
 {
    splinterdb_close(&data->kvsb);
    data->cfg.data_cfg = test_data_config;
-   // data->cfg.data_cfg->max_key_size = 20;
    int rc = splinterdb_create(&data->cfg, &data->kvsb);
    ASSERT_EQUAL(0, rc);
 
@@ -1671,7 +1668,7 @@ CTEST2(splinterdb_quick, test_splinterdb_create_w_background_threads)
 {
    splinterdb_close(&data->kvsb);
 
-   default_data_config_init(TEST_MAX_KEY_SIZE, &data->default_data_cfg.super);
+   default_data_config_init(&data->default_data_cfg.super);
    create_default_cfg(&data->cfg, &data->default_data_cfg.super);
 
    // Task system should be setup with background threads
@@ -1692,7 +1689,7 @@ CTEST2(splinterdb_quick, test_splinterdb_create_w_all_background_threads)
 {
    splinterdb_close(&data->kvsb);
 
-   default_data_config_init(TEST_MAX_KEY_SIZE, &data->default_data_cfg.super);
+   default_data_config_init(&data->default_data_cfg.super);
    create_default_cfg(&data->cfg, &data->default_data_cfg.super);
 
    // Task system should be setup with all background threads

--- a/tests/unit/splinterdb_stress_test.c
+++ b/tests/unit/splinterdb_stress_test.c
@@ -32,7 +32,6 @@ typedef struct {
    uint32_t    num_inserts;
    int         random_data;
    splinterdb *kvsb;
-   uint16_t    max_key_size;
    uint16_t    max_value_size;
 } worker_config;
 
@@ -54,8 +53,7 @@ CTEST_SETUP(splinterdb_stress)
                                    .data_cfg   = &data->default_data_config,
                                    .num_memtable_bg_threads = 2,
                                    .num_normal_bg_threads   = 2};
-   size_t max_key_size = TEST_KEY_SIZE;
-   default_data_config_init(max_key_size, data->cfg.data_cfg);
+   default_data_config_init(data->cfg.data_cfg);
 
    data->cfg.use_shmem =
       config_parse_use_shmem(Ctest_argc, (char **)Ctest_argv);


### PR DESCRIPTION
Remove max_key_size from data_config.

The primary challenge is that it ha become deeply embedded in the tests as the configuration of what size keys to generate.

So this PR introduces a new test config struct to carry that information.
